### PR TITLE
fix(evals): classify partial X runs correctly

### DIFF
--- a/scripts/check-yesterday-social-collection-quality.ts
+++ b/scripts/check-yesterday-social-collection-quality.ts
@@ -168,6 +168,10 @@ type Report = {
   };
   readonly operationalWarnings: {
     readonly xCollectorFailedRunCount: number;
+    readonly xCollectorPartialUsableRunCount: number;
+    readonly xCollectorHardFailedRunCount: number;
+    readonly xCollectorNonTerminalOrUnknownRunCount: number;
+    readonly xCollectorPartialUsableReturnedTweetCount: number;
     readonly xCollectorTaskFailureCount: number;
     readonly primarySourcesSplitAcrossInterests: boolean;
     readonly summaryArtifactMissing: boolean;
@@ -367,9 +371,18 @@ async function tryBuildReport(): Promise<Report | undefined> {
       xCollectorLedgerAvailable: xCollectorLedger.available,
       xCollectorRunCountAtLeast20: xCollectorLedger.runCount >= 20,
       xCollectorCompletedRunRateAtLeast94Percent:
-        xCollectorLedger.completedRunRate >= 0.94,
-      xCollectorFailedRunsReturnedNoTweets:
-        xCollectorLedger.failedReturnedTweetCount === 0,
+        runRateAtLeast(
+          xCollectorLedger.completedRunCount,
+          xCollectorLedger.runCount,
+          94,
+        ),
+      xCollectorUsableRunRateAtLeast94Percent: runRateAtLeast(
+        xCollectorLedger.usableRunCount,
+        xCollectorLedger.runCount,
+        94,
+      ),
+      xCollectorNoNonTerminalOrUnknownRuns:
+        xCollectorLedger.nonTerminalOrUnknownRunCount === 0,
       xCollectorLedgerJsonValid: xCollectorLedger.invalidJsonFieldCount === 0,
       xCollectorReturnedAtLeast500Tweets:
         xCollectorLedger.returnedTweetCount >= 500,
@@ -440,6 +453,13 @@ async function tryBuildReport(): Promise<Report | undefined> {
       summaryArtifactCoverage,
       operationalWarnings: {
         xCollectorFailedRunCount: xCollectorLedger.failedRunCount,
+        xCollectorPartialUsableRunCount:
+          xCollectorLedger.partialUsableRunCount,
+        xCollectorHardFailedRunCount: xCollectorLedger.hardFailedRunCount,
+        xCollectorNonTerminalOrUnknownRunCount:
+          xCollectorLedger.nonTerminalOrUnknownRunCount,
+        xCollectorPartialUsableReturnedTweetCount:
+          xCollectorLedger.partialUsableReturnedTweetCount,
         xCollectorTaskFailureCount: xCollectorLedger.taskFailureCount,
         primarySourcesSplitAcrossInterests:
           !primarySourcesCoLocatedInSingleInterest,
@@ -1069,6 +1089,17 @@ function providerFeedItemCountAtLeast(
   return (
     (reports.find((item) => item.providerKey === providerKey)
       ?.visibleFeedItemCount ?? 0) >= threshold
+  );
+}
+
+function runRateAtLeast(
+  acceptedRunCount: number,
+  totalRunCount: number,
+  thresholdPercent: number,
+): boolean {
+  return (
+    totalRunCount > 0 &&
+    acceptedRunCount * 100 >= totalRunCount * thresholdPercent
   );
 }
 

--- a/scripts/lib/x-collector-quality-report-support.spec.ts
+++ b/scripts/lib/x-collector-quality-report-support.spec.ts
@@ -286,6 +286,95 @@ describe("x collector quality report support", () => {
     }
   });
 
+  it("treats failed Scweet runs with collected tweets as usable partial runs", () => {
+    const directory = mkdtempSync(join(tmpdir(), "x-collector-quality-"));
+    const dbPath = join(directory, "scweet_state.db");
+
+    try {
+      execSql(
+        dbPath,
+        `
+          create table runs (
+            id integer primary key,
+            run_id text not null,
+            status text not null,
+            started_at real not null,
+            finished_at real,
+            query_hash text not null,
+            tweets_count integer not null,
+            input_json text,
+            stats_json text
+          );
+        `,
+      );
+      insertRun({
+        dbPath,
+        id: 1,
+        displayType: "Top",
+        startedAt: "2026-07-12T00:01:00Z",
+        finishedAt: "2026-07-12T00:02:00Z",
+        tweets: 20,
+        since: "2026-07-11",
+        until: "2026-07-12",
+      });
+      insertRun({
+        dbPath,
+        id: 2,
+        displayType: "Latest",
+        startedAt: "2026-07-12T00:02:00Z",
+        finishedAt: "2026-07-12T00:03:00Z",
+        tweets: 9,
+        since: "2026-07-11",
+        until: "2026-07-12",
+        status: "failed",
+      });
+      insertRun({
+        dbPath,
+        id: 4,
+        displayType: "Top",
+        startedAt: "2026-07-12T00:04:00Z",
+        finishedAt: "2026-07-12T00:05:00Z",
+        tweets: 99,
+        since: "2026-07-11",
+        until: "2026-07-12",
+        status: "running",
+      });
+      insertRun({
+        dbPath,
+        id: 3,
+        displayType: "Latest",
+        startedAt: "2026-07-12T00:03:00Z",
+        finishedAt: "2026-07-12T00:04:00Z",
+        tweets: 0,
+        since: "2026-07-11",
+        until: "2026-07-12",
+        status: "failed",
+      });
+
+      const ledger = buildXCollectorLedgerReport({
+        ledgerPath: dbPath,
+        collectionDate: "2026-07-11",
+      });
+
+      expect(ledger).toMatchObject({
+        runCount: 4,
+        completedRunCount: 1,
+        failedRunCount: 2,
+        partialUsableRunCount: 1,
+        partialUsableReturnedTweetCount: 9,
+        hardFailedRunCount: 1,
+        nonTerminalOrUnknownRunCount: 1,
+        usableRunCount: 2,
+        completedRunRate: 0.25,
+        usableRunRate: 0.5,
+        failedReturnedTweetCount: 9,
+        returnedTweetCount: 128,
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it("reports observed per-account budget limit profiles", () => {
     const directory = mkdtempSync(join(tmpdir(), "x-collector-quality-"));
     const dbPath = join(directory, "scweet_state.db");
@@ -406,7 +495,7 @@ function insertRun(params: {
   readonly tweets: number;
   readonly since?: string;
   readonly until?: string;
-  readonly status?: "completed" | "failed";
+  readonly status?: string;
 }): void {
   const input = JSON.stringify({
     since: params.since ?? "2026-07-07_00:00:00_UTC",

--- a/scripts/lib/x-collector-quality-report-support.ts
+++ b/scripts/lib/x-collector-quality-report-support.ts
@@ -99,6 +99,10 @@ export function buildXCollectorLedgerReport(params: BuildParams) {
   const invalidJsonFields: XCollectorJsonWarning[] = [];
   let completedRunCount = 0;
   let failedRunCount = 0;
+  let partialUsableRunCount = 0;
+  let partialUsableReturnedTweetCount = 0;
+  let hardFailedRunCount = 0;
+  let nonTerminalOrUnknownRunCount = 0;
   let failedReturnedTweetCount = 0;
   let returnedTweetCount = 0;
   let strictEngagementRunCount = 0;
@@ -126,13 +130,22 @@ export function buildXCollectorLedgerReport(params: BuildParams) {
     const minReplies = input?.min_replies ?? 0;
     const query = input?.search_query ?? "";
 
+    const tweetCount = normalizedTweetCount(row.tweets_count);
     if (row.status === "completed") {
       completedRunCount += 1;
-    } else {
+    } else if (row.status === "failed") {
       failedRunCount += 1;
-      failedReturnedTweetCount += row.tweets_count ?? 0;
+      failedReturnedTweetCount += tweetCount;
+      if (tweetCount > 0) {
+        partialUsableRunCount += 1;
+        partialUsableReturnedTweetCount += tweetCount;
+      } else {
+        hardFailedRunCount += 1;
+      }
+    } else {
+      nonTerminalOrUnknownRunCount += 1;
     }
-    returnedTweetCount += row.tweets_count ?? 0;
+    returnedTweetCount += tweetCount;
     if (row.query_hash !== undefined && row.query_hash.length > 0) {
       queryHashes.add(row.query_hash);
     }
@@ -164,8 +177,19 @@ export function buildXCollectorLedgerReport(params: BuildParams) {
     runCount: rows.length,
     completedRunCount,
     failedRunCount,
+    partialUsableRunCount,
+    partialUsableReturnedTweetCount,
+    hardFailedRunCount,
+    nonTerminalOrUnknownRunCount,
+    usableRunCount: completedRunCount + partialUsableRunCount,
     completedRunRate:
       rows.length === 0 ? 0 : roundMetric(completedRunCount / rows.length),
+    usableRunRate:
+      rows.length === 0
+        ? 0
+        : roundMetric(
+            (completedRunCount + partialUsableRunCount) / rows.length,
+          ),
     failedReturnedTweetCount,
     returnedTweetCount,
     distinctQueryHashCount: queryHashes.size,
@@ -285,7 +309,13 @@ function emptyXCollectorLedgerReport(
     runCount: 0,
     completedRunCount: 0,
     failedRunCount: 0,
+    partialUsableRunCount: 0,
+    partialUsableReturnedTweetCount: 0,
+    hardFailedRunCount: 0,
+    nonTerminalOrUnknownRunCount: 0,
+    usableRunCount: 0,
     completedRunRate: 0,
+    usableRunRate: 0,
     failedReturnedTweetCount: 0,
     returnedTweetCount: 0,
     distinctQueryHashCount: 0,
@@ -866,6 +896,12 @@ function fingerprint(value: string): string {
 
 function roundMetric(value: number): number {
   return Number(value.toFixed(3));
+}
+
+function normalizedTweetCount(value: number | undefined): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : 0;
 }
 
 function errorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary
- classify Scweet failed rows with collected tweets as explicit usable partial runs
- keep the strict 94% completed-run SLO and add an exact 94% usable-run SLO
- fail closed on non-terminal or unknown ledger statuses

## Why
Scweet 5.3 can return a SearchResult while recording the run as failed when one worker fails after other workers collected tweets. The old gate treated this valid partial state as impossible.

## Verification
- focused ledger tests: 4 passed
- architecture and source line cap passed
- full TypeScript build passed
- git diff --check passed