### PR TITLE
fix(evals): account for isolated GitHub appendix

### DIFF
--- a/scripts/check-yesterday-reader-summary-artifact-quality.ts
+++ b/scripts/check-yesterday-reader-summary-artifact-quality.ts
@@ -33,6 +33,7 @@ import {
   dailyPeriodKey,
   isLocalDataSourceUnavailable,
 } from "./lib/reader-summary-quality-eval-support";
+import { selectedCoverageMatchesProviderBreakdown } from "./lib/reader-summary-artifact-coverage";
 
 type ProviderCountRow = {
   readonly providerKey: string;
@@ -432,10 +433,6 @@ async function buildReport(): Promise<ArtifactQualityReport> {
           item.confidence.level === "low" && hasHighEngagementMetric(item),
       ).length,
     };
-    const coverageSelectedProviderSum = coverage.providerBreakdown.reduce(
-      (sum, item) => sum + item.selectedFeedItemCount,
-      0,
-    );
     const reportWithoutSecretGate = {
       schemaVersion: 1,
       artifactFormat: "yesterday-reader-summary-artifact-quality-v1",
@@ -548,7 +545,7 @@ async function buildReport(): Promise<ArtifactQualityReport> {
           coverage.selectedFeedItemCount ===
           view.sourceWindow.selectedFeedItemIds.length,
         coverageSelectedMatchesProviderBreakdown:
-          coverage.selectedFeedItemCount === coverageSelectedProviderSum,
+          selectedCoverageMatchesProviderBreakdown(coverage, selectedPosts),
         selectedPostsMismatchIsExplained: selectedPostsMismatchDocumented,
         topReadsHaveCanonicalUrls:
           topReads.length > 0 &&

--- a/scripts/lib/reader-summary-artifact-coverage.spec.ts
+++ b/scripts/lib/reader-summary-artifact-coverage.spec.ts
@@ -1,0 +1,40 @@
+import { selectedCoverageMatchesProviderBreakdown } from "./reader-summary-artifact-coverage";
+
+describe("selectedCoverageMatchesProviderBreakdown", () => {
+  it("accounts for isolated GitHub Trending appendix posts", () => {
+    expect(
+      selectedCoverageMatchesProviderBreakdown(
+        {
+          selectedFeedItemCount: 123,
+          providerBreakdown: [
+            { providerKey: "reddit", selectedFeedItemCount: 30 },
+            { providerKey: "rss", selectedFeedItemCount: 30 },
+            { providerKey: "hacker-news", selectedFeedItemCount: 30 },
+            { providerKey: "x-twitter", selectedFeedItemCount: 30 },
+            { providerKey: "github-trending-page", selectedFeedItemCount: 0 },
+          ],
+        },
+        Array.from({ length: 3 }, () => ({
+          providerKey: "github-trending-page",
+        })),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not double count GitHub posts already present in breakdown", () => {
+    expect(
+      selectedCoverageMatchesProviderBreakdown(
+        {
+          selectedFeedItemCount: 123,
+          providerBreakdown: [
+            { providerKey: "reddit", selectedFeedItemCount: 120 },
+            { providerKey: "github-trending-page", selectedFeedItemCount: 3 },
+          ],
+        },
+        Array.from({ length: 3 }, () => ({
+          providerKey: "github-trending-page",
+        })),
+      ),
+    ).toBe(true);
+  });
+});

--- a/scripts/lib/reader-summary-artifact-coverage.ts
+++ b/scripts/lib/reader-summary-artifact-coverage.ts
@@ -1,0 +1,32 @@
+export type ProviderSelectedCount = {
+  readonly providerKey: string;
+  readonly selectedFeedItemCount: number;
+};
+
+export const selectedCoverageMatchesProviderBreakdown = (
+  coverage: {
+    readonly selectedFeedItemCount: number;
+    readonly providerBreakdown: readonly ProviderSelectedCount[];
+  },
+  selectedPosts: readonly { readonly providerKey: string }[],
+): boolean => {
+  const providerSelectedCount = coverage.providerBreakdown.reduce(
+    (sum, provider) => sum + provider.selectedFeedItemCount,
+    0,
+  );
+  const githubTrendingProviderCount =
+    coverage.providerBreakdown.find(
+      (provider) => provider.providerKey === "github-trending-page",
+    )?.selectedFeedItemCount ?? 0;
+  const githubTrendingSelectedPostCount = selectedPosts.filter(
+    (post) => post.providerKey === "github-trending-page",
+  ).length;
+  const appendixOnlyCount = Math.max(
+    0,
+    githubTrendingSelectedPostCount - githubTrendingProviderCount,
+  );
+
+  return (
+    coverage.selectedFeedItemCount === providerSelectedCount + appendixOnlyCount
+  );
+};


### PR DESCRIPTION
## Summary
- account for GitHub Trending appendix posts outside reader-facing provider breakdown
- avoid double counting when a provider breakdown already includes them
- move the accounting behavior into a bounded helper and shrink the legacy gate script

## Verification
- focused helper suite, 2 tests passed
- source/test line cap passed
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage validation accuracy for selected content.
  * Corrected handling of supplemental trending content to prevent omissions and double counting.
  * Added validation scenarios covering content that appears both in supplemental sections and standard provider results.

* **Tests**
  * Expanded automated coverage checks to verify accurate provider totals and selected-content counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->