### PR TITLE
fix(summary): deduplicate GitHub Trending appendix

### DIFF
--- a/libs/summary/domain/aggregates/reader-summary.spec.ts
+++ b/libs/summary/domain/aggregates/reader-summary.spec.ts
@@ -1143,6 +1143,54 @@ describe("buildReaderSummary", () => {
     expect(readerSummary.selectedPosts).toHaveLength(1);
   });
 
+  it("keeps the deterministic GitHub Trending appendix idempotent", () => {
+    const input = readerTopReadFixture(1);
+    const githubEvidence = {
+      feedItemId: "github-feed",
+      sourceItemId: "github-source",
+      sourceBindingId: "github-binding",
+      interestId: "ai-developer-tools",
+      providerKey: "github-trending-page",
+      providerName: "GitHub Trending",
+      canonicalUrl: "https://github.com/example/repository",
+      title: "example/repository",
+      publishedAt: new Date("2026-06-23T08:00:00.000Z"),
+      observedAt: new Date("2026-06-23T09:00:00.000Z"),
+      score: 1.5,
+      readerActionKind: "watch_repository",
+      whyImportant: ["Repository gained more than 1,000 stars today."],
+      providerMetricSummary: "#1, +1,500 stars today",
+      providerMetricLabels: [
+        { label: "GitHub Trending today", value: "#1, +1,500 stars today" },
+      ],
+    } satisfies SummaryEvidenceItem;
+    const githubCitation = {
+      citationId: "github-citation",
+      feedItemId: githubEvidence.feedItemId,
+      sourceItemId: githubEvidence.sourceItemId,
+      providerKey: githubEvidence.providerKey,
+      field: "title",
+      canonicalUrl: githubEvidence.canonicalUrl,
+    } satisfies ReaderSummaryCitation;
+    const withGitHub = {
+      ...input,
+      selectedEvidence: [...input.selectedEvidence, githubEvidence],
+      citationMap: [...input.citationMap, githubCitation],
+    };
+
+    const first = buildReaderSummary(withGitHub);
+    const second = buildReaderSummary({
+      ...withGitHub,
+      narrativeSections: first.narrativeSections,
+    });
+
+    expect(
+      second.narrativeSections?.filter(
+        (section) => section.id === "github-trending",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("marks cross-source source mix when multiple providers confirm one story cluster", () => {
     const readerSummary = buildReaderSummary({
       headline: "AI agent pain signal",

--- a/libs/summary/domain/aggregates/reader-summary.ts
+++ b/libs/summary/domain/aggregates/reader-summary.ts
@@ -30,6 +30,7 @@ import { enrichTopReadCandidateDescriptions } from "../policies/reader-summary-t
 import { buildReaderSummaryReliabilityReport } from "../policies/reader-summary-reliability-calibration-policy";
 import {
   buildGitHubTrendingNarrativeAppendix,
+  githubTrendingNarrativeSectionId,
   isGitHubTrendingEvidence,
   selectGitHubTrendingHighlights,
 } from "../policies/reader-summary-github-trending-policy";
@@ -202,7 +203,9 @@ export class ReaderSummary {
       }),
       bullets: buildReaderSummaryBullets(readerInput, topReads),
       narrativeSections: [
-        ...(input.narrativeSections ?? []),
+        ...(input.narrativeSections ?? []).filter(
+          (section) => section.id !== githubTrendingNarrativeSectionId,
+        ),
         ...(githubTrendingAppendix === undefined
           ? []
           : [githubTrendingAppendix]),

--- a/libs/summary/domain/policies/reader-summary-github-trending-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-github-trending-policy.ts
@@ -6,6 +6,7 @@ import type { ReaderSummaryCitation } from "../entities/citation";
 import type { ReaderSummaryNarrativeSection } from "../entities/reader-summary-narrative-section";
 
 export const githubTrendingProviderKey = "github-trending-page";
+export const githubTrendingNarrativeSectionId = "github-trending";
 export const minimumGitHubTrendingStarsGained = 1_000;
 export const maxGitHubTrendingHighlights = 3;
 
@@ -136,7 +137,7 @@ export const buildGitHubTrendingNarrativeAppendix = (params: {
   }
 
   return {
-    id: "github-trending",
+    id: githubTrendingNarrativeSectionId,
     kind: "watch",
     title: "GitHub Trending",
     text: citedHighlights


### PR DESCRIPTION
## Summary
- make the deterministic GitHub Trending appendix idempotent
- replace any prior appendix before appending the current top three
- add a regression test for repeated aggregate construction

## Verification
- 2 focused suites, 18 tests passed
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate GitHub Trending sections from appearing when summaries are rebuilt.
  - Ensured refreshed summaries consistently retain a single GitHub Trending narrative section.

- **Tests**
  - Added coverage verifying GitHub Trending sections remain unique across repeated summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->