### PR TITLE
fix(summary): exclude GitHub Trending from source mix

### DIFF
--- a/libs/summary/domain/policies/source-mix-quality-policy.spec.ts
+++ b/libs/summary/domain/policies/source-mix-quality-policy.spec.ts
@@ -9,7 +9,7 @@ import type {
 } from "../value-objects/summary-evidence-item";
 
 describe("buildSourceMix", () => {
-  it("orders social and news sources before GitHub supporting evidence", () => {
+  it("excludes GitHub Trending from the reader-facing source mix", () => {
     const sourceMix = buildSourceMix({
       selectedEvidence: [
         evidenceItem("github-trending-page", 1),
@@ -41,9 +41,8 @@ describe("buildSourceMix", () => {
       "x-twitter",
       "reddit",
       "hacker-news",
-      "github-trending-page",
     ]);
-    expect(sourceMix.map((entry) => entry.itemCount)).toEqual([1, 1, 1, 3]);
+    expect(sourceMix.map((entry) => entry.itemCount)).toEqual([1, 1, 1]);
   });
 
   it("does not label multi-provider source-local coverage as a single source", () => {

--- a/libs/summary/domain/policies/source-mix-quality-policy.ts
+++ b/libs/summary/domain/policies/source-mix-quality-policy.ts
@@ -9,6 +9,7 @@ import type {
   ReaderSummaryQualityState,
 } from "../value-objects/summary-quality";
 import { compactUnique, uniqueNonEmpty } from "../value-objects/summary-text";
+import { isGitHubTrendingEvidence } from "./reader-summary-github-trending-policy";
 
 export type SourceMixQualityPolicyInput = {
   readonly selectedEvidence?: readonly SummaryEvidenceItem[];
@@ -31,12 +32,18 @@ export const buildSourceMix = (
   >();
 
   for (const item of input.selectedEvidence ?? []) {
+    if (isGitHubTrendingEvidence(item)) {
+      continue;
+    }
     const current = sourceMixCount(counts, item.providerKey);
     current.itemIds.add(item.feedItemId);
     current.interestIds.add(item.interestId);
   }
 
   for (const citation of input.citationMap) {
+    if (isGitHubTrendingEvidence(citation)) {
+      continue;
+    }
     const current = sourceMixCount(counts, citation.providerKey);
     current.itemIds.add(citation.feedItemId);
     current.citationIds.add(citation.citationId);
@@ -45,6 +52,9 @@ export const buildSourceMix = (
   for (const cluster of input.storyClusters) {
     const isCrossSource = cluster.providerKeys.length > 1;
     for (const providerKey of cluster.providerKeys) {
+      if (isGitHubTrendingEvidence({ providerKey })) {
+        continue;
+      }
       const current = sourceMixCount(counts, providerKey);
       current.storyClusterIds.add(cluster.id);
       if (isCrossSource) {


### PR DESCRIPTION
## Summary
- exclude GitHub Trending from reader-facing source mix counts
- retain raw coverage and the dedicated deterministic top-three appendix
- update the source-mix policy regression

## Verification
- 3 focused suites, 20 tests passed
- architecture boundaries passed
- source/test line cap passed
- npm run build
- git diff --check