### PR TITLE
test(summary): keep appendix regression under line cap

### DIFF
--- a/libs/summary/domain/aggregates/reader-summary.spec.ts
+++ b/libs/summary/domain/aggregates/reader-summary.spec.ts
@@ -1143,54 +1143,6 @@ describe("buildReaderSummary", () => {
     expect(readerSummary.selectedPosts).toHaveLength(1);
   });
 
-  it("keeps the deterministic GitHub Trending appendix idempotent", () => {
-    const input = readerTopReadFixture(1);
-    const githubEvidence = {
-      feedItemId: "github-feed",
-      sourceItemId: "github-source",
-      sourceBindingId: "github-binding",
-      interestId: "ai-developer-tools",
-      providerKey: "github-trending-page",
-      providerName: "GitHub Trending",
-      canonicalUrl: "https://github.com/example/repository",
-      title: "example/repository",
-      publishedAt: new Date("2026-06-23T08:00:00.000Z"),
-      observedAt: new Date("2026-06-23T09:00:00.000Z"),
-      score: 1.5,
-      readerActionKind: "watch_repository",
-      whyImportant: ["Repository gained more than 1,000 stars today."],
-      providerMetricSummary: "#1, +1,500 stars today",
-      providerMetricLabels: [
-        { label: "GitHub Trending today", value: "#1, +1,500 stars today" },
-      ],
-    } satisfies SummaryEvidenceItem;
-    const githubCitation = {
-      citationId: "github-citation",
-      feedItemId: githubEvidence.feedItemId,
-      sourceItemId: githubEvidence.sourceItemId,
-      providerKey: githubEvidence.providerKey,
-      field: "title",
-      canonicalUrl: githubEvidence.canonicalUrl,
-    } satisfies ReaderSummaryCitation;
-    const withGitHub = {
-      ...input,
-      selectedEvidence: [...input.selectedEvidence, githubEvidence],
-      citationMap: [...input.citationMap, githubCitation],
-    };
-
-    const first = buildReaderSummary(withGitHub);
-    const second = buildReaderSummary({
-      ...withGitHub,
-      narrativeSections: first.narrativeSections,
-    });
-
-    expect(
-      second.narrativeSections?.filter(
-        (section) => section.id === "github-trending",
-      ),
-    ).toHaveLength(1);
-  });
-
   it("marks cross-source source mix when multiple providers confirm one story cluster", () => {
     const readerSummary = buildReaderSummary({
       headline: "AI agent pain signal",

--- a/libs/summary/domain/aggregates/reader-summary.ts
+++ b/libs/summary/domain/aggregates/reader-summary.ts
@@ -30,9 +30,9 @@ import { enrichTopReadCandidateDescriptions } from "../policies/reader-summary-t
 import { buildReaderSummaryReliabilityReport } from "../policies/reader-summary-reliability-calibration-policy";
 import {
   buildGitHubTrendingNarrativeAppendix,
-  githubTrendingNarrativeSectionId,
   isGitHubTrendingEvidence,
   selectGitHubTrendingHighlights,
+  withGitHubTrendingNarrativeAppendix,
 } from "../policies/reader-summary-github-trending-policy";
 import type {
   SummaryEvidenceSelection,
@@ -202,14 +202,10 @@ export class ReaderSummary {
         sourceMix,
       }),
       bullets: buildReaderSummaryBullets(readerInput, topReads),
-      narrativeSections: [
-        ...(input.narrativeSections ?? []).filter(
-          (section) => section.id !== githubTrendingNarrativeSectionId,
-        ),
-        ...(githubTrendingAppendix === undefined
-          ? []
-          : [githubTrendingAppendix]),
-      ],
+      narrativeSections: withGitHubTrendingNarrativeAppendix({
+        narrativeSections: input.narrativeSections ?? [],
+        appendix: githubTrendingAppendix,
+      }),
       mainTopics: buildReaderSummaryMainTopics({
         headline: input.headline,
         executiveSummary: input.executiveSummary,

--- a/libs/summary/domain/policies/reader-summary-github-trending-policy.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-github-trending-policy.spec.ts
@@ -3,6 +3,7 @@ import {
   buildGitHubTrendingNarrativeAppendix,
   githubTrendingStarsGained,
   selectGitHubTrendingHighlights,
+  withGitHubTrendingNarrativeAppendix,
 } from "./reader-summary-github-trending-policy";
 
 describe("reader summary GitHub Trending policy", () => {
@@ -74,6 +75,43 @@ describe("reader summary GitHub Trending policy", () => {
       text: "- **owner/repo**: +1,234 stars today.",
       citationIds: ["c9"],
     });
+  });
+
+  it("replaces an existing deterministic appendix instead of duplicating it", () => {
+    const staleAppendix = {
+      id: "github-trending",
+      kind: "watch" as const,
+      title: "GitHub Trending",
+      text: "Stale repository list.",
+      citationIds: ["old-citation"],
+    };
+    const currentAppendix = {
+      ...staleAppendix,
+      text: "Current repository list.",
+      citationIds: ["current-citation"],
+    };
+
+    expect(
+      withGitHubTrendingNarrativeAppendix({
+        narrativeSections: [
+          {
+            id: "lead",
+            kind: "lead",
+            title: "Lead",
+            text: "Primary summary.",
+            citationIds: ["lead-citation"],
+          },
+          staleAppendix,
+        ],
+        appendix: currentAppendix,
+      }),
+    ).toEqual([
+      expect.objectContaining({ id: "lead" }),
+      expect.objectContaining({
+        id: "github-trending",
+        text: "Current repository list.",
+      }),
+    ]);
   });
 });
 

--- a/libs/summary/domain/policies/reader-summary-github-trending-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-github-trending-policy.ts
@@ -10,6 +10,16 @@ export const githubTrendingNarrativeSectionId = "github-trending";
 export const minimumGitHubTrendingStarsGained = 1_000;
 export const maxGitHubTrendingHighlights = 3;
 
+export const withGitHubTrendingNarrativeAppendix = (params: {
+  readonly narrativeSections: readonly ReaderSummaryNarrativeSection[];
+  readonly appendix: ReaderSummaryNarrativeSection | undefined;
+}): readonly ReaderSummaryNarrativeSection[] => [
+  ...params.narrativeSections.filter(
+    (section) => section.id !== githubTrendingNarrativeSectionId,
+  ),
+  ...(params.appendix === undefined ? [] : [params.appendix]),
+];
+
 export const isGitHubTrendingEvidence = (
   item: Pick<SummaryEvidenceItem, "providerKey">,
 ): boolean =>


### PR DESCRIPTION
## Summary
- move the idempotence regression into the bounded GitHub Trending policy suite
- keep the legacy aggregate spec from growing
- centralize replacement of a stale appendix before appending the current one

## Verification
- 2 focused suites, 18 tests passed
- source/test line cap passed
- npm run build
- git diff --check