### PR TITLE
fix(summary): bound topic relation verification

### DIFF
--- a/libs/summary/domain/services/reader-summary-topic-relation-candidates.spec.ts
+++ b/libs/summary/domain/services/reader-summary-topic-relation-candidates.spec.ts
@@ -1,6 +1,7 @@
 import {
   buildExistingReaderSummaryTopicRelations,
   buildReaderSummaryTopicRelationCandidates,
+  buildReaderSummaryTopicRelationVerificationForest,
   buildSemanticallyEquivalentReaderSummaryTopicRelations,
 } from "./reader-summary-topic-relation-candidates";
 
@@ -62,6 +63,67 @@ describe("buildReaderSummaryTopicRelationCandidates", () => {
       },
     ]);
   });
+
+  it("reduces a ten-node merge clique to a deterministic spanning tree", () => {
+    const candidates = Array.from({ length: 10 }, (_, index) =>
+      candidate(`node:${index}`, [`Shared topic ${index}`]),
+    );
+    const existing = buildExistingReaderSummaryTopicRelations(
+      candidates,
+      candidates.map((item) => ({
+        nodeId: item.nodeId,
+        topicId: "topic:shared",
+      })),
+    );
+
+    expect(existing).toHaveLength(45);
+    const forest = buildReaderSummaryTopicRelationVerificationForest(
+      existing,
+      [],
+    );
+    expect(forest).toHaveLength(9);
+    expect(
+      new Set(
+        forest.flatMap((relation) => [
+          relation.sourceNodeId,
+          relation.targetNodeId,
+        ]),
+      ).size,
+    ).toBe(10);
+    expect(
+      buildReaderSummaryTopicRelationVerificationForest(
+        existing
+          .slice()
+          .reverse()
+          .map((relation) => ({
+            ...relation,
+            sourceNodeId: relation.targetNodeId,
+            targetNodeId: relation.sourceNodeId,
+          })),
+        [],
+      ),
+    ).toEqual(forest);
+  });
+
+  it("deduplicates edges and preserves disconnected components", () => {
+    const forest = buildReaderSummaryTopicRelationVerificationForest(
+      [
+        relation("node:a", "node:b", ["existing"]),
+        relation("node:b", "node:a", ["duplicate"]),
+        relation("node:b", "node:c", ["bridge"]),
+        relation("node:a", "node:c", ["cycle"]),
+        relation("node:d", "node:d", ["self"]),
+      ],
+      [relation("node:x", "node:y", ["semantic"])],
+    );
+
+    expect(forest).toHaveLength(3);
+    expect(
+      new Set(
+        forest.flatMap((item) => [item.sourceNodeId, item.targetNodeId]),
+      ),
+    ).toEqual(new Set(["node:a", "node:b", "node:c", "node:x", "node:y"]));
+  });
 });
 
 const candidate = (nodeId: string, keywords: readonly string[]) => ({
@@ -83,3 +145,9 @@ const semanticLabel = (
     confidenceScore: 0.9,
   },
 });
+
+const relation = (
+  sourceNodeId: string,
+  targetNodeId: string,
+  sharedTerms: readonly string[],
+) => ({ sourceNodeId, targetNodeId, sharedTerms });

--- a/libs/summary/domain/services/reader-summary-topic-relation-candidates.ts
+++ b/libs/summary/domain/services/reader-summary-topic-relation-candidates.ts
@@ -174,6 +174,62 @@ export const combineReaderSummaryTopicRelations = (
   return [...combined.values()].slice(0, Math.max(0, limit));
 };
 
+export const buildReaderSummaryTopicRelationVerificationForest = (
+  existing: readonly ReaderSummaryTopicRelationCandidate[],
+  semantic: readonly ReaderSummaryTopicRelationCandidate[],
+): readonly ReaderSummaryTopicRelationCandidate[] => {
+  const rankedByPair = new Map<
+    string,
+    {
+      readonly priority: number;
+      readonly relation: ReaderSummaryTopicRelationCandidate;
+    }
+  >();
+  const addRelations = (
+    relations: readonly ReaderSummaryTopicRelationCandidate[],
+    priority: number,
+  ): void => {
+    for (const relation of relations) {
+      const canonical = canonicalRelation(relation);
+      if (canonical.sourceNodeId === canonical.targetNodeId) {
+        continue;
+      }
+      const key = relationPairKey(canonical);
+      const current = rankedByPair.get(key);
+      rankedByPair.set(key, {
+        priority: Math.min(current?.priority ?? priority, priority),
+        relation: {
+          ...canonical,
+          sharedTerms: canonicalSharedTerms([
+            ...(current?.relation.sharedTerms ?? []),
+            ...canonical.sharedTerms,
+          ]),
+        },
+      });
+    }
+  };
+
+  addRelations(existing, 0);
+  addRelations(semantic, 1);
+  const ranked = [...rankedByPair.values()].sort(compareVerificationEdges);
+  const parents = new Map<string, string>();
+  const forest: ReaderSummaryTopicRelationCandidate[] = [];
+  for (const edge of ranked) {
+    const sourceRoot = findRelationRoot(parents, edge.relation.sourceNodeId);
+    const targetRoot = findRelationRoot(parents, edge.relation.targetNodeId);
+    if (sourceRoot === targetRoot) {
+      continue;
+    }
+    parents.set(
+      sourceRoot.localeCompare(targetRoot) <= 0 ? targetRoot : sourceRoot,
+      sourceRoot.localeCompare(targetRoot) <= 0 ? sourceRoot : targetRoot,
+    );
+    forest.push(edge.relation);
+  }
+
+  return forest;
+};
+
 const candidateRelationshipTerms = (
   candidate: ReaderSummaryTopicRelationSource,
 ): ReadonlySet<string> =>
@@ -201,6 +257,52 @@ const relationshipNoiseTerms = new Set([
   "release",
   "rollout",
 ]);
+
+const canonicalRelation = (
+  relation: ReaderSummaryTopicRelationCandidate,
+): ReaderSummaryTopicRelationCandidate =>
+  relation.sourceNodeId.localeCompare(relation.targetNodeId) <= 0
+    ? { ...relation, sharedTerms: canonicalSharedTerms(relation.sharedTerms) }
+    : {
+        sourceNodeId: relation.targetNodeId,
+        targetNodeId: relation.sourceNodeId,
+        sharedTerms: canonicalSharedTerms(relation.sharedTerms),
+      };
+
+const canonicalSharedTerms = (terms: readonly string[]): readonly string[] =>
+  [...new Set(terms.map((term) => term.trim()).filter(Boolean))].sort();
+
+const compareVerificationEdges = (
+  left: {
+    readonly priority: number;
+    readonly relation: ReaderSummaryTopicRelationCandidate;
+  },
+  right: {
+    readonly priority: number;
+    readonly relation: ReaderSummaryTopicRelationCandidate;
+  },
+): number =>
+  left.priority - right.priority ||
+  right.relation.sharedTerms.length - left.relation.sharedTerms.length ||
+  left.relation.sharedTerms.join("\u0000").localeCompare(
+    right.relation.sharedTerms.join("\u0000"),
+  ) ||
+  left.relation.sourceNodeId.localeCompare(right.relation.sourceNodeId) ||
+  left.relation.targetNodeId.localeCompare(right.relation.targetNodeId);
+
+const findRelationRoot = (
+  parents: Map<string, string>,
+  nodeId: string,
+): string => {
+  const parent = parents.get(nodeId) ?? nodeId;
+  if (parent === nodeId) {
+    parents.set(nodeId, nodeId);
+    return nodeId;
+  }
+  const root = findRelationRoot(parents, parent);
+  parents.set(nodeId, root);
+  return root;
+};
 
 const relationPairKey = (relation: {
   readonly sourceNodeId: string;

--- a/libs/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.use-case.spec.ts
+++ b/libs/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.use-case.spec.ts
@@ -181,6 +181,49 @@ describe("BuildReaderSummaryTopicMapUseCase", () => {
       "topic:story:work-1",
     ]);
   });
+
+  it("verifies a ten-node proposed merge with a minimal relation tree", async () => {
+    const verifier = new AcceptingTopicRelationVerifier();
+    const result = await new BuildReaderSummaryTopicMapUseCase({
+      mode: "agent-runtime",
+      labeler: new MergedRelatedTopicLabeler(),
+      relationVerifier: verifier,
+    }).execute(manyTopicCommand(10));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw result.error;
+    }
+    expect(verifier.inputs[0]?.relations).toHaveLength(24);
+    expect(
+      new Set(
+        verifier.inputs[0]?.relations
+          .slice(0, 9)
+          .flatMap((relation) => [
+            relation.sourceNodeId,
+            relation.targetNodeId,
+          ]),
+      ).size,
+    ).toBe(10);
+    expect(result.value.nodes).toHaveLength(1);
+  });
+
+  it("keeps the hard limit for a genuinely oversized verification tree", async () => {
+    const verifier = new AcceptingTopicRelationVerifier();
+    const result = await new BuildReaderSummaryTopicMapUseCase({
+      mode: "agent-runtime",
+      labeler: new MergedRelatedTopicLabeler(),
+      relationVerifier: verifier,
+    }).execute(manyTopicCommand(26));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected oversized topic verification to fail");
+    }
+    expect(result.error.message).toContain("25 checks");
+    expect(result.error.message).toContain("safe limit of 24");
+    expect(verifier.inputs).toHaveLength(0);
+  });
 });
 
 class CapturingTopicLabeler implements ReaderSummaryTopicLabelerPort {
@@ -480,5 +523,27 @@ const relatedTopicCommand = (): ReturnType<typeof command> => {
       field: "title" as const,
       canonicalUrl: item.canonicalUrl,
     })),
+  };
+};
+
+const manyTopicCommand = (count: number): ReturnType<typeof command> => {
+  const base = command();
+  const selectedEvidence = Array.from({ length: count }, (_, index) => ({
+    ...base.selectedEvidence[0]!,
+    feedItemId: `feed-many-${index}`,
+    sourceItemId: `source-many-${index}`,
+    title: `Shared work topic ${index}`,
+  }));
+  return {
+    ...base,
+    clusters: selectedEvidence.map((item, index) => ({
+      ...base.clusters[0]!,
+      id: `story:many-${index}`,
+      storyKey: `many-${index}`,
+      representativeFeedItemId: item.feedItemId,
+    })),
+    selectedEvidence,
+    topStories: [],
+    citationMap: [],
   };
 };

--- a/libs/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.use-case.ts
+++ b/libs/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.use-case.ts
@@ -9,6 +9,7 @@ import {
   buildExistingReaderSummaryTopicRelations,
   buildReaderSummaryTopicMap,
   buildReaderSummaryTopicRelationCandidates,
+  buildReaderSummaryTopicRelationVerificationForest,
   buildSemanticallyEquivalentReaderSummaryTopicRelations,
   combineReaderSummaryTopicRelations,
   evaluateReaderSummaryTopicMapStructure,
@@ -213,13 +214,12 @@ export class BuildReaderSummaryTopicMapUseCase {
             ),
           );
     }
-    const requiredRelations = combineReaderSummaryTopicRelations(
+    const requiredRelations = buildReaderSummaryTopicRelationVerificationForest(
       existingRelations,
       buildSemanticallyEquivalentReaderSummaryTopicRelations(
         reviewedCandidates,
         labelPlan.nodeLabels,
       ),
-      Number.MAX_SAFE_INTEGER,
     );
     if (
       requiredRelations.length > READER_SUMMARY_TOPIC_RELATION_MAX_CANDIDATES


### PR DESCRIPTION
## Summary
- replace quadratic required topic relation cliques with a deterministic minimum verification forest
- preserve connected-component coverage and existing-merge priority
- keep the hard 24-check safety limit for genuinely oversized forests
- retain fail-closed reconciliation for rejected, missing, or unavailable decisions

## Verification
- focused Jest: 21 tests passed
- focused ESLint passed
- npm build passed
- architecture boundaries passed
- source line cap passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved topic relation verification by selecting a consistent, minimal connection structure.
  * Duplicate relationships are consolidated, disconnected topic groups remain supported, and relationship metadata is normalized.

* **Bug Fixes**
  * Added safeguards for oversized relation trees, including clear rejection when the safe limit is exceeded.
  * Improved handling of reversed relationships and self-loop data during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->