### PR TITLE
fix(ops): read x ledger in readonly mode

### DIFF
--- a/scripts/lib/x-collector-quality-report-support.spec.ts
+++ b/scripts/lib/x-collector-quality-report-support.spec.ts
@@ -8,8 +8,22 @@ import {
   buildXCollectorLedgerReport,
 } from "./x-collector-quality-report-support";
 
+jest.mock("node:child_process", () => {
+  const actual = jest.requireActual("node:child_process") as Record<
+    string,
+    unknown
+  > & {
+    readonly execFileSync: typeof execFileSync;
+  };
+
+  return {
+    ...actual,
+    execFileSync: jest.fn(actual.execFileSync),
+  };
+});
+
 describe("x collector quality report support", () => {
-  it("counts historical backfill runs by target search window", () => {
+  it("reads the ledger in read-only mode and counts target search windows", () => {
     const directory = mkdtempSync(join(tmpdir(), "x-collector-quality-"));
     const dbPath = join(directory, "scweet_state.db");
 
@@ -143,6 +157,7 @@ describe("x collector quality report support", () => {
         accepted: 99,
       });
 
+      jest.mocked(execFileSync).mockClear();
       const ledger = buildXCollectorLedgerReport({
         ledgerPath: dbPath,
         collectionDate: "2026-07-07",
@@ -165,6 +180,14 @@ describe("x collector quality report support", () => {
       expect(accountPool.accounts[0]?.fetchedCount).toBe(31);
       expect(accountPool.accounts[0]?.dailyRequestsLimit).toBeNull();
       expect(accountPool.accounts[0]?.dailyTweetsLimit).toBeNull();
+      expect(jest.mocked(execFileSync)).toHaveBeenCalled();
+      for (const [command, args] of jest.mocked(execFileSync).mock.calls) {
+        expect(command).toBe("sqlite3");
+        expect(Array.isArray(args) ? args.slice(0, 2) : args).toEqual([
+          "-readonly",
+          "-json",
+        ]);
+      }
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/scripts/lib/x-collector-quality-report-support.ts
+++ b/scripts/lib/x-collector-quality-report-support.ts
@@ -547,10 +547,14 @@ function readSqliteJson<TValue>(
       readonly error: string;
     } {
   try {
-    const output = execFileSync("sqlite3", ["-json", ledgerPath, sql], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const output = execFileSync(
+      "sqlite3",
+      ["-readonly", "-json", ledgerPath, sql],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     const normalized = output.trim();
 
     return {


### PR DESCRIPTION
## Summary
- open the production X collector SQLite ledger explicitly read-only
- keep the ledger bind mount immutable during daily quality checks
- cover every quality-read invocation with a focused regression test

## Verification
- focused Jest: 2 tests passed
- focused ESLint passed
- npm build passed
- source line cap passed
- source certification passed
- git diff --check passed

Known baseline: check:code-quality still reports 10 unchanged oversized production files outside this hotfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite report generation now accesses ledger data in read-only mode, reducing the risk of unintended database changes.
  * Improved validation confirms report queries use the expected read-only JSON output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->