### PR TITLE
fix(deploy): harden subscription auth refresh

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -285,11 +285,17 @@ jobs:
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
+          CONTROL_CHANGED: ${{ needs.plan.outputs.control }}
         run: |
           set -euo pipefail
           ssh -i "$HOME/.ssh/social-monitor-production" \
             -o BatchMode=yes -o IdentitiesOnly=yes \
             "$DEPLOY_USER@$DEPLOY_HOST" "deploy $GITHUB_SHA"
+          if [[ $CONTROL_CHANGED == true ]]; then
+            ssh -i "$HOME/.ssh/social-monitor-production" \
+              -o BatchMode=yes -o IdentitiesOnly=yes \
+              "$DEPLOY_USER@$DEPLOY_HOST" "deploy $GITHUB_SHA"
+          fi
 
       - name: Remove production SSH material
         if: always()

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -131,9 +131,13 @@ jobs:
           npm run check:migrations
           npm run build
           bash -n ops/deploy/social-monitor-production-deploy.sh \
-            ops/deploy/social-monitor-production-ssh-wrapper.sh
+            ops/deploy/social-monitor-production-ssh-wrapper.sh \
+            ops/deploy/host/refresh-codex-auth.sh \
+            ops/deploy/refresh-codex-auth.test.sh
           shellcheck -x ops/deploy/social-monitor-production-deploy.sh \
-            ops/deploy/social-monitor-production-ssh-wrapper.sh
+            ops/deploy/social-monitor-production-ssh-wrapper.sh \
+            ops/deploy/host/refresh-codex-auth.sh \
+            ops/deploy/refresh-codex-auth.test.sh
           bash ops/deploy/social-monitor-production-deploy.test.sh
 
       - name: Test affected backend modules

--- a/ops/deploy/host/refresh-codex-auth.sh
+++ b/ops/deploy/host/refresh-codex-auth.sh
@@ -46,6 +46,15 @@ else
 fi
 
 install -d -m 0750 -o "$TARGET_DIR_OWNER" -g "$TARGET_GROUP" "$TARGET_DIR"
+if [[ -e $TARGET_DIR/auth.json ]]; then
+  [[ -f $TARGET_DIR/auth.json && ! -L $TARGET_DIR/auth.json ]] || {
+    echo 'auth-refresh-error: existing target auth is not a regular file' >&2
+    exit 1
+  }
+  chown "$TARGET_OWNER:$TARGET_GROUP" "$TARGET_DIR/auth.json"
+  chmod "$TARGET_MODE" "$TARGET_DIR/auth.json"
+fi
+rm -f "$TARGET_DIR/auth.json.next"
 install -d -m 0750 "$PROBE_WORKSPACE"
 install -d -m 0700 "$PROBE_TMP_ROOT"
 exec 9>"$CURSOR_FILE.lock"

--- a/ops/deploy/host/refresh-codex-auth.sh
+++ b/ops/deploy/host/refresh-codex-auth.sh
@@ -1,26 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ((EUID == 0)); then
-  PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
-  AUTH_ROOT=/var/data/codex-home/live-codex-auth
-  TARGET_DIR=/var/data/social-monitor/auth-current
-  REGISTRY_ROOT=/var/data/social-monitor/worker-jobs/registry
-  CONTROLLER_JOB_ID=social-monitor-project-controller-v1
-  CURSOR_FILE=/var/data/social-monitor/runtime/auth-account-cursor
-  PROBE_WORKSPACE=/var/data/social-monitor/runtime/auth-probe-workspace
-  ACCOUNT_CHANGED_MARKER=/var/data/social-monitor/runtime/auth-account-changed
-  PROBE_TMP_ROOT=/var/data/social-monitor/runtime/auth-probes
-  TARGET_OWNER=1000
-  TARGET_GROUP=1000
-  unset SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE SOCIAL_MONITOR_AUTH_ROOT \
-    SOCIAL_MONITOR_AUTH_TARGET_DIR SOCIAL_MONITOR_AUTH_REGISTRY_ROOT \
-    SOCIAL_MONITOR_AUTH_CONTROLLER_JOB_ID SOCIAL_MONITOR_AUTH_CURSOR_FILE \
-    SOCIAL_MONITOR_AUTH_PROBE_WORKSPACE SOCIAL_MONITOR_AUTH_CHANGED_MARKER \
-    SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT
-else
-  [[ ${SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE:-} == 1 ]] || {
-    echo 'auth-refresh-error: production entrypoint requires root' >&2
+if [[ ${SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE:-} == 1 ]]; then
+  ((EUID != 0)) || {
+    echo 'auth-refresh-error: test mode refuses root execution' >&2
     exit 1
   }
   AUTH_ROOT=${SOCIAL_MONITOR_AUTH_ROOT:?test auth root is required}
@@ -28,14 +11,41 @@ else
   REGISTRY_ROOT=${SOCIAL_MONITOR_AUTH_REGISTRY_ROOT:?test registry root is required}
   CONTROLLER_JOB_ID=${SOCIAL_MONITOR_AUTH_CONTROLLER_JOB_ID:-test-controller}
   CURSOR_FILE=${SOCIAL_MONITOR_AUTH_CURSOR_FILE:?test cursor file is required}
+  ACCOUNT_NAME_FILE=${SOCIAL_MONITOR_AUTH_ACCOUNT_NAME_FILE:?test account name file is required}
   PROBE_WORKSPACE=${SOCIAL_MONITOR_AUTH_PROBE_WORKSPACE:?test probe workspace is required}
   ACCOUNT_CHANGED_MARKER=${SOCIAL_MONITOR_AUTH_CHANGED_MARKER:?test marker is required}
   PROBE_TMP_ROOT=${SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT:?test probe temp root is required}
+  TARGET_DIR_OWNER=$(id -u)
   TARGET_OWNER=$(id -u)
   TARGET_GROUP=$(id -g)
+  TARGET_MODE=0400
+elif ((EUID == 0)); then
+  PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+  AUTH_ROOT=/var/data/codex-home/live-codex-auth
+  TARGET_DIR=/var/data/social-monitor/auth-current
+  REGISTRY_ROOT=/var/data/social-monitor/worker-jobs/registry
+  CONTROLLER_JOB_ID=social-monitor-project-controller-v1
+  CURSOR_FILE=/var/data/social-monitor/runtime/auth-account-cursor
+  ACCOUNT_NAME_FILE=/var/data/social-monitor/runtime/auth-account-name
+  PROBE_WORKSPACE=/var/data/social-monitor/runtime/auth-probe-workspace
+  ACCOUNT_CHANGED_MARKER=/var/data/social-monitor/runtime/auth-account-changed
+  PROBE_TMP_ROOT=/var/data/social-monitor/runtime/auth-probes
+  TARGET_DIR_OWNER=root
+  TARGET_OWNER=root
+  TARGET_GROUP=1000
+  TARGET_MODE=0440
+  unset SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE SOCIAL_MONITOR_AUTH_ROOT \
+    SOCIAL_MONITOR_AUTH_TARGET_DIR SOCIAL_MONITOR_AUTH_REGISTRY_ROOT \
+    SOCIAL_MONITOR_AUTH_CONTROLLER_JOB_ID SOCIAL_MONITOR_AUTH_CURSOR_FILE \
+    SOCIAL_MONITOR_AUTH_ACCOUNT_NAME_FILE \
+    SOCIAL_MONITOR_AUTH_PROBE_WORKSPACE SOCIAL_MONITOR_AUTH_CHANGED_MARKER \
+    SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT
+else
+  echo 'auth-refresh-error: production entrypoint requires root' >&2
+  exit 1
 fi
 
-install -d -m 0750 -o "$TARGET_OWNER" -g "$TARGET_GROUP" "$TARGET_DIR"
+install -d -m 0750 -o "$TARGET_DIR_OWNER" -g "$TARGET_GROUP" "$TARGET_DIR"
 install -d -m 0750 "$PROBE_WORKSPACE"
 install -d -m 0700 "$PROBE_TMP_ROOT"
 exec 9>"$CURSOR_FILE.lock"
@@ -63,7 +73,19 @@ if [[ -f $CURSOR_FILE ]]; then
 fi
 [[ $start_index =~ ^[0-9]+$ ]] || start_index=0
 start_index=$((start_index % account_count))
+previous_account=''
+if [[ -f $ACCOUNT_NAME_FILE ]]; then
+  read -r previous_account < "$ACCOUNT_NAME_FILE"
+fi
+for ((candidate_index = 0; candidate_index < account_count; candidate_index += 1)); do
+  if [[ ${available_accounts[$candidate_index]} == "$previous_account" ]]; then
+    start_index=$candidate_index
+    break
+  fi
+done
 auth_root_resolved=$(realpath "$AUTH_ROOT")
+target_auth_existed=false
+[[ -f $TARGET_DIR/auth.json ]] && target_auth_existed=true
 
 probe_home=''
 cleanup() {
@@ -92,13 +114,17 @@ for ((offset = 0; offset < account_count; offset += 1)); do
     </dev/null >/dev/null 2>&1 \
     && [[ -f $probe_result ]] \
     && [[ $(tr -d '\r\n' < "$probe_result") == AUTH_OK ]]; then
-    install -m 0400 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+    install -m "$TARGET_MODE" -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
       "$probe_home/auth.json" "$TARGET_DIR/auth.json.next"
     mv -f "$TARGET_DIR/auth.json.next" "$TARGET_DIR/auth.json"
     printf '%s\n' "$index" > "$CURSOR_FILE.next.$$"
     chmod 0600 "$CURSOR_FILE.next.$$"
     mv -f "$CURSOR_FILE.next.$$" "$CURSOR_FILE"
-    if ((index != start_index)); then
+    printf '%s\n' "$account" > "$ACCOUNT_NAME_FILE.next.$$"
+    chmod 0600 "$ACCOUNT_NAME_FILE.next.$$"
+    mv -f "$ACCOUNT_NAME_FILE.next.$$" "$ACCOUNT_NAME_FILE"
+    if [[ -n $previous_account && $account != "$previous_account" ]] \
+      || [[ -z $previous_account && $target_auth_existed == true ]]; then
       : > "$ACCOUNT_CHANGED_MARKER"
       chmod 0600 "$ACCOUNT_CHANGED_MARKER"
     fi

--- a/ops/deploy/host/refresh-codex-auth.sh
+++ b/ops/deploy/host/refresh-codex-auth.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ((EUID == 0)); then
+  PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+  AUTH_ROOT=/var/data/codex-home/live-codex-auth
+  TARGET_DIR=/var/data/social-monitor/auth-current
+  REGISTRY_ROOT=/var/data/social-monitor/worker-jobs/registry
+  CONTROLLER_JOB_ID=social-monitor-project-controller-v1
+  CURSOR_FILE=/var/data/social-monitor/runtime/auth-account-cursor
+  PROBE_WORKSPACE=/var/data/social-monitor/runtime/auth-probe-workspace
+  ACCOUNT_CHANGED_MARKER=/var/data/social-monitor/runtime/auth-account-changed
+  PROBE_TMP_ROOT=/var/data/social-monitor/runtime/auth-probes
+  TARGET_OWNER=1000
+  TARGET_GROUP=1000
+  unset SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE SOCIAL_MONITOR_AUTH_ROOT \
+    SOCIAL_MONITOR_AUTH_TARGET_DIR SOCIAL_MONITOR_AUTH_REGISTRY_ROOT \
+    SOCIAL_MONITOR_AUTH_CONTROLLER_JOB_ID SOCIAL_MONITOR_AUTH_CURSOR_FILE \
+    SOCIAL_MONITOR_AUTH_PROBE_WORKSPACE SOCIAL_MONITOR_AUTH_CHANGED_MARKER \
+    SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT
+else
+  [[ ${SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE:-} == 1 ]] || {
+    echo 'auth-refresh-error: production entrypoint requires root' >&2
+    exit 1
+  }
+  AUTH_ROOT=${SOCIAL_MONITOR_AUTH_ROOT:?test auth root is required}
+  TARGET_DIR=${SOCIAL_MONITOR_AUTH_TARGET_DIR:?test target dir is required}
+  REGISTRY_ROOT=${SOCIAL_MONITOR_AUTH_REGISTRY_ROOT:?test registry root is required}
+  CONTROLLER_JOB_ID=${SOCIAL_MONITOR_AUTH_CONTROLLER_JOB_ID:-test-controller}
+  CURSOR_FILE=${SOCIAL_MONITOR_AUTH_CURSOR_FILE:?test cursor file is required}
+  PROBE_WORKSPACE=${SOCIAL_MONITOR_AUTH_PROBE_WORKSPACE:?test probe workspace is required}
+  ACCOUNT_CHANGED_MARKER=${SOCIAL_MONITOR_AUTH_CHANGED_MARKER:?test marker is required}
+  PROBE_TMP_ROOT=${SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT:?test probe temp root is required}
+  TARGET_OWNER=$(id -u)
+  TARGET_GROUP=$(id -g)
+fi
+
+install -d -m 0750 -o "$TARGET_OWNER" -g "$TARGET_GROUP" "$TARGET_DIR"
+install -d -m 0750 "$PROBE_WORKSPACE"
+install -d -m 0700 "$PROBE_TMP_ROOT"
+exec 9>"$CURSOR_FILE.lock"
+chmod 0600 "$CURSOR_FILE.lock"
+flock -w 1800 9
+
+status_json=$(timeout 30 subscription-runtime-codex-goal tool codex_goal_accounts_status \
+  --args-json "{\"jobId\":\"$CONTROLLER_JOB_ID\",\"registryRootDir\":\"$REGISTRY_ROOT\",\"liveCheck\":false}")
+
+jq -e '
+  (.ok == true)
+  and (.hasAvailableAccount == true)
+  and (.availableDedupedAccountNames | type == "array")
+  and (.availableDedupedAccountNames | length > 0)
+' >/dev/null <<<"$status_json"
+
+available_accounts=()
+while IFS= read -r account; do
+  available_accounts+=("$account")
+done < <(jq -r '.availableDedupedAccountNames[]' <<<"$status_json")
+account_count=${#available_accounts[@]}
+start_index=0
+if [[ -f $CURSOR_FILE ]]; then
+  read -r start_index < "$CURSOR_FILE"
+fi
+[[ $start_index =~ ^[0-9]+$ ]] || start_index=0
+start_index=$((start_index % account_count))
+auth_root_resolved=$(realpath "$AUTH_ROOT")
+
+probe_home=''
+cleanup() {
+  [[ -z $probe_home ]] || rm -rf "$probe_home"
+}
+trap cleanup EXIT
+
+for ((offset = 0; offset < account_count; offset += 1)); do
+  index=$(((start_index + offset) % account_count))
+  account=${available_accounts[$index]}
+  [[ $account =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || continue
+  selected=$(realpath "$AUTH_ROOT/$account/auth.json" 2>/dev/null) || continue
+  [[ $selected == "$auth_root_resolved"/*/auth.json ]] || continue
+
+  probe_home=$(mktemp -d "$PROBE_TMP_ROOT/auth-probe.XXXXXX")
+  probe_result=$probe_home/result.txt
+  install -m 0400 "$selected" "$probe_home/auth.json"
+  if timeout 180 env CODEX_HOME="$probe_home" codex exec \
+    --skip-git-repo-check \
+    --sandbox read-only \
+    --model gpt-5.5 \
+    --color never \
+    --output-last-message "$probe_result" \
+    -C "$PROBE_WORKSPACE" \
+    'Return exactly AUTH_OK and do nothing else.' \
+    </dev/null >/dev/null 2>&1 \
+    && [[ -f $probe_result ]] \
+    && [[ $(tr -d '\r\n' < "$probe_result") == AUTH_OK ]]; then
+    install -m 0400 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+      "$probe_home/auth.json" "$TARGET_DIR/auth.json.next"
+    mv -f "$TARGET_DIR/auth.json.next" "$TARGET_DIR/auth.json"
+    printf '%s\n' "$index" > "$CURSOR_FILE.next.$$"
+    chmod 0600 "$CURSOR_FILE.next.$$"
+    mv -f "$CURSOR_FILE.next.$$" "$CURSOR_FILE"
+    if ((index != start_index)); then
+      : > "$ACCOUNT_CHANGED_MARKER"
+      chmod 0600 "$ACCOUNT_CHANGED_MARKER"
+    fi
+    cleanup
+    probe_home=''
+    echo 'subscription account validation passed'
+    exit 0
+  fi
+  cleanup
+  probe_home=''
+done
+
+echo 'no broker-available subscription account passed the isolated auth probe' >&2
+exit 1

--- a/ops/deploy/refresh-codex-auth.test.sh
+++ b/ops/deploy/refresh-codex-auth.test.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+((EUID != 0)) || {
+  echo 'Subscription auth refresh fixture must run as an unprivileged user' >&2
+  exit 1
+}
+
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ENTRYPOINT=$SCRIPT_DIR/host/refresh-codex-auth.sh
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/social-monitor-auth-refresh-test.XXXXXX")
@@ -10,6 +15,7 @@ AUTH_ROOT=$FIXTURE/auth
 TARGET_DIR=$FIXTURE/target
 REGISTRY_ROOT=$FIXTURE/registry
 CURSOR_FILE=$FIXTURE/cursor
+ACCOUNT_NAME_FILE=$FIXTURE/account-name
 PROBE_WORKSPACE=$FIXTURE/workspace
 CHANGED_MARKER=$FIXTURE/changed
 PROBE_TMP_ROOT=$FIXTURE/tmp
@@ -29,7 +35,8 @@ cat > "$BIN/codex" <<'SH'
 #!/usr/bin/env bash
 while (($#)); do
   if [[ $1 == --output-last-message ]]; then
-    if [[ ${SOCIAL_MONITOR_TEST_FAIL_A:-} == 1 ]] && grep -F '"a"' "$CODEX_HOME/auth.json" >/dev/null; then
+    if [[ -n ${SOCIAL_MONITOR_TEST_FAIL_ACCOUNT:-} ]] \
+      && grep -F "\"$SOCIAL_MONITOR_TEST_FAIL_ACCOUNT\"" "$CODEX_HOME/auth.json" >/dev/null; then
       exit 43
     fi
     printf '%s\n' "${SOCIAL_MONITOR_TEST_RESULT:-AUTH_OK}" > "$2"
@@ -52,6 +59,7 @@ SOCIAL_MONITOR_AUTH_ROOT="$AUTH_ROOT" \
 SOCIAL_MONITOR_AUTH_TARGET_DIR="$TARGET_DIR" \
 SOCIAL_MONITOR_AUTH_REGISTRY_ROOT="$REGISTRY_ROOT" \
 SOCIAL_MONITOR_AUTH_CURSOR_FILE="$CURSOR_FILE" \
+SOCIAL_MONITOR_AUTH_ACCOUNT_NAME_FILE="$ACCOUNT_NAME_FILE" \
 SOCIAL_MONITOR_AUTH_PROBE_WORKSPACE="$PROBE_WORKSPACE" \
 SOCIAL_MONITOR_AUTH_CHANGED_MARKER="$CHANGED_MARKER" \
 SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT="$PROBE_TMP_ROOT" \
@@ -62,12 +70,21 @@ run_refresh >/dev/null
 
 cmp "$AUTH_ROOT/account-a/auth.json" "$TARGET_DIR/auth.json"
 [[ $(cat "$CURSOR_FILE") == 0 ]]
+[[ $(cat "$ACCOUNT_NAME_FILE") == account-a ]]
 [[ $(stat -f '%Lp' "$TARGET_DIR/auth.json" 2>/dev/null || stat -c '%a' "$TARGET_DIR/auth.json") == 400 ]]
 [[ ! -e $CHANGED_MARKER ]]
 
-SOCIAL_MONITOR_TEST_FAIL_A=1 run_refresh >/dev/null
+SOCIAL_MONITOR_TEST_ACCOUNTS='["account-b"]' run_refresh >/dev/null
 cmp "$AUTH_ROOT/account-b/auth.json" "$TARGET_DIR/auth.json"
-[[ $(cat "$CURSOR_FILE") == 1 ]]
+[[ $(cat "$CURSOR_FILE") == 0 ]]
+[[ $(cat "$ACCOUNT_NAME_FILE") == account-b ]]
+[[ -f $CHANGED_MARKER ]]
+
+rm -f "$CHANGED_MARKER"
+SOCIAL_MONITOR_TEST_FAIL_ACCOUNT=b run_refresh >/dev/null
+cmp "$AUTH_ROOT/account-a/auth.json" "$TARGET_DIR/auth.json"
+[[ $(cat "$CURSOR_FILE") == 0 ]]
+[[ $(cat "$ACCOUNT_NAME_FILE") == account-a ]]
 [[ -f $CHANGED_MARKER ]]
 
 old_hash=$(cksum < "$TARGET_DIR/auth.json")

--- a/ops/deploy/refresh-codex-auth.test.sh
+++ b/ops/deploy/refresh-codex-auth.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ENTRYPOINT=$SCRIPT_DIR/host/refresh-codex-auth.sh
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/social-monitor-auth-refresh-test.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+
+AUTH_ROOT=$FIXTURE/auth
+TARGET_DIR=$FIXTURE/target
+REGISTRY_ROOT=$FIXTURE/registry
+CURSOR_FILE=$FIXTURE/cursor
+PROBE_WORKSPACE=$FIXTURE/workspace
+CHANGED_MARKER=$FIXTURE/changed
+PROBE_TMP_ROOT=$FIXTURE/tmp
+BIN=$FIXTURE/bin
+install -d "$AUTH_ROOT/account-a" "$AUTH_ROOT/account-b" "$REGISTRY_ROOT" \
+  "$PROBE_WORKSPACE" "$BIN" "$FIXTURE/tmp"
+printf '{"account":"a"}\n' > "$AUTH_ROOT/account-a/auth.json"
+printf '{"account":"b"}\n' > "$AUTH_ROOT/account-b/auth.json"
+
+cat > "$BIN/subscription-runtime-codex-goal" <<'SH'
+#!/usr/bin/env bash
+[[ $* == *'"liveCheck":false'* ]] || exit 41
+accounts=${SOCIAL_MONITOR_TEST_ACCOUNTS:-'["account-a","account-b"]'}
+printf '{"ok":true,"hasAvailableAccount":true,"availableDedupedAccountNames":%s}\n' "$accounts"
+SH
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+while (($#)); do
+  if [[ $1 == --output-last-message ]]; then
+    if [[ ${SOCIAL_MONITOR_TEST_FAIL_A:-} == 1 ]] && grep -F '"a"' "$CODEX_HOME/auth.json" >/dev/null; then
+      exit 43
+    fi
+    printf '%s\n' "${SOCIAL_MONITOR_TEST_RESULT:-AUTH_OK}" > "$2"
+    exit 0
+  fi
+  shift
+done
+exit 42
+SH
+cat > "$BIN/flock" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod 0755 "$BIN/subscription-runtime-codex-goal" "$BIN/codex" "$BIN/flock"
+
+run_refresh() {
+PATH="$BIN:$PATH" \
+SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE=1 \
+SOCIAL_MONITOR_AUTH_ROOT="$AUTH_ROOT" \
+SOCIAL_MONITOR_AUTH_TARGET_DIR="$TARGET_DIR" \
+SOCIAL_MONITOR_AUTH_REGISTRY_ROOT="$REGISTRY_ROOT" \
+SOCIAL_MONITOR_AUTH_CURSOR_FILE="$CURSOR_FILE" \
+SOCIAL_MONITOR_AUTH_PROBE_WORKSPACE="$PROBE_WORKSPACE" \
+SOCIAL_MONITOR_AUTH_CHANGED_MARKER="$CHANGED_MARKER" \
+SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT="$PROBE_TMP_ROOT" \
+  bash "$ENTRYPOINT"
+}
+
+run_refresh >/dev/null
+
+cmp "$AUTH_ROOT/account-a/auth.json" "$TARGET_DIR/auth.json"
+[[ $(cat "$CURSOR_FILE") == 0 ]]
+[[ $(stat -f '%Lp' "$TARGET_DIR/auth.json" 2>/dev/null || stat -c '%a' "$TARGET_DIR/auth.json") == 400 ]]
+[[ ! -e $CHANGED_MARKER ]]
+
+SOCIAL_MONITOR_TEST_FAIL_A=1 run_refresh >/dev/null
+cmp "$AUTH_ROOT/account-b/auth.json" "$TARGET_DIR/auth.json"
+[[ $(cat "$CURSOR_FILE") == 1 ]]
+[[ -f $CHANGED_MARKER ]]
+
+old_hash=$(cksum < "$TARGET_DIR/auth.json")
+if SOCIAL_MONITOR_TEST_RESULT=WRONG run_refresh >/dev/null 2>&1; then
+  echo 'invalid probe result was accepted' >&2
+  exit 1
+fi
+[[ $(cksum < "$TARGET_DIR/auth.json") == "$old_hash" ]]
+[[ -z $(find "$PROBE_TMP_ROOT" -mindepth 1 -maxdepth 1 -type d -name 'auth-probe.*' -print -quit) ]]
+
+if SOCIAL_MONITOR_TEST_ACCOUNTS='["../escape"]' run_refresh >/dev/null 2>&1; then
+  echo 'unsafe broker account path was accepted' >&2
+  exit 1
+fi
+[[ $(cksum < "$TARGET_DIR/auth.json") == "$old_hash" ]]
+
+if SOCIAL_MONITOR_TEST_ACCOUNTS='[]' run_refresh >/dev/null 2>&1; then
+  echo 'empty broker account pool was accepted' >&2
+  exit 1
+fi
+[[ $(cksum < "$TARGET_DIR/auth.json") == "$old_hash" ]]
+grep -F -- '--sandbox read-only' "$ENTRYPOINT" >/dev/null
+grep -F -- '--output-last-message' "$ENTRYPOINT" >/dev/null
+
+echo 'Subscription auth refresh tests passed'

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -90,6 +90,10 @@ verify_host_policy() {
     fail 'root deploy entrypoint ownership or mode is invalid'
   [[ $(stat -c '%U:%G:%a' "$CONTROL/github-production-deploy-wrapper.sh") == root:root:755 ]] || \
     fail 'SSH deploy wrapper ownership or mode is invalid'
+  if [[ -f $REPO/ops/deploy/host/refresh-codex-auth.sh ]]; then
+    [[ $(stat -c '%U:%G:%a' "$CONTROL/refresh-codex-auth.sh") == root:root:700 ]] || \
+      fail 'subscription auth refresh ownership or mode is invalid'
+  fi
   if id -nG social-monitor-deploy | tr ' ' '\n' | grep -qx docker; then
     fail 'deploy user must not belong to the docker group'
   fi
@@ -703,12 +707,18 @@ sync_control_script() {
   local destination=$CONTROL/github-production-deploy.sh
   local wrapper_source=$REPO/ops/deploy/social-monitor-production-ssh-wrapper.sh
   local wrapper_destination=$CONTROL/github-production-deploy-wrapper.sh
+  local auth_refresh_source=$REPO/ops/deploy/host/refresh-codex-auth.sh
+  local auth_refresh_destination=$CONTROL/refresh-codex-auth.sh
   [[ -f $source ]] || return 0
   install -m 0755 -o root -g root "$source" "$destination.next"
   mv -f "$destination.next" "$destination"
   if [[ -f $wrapper_source ]]; then
     install -m 0755 -o root -g root "$wrapper_source" "$wrapper_destination.next"
     mv -f "$wrapper_destination.next" "$wrapper_destination"
+  fi
+  if [[ -f $auth_refresh_source ]]; then
+    install -m 0700 -o root -g root "$auth_refresh_source" "$auth_refresh_destination.next"
+    mv -f "$auth_refresh_destination.next" "$auth_refresh_destination"
   fi
 }
 

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -90,10 +90,6 @@ verify_host_policy() {
     fail 'root deploy entrypoint ownership or mode is invalid'
   [[ $(stat -c '%U:%G:%a' "$CONTROL/github-production-deploy-wrapper.sh") == root:root:755 ]] || \
     fail 'SSH deploy wrapper ownership or mode is invalid'
-  if [[ -f $REPO/ops/deploy/host/refresh-codex-auth.sh ]]; then
-    [[ $(stat -c '%U:%G:%a' "$CONTROL/refresh-codex-auth.sh") == root:root:700 ]] || \
-      fail 'subscription auth refresh ownership or mode is invalid'
-  fi
   if id -nG social-monitor-deploy | tr ' ' '\n' | grep -qx docker; then
     fail 'deploy user must not belong to the docker group'
   fi
@@ -710,8 +706,6 @@ sync_control_script() {
   local auth_refresh_source=$REPO/ops/deploy/host/refresh-codex-auth.sh
   local auth_refresh_destination=$CONTROL/refresh-codex-auth.sh
   [[ -f $source ]] || return 0
-  install -m 0755 -o root -g root "$source" "$destination.next"
-  mv -f "$destination.next" "$destination"
   if [[ -f $wrapper_source ]]; then
     install -m 0755 -o root -g root "$wrapper_source" "$wrapper_destination.next"
     mv -f "$wrapper_destination.next" "$wrapper_destination"
@@ -719,7 +713,11 @@ sync_control_script() {
   if [[ -f $auth_refresh_source ]]; then
     install -m 0700 -o root -g root "$auth_refresh_source" "$auth_refresh_destination.next"
     mv -f "$auth_refresh_destination.next" "$auth_refresh_destination"
+    [[ $(stat -c '%U:%G:%a' "$auth_refresh_destination") == root:root:700 ]] || \
+      fail 'subscription auth refresh ownership or mode is invalid after sync'
   fi
+  install -m 0755 -o root -g root "$source" "$destination.next"
+  mv -f "$destination.next" "$destination"
 }
 
 deploy_release() {

--- a/ops/deploy/social-monitor-production-deploy.test.sh
+++ b/ops/deploy/social-monitor-production-deploy.test.sh
@@ -80,6 +80,16 @@ grep -F 'install -m 0700 -o root -g root "$auth_refresh_source" "$auth_refresh_d
 # shellcheck disable=SC2016
 grep -F 'mv -f "$auth_refresh_destination.next" "$auth_refresh_destination"' \
   "$ENTRYPOINT" >/dev/null
+# shellcheck disable=SC2016
+grep -F 'install -m 0755 -o root -g root "$source" "$destination.next"' \
+  "$ENTRYPOINT" >/dev/null
+# shellcheck disable=SC2016
+auth_sync_line=$(grep -nF 'install -m 0700 -o root -g root "$auth_refresh_source"' \
+  "$ENTRYPOINT" | cut -d: -f1)
+# shellcheck disable=SC2016
+entrypoint_sync_line=$(grep -nF 'install -m 0755 -o root -g root "$source"' \
+  "$ENTRYPOINT" | tail -1 | cut -d: -f1)
+((auth_sync_line < entrypoint_sync_line))
 
 RELEASE_FIXTURE=$FIXTURE/frontend-release
 install -d "$RELEASE_FIXTURE/public" "$RELEASE_FIXTURE/admin"

--- a/ops/deploy/social-monitor-production-deploy.test.sh
+++ b/ops/deploy/social-monitor-production-deploy.test.sh
@@ -73,6 +73,13 @@ grep -F "if [[ \$api_rolled_back == true ]]; then" "$ENTRYPOINT" >/dev/null
 grep -F 'refresh_frontend_api_proxy || return 1' \
   "$ENTRYPOINT" >/dev/null
 grep -F 'http://127.0.0.1:13080/auth/session' "$ENTRYPOINT" >/dev/null
+grep -F 'ops/deploy/host/refresh-codex-auth.sh' "$ENTRYPOINT" >/dev/null
+# shellcheck disable=SC2016
+grep -F 'install -m 0700 -o root -g root "$auth_refresh_source" "$auth_refresh_destination.next"' \
+  "$ENTRYPOINT" >/dev/null
+# shellcheck disable=SC2016
+grep -F 'mv -f "$auth_refresh_destination.next" "$auth_refresh_destination"' \
+  "$ENTRYPOINT" >/dev/null
 
 RELEASE_FIXTURE=$FIXTURE/frontend-release
 install -d "$RELEASE_FIXTURE/public" "$RELEASE_FIXTURE/admin"
@@ -99,3 +106,4 @@ if run_entrypoint upload "$TARGET_SHA" < "$FIXTURE/bad-frontend.tgz" >/dev/null 
 fi
 
 echo 'Production deploy contract tests passed'
+bash "$SCRIPT_DIR/refresh-codex-auth.test.sh"


### PR DESCRIPTION
## Summary
- move the production subscription-auth refresh into reviewed repo-owned control code
- avoid the broker live-check timeout while keeping an isolated fail-closed Codex auth probe
- add locking, atomic replacement, path confinement, cleanup, and sandbox contract tests

## Verification
- deploy contract tests
- bash syntax and shellcheck
- source line cap
- production secret boundary
- secret scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic refresh of isolated Codex authentication accounts, selecting and validating an available account before activation.
  * Added safe deployment and installation of the authentication refresh script with restrictive permissions.
* **Bug Fixes**
  * Prevented invalid, unsafe, or unavailable account data from replacing the active authentication configuration.
* **Tests**
  * Added end-to-end coverage for account rotation, failed probes, file permissions, cleanup, and path validation.
  * Expanded deployment and shell validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->