### PR TITLE
fix(ops): open readonly x ledger as immutable

### DIFF
--- a/scripts/lib/x-collector-quality-report-support.spec.ts
+++ b/scripts/lib/x-collector-quality-report-support.spec.ts
@@ -183,10 +183,14 @@ describe("x collector quality report support", () => {
       expect(jest.mocked(execFileSync)).toHaveBeenCalled();
       for (const [command, args] of jest.mocked(execFileSync).mock.calls) {
         expect(command).toBe("sqlite3");
-        expect(Array.isArray(args) ? args.slice(0, 2) : args).toEqual([
-          "-readonly",
-          "-json",
-        ]);
+        expect(Array.isArray(args)).toBe(true);
+        if (!Array.isArray(args)) {
+          continue;
+        }
+        expect(args.slice(0, 2)).toEqual(["-readonly", "-json"]);
+        const ledgerUri = new URL(String(args[2]));
+        expect(ledgerUri.protocol).toBe("file:");
+        expect(ledgerUri.searchParams.get("immutable")).toBe("1");
       }
     } finally {
       rmSync(directory, { recursive: true, force: true });

--- a/scripts/lib/x-collector-quality-report-support.ts
+++ b/scripts/lib/x-collector-quality-report-support.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 type XRunRow = {
   readonly run_id?: string;
@@ -549,7 +550,12 @@ function readSqliteJson<TValue>(
   try {
     const output = execFileSync(
       "sqlite3",
-      ["-readonly", "-json", ledgerPath, sql],
+      [
+        "-readonly",
+        "-json",
+        `${pathToFileURL(ledgerPath).href}?immutable=1`,
+        sql,
+      ],
       {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
- open the X ledger through a file URI with immutable=1
- prevent SQLite WAL/shared-memory writes on the production read-only bind mount
- assert immutable URI semantics in the focused regression test

## Verification
- focused ESLint passed
- focused Jest: 2 tests passed
- npm build passed
- git diff --check passed
- production-shaped read-only mount query returned the run count