### PR TITLE
fix(ops): refresh frontend after api recreate

### DIFF
--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -459,13 +459,21 @@ rollback_backend_images() {
   local state_file=$1
   [[ -s $state_file ]] || return 0
   local service image_id
+  local api_rolled_back=false
+  local -a rollback_services
   while read -r service image_id; do
     docker image tag "$image_id" "$(compose_image_name "$service")" || return 1
   done < "$state_file"
   mapfile -t rollback_services < <(awk '$1 != "migrate" && $1 != "daily-runner" {print $1}' "$state_file")
   if ((${#rollback_services[@]} > 0)); then
+    if printf '%s\n' "${rollback_services[@]}" | grep -qx api; then
+      api_rolled_back=true
+    fi
     "${COMPOSE[@]}" --profile app up -d --no-deps --force-recreate "${rollback_services[@]}" || return 1
     verify_backend_with_retry "${rollback_services[@]}" || return 1
+    if [[ $api_rolled_back == true ]]; then
+      refresh_frontend_api_proxy || return 1
+    fi
   fi
 }
 
@@ -558,6 +566,27 @@ verify_backend_with_retry() {
   return 1
 }
 
+verify_frontend_api_proxy() {
+  local frontend_id status oom
+  frontend_id=$("${COMPOSE[@]}" --profile app ps -q frontend)
+  [[ -n $frontend_id ]] || return 1
+  status=$(docker inspect "$frontend_id" --format '{{.State.Status}}')
+  oom=$(docker inspect "$frontend_id" --format '{{.State.OOMKilled}}')
+  [[ $status == running && $oom == false ]] || return 1
+  curl -fsS --max-time 15 \
+    -H 'Host: social-monitor.app' \
+    http://127.0.0.1:13080/auth/session >/dev/null
+}
+
+refresh_frontend_api_proxy() {
+  "${COMPOSE[@]}" --profile app up -d --no-deps --force-recreate frontend || return 1
+  for _ in {1..20}; do
+    verify_frontend_api_proxy && return 0
+    sleep 3
+  done
+  return 1
+}
+
 deploy_backend() {
   local sha=$1
   local from
@@ -603,6 +632,10 @@ deploy_backend() {
     if ! verify_backend_with_retry "${persistent[@]}"; then
       rollback_backend_images "$previous" || fail 'backend health and rollback verification both failed'
       fail 'backend health failed; previous images restored'
+    fi
+    if printf '%s\n' "${persistent[@]}" | grep -qx api && ! refresh_frontend_api_proxy; then
+      rollback_backend_images "$previous" || fail 'frontend API proxy refresh and backend rollback both failed'
+      fail 'frontend API proxy refresh failed; previous backend images restored'
     fi
   fi
   printf '%s\n' "$sha" > "$STATE/backend.sha"

--- a/ops/deploy/social-monitor-production-deploy.test.sh
+++ b/ops/deploy/social-monitor-production-deploy.test.sh
@@ -67,6 +67,13 @@ if SSH_ORIGINAL_COMMAND=$'plan '"$TARGET_SHA"$'\ndeploy '"$TARGET_SHA" \
   exit 1
 fi
 
+grep -F "if printf '%s\\n' \"\${persistent[@]}\" | grep -qx api && ! refresh_frontend_api_proxy; then" \
+  "$ENTRYPOINT" >/dev/null
+grep -F "if [[ \$api_rolled_back == true ]]; then" "$ENTRYPOINT" >/dev/null
+grep -F 'refresh_frontend_api_proxy || return 1' \
+  "$ENTRYPOINT" >/dev/null
+grep -F 'http://127.0.0.1:13080/auth/session' "$ENTRYPOINT" >/dev/null
+
 RELEASE_FIXTURE=$FIXTURE/frontend-release
 install -d "$RELEASE_FIXTURE/public" "$RELEASE_FIXTURE/admin"
 printf '<html>public</html>\n' > "$RELEASE_FIXTURE/public/index.html"


### PR DESCRIPTION
## Summary
- recreate the frontend reverse proxy after an API container replacement so nginx resolves the new Compose address
- verify the guest session route through nginx before marking the backend deployment successful
- repeat the proxy refresh after an API rollback

## Verification
- `bash -n ops/deploy/social-monitor-production-deploy.sh ops/deploy/social-monitor-production-deploy.test.sh`
- `shellcheck -x ops/deploy/social-monitor-production-deploy.sh ops/deploy/social-monitor-production-deploy.test.sh`
- `bash ops/deploy/social-monitor-production-deploy.test.sh`
- `npm run check:source-line-cap`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment reliability by refreshing the frontend API connection after backend updates or rollbacks.
  * Added validation to confirm the frontend remains healthy and session authentication works after deployment.
  * Deployments now fail safely and roll back when the frontend API refresh cannot be verified.

* **Tests**
  * Added automated checks covering frontend API refresh and rollback validation during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->