### PR TITLE
fix(evals): isolate X ledger day windows

### DIFF
--- a/scripts/lib/x-collector-quality-report-support.spec.ts
+++ b/scripts/lib/x-collector-quality-report-support.spec.ts
@@ -107,6 +107,17 @@ describe("x collector quality report support", () => {
         since: "2026-07-08_00:00:00_UTC",
         until: "2026-07-08_23:59:59_UTC",
       });
+      insertRun({
+        dbPath,
+        id: 4,
+        displayType: "Top",
+        startedAt: "2026-07-07T04:40:00Z",
+        finishedAt: "2026-07-07T04:41:00Z",
+        tweets: 99,
+        since: "2026-07-06",
+        until: "2026-07-07",
+        status: "failed",
+      });
       execSql(
         dbPath,
         `
@@ -156,6 +167,15 @@ describe("x collector quality report support", () => {
         fetched: 99,
         accepted: 99,
       });
+      insertEvent({
+        dbPath,
+        id: "event-old-target-date-failure",
+        type: "pass_failed",
+        occurredAt: "2026-07-07T12:00:00.000Z",
+        accountId: 1,
+        fetched: null,
+        accepted: null,
+      });
 
       jest.mocked(execFileSync).mockClear();
       const ledger = buildXCollectorLedgerReport({
@@ -168,6 +188,7 @@ describe("x collector quality report support", () => {
       });
 
       expect(ledger.runCount).toBe(2);
+      expect(ledger.failedRunCount).toBe(0);
       expect(ledger.returnedTweetCount).toBe(51);
       expect(ledger.hasTopAndLatest).toBe(true);
       expect(accountPool.eventCount).toBe(3);
@@ -192,6 +213,74 @@ describe("x collector quality report support", () => {
         expect(ledgerUri.protocol).toBe("file:");
         expect(ledgerUri.searchParams.get("immutable")).toBe("1");
       }
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the target UTC window instead of run execution date", () => {
+    const directory = mkdtempSync(join(tmpdir(), "x-collector-quality-"));
+    const dbPath = join(directory, "scweet_state.db");
+
+    try {
+      execSql(
+        dbPath,
+        `
+          create table runs (
+            id integer primary key,
+            run_id text not null,
+            status text not null,
+            started_at real not null,
+            finished_at real,
+            query_hash text not null,
+            tweets_count integer not null,
+            input_json text,
+            stats_json text
+          );
+        `,
+      );
+      insertRun({
+        dbPath,
+        id: 1,
+        displayType: "Top",
+        startedAt: "2026-07-11T04:00:00Z",
+        finishedAt: "2026-07-11T04:01:00Z",
+        tweets: 99,
+        since: "2026-07-10",
+        until: "2026-07-11",
+        status: "failed",
+      });
+      insertRun({
+        dbPath,
+        id: 2,
+        displayType: "Top",
+        startedAt: "2026-07-12T00:02:00Z",
+        finishedAt: "2026-07-12T00:03:00Z",
+        tweets: 31,
+        since: "2026-07-11",
+        until: "2026-07-12",
+      });
+      insertRun({
+        dbPath,
+        id: 3,
+        displayType: "Latest",
+        startedAt: "2026-07-12T00:03:00Z",
+        finishedAt: "2026-07-12T00:04:00Z",
+        tweets: 20,
+        since: "2026-07-11_00:00:00_UTC",
+        until: "2026-07-11_23:59:59_UTC",
+      });
+
+      const ledger = buildXCollectorLedgerReport({
+        ledgerPath: dbPath,
+        collectionDate: "2026-07-11",
+      });
+
+      expect(ledger.runCount).toBe(2);
+      expect(ledger.completedRunCount).toBe(2);
+      expect(ledger.failedRunCount).toBe(0);
+      expect(ledger.returnedTweetCount).toBe(51);
+      expect(ledger.hasTopAndLatest).toBe(true);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
@@ -317,6 +406,7 @@ function insertRun(params: {
   readonly tweets: number;
   readonly since?: string;
   readonly until?: string;
+  readonly status?: "completed" | "failed";
 }): void {
   const input = JSON.stringify({
     since: params.since ?? "2026-07-07_00:00:00_UTC",
@@ -336,7 +426,7 @@ function insertRun(params: {
         id, run_id, status, started_at, finished_at, query_hash,
         tweets_count, input_json, stats_json
       ) values (
-        ${params.id}, 'run-${params.id}', 'completed',
+        ${params.id}, 'run-${params.id}', ${sqlString(params.status ?? "completed")},
         ${epochSeconds(params.startedAt)}, ${epochSeconds(params.finishedAt)},
         'hash-${params.id}', ${params.tweets},
         ${sqlString(input)}, ${sqlString(stats)}

--- a/scripts/lib/x-collector-quality-report-support.ts
+++ b/scripts/lib/x-collector-quality-report-support.ts
@@ -445,7 +445,7 @@ function readXAccountUsageEventRows(params: BuildParams):
   if (!runRows.ok) {
     return runRows;
   }
-  const runWindow = executionWindow(
+  const runWindows = executionWindows(
     runRows.rows.filter((row) =>
       runTargetsCollectionDate(row, params.collectionDate),
     ),
@@ -497,10 +497,8 @@ function readXAccountUsageEventRows(params: BuildParams):
 
   return {
     ok: true,
-    rows: events.rows.filter(
-      (event) =>
-        eventDate(event.occurred_at) === params.collectionDate ||
-        eventFallsInsideWindow(event, runWindow),
+    rows: events.rows.filter((event) =>
+      eventFallsInsideWindows(event, runWindows),
     ),
   };
 }
@@ -606,10 +604,6 @@ function runTargetsCollectionDate(
   row: XRunRow,
   collectionDate: string,
 ): boolean {
-  if (eventDate(row.started_at) === collectionDate) {
-    return true;
-  }
-
   const input = parseJson<XRunInput>(row.input_json);
   if (input === undefined) {
     return false;
@@ -623,52 +617,71 @@ function scweetWindowContainsDate(
   until: string | undefined,
   collectionDate: string,
 ): boolean {
-  const sinceDate = scweetDatePart(since);
-  const untilDate = scweetDatePart(until);
-  if (sinceDate === collectionDate || untilDate === collectionDate) {
-    return true;
-  }
-  if (sinceDate === undefined || untilDate === undefined) {
+  const sinceAt = parseScweetTimestamp(since);
+  const untilAt = parseScweetTimestamp(until);
+  const dayStartedAt = Date.parse(`${collectionDate}T00:00:00.000Z`);
+  if (
+    sinceAt === undefined ||
+    untilAt === undefined ||
+    !Number.isFinite(dayStartedAt)
+  ) {
     return false;
   }
 
-  return sinceDate <= collectionDate && collectionDate <= untilDate;
+  const dayEndedAt = dayStartedAt + 24 * 60 * 60 * 1000;
+  return sinceAt < dayEndedAt && untilAt > dayStartedAt;
 }
 
-function executionWindow(
+function executionWindows(
   rows: readonly XRunRow[],
-): { readonly startedAt: number; readonly finishedAt: number } | undefined {
-  const times = rows.flatMap((row) => [
-    parseTimestamp(row.started_at),
-    parseTimestamp(row.finished_at),
-  ]);
-  const finiteTimes = times.filter(
-    (time): time is number => time !== undefined,
-  );
-  if (finiteTimes.length === 0) {
-    return undefined;
-  }
-
+): readonly { readonly startedAt: number; readonly finishedAt: number }[] {
   const marginMs = 5 * 60 * 1000;
-  return {
-    startedAt: Math.min(...finiteTimes) - marginMs,
-    finishedAt: Math.max(...finiteTimes) + marginMs,
-  };
+  return rows.flatMap((row) => {
+    const times = [
+      parseTimestamp(row.started_at),
+      parseTimestamp(row.finished_at),
+    ].filter((time): time is number => time !== undefined);
+    if (times.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        startedAt: Math.min(...times) - marginMs,
+        finishedAt: Math.max(...times) + marginMs,
+      },
+    ];
+  });
 }
 
-function eventFallsInsideWindow(
+function eventFallsInsideWindows(
   event: XAccountUsageEventRow,
-  window:
-    { readonly startedAt: number; readonly finishedAt: number } | undefined,
+  windows: readonly {
+    readonly startedAt: number;
+    readonly finishedAt: number;
+  }[],
 ): boolean {
   const occurredAt = parseTimestamp(event.occurred_at);
 
   return (
     occurredAt !== undefined &&
-    window !== undefined &&
-    window.startedAt <= occurredAt &&
-    occurredAt <= window.finishedAt
+    windows.some(
+      (window) =>
+        window.startedAt <= occurredAt && occurredAt <= window.finishedAt,
+    )
   );
+}
+
+function parseScweetTimestamp(value: string | undefined): number | undefined {
+  const match = value?.match(
+    /^(\d{4}-\d{2}-\d{2})(?:[T_ ](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|_UTC)?)?$/u,
+  );
+  if (match === null || match === undefined) {
+    return undefined;
+  }
+
+  const parsed = Date.parse(`${match[1]}T${match[2] ?? "00:00:00"}Z`);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function parseTimestamp(value: string | undefined): number | undefined {
@@ -682,14 +695,6 @@ function parseTimestamp(value: string | undefined): number | undefined {
   const parsed = Date.parse(normalized);
 
   return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function eventDate(value: string | undefined): string | undefined {
-  return value?.slice(0, 10);
-}
-
-function scweetDatePart(value: string | undefined): string | undefined {
-  return value?.slice(0, 10);
 }
 
 function accountBucketKey(


### PR DESCRIPTION
Fix X collector quality attribution so historical retries do not contaminate adjacent UTC days. Date-only until boundaries are treated as exclusive, legacy timestamp windows remain supported, and account events are scoped to the matching run windows.\n\nChecks:\n- npx jest --runInBand scripts/lib/x-collector-quality-report-support.spec.ts\n- npm run check:source-line-cap\n- git diff --check