### PR TITLE
feat(summary): isolate GitHub trending highlights

### DIFF
--- a/apps/api-gateway/src/health-reporter.spec.ts
+++ b/apps/api-gateway/src/health-reporter.spec.ts
@@ -37,7 +37,7 @@ const readinessProfiles: readonly SourceReadinessProfile[] = [
     liveEvidenceRequirements: [],
     freshnessGuard: makeFreshnessGuard({
       maxStalenessSeconds: 86_400,
-      minimumScanIntervalSeconds: 3_600,
+      minimumScanIntervalSeconds: 86_400,
       skipRecentlyScanned: false,
     }),
     acquisitionMode: 'api',

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_provider_coverage_rows.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_provider_coverage_rows.dart
@@ -95,26 +95,27 @@ List<_ProviderCoverageRowData> _providerCoverageRows(ReaderSummary summary) {
   if (coverageRows.isNotEmpty) {
     return _sortProviderCoverageRows([
       for (final provider in coverageRows)
-        _ProviderCoverageRowData(
-          providerKey: provider.providerKey,
-          collectedFeedItemCount: _safeNullableCoverageCount(
-            provider.collectedFeedItemCount,
+        if (!_isGitHubProvider(provider.providerKey))
+          _ProviderCoverageRowData(
+            providerKey: provider.providerKey,
+            collectedFeedItemCount: _safeNullableCoverageCount(
+              provider.collectedFeedItemCount,
+            ),
+            selectedFeedItemCount: _safeCoverageCount(
+              provider.selectedFeedItemCount,
+            ),
+            topReadCount: _safeCoverageCount(provider.topReadCount),
+            citationCount: _safeCoverageCount(provider.citationCount),
+            lowRelevanceFeedItemCount: _safeCoverageCount(
+              provider.lowRelevanceFeedItemCount,
+            ),
+            mutedFeedItemCount: _safeCoverageCount(provider.mutedFeedItemCount),
+            userRatedFeedItemCount: _safeCoverageCount(
+              provider.userRatedFeedItemCount,
+            ),
+            collectionHealth: provider.collectionHealth,
+            color: _providerCoverageColor(provider.providerKey),
           ),
-          selectedFeedItemCount: _safeCoverageCount(
-            provider.selectedFeedItemCount,
-          ),
-          topReadCount: _safeCoverageCount(provider.topReadCount),
-          citationCount: _safeCoverageCount(provider.citationCount),
-          lowRelevanceFeedItemCount: _safeCoverageCount(
-            provider.lowRelevanceFeedItemCount,
-          ),
-          mutedFeedItemCount: _safeCoverageCount(provider.mutedFeedItemCount),
-          userRatedFeedItemCount: _safeCoverageCount(
-            provider.userRatedFeedItemCount,
-          ),
-          collectionHealth: provider.collectionHealth,
-          color: _providerCoverageColor(provider.providerKey),
-        ),
     ]);
   }
 
@@ -130,7 +131,7 @@ List<_ProviderCoverageRowData> _providerCoverageRows(ReaderSummary summary) {
   final rowsByProvider = <String, _ProviderCoverageRowData>{};
   for (final source in summary.content.sourceMix) {
     final key = source.providerKey.trim();
-    if (key.isEmpty) {
+    if (key.isEmpty || _isGitHubProvider(key)) {
       continue;
     }
     rowsByProvider[key] = _ProviderCoverageRowData(
@@ -146,6 +147,9 @@ List<_ProviderCoverageRowData> _providerCoverageRows(ReaderSummary summary) {
   }
 
   for (final entry in topReadCounts.entries) {
+    if (_isGitHubProvider(entry.key)) {
+      continue;
+    }
     rowsByProvider.putIfAbsent(
       entry.key,
       () => _ProviderCoverageRowData(
@@ -162,6 +166,16 @@ List<_ProviderCoverageRowData> _providerCoverageRows(ReaderSummary summary) {
   }
 
   return _sortProviderCoverageRows(rowsByProvider.values.toList());
+}
+
+bool _isGitHubProvider(String providerKey) {
+  return switch (providerKey.trim().toLowerCase()) {
+    'github' ||
+    'github-issues' ||
+    'github-trending-page' ||
+    'github-repo-radar' => true,
+    _ => false,
+  };
 }
 
 String _collectionHealthText(ReaderSummaryProviderCollectionHealth health) {

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_layout_regressions_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_layout_regressions_test.dart
@@ -225,12 +225,11 @@ void main() {
     expect(hackerNews, findsOneWidget);
     expect(rss, findsOneWidget);
     expect(reddit, findsOneWidget);
-    expect(github, findsOneWidget);
+    expect(github, findsNothing);
 
     final firstTop = tester.getTopLeft(hackerNews).dy;
     expect((tester.getTopLeft(rss).dy - firstTop).abs(), lessThan(1));
     expect((tester.getTopLeft(reddit).dy - firstTop).abs(), lessThan(1));
-    expect((tester.getTopLeft(github).dy - firstTop).abs(), lessThan(1));
     expect(
       tester.getTopLeft(rss).dx,
       greaterThan(tester.getTopLeft(hackerNews).dx),
@@ -238,10 +237,6 @@ void main() {
     expect(
       tester.getTopLeft(reddit).dx,
       greaterThan(tester.getTopLeft(rss).dx),
-    );
-    expect(
-      tester.getTopLeft(github).dx,
-      greaterThan(tester.getTopLeft(reddit).dx),
     );
   });
 }

--- a/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
@@ -53,15 +53,14 @@ void main() {
         const ValueKey('reader-summary-provider-coverage-github-trending-page'),
         skipOffstage: false,
       ),
-      findsOneWidget,
+      findsNothing,
     );
-    expect(find.text('22 collected', skipOffstage: false), findsOneWidget);
     expect(
-      find.text(
-        '3 selected (14%) · 3 top reads · 3 citations',
+      find.byKey(
+        const ValueKey('reader-summary-coverage-by-source'),
         skipOffstage: false,
       ),
-      findsOneWidget,
+      findsNothing,
     );
     expect(find.text('Repositories ranked by GitHub momentum'), findsOneWidget);
     await tester.scrollUntilVisible(

--- a/libs/ingestion/adapters/source/source-readiness-profiles.ts
+++ b/libs/ingestion/adapters/source/source-readiness-profiles.ts
@@ -240,8 +240,8 @@ export const sourceReadinessProfiles: readonly SourceReadinessProfile[] = [
     ],
     liveEvidenceRequirements: githubTrendingPageLiveEvidenceRequirements,
     freshnessGuard: {
-      maxStalenessSeconds: 3_600,
-      minimumScanIntervalSeconds: 3_600,
+      maxStalenessSeconds: 86_400,
+      minimumScanIntervalSeconds: 86_400,
       skipRecentlyScanned: true,
       scanHistoryRequired: true,
       cursorResumeRequired: true,

--- a/libs/monitoring/features/set-scan-policy/set-scan-policy.use-case.spec.ts
+++ b/libs/monitoring/features/set-scan-policy/set-scan-policy.use-case.spec.ts
@@ -287,7 +287,7 @@ describe('SetScanPolicyUseCase', () => {
   });
 
   it.each([
-    ['github-trending-page', 3_600],
+    ['github-trending-page', 86_400],
     ['github-repo-radar', 21_600],
   ])(
     'rejects scan intervals below %s provider cadence minimum',

--- a/libs/monitoring/features/shared/scan-cadence-policy.spec.ts
+++ b/libs/monitoring/features/shared/scan-cadence-policy.spec.ts
@@ -31,9 +31,9 @@ describe('scan cadence policy', () => {
       defaultRetryBudget: 3,
     });
     expect(providerScanCadenceProfile('github-trending-page')).toEqual({
-      minimumIntervalSeconds: 3_600,
-      defaultIntervalSeconds: 3_600,
-      defaultFreshnessSeconds: 3_600,
+      minimumIntervalSeconds: 86_400,
+      defaultIntervalSeconds: 86_400,
+      defaultFreshnessSeconds: 86_400,
       defaultRetryBudget: 1,
     });
     expect(providerScanCadenceProfile('unknown-provider')).toEqual({

--- a/libs/monitoring/features/shared/scan-cadence-policy.ts
+++ b/libs/monitoring/features/shared/scan-cadence-policy.ts
@@ -72,9 +72,9 @@ const providerScanCadenceProfiles = new Map<string, ProviderScanCadenceProfile>(
   [
     'github-trending-page',
     {
-      minimumIntervalSeconds: 3_600,
-      defaultIntervalSeconds: 3_600,
-      defaultFreshnessSeconds: 3_600,
+      minimumIntervalSeconds: 86_400,
+      defaultIntervalSeconds: 86_400,
+      defaultFreshnessSeconds: 86_400,
       defaultRetryBudget: 1,
     },
   ],

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence-support.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence-support.ts
@@ -25,7 +25,6 @@ export const readerSummaryProviderDiversityOrder = [
   "reddit",
   "hacker-news",
   "rss",
-  "github-trending-page",
   "github-repo-radar",
 ];
 

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence-test-fixtures.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence-test-fixtures.ts
@@ -1,0 +1,25 @@
+import type { Clock } from "@social-monitor/shared-kernel";
+
+import type { ReaderSummaryPeriod } from "../../domain";
+
+export const readerSummaryEvidenceTestClock: Clock = {
+  now: () => new Date("2026-06-23T12:00:00.000Z"),
+};
+
+export const readerSummaryEvidenceTestPeriod: ReaderSummaryPeriod = {
+  cadence: "daily",
+  startedAt: new Date("2026-06-23T00:00:00.000Z"),
+  endedAt: new Date("2026-06-24T00:00:00.000Z"),
+  timezone: "UTC",
+  periodKey: "daily:2026-06-23T00:00:00.000Z:2026-06-24T00:00:00.000Z:UTC",
+};
+
+export const githubTrendingMetadataFixture = (starsGained: number) => ({
+  kind: "github_trending_page_repository",
+  repository: {
+    fullName: "owner/repository",
+    totalStars: 20_000,
+    forksCount: 500,
+  },
+  trending: { rank: 1, starsGained, window: "daily" },
+});

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.spec.ts
@@ -3,31 +3,16 @@ import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
 import type { RankFeedItemsCommand } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.command";
 import type { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
 import type { RankedFeedItemView } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.result";
-import {
-  ok,
-  tenantId,
-  workspaceId,
-  type Clock,
-} from "@social-monitor/shared-kernel";
+import { ok, tenantId, workspaceId } from "@social-monitor/shared-kernel";
 
 import { RelevanceReaderSummaryEvidenceSelector } from "./relevance-reader-summary-evidence.selector";
-import type {
-  ReaderSummaryPeriod,
-  SummaryEvidenceSelection,
-} from "../../domain";
+import {
+  githubTrendingMetadataFixture,
+  readerSummaryEvidenceTestClock as clock,
+  readerSummaryEvidenceTestPeriod as readerSummaryPeriod,
+} from "./relevance-reader-summary-evidence-test-fixtures";
+import type { SummaryEvidenceSelection } from "../../domain";
 import type { StoryRankingMetricsPort } from "../../ports";
-
-const clock: Clock = {
-  now: () => new Date("2026-06-23T12:00:00.000Z"),
-};
-
-const readerSummaryPeriod: ReaderSummaryPeriod = {
-  cadence: "daily",
-  startedAt: new Date("2026-06-23T00:00:00.000Z"),
-  endedAt: new Date("2026-06-24T00:00:00.000Z"),
-  timezone: "UTC",
-  periodKey: "daily:2026-06-23T00:00:00.000Z:2026-06-24T00:00:00.000Z:UTC",
-};
 
 const rankedItem = (
   overrides: Partial<RankedFeedItemView> & {
@@ -87,6 +72,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         providerKey: "github-trending-page",
         rank: 1,
         score: 2.5,
+        providerMetadata: githubTrendingMetadataFixture(2_500),
       }),
       rankedItem({
         feedItemId: "feed-hn",
@@ -115,6 +101,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         providerKey: "github-trending-page",
         rank: 5,
         score: 2.1,
+        providerMetadata: githubTrendingMetadataFixture(1_500),
       }),
       rankedItem({
         feedItemId: "feed-issues",
@@ -142,7 +129,11 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
       ),
     } as unknown as RankFeedItemsUseCase;
     const feedItems: FeedItemReadRepositoryPort = {
-      list: jest.fn(async () => ({ items: [] })),
+      list: jest.fn(async ({ cursor }) =>
+        cursor === undefined
+          ? { items: [], nextCursor: "github-page-2" }
+          : { items: [] },
+      ),
       findById: jest.fn(async () => null),
     };
     const storyRankingMetrics = new FakeStoryRankingMetrics();
@@ -168,6 +159,12 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         limit: 200,
       }),
     );
+    expect(feedItems.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerKey: "github-trending-page",
+        cursor: "github-page-2",
+      }),
+    );
     expect(
       selection.selectedEvidence.map((item) => item.providerKey).sort(),
     ).toEqual([
@@ -178,10 +175,10 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
       "rss",
     ]);
     expect(selection.selectedEvidence.map((item) => item.providerKey)).toEqual([
-      "github-trending-page",
       "hacker-news",
       "reddit",
       "rss",
+      "github-trending-page",
       "github-trending-page",
     ]);
     expect(selection.sourceWindow.selectedFeedItemIds).toContain(
@@ -228,6 +225,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         providerKey: "github-trending-page",
         rank: 81,
         score: 1.6,
+        providerMetadata: githubTrendingMetadataFixture(1_500),
       }),
       rankedItem({
         feedItemId: "feed-github-deep",
@@ -266,12 +264,9 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
     expect(rankFeedItems.execute).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 200 }),
     );
-    expect(
-      selection.selectedEvidence.map((item) => item.feedItemId),
-    ).not.toContain("feed-github-deep");
-    expect(
-      selection.selectedEvidence.map((item) => item.feedItemId),
-    ).toContain("feed-github-trending");
+    expect(selection.selectedEvidence.map((item) => item.feedItemId)).toContain(
+      "feed-github-trending",
+    );
     expect(
       selection.selectedEvidence.map((item) => item.feedItemId),
     ).not.toContain("feed-github-deep");
@@ -284,6 +279,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         providerKey: "github-trending-page",
         rank: 1,
         score: 3.0,
+        providerMetadata: githubTrendingMetadataFixture(1_500),
       }),
       rankedItem({
         feedItemId: "feed-github-repo",
@@ -345,10 +341,11 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
     });
 
     expect(selection.selectedEvidence.map((item) => item.providerKey)).toEqual([
-      "github-trending-page",
       "github-repo-radar",
       "reddit",
       "hacker-news",
+      "rss",
+      "github-trending-page",
     ]);
   });
 
@@ -911,6 +908,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         providerKey: "github-trending-page",
         rank: 1,
         score: 3,
+        providerMetadata: githubTrendingMetadataFixture(1_500),
       }),
       rankedItem({
         feedItemId: "feed-x-url-only",
@@ -966,8 +964,8 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
     });
 
     expect(selection.selectedEvidence.map((item) => item.feedItemId)).toEqual([
-      "feed-github",
       "feed-reddit",
+      "feed-github",
     ]);
   });
 });

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
@@ -10,6 +10,8 @@ import type { Clock } from "@social-monitor/shared-kernel";
 import {
   approvedStoryRelationPairs,
   buildStoryRelationCandidates,
+  isGitHubTrendingEvidence,
+  selectGitHubTrendingHighlights,
   StoryClusteringService,
   type SummaryEvidenceItem,
   type SummaryEvidenceSelection,
@@ -81,22 +83,30 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
       ),
       params.period,
     );
-    const candidateItems = await this.withTopReadCandidateSupplements(
+    const candidateItems = await this.withGitHubTrendingCandidates(
       params,
-      await this.withProviderDiversitySupplements(params, rankedItems),
+      await this.withTopReadCandidateSupplements(
+        params,
+        await this.withProviderDiversitySupplements(params, rankedItems),
+      ),
     );
+    const primaryCandidateItems = candidateItems.filter(
+      (item) => !isGitHubTrendingEvidence(item),
+    );
+    const githubTrendingHighlights =
+      selectGitHubTrendingHighlights(candidateItems);
     const candidateSelection = this.clusterer.cluster({
       identity: {
         tenantId: params.tenantId,
         workspaceId: params.workspaceId,
         scope: params.scope,
       },
-      items: candidateItems,
-      limit: candidateItems.length,
+      items: primaryCandidateItems,
+      limit: primaryCandidateItems.length,
     });
     const approvedPairs = await this.verifiedStoryRelationPairs(
       params,
-      candidateItems,
+      primaryCandidateItems,
       candidateSelection,
     );
     const verifiedCandidateSelection =
@@ -108,12 +118,12 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
               workspaceId: params.workspaceId,
               scope: params.scope,
             },
-            items: candidateItems,
-            limit: candidateItems.length,
+            items: primaryCandidateItems,
+            limit: primaryCandidateItems.length,
             verifiedStoryRelationPairs: approvedPairs,
           });
     const items = selectRankedEvidence(
-      candidateItems,
+      primaryCandidateItems,
       params.maxItems,
       crossProviderReserveIds(verifiedCandidateSelection),
     );
@@ -127,8 +137,17 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
       limit: params.maxItems,
       verifiedStoryRelationPairs: approvedPairs,
     });
+    const selectedEvidence = [
+      ...selection.selectedEvidence,
+      ...githubTrendingHighlights,
+    ];
     const personalizedSelection = {
       ...selection,
+      sourceWindow: {
+        ...selection.sourceWindow,
+        selectedFeedItemIds: selectedEvidence.map((item) => item.feedItemId),
+      },
+      selectedEvidence,
       personalization:
         ranked.value.memoryGuidance === undefined
           ? undefined
@@ -352,6 +371,49 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
         providerCount += 1;
       }
     }
+
+    return [...itemsById.values()];
+  }
+
+  private async withGitHubTrendingCandidates(
+    params: Parameters<ReaderSummaryEvidenceSelectorPort["select"]>[0],
+    rankedItems: readonly SummaryEvidenceItem[],
+  ): Promise<readonly SummaryEvidenceItem[]> {
+    const itemsById = new Map(
+      rankedItems.map((item) => [item.feedItemId, item] as const),
+    );
+    let cursor: string | undefined;
+    do {
+      const page = await this.feedItems.list({
+        tenantId: params.tenantId,
+        workspaceId: params.workspaceId,
+        interestId:
+          params.scope.type === "interest"
+            ? params.scope.interestId
+            : undefined,
+        providerKey: "github-trending-page",
+        publishedAtOrAfter: params.period.startedAt,
+        publishedBefore: params.period.endedAt,
+        limit: 100,
+        cursor,
+      });
+      for (const feedItem of page.items) {
+        const snapshot = feedItem.toSnapshot();
+        if (itemsById.has(snapshot.id)) {
+          continue;
+        }
+        itemsById.set(
+          snapshot.id,
+          mapSupplementFeedItem({
+            snapshot,
+            qualityPolicy: this.qualityPolicy,
+            safetyPolicy: this.safetyPolicy,
+            now: this.clock.now(),
+          }),
+        );
+      }
+      cursor = page.nextCursor;
+    } while (cursor !== undefined);
 
     return [...itemsById.values()];
   }

--- a/libs/summary/adapters/model/agent-runtime-reader-summary-model.adapter.ts
+++ b/libs/summary/adapters/model/agent-runtime-reader-summary-model.adapter.ts
@@ -1,4 +1,8 @@
-import { buildReaderSummary, readerSummaryScopeKey } from "../../domain";
+import {
+  buildReaderSummary,
+  primaryReaderSummaryEvidence,
+  readerSummaryScopeKey,
+} from "../../domain";
 import type {
   AgentRuntimeClientPort,
   AgentRuntimeProvider,
@@ -134,7 +138,7 @@ export class AgentRuntimeReaderSummaryModelAdapter implements ReaderSummaryModel
         this.inputTokenDivisor,
     );
     const outputTokens =
-      input.evidence.selectedEvidence.length === 0
+      primaryReaderSummaryEvidence(input.evidence).selectedEvidence.length === 0
         ? 128
         : Math.min(
             this.maxOutputTokens,
@@ -152,7 +156,9 @@ export class AgentRuntimeReaderSummaryModelAdapter implements ReaderSummaryModel
     input: ReaderSummaryModelInput,
     selectedRoute: ReaderSummaryModelRoute,
   ): Promise<ProviderReaderSummaryAttempt> {
-    if (input.evidence.selectedEvidence.length === 0) {
+    if (
+      primaryReaderSummaryEvidence(input.evidence).selectedEvidence.length === 0
+    ) {
       return this.buildNoSignalAttempt(input, selectedRoute);
     }
 

--- a/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
+++ b/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
@@ -35,25 +35,16 @@ describe("DeterministicReaderSummaryModelAdapter", () => {
     ).toBe(true);
     expect(attempt.draft.content).toBeDefined();
     expect(attempt.draft.headline).toBe(
-      "Workspace readerSummary: 10 stories across 5 sources (RSS, GitHub Trending, Hacker News + 2 more)",
+      "Workspace readerSummary: 9 stories across 4 sources (RSS, Hacker News, Reddit + 1 more)",
     );
     expect(attempt.draft.content?.headline).toBe(attempt.draft.headline);
     expect(attempt.draft.headline).not.toBe("rss story 1");
     expect(
       attempt.draft.content?.topReads.map((item) => item.providerKey),
-    ).not.toContain("github-issues");
+    ).toContain("github-issues");
     expect(
       attempt.draft.content?.topReads.map((item) => item.providerKey),
-    ).toEqual([
-      "github-trending-page",
-      "github-trending-page",
-      "github-trending-page",
-      "rss",
-      "rss",
-      "rss",
-      "hacker-news",
-      "reddit",
-    ]);
+    ).not.toContain("github-trending-page");
     expect(attempt.draft.executiveSummary).toContain(
       "Current executive summary covers 12 selected stories for workspace in an analytical tone.",
     );

--- a/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.ts
+++ b/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.ts
@@ -9,7 +9,7 @@ import type {
   ReaderSummaryModelValidationResult,
   ProviderReaderSummaryAttempt,
 } from "../../ports";
-import { buildReaderSummary } from "../../domain";
+import { buildReaderSummary, primaryReaderSummaryEvidence } from "../../domain";
 import {
   normalizeReaderSummaryStoryLimit,
   selectProviderDiverseRankedEvidence,
@@ -50,7 +50,9 @@ export class DeterministicReaderSummaryModelAdapter implements ReaderSummaryMode
   ): ReaderSummaryModelEstimate {
     void selectedRoute;
 
-    const evidenceTextLength = input.evidence.selectedEvidence.reduce(
+    const evidenceTextLength = primaryReaderSummaryEvidence(
+      input.evidence,
+    ).selectedEvidence.reduce(
       (total, item) =>
         total + item.title.length + (item.bodyPreview?.length ?? 0),
       0,
@@ -61,7 +63,9 @@ export class DeterministicReaderSummaryModelAdapter implements ReaderSummaryMode
     );
     const inputTokens = Math.ceil((evidenceTextLength + contextTextLength) / 4);
     const outputTokens =
-      input.evidence.selectedEvidence.length === 0 ? 64 : 260;
+      primaryReaderSummaryEvidence(input.evidence).selectedEvidence.length === 0
+        ? 64
+        : 260;
 
     return {
       inputTokens,
@@ -84,7 +88,8 @@ export class DeterministicReaderSummaryModelAdapter implements ReaderSummaryMode
       evalDatasetVersion: "reader_summary.eval.mvp.v1",
       rankingPolicyVersion: input.evidence.rankingPolicyVersion,
     } as const;
-    const firstItem = input.evidence.selectedEvidence[0];
+    const primaryEvidence = primaryReaderSummaryEvidence(input.evidence);
+    const firstItem = primaryEvidence.selectedEvidence[0];
 
     if (firstItem === undefined) {
       const noSignalDraft = {
@@ -130,7 +135,7 @@ export class DeterministicReaderSummaryModelAdapter implements ReaderSummaryMode
 
     const citedEvidence = input.evidence.selectedEvidence;
     const selectedEvidence = selectRankedEvidence(
-      input.evidence.selectedEvidence,
+      primaryEvidence.selectedEvidence,
       input.policy.maxStories,
     );
     const citationMap = citedEvidence.map((item, index) => ({

--- a/libs/summary/adapters/model/openai-responses-reader-summary-adaptive-evidence.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-adaptive-evidence.ts
@@ -15,11 +15,17 @@ const maxRelevantFragments = 3;
 export const buildAdaptiveReaderSummaryEvidence = (
   selection: SummaryEvidenceSelection,
   coveragePlan: ReaderSummaryCoveragePlan,
+  citationIdByFeedItemId?: ReadonlyMap<string, string>,
 ): readonly Record<string, unknown>[] => {
   const expandedIds = expandedEvidenceIds(selection, coveragePlan);
 
   return selection.selectedEvidence.map((item, index) =>
-    promptEvidenceItem(item, index, expandedIds.has(item.feedItemId)),
+    promptEvidenceItem(
+      item,
+      index,
+      expandedIds.has(item.feedItemId),
+      citationIdByFeedItemId?.get(item.feedItemId) ?? `c${index + 1}`,
+    ),
   );
 };
 
@@ -75,12 +81,13 @@ const promptEvidenceItem = (
   item: SummaryEvidenceItem,
   index: number,
   expanded: boolean,
+  citationId: string,
 ): Record<string, unknown> => {
   const baselineSource = item.sourceText ?? item.bodyPreview;
 
   return {
     index: index + 1,
-    citationId: `c${index + 1}`,
+    citationId,
     feedItemId: item.feedItemId,
     sourceItemId: item.sourceItemId,
     providerKey: item.providerKey,

--- a/libs/summary/adapters/model/openai-responses-reader-summary-model.adapter.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-model.adapter.ts
@@ -9,7 +9,7 @@ import type {
   ReaderSummaryModelValidationResult,
   ProviderReaderSummaryAttempt,
 } from "../../ports";
-import { buildReaderSummary } from "../../domain";
+import { buildReaderSummary, primaryReaderSummaryEvidence } from "../../domain";
 import {
   asRecord,
   assertOpenAiReaderSummaryDraftShape,
@@ -144,7 +144,7 @@ export class OpenAiResponsesReaderSummaryModelAdapter implements ReaderSummaryMo
         this.inputTokenDivisor,
     );
     const outputTokens =
-      input.evidence.selectedEvidence.length === 0
+      primaryReaderSummaryEvidence(input.evidence).selectedEvidence.length === 0
         ? 128
         : Math.min(
             this.maxOutputTokens,
@@ -166,7 +166,9 @@ export class OpenAiResponsesReaderSummaryModelAdapter implements ReaderSummaryMo
     input: ReaderSummaryModelInput,
     selectedRoute: ReaderSummaryModelRoute,
   ): Promise<ProviderReaderSummaryAttempt> {
-    if (input.evidence.selectedEvidence.length === 0) {
+    if (
+      primaryReaderSummaryEvidence(input.evidence).selectedEvidence.length === 0
+    ) {
       return this.buildNoSignalAttempt(input, selectedRoute);
     }
 

--- a/libs/summary/adapters/model/openai-responses-reader-summary-prompt-contract.spec.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-prompt-contract.spec.ts
@@ -1,5 +1,11 @@
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+
+import { buildReaderSummaryCoveragePlan } from "../../domain";
 import type { ReaderSummaryModelInput } from "../../ports";
-import { buildOpenAiReaderSummaryInstructions } from "./openai-responses-reader-summary-prompt";
+import {
+  buildOpenAiReaderSummaryInstructions,
+  buildOpenAiReaderSummaryPromptPayload,
+} from "./openai-responses-reader-summary-prompt";
 import { openAiReaderSummaryJsonSchema } from "./openai-responses-reader-summary-schema";
 
 describe("OpenAI reader summary prompt contract", () => {
@@ -47,4 +53,90 @@ describe("OpenAI reader summary prompt contract", () => {
       },
     });
   });
+
+  it("does not expose GitHub Trending evidence or coverage to the model", () => {
+    const input = promptInputWithGitHubTrending();
+    const payload = buildOpenAiReaderSummaryPromptPayload(input);
+
+    expect(payload).not.toContain("github-trending-page");
+    expect(payload).not.toContain("owner/private-prompt-influence");
+    expect(payload).toContain("reddit-main-signal");
+  });
+});
+
+const promptInputWithGitHubTrending = (): ReaderSummaryModelInput => {
+  const selectedEvidence = [
+    promptEvidence("github-trending-page", "owner/private-prompt-influence", 2),
+    promptEvidence("reddit", "reddit-main-signal", 1),
+  ];
+  const clusters = selectedEvidence.map((item) => ({
+    id: `cluster-${item.feedItemId}`,
+    storyKey: `story-${item.feedItemId}`,
+    representativeFeedItemId: item.feedItemId,
+    duplicateFeedItemIds: [],
+    interestIds: [item.interestId],
+    providerKeys: [item.providerKey],
+    score: item.score,
+    observedAtRange: { startedAt: item.observedAt, endedAt: item.observedAt },
+    whyImportant: item.whyImportant,
+  }));
+  const evidence = {
+    rankingPolicyVersion: "story_ranking_test",
+    sourceWindow: {
+      windowId: "window-test",
+      startedAt: new Date("2026-07-10T00:00:00.000Z"),
+      endedAt: new Date("2026-07-11T00:00:00.000Z"),
+      selectedFeedItemIds: selectedEvidence.map((item) => item.feedItemId),
+      storyClusterIds: clusters.map((cluster) => cluster.id),
+    },
+    clusters,
+    selectedEvidence,
+  };
+
+  return {
+    tenantId: tenantId("tenant-prompt"),
+    workspaceId: workspaceId("workspace-prompt"),
+    scope: { type: "workspace" },
+    period: {
+      cadence: "daily",
+      startedAt: new Date("2026-07-10T00:00:00.000Z"),
+      endedAt: new Date("2026-07-11T00:00:00.000Z"),
+      timezone: "UTC",
+      periodKey: "daily:2026-07-10:UTC",
+    },
+    evidence,
+    coveragePlan: buildReaderSummaryCoveragePlan(evidence),
+    contextArtifacts: [],
+    policy: {
+      language: "auto",
+      format: "executive_brief",
+      tone: "analytical",
+      maxStories: 10,
+      includeRisks: true,
+      includeInterestHighlights: true,
+      includeRepeatedSignals: true,
+      dedupeStrategy: "canonical_url_then_title",
+      rulesVersion: "reader_summary.rules.test",
+    },
+    requestedAt: new Date("2026-07-11T00:00:01.000Z"),
+  };
+};
+
+const promptEvidence = (
+  providerKey: string,
+  title: string,
+  index: number,
+): ReaderSummaryModelInput["evidence"]["selectedEvidence"][number] => ({
+  feedItemId: `feed-${index}`,
+  sourceItemId: `source-${index}`,
+  sourceBindingId: `binding-${providerKey}`,
+  interestId: "interest-ai",
+  providerKey,
+  canonicalUrl: `https://example.test/${index}`,
+  title,
+  bodyPreview: `${title} body`,
+  publishedAt: new Date("2026-07-10T12:00:00.000Z"),
+  observedAt: new Date("2026-07-10T12:01:00.000Z"),
+  score: 2,
+  whyImportant: [title],
 });

--- a/libs/summary/adapters/model/openai-responses-reader-summary-prompt.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-prompt.ts
@@ -1,6 +1,8 @@
 import {
   buildSummaryEvidencePack,
   buildSummaryEvidenceProfile,
+  buildReaderSummaryCoveragePlan,
+  primaryReaderSummaryEvidence,
   type ReaderSummaryCoveragePlanItem,
 } from "../../domain";
 import type { ReaderSummaryModelInput } from "../../ports";
@@ -76,20 +78,21 @@ export const buildOpenAiReaderSummaryInstructions = (
 export const buildOpenAiReaderSummaryPromptPayload = (
   input: ReaderSummaryModelInput,
 ): string => {
+  const primaryEvidence = primaryReaderSummaryEvidence(input.evidence);
   const citationIdByFeedItemId = new Map(
     input.evidence.selectedEvidence.map(
       (item, index) => [item.feedItemId, `c${index + 1}`] as const,
     ),
   );
-  const coveragePlan = input.coveragePlan;
+  const coveragePlan = buildReaderSummaryCoveragePlan(primaryEvidence);
 
   return JSON.stringify({
     scope: input.scope,
     requestedAt: input.requestedAt.toISOString(),
     policy: input.policy,
     personalization: input.evidence.personalization,
-    evidenceProfile: buildSummaryEvidenceProfile(input.evidence),
-    evidencePack: buildSummaryEvidencePack(input.evidence),
+    evidenceProfile: buildSummaryEvidenceProfile(primaryEvidence),
+    evidencePack: buildSummaryEvidencePack(primaryEvidence),
     coveragePlan: {
       lead:
         coveragePlan.lead === undefined
@@ -104,7 +107,7 @@ export const buildOpenAiReaderSummaryPromptPayload = (
       startedAt: input.evidence.sourceWindow.startedAt.toISOString(),
       endedAt: input.evidence.sourceWindow.endedAt.toISOString(),
     },
-    storyClusters: input.evidence.clusters.map((cluster) => ({
+    storyClusters: primaryEvidence.clusters.map((cluster) => ({
       id: cluster.id,
       storyKey: cluster.storyKey,
       representativeFeedItemId: cluster.representativeFeedItemId,
@@ -125,7 +128,11 @@ export const buildOpenAiReaderSummaryPromptPayload = (
       generatedAt: artifact.generatedAt.toISOString(),
       freshness: artifact.freshness,
     })),
-    evidence: buildAdaptiveReaderSummaryEvidence(input.evidence, coveragePlan),
+    evidence: buildAdaptiveReaderSummaryEvidence(
+      primaryEvidence,
+      coveragePlan,
+      citationIdByFeedItemId,
+    ),
   });
 };
 

--- a/libs/summary/domain/aggregates/reader-summary.spec.ts
+++ b/libs/summary/domain/aggregates/reader-summary.spec.ts
@@ -1056,7 +1056,7 @@ describe("buildReaderSummary", () => {
     ]);
   });
 
-  it("keeps GitHub Trending page summaries distinct from Repo Radar", () => {
+  it("does not let a GitHub Trending-only signal become the main summary", () => {
     const readerSummary = buildReaderSummary({
       headline: "GitHub Trending today",
       executiveSummary:
@@ -1134,40 +1134,13 @@ describe("buildReaderSummary", () => {
       qualityFlags: [],
     });
 
-    expect(readerSummary.sourceMix).toEqual([
-      expect.objectContaining({
-        providerKey: "github-trending-page",
-        itemCount: 1,
-      }),
+    expect(readerSummary.sourceMix).toEqual([]);
+    expect(readerSummary.topReads).toEqual([]);
+    expect(readerSummary.qualityState.flags).toContain("no_signal");
+    expect(readerSummary.narrativeSections).toEqual([
+      expect.objectContaining({ id: "github-trending", kind: "watch" }),
     ]);
-    expect(readerSummary.trendDelta.newSignals).toEqual([
-      "1 GitHub Trending item selected",
-    ]);
-    expect(readerSummary.openQuestions).toContain(
-      "Is this signal confirmed outside GitHub Trending?",
-    );
-    expect(readerSummary.topReads[0]).toMatchObject({
-      providerKey: "github-trending-page",
-      whyNow: "Current summary window has GitHub Trending coverage.",
-      providerMetrics: [
-        {
-          label: "GitHub Trending evidence",
-          value: "#1, +3,703 stars today",
-        },
-        {
-          label: "GitHub Trending today",
-          value: "#1, +3,703 stars today",
-        },
-        { label: "Stars", value: "18,398" },
-        { label: "Forks", value: "2,113" },
-      ],
-    });
-    expect(readerSummary.nextActions[0]).toEqual(
-      expect.objectContaining({
-        kind: "watch_repository",
-        label: "Watch calesthio/OpenMontage",
-      }),
-    );
+    expect(readerSummary.selectedPosts).toHaveLength(1);
   });
 
   it("marks cross-source source mix when multiple providers confirm one story cluster", () => {

--- a/libs/summary/domain/aggregates/reader-summary.ts
+++ b/libs/summary/domain/aggregates/reader-summary.ts
@@ -28,6 +28,11 @@ import {
 import { selectRenderedTopReadCandidates } from "../policies/rendered-top-read-selection-policy";
 import { enrichTopReadCandidateDescriptions } from "../policies/reader-summary-top-read-description-policy";
 import { buildReaderSummaryReliabilityReport } from "../policies/reader-summary-reliability-calibration-policy";
+import {
+  buildGitHubTrendingNarrativeAppendix,
+  isGitHubTrendingEvidence,
+  selectGitHubTrendingHighlights,
+} from "../policies/reader-summary-github-trending-policy";
 import type {
   SummaryEvidenceSelection,
   StoryCluster,
@@ -92,15 +97,20 @@ export class ReaderSummary {
       return ReaderSummary.create(buildNoSignalReaderSummary(input));
     }
 
+    const primarySelectedEvidence = (input.selectedEvidence ?? []).filter(
+      (item) => !isGitHubTrendingEvidence(item),
+    );
+    const primaryInput = {
+      ...input,
+      selectedEvidence: primarySelectedEvidence,
+    };
     const citationById = new Map(
       input.citationMap.map(
         (citation) => [citation.citationId, citation] as const,
       ),
     );
     const evidenceByFeedItemId = new Map(
-      (input.selectedEvidence ?? []).map(
-        (item) => [item.feedItemId, item] as const,
-      ),
+      primarySelectedEvidence.map((item) => [item.feedItemId, item] as const),
     );
     const clusterById = new Map(
       input.storyClusters.map((cluster) => [cluster.id, cluster] as const),
@@ -109,7 +119,7 @@ export class ReaderSummary {
       input.storyClusters,
       evidenceByFeedItemId,
     );
-    const sourceMix = buildSourceMix(input);
+    const sourceMix = buildSourceMix(primaryInput);
     const curatedReaderTopStories = selectUniqueTopReadCandidates(
       input.topStories,
       citationById,
@@ -162,7 +172,7 @@ export class ReaderSummary {
       (candidate) => candidate.topRead,
     );
     const readerInput = {
-      ...input,
+      ...primaryInput,
       topStories: readerTopStories,
     };
     const qualityState = buildReaderSummaryQualityState(
@@ -173,6 +183,10 @@ export class ReaderSummary {
       topReads,
       selectedEvidence: input.selectedEvidence,
       citationById,
+    });
+    const githubTrendingAppendix = buildGitHubTrendingNarrativeAppendix({
+      evidence: input.selectedEvidence ?? [],
+      citations: input.citationMap,
     });
 
     return ReaderSummary.create({
@@ -187,7 +201,12 @@ export class ReaderSummary {
         sourceMix,
       }),
       bullets: buildReaderSummaryBullets(readerInput, topReads),
-      narrativeSections: [...(input.narrativeSections ?? [])],
+      narrativeSections: [
+        ...(input.narrativeSections ?? []),
+        ...(githubTrendingAppendix === undefined
+          ? []
+          : [githubTrendingAppendix]),
+      ],
       mainTopics: buildReaderSummaryMainTopics({
         headline: input.headline,
         executiveSummary: input.executiveSummary,
@@ -195,7 +214,7 @@ export class ReaderSummary {
         topStories: readerTopStories,
         interestHighlights: input.interestHighlights,
         repeatedSignals: input.repeatedSignals,
-        selectedEvidence: input.selectedEvidence,
+        selectedEvidence: primarySelectedEvidence,
       }),
       topicMap: input.topicMap ?? emptyReaderSummaryTopicMap(),
       qualityState,
@@ -208,10 +227,10 @@ export class ReaderSummary {
         narrativeSections: input.narrativeSections,
         risksAndUnknowns: input.risksAndUnknowns,
         citationMap: input.citationMap,
-        selectedEvidence: input.selectedEvidence,
+        selectedEvidence: primarySelectedEvidence,
       }),
       reliabilityReport: buildReaderSummaryReliabilityReport(
-        reliabilitySelectionFromInput(input),
+        reliabilitySelectionFromInput(primaryInput),
       ),
       trendDelta: buildTrendDelta(readerInput, topReads, sourceMix),
       openQuestions: buildOpenQuestions(
@@ -280,12 +299,25 @@ const buildNoSignalReaderSummary = (
   const reason =
     input.noSignalReason ??
     "No eligible evidence was selected for this summary window.";
+  const githubTrendingHighlights = selectGitHubTrendingHighlights(
+    input.selectedEvidence ?? [],
+  );
+  const citationById = new Map(
+    input.citationMap.map(
+      (citation) => [citation.citationId, citation] as const,
+    ),
+  );
+  const githubTrendingAppendix = buildGitHubTrendingNarrativeAppendix({
+    evidence: githubTrendingHighlights,
+    citations: input.citationMap,
+  });
 
   return {
     headline: nonEmpty(input.headline, "No reliable workspace signal yet"),
     oneLineTakeaway: reason,
     bullets: [reason],
-    narrativeSections: [],
+    narrativeSections:
+      githubTrendingAppendix === undefined ? [] : [githubTrendingAppendix],
     qualityState: {
       status: "no_signal",
       flags: uniqueNonEmpty([
@@ -293,7 +325,7 @@ const buildNoSignalReaderSummary = (
         "no_signal",
       ]) as readonly ReaderSummaryQualityFlag[],
       warnings: [
-        "No cited source evidence passed the summary selection policy.",
+        "No primary cited source evidence passed the summary selection policy.",
       ],
       isSingleSource: false,
     },
@@ -302,7 +334,11 @@ const buildNoSignalReaderSummary = (
     interestSections: [],
     sourceMix: [],
     topReads: [],
-    selectedPosts: [],
+    selectedPosts: buildReaderSummarySelectedPosts({
+      topReads: [],
+      selectedEvidence: githubTrendingHighlights,
+      citationById,
+    }),
     claimBoard: [],
     reliabilityReport: emptyReaderSummaryReliabilityReport(),
     trendDelta: {

--- a/libs/summary/domain/index.ts
+++ b/libs/summary/domain/index.ts
@@ -25,6 +25,7 @@ export * from "./events/summary-ready.event";
 export * from "./policies/reader-action-policy";
 export * from "./policies/reader-summary-reliability-calibration-policy";
 export * from "./policies/reader-summary-evidence-eligibility-policy";
+export * from "./policies/reader-summary-github-trending-policy";
 export * from "./policies/reader-summary-model-authority-policy";
 export * from "./policies/reader-summary-multi-day-quality-eval";
 export * from "./policies/reader-summary-multi-day-generation-profile";

--- a/libs/summary/domain/policies/reader-summary-github-trending-policy.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-github-trending-policy.spec.ts
@@ -1,0 +1,103 @@
+import type { SummaryEvidenceItem } from "../value-objects/summary-evidence-item";
+import {
+  buildGitHubTrendingNarrativeAppendix,
+  githubTrendingStarsGained,
+  selectGitHubTrendingHighlights,
+} from "./reader-summary-github-trending-policy";
+
+describe("reader summary GitHub Trending policy", () => {
+  it("keeps at most three repositories with more than 1,000 gained stars", () => {
+    const selected = selectGitHubTrendingHighlights([
+      evidence("repo-low", 999),
+      evidence("repo-boundary", 1_000),
+      evidence("repo-third", 1_050),
+      evidence("repo-first", 4_200),
+      evidence("repo-fourth", 1_001),
+      evidence("repo-second", 2_500),
+      evidence("reddit", 50_000, "reddit"),
+    ]);
+
+    expect(selected.map((item) => item.feedItemId)).toEqual([
+      "repo-first",
+      "repo-second",
+      "repo-third",
+    ]);
+  });
+
+  it("reads comma-formatted stars gained without confusing total stars", () => {
+    const item = {
+      ...evidence("repo", 3_703),
+      providerMetricLabels: [
+        { label: "GitHub Trending today", value: "#1, +3,703 stars today" },
+        { label: "Stars", value: "18,398" },
+      ],
+    };
+
+    expect(githubTrendingStarsGained(item)).toBe(3_703);
+  });
+
+  it("rejects non-daily Trending windows", () => {
+    const item = {
+      ...evidence("repo", 3_703),
+      providerMetricLabels: [
+        {
+          label: "GitHub Trending this week",
+          value: "#1, +3,703 stars this week",
+        },
+      ],
+    };
+
+    expect(githubTrendingStarsGained(item)).toBeUndefined();
+  });
+
+  it("builds a compact deterministic appendix from cited highlights", () => {
+    const item = evidence("owner/repo - useful developer tool", 1_234);
+
+    expect(
+      buildGitHubTrendingNarrativeAppendix({
+        evidence: [item],
+        citations: [
+          {
+            citationId: "c9",
+            feedItemId: item.feedItemId,
+            sourceItemId: item.sourceItemId,
+            providerKey: item.providerKey,
+            field: "canonicalUrl",
+            canonicalUrl: item.canonicalUrl,
+          },
+        ],
+      }),
+    ).toEqual({
+      id: "github-trending",
+      kind: "watch",
+      title: "GitHub Trending",
+      text: "- **owner/repo**: +1,234 stars today.",
+      citationIds: ["c9"],
+    });
+  });
+});
+
+const evidence = (
+  feedItemId: string,
+  starsGained: number,
+  providerKey = "github-trending-page",
+): SummaryEvidenceItem => ({
+  feedItemId,
+  sourceItemId: `source-${feedItemId}`,
+  sourceBindingId: `binding-${providerKey}`,
+  interestId: "interest-ai",
+  providerKey,
+  canonicalUrl: `https://example.test/${feedItemId}`,
+  title: feedItemId,
+  publishedAt: new Date("2026-07-10T12:00:00.000Z"),
+  observedAt: new Date("2026-07-10T12:05:00.000Z"),
+  score: 1,
+  whyImportant: [],
+  providerMetricLabels: [
+    {
+      label: "GitHub Trending today",
+      value: `#1, +${starsGained.toLocaleString("en-US")} stars today`,
+    },
+    { label: "Stars", value: "500,000" },
+  ],
+});

--- a/libs/summary/domain/policies/reader-summary-github-trending-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-github-trending-policy.ts
@@ -1,0 +1,159 @@
+import type {
+  SummaryEvidenceItem,
+  SummaryEvidenceSelection,
+} from "../value-objects/summary-evidence-item";
+import type { ReaderSummaryCitation } from "../entities/citation";
+import type { ReaderSummaryNarrativeSection } from "../entities/reader-summary-narrative-section";
+
+export const githubTrendingProviderKey = "github-trending-page";
+export const minimumGitHubTrendingStarsGained = 1_000;
+export const maxGitHubTrendingHighlights = 3;
+
+export const isGitHubTrendingEvidence = (
+  item: Pick<SummaryEvidenceItem, "providerKey">,
+): boolean =>
+  item.providerKey.trim().toLocaleLowerCase("en-US") ===
+  githubTrendingProviderKey;
+
+export const primaryReaderSummaryEvidence = (
+  selection: SummaryEvidenceSelection,
+): SummaryEvidenceSelection => {
+  const selectedEvidence = selection.selectedEvidence.filter(
+    (item) => !isGitHubTrendingEvidence(item),
+  );
+  const selectedFeedItemIds = new Set(
+    selectedEvidence.map((item) => item.feedItemId),
+  );
+  const evidenceById = new Map(
+    selectedEvidence.map((item) => [item.feedItemId, item] as const),
+  );
+  const clusters = selection.clusters.flatMap((cluster) => {
+    const feedItemIds = [
+      cluster.representativeFeedItemId,
+      ...cluster.duplicateFeedItemIds,
+    ].filter((feedItemId) => selectedFeedItemIds.has(feedItemId));
+    const representativeFeedItemId = feedItemIds[0];
+    if (representativeFeedItemId === undefined) {
+      return [];
+    }
+    const evidence = feedItemIds.flatMap((feedItemId) => {
+      const item = evidenceById.get(feedItemId);
+      return item === undefined ? [] : [item];
+    });
+
+    return [
+      {
+        ...cluster,
+        representativeFeedItemId,
+        duplicateFeedItemIds: feedItemIds.slice(1),
+        interestIds: [...new Set(evidence.map((item) => item.interestId))],
+        providerKeys: [...new Set(evidence.map((item) => item.providerKey))],
+        whyImportant: [
+          ...new Set(evidence.flatMap((item) => item.whyImportant)),
+        ],
+      },
+    ];
+  });
+  const storyClusterIds = new Set(clusters.map((cluster) => cluster.id));
+
+  return {
+    ...selection,
+    clusters,
+    selectedEvidence,
+    sourceWindow: {
+      ...selection.sourceWindow,
+      selectedFeedItemIds: selection.sourceWindow.selectedFeedItemIds.filter(
+        (feedItemId) => selectedFeedItemIds.has(feedItemId),
+      ),
+      storyClusterIds: selection.sourceWindow.storyClusterIds.filter(
+        (storyClusterId) => storyClusterIds.has(storyClusterId),
+      ),
+    },
+  };
+};
+
+export const selectGitHubTrendingHighlights = (
+  items: readonly SummaryEvidenceItem[],
+): readonly SummaryEvidenceItem[] =>
+  items
+    .map((item) => ({ item, starsGained: githubTrendingStarsGained(item) }))
+    .filter(
+      (
+        candidate,
+      ): candidate is {
+        readonly item: SummaryEvidenceItem;
+        readonly starsGained: number;
+      } =>
+        isGitHubTrendingEvidence(candidate.item) &&
+        candidate.starsGained !== undefined &&
+        candidate.starsGained > minimumGitHubTrendingStarsGained &&
+        candidate.item.contentQuality?.eligibleForSummary !== false,
+    )
+    .sort(
+      (left, right) =>
+        right.starsGained - left.starsGained ||
+        right.item.score - left.item.score ||
+        left.item.feedItemId.localeCompare(right.item.feedItemId),
+    )
+    .slice(0, maxGitHubTrendingHighlights)
+    .map((candidate) => candidate.item);
+
+export const githubTrendingStarsGained = (
+  item: Pick<SummaryEvidenceItem, "providerMetricLabels">,
+): number | undefined => {
+  const metric = item.providerMetricLabels?.find(
+    (candidate) =>
+      candidate.label.toLocaleLowerCase("en-US") === "github trending today",
+  );
+  const match = metric?.value.match(/\+([\d,]+)\s+stars\b/iu);
+  if (match === null || match === undefined) {
+    return undefined;
+  }
+
+  const value = Number(match[1]?.replaceAll(",", ""));
+  return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+};
+
+export const buildGitHubTrendingNarrativeAppendix = (params: {
+  readonly evidence: readonly SummaryEvidenceItem[];
+  readonly citations: readonly ReaderSummaryCitation[];
+}): ReaderSummaryNarrativeSection | undefined => {
+  const highlights = selectGitHubTrendingHighlights(params.evidence);
+  const citationByFeedItemId = new Map(
+    params.citations.map(
+      (citation) => [citation.feedItemId, citation] as const,
+    ),
+  );
+  const citedHighlights = highlights.flatMap((item) => {
+    const citation = citationByFeedItemId.get(item.feedItemId);
+    const starsGained = githubTrendingStarsGained(item);
+    return citation === undefined || starsGained === undefined
+      ? []
+      : [{ item, citation, starsGained }];
+  });
+  if (citedHighlights.length === 0) {
+    return undefined;
+  }
+
+  return {
+    id: "github-trending",
+    kind: "watch",
+    title: "GitHub Trending",
+    text: citedHighlights
+      .map(
+        ({ item, starsGained }) =>
+          `- **${compactRepositoryTitle(item.title)}**: +${starsGained.toLocaleString("en-US")} stars today.`,
+      )
+      .join("\n"),
+    citationIds: citedHighlights.map(({ citation }) => citation.citationId),
+  };
+};
+
+const compactRepositoryTitle = (title: string): string => {
+  const normalized = title
+    .replace(/[*_`\[\]<>]/gu, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+  const repositoryName = normalized.split(/\s+[—-]\s+/u)[0]?.trim();
+  return (repositoryName ?? normalized).slice(0, 120);
+};

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.ts
@@ -17,6 +17,7 @@ import {
   defaultReaderSummaryGenerationPolicy,
   ReaderSummaryArtifact,
   ReaderSummaryPublicationPolicy,
+  primaryReaderSummaryEvidence,
   resolveEffectiveReaderSummaryPolicy,
   type ReaderSummaryContextArtifact,
   type ReaderSummaryJob,
@@ -271,6 +272,7 @@ export class ExecuteReaderSummaryJobUseCase {
       subscriptionId: snapshot.subscriptionId,
       maxItems: maxEvidenceItems,
     });
+    const primaryEvidence = primaryReaderSummaryEvidence(evidence);
     const policy = await this.readerSummaryPolicies.findByScope({
       tenantId: snapshot.tenantId,
       workspaceId: snapshot.workspaceId,
@@ -286,7 +288,7 @@ export class ExecuteReaderSummaryJobUseCase {
             subscriptionId: snapshot.subscriptionId,
             interestId: readerSummaryPreferenceInterestId(snapshot),
           });
-    const context = await this.safeBuildContext(snapshot, evidence);
+    const context = await this.safeBuildContext(snapshot, primaryEvidence);
     const basePolicy =
       policy?.toGenerationPolicy() ?? defaultReaderSummaryGenerationPolicy();
     const input = {
@@ -297,7 +299,7 @@ export class ExecuteReaderSummaryJobUseCase {
       userId: snapshot.userId,
       subscriptionId: snapshot.subscriptionId,
       evidence,
-      coveragePlan: buildReaderSummaryCoveragePlan(evidence),
+      coveragePlan: buildReaderSummaryCoveragePlan(primaryEvidence),
       contextArtifacts: context.artifacts,
       policy: resolveEffectiveReaderSummaryPolicy(basePolicy, userPreference),
       requestedAt: snapshot.requestedAt,
@@ -357,14 +359,15 @@ export class ExecuteReaderSummaryJobUseCase {
     evidence: SummaryEvidenceSelection,
     draft: ProviderReaderSummaryAttempt["draft"],
   ): Promise<Result<ProviderReaderSummaryAttempt["draft"], DomainError>> {
+    const primaryEvidence = primaryReaderSummaryEvidence(evidence);
     const topicMapResult = await this.topicMapBuilder.execute({
       tenantId: snapshot.tenantId,
       workspaceId: snapshot.workspaceId,
       scope: snapshot.scope,
       period: snapshot.period,
       requestedAt: snapshot.requestedAt,
-      clusters: evidence.clusters,
-      selectedEvidence: evidence.selectedEvidence,
+      clusters: primaryEvidence.clusters,
+      selectedEvidence: primaryEvidence.selectedEvidence,
       topStories: draft.topStories,
       citationMap: draft.citationMap,
     });

--- a/ops/ingestion/source-provider-certification.json
+++ b/ops/ingestion/source-provider-certification.json
@@ -258,8 +258,8 @@
         }
       ],
       "freshnessGuard": {
-        "maxStalenessSeconds": 3600,
-        "minimumScanIntervalSeconds": 3600,
+        "maxStalenessSeconds": 86400,
+        "minimumScanIntervalSeconds": 86400,
         "skipRecentlyScanned": true,
         "scanHistoryRequired": true,
         "cursorResumeRequired": true,

--- a/scripts/check-source-binding-health-rest-smoke.ts
+++ b/scripts/check-source-binding-health-rest-smoke.ts
@@ -646,7 +646,7 @@ async function main(): Promise<void> {
       'too-fast GitHub Trending page scan policy problem must expose configured interval',
     );
     assert(
-      tooFastTrendingPagePolicy.body.details.minimumIntervalSeconds === 3_600,
+      tooFastTrendingPagePolicy.body.details.minimumIntervalSeconds === 86_400,
       'too-fast GitHub Trending page scan policy problem must expose provider minimum interval',
     );
 
@@ -671,7 +671,7 @@ async function main(): Promise<void> {
       headers: viewerHeaders,
     });
     assert(
-      trendingPageHealth.body.scanPolicy.cadence.minimumIntervalSeconds === 3_600,
+      trendingPageHealth.body.scanPolicy.cadence.minimumIntervalSeconds === 86_400,
       'GitHub Trending page scan policy must expose provider minimum interval',
     );
     assert(
@@ -679,7 +679,7 @@ async function main(): Promise<void> {
       'GitHub Trending page scan policy must expose legacy configured interval',
     );
     assert(
-      trendingPageHealth.body.scanPolicy.cadence.effectiveIntervalSeconds === 3_600,
+      trendingPageHealth.body.scanPolicy.cadence.effectiveIntervalSeconds === 86_400,
       'GitHub Trending page scan policy must expose provider-capped effective interval',
     );
     assert(
@@ -687,11 +687,11 @@ async function main(): Promise<void> {
       'GitHub Trending page scan policy must mark provider minimum enforcement',
     );
     assert(
-      trendingPageHealth.body.schedulerDecision.minimumIntervalSeconds === 3_600,
+      trendingPageHealth.body.schedulerDecision.minimumIntervalSeconds === 86_400,
       'GitHub Trending page health decision must expose provider minimum interval',
     );
     assert(
-      trendingPageHealth.body.schedulerDecision.effectiveIntervalSeconds === 3_600,
+      trendingPageHealth.body.schedulerDecision.effectiveIntervalSeconds === 86_400,
       'GitHub Trending page health decision must use provider-capped effective interval',
     );
     assert(

--- a/scripts/check-source-profile-rest-smoke.ts
+++ b/scripts/check-source-profile-rest-smoke.ts
@@ -320,12 +320,12 @@ async function main(): Promise<void> {
     );
     const githubTrendingGuard = requireFreshnessGuard(githubTrendingPage);
     assert(
-      githubTrendingGuard.maxStalenessSeconds === 3_600,
-      'GitHub Trending page must expose hourly freshness guard',
+      githubTrendingGuard.maxStalenessSeconds === 86_400,
+      'GitHub Trending page must expose daily freshness guard',
     );
     assert(
-      githubTrendingGuard.minimumScanIntervalSeconds === 3_600,
-      'GitHub Trending page must expose hourly minimum scan interval',
+      githubTrendingGuard.minimumScanIntervalSeconds === 86_400,
+      'GitHub Trending page must expose daily minimum scan interval',
     );
     assert(
       githubTrendingGuard.skipRecentlyScanned === true,


### PR DESCRIPTION
## Summary
- collect GitHub Trending at daily cadence
- exclude GitHub Trending from LLM narrative, context, coverage planning, stories and topic maps
- append at most 3 repositories with more than 1,000 daily gained stars after generation
- keep the GitHub Trends tab but hide GitHub provider coverage counters
- paginate the complete daily GitHub set before selecting highlights

## Verification
- 51 focused backend tests, plus pagination/boundary/no-signal review cases
- source binding health REST smoke
- backend build and architecture checks
- runtime profile, source certification/profile, secrets and source line-cap checks
- Flutter analyze
- 147 summaries feature tests
- frontend architecture boundaries

## Known baseline
- npm run check:code-quality remains red on pre-existing legacy files over its 500-line budget; this PR does not add behavior to those files.