### PR TITLE
fix(summary): harden ranking quality gate

### DIFF
--- a/libs/summary/domain/policies/reader-summary-editorial-curation-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-editorial-curation-policy.ts
@@ -7,6 +7,9 @@ export type EditoriallyCuratedTopReadCandidate = TopReadCandidate & {
 export const readerSummaryEditorialCurationRule =
   "rule:reader-summary-model-curated";
 
+export const readerSummaryUnverifiedLegalSafetyDemotionRule =
+  "rule:reader-summary-unverified-legal-safety-demotion";
+
 export const withReaderSummaryEditorialCuration = (
   candidate: TopReadCandidate,
   editoriallyCurated: boolean,
@@ -26,6 +29,24 @@ export const readerSummaryEditorialCurationRules = (
 export const hasReaderSummaryEditorialCurationRule = (
   matchedRules: Pick<TopRead, "matchedRules">["matchedRules"],
 ): boolean => matchedRules.includes(readerSummaryEditorialCurationRule);
+
+export const readerSummaryUnverifiedLegalSafetyDemotionRules = (
+  builderConfirmed: boolean,
+): readonly string[] =>
+  builderConfirmed ? [readerSummaryUnverifiedLegalSafetyDemotionRule] : [];
+
+export const withoutReaderSummaryUnverifiedLegalSafetyDemotionRule = (
+  matchedRules: readonly string[],
+): readonly string[] =>
+  matchedRules.filter(
+    (rule) => rule !== readerSummaryUnverifiedLegalSafetyDemotionRule,
+  );
+
+export const hasReaderSummaryUnverifiedLegalSafetyDemotionRule = (
+  matchedRules: readonly string[] | undefined,
+): boolean =>
+  matchedRules?.includes(readerSummaryUnverifiedLegalSafetyDemotionRule) ===
+  true;
 
 const isReaderSummaryEditoriallyCuratedCandidate = (
   candidate: TopReadCandidate,

--- a/libs/summary/domain/services/reader-summary-top-read-builder-source-lineage.spec.ts
+++ b/libs/summary/domain/services/reader-summary-top-read-builder-source-lineage.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "./reader-summary-top-read-builder";
 import {
   readerSummaryEditorialCurationRule,
+  readerSummaryUnverifiedLegalSafetyDemotionRule,
   withReaderSummaryEditorialCuration,
 } from "../policies/reader-summary-editorial-curation-policy";
 
@@ -53,6 +54,12 @@ describe("reader summary top read source lineage", () => {
       "Reports say Apple sued OpenAI over alleged trade secret theft",
     );
     expect(topRead.reason).not.toMatch(/Hacker News|RSS/u);
+    expect(topRead.matchedRules).toContain(
+      readerSummaryUnverifiedLegalSafetyDemotionRule,
+    );
+    expect(topRead.matchedRules).not.toContain(
+      readerSummaryEditorialCurationRule,
+    );
   });
 
   it("persists editorial curation provenance as a non-public matched rule", () => {
@@ -66,7 +73,12 @@ describe("reader summary top read source lineage", () => {
       citationIds: ["citation-reddit"],
     };
     const story = withReaderSummaryEditorialCuration(baseStory, true);
-    const evidence = redditEvidence();
+    const evidence = redditEvidence({
+      feedItemId: "feed-reddit-comparison",
+      sourceItemId: "source-reddit-comparison",
+      canonicalUrl: "https://reddit.com/r/ai/cost-comparison",
+      title: "Coding-agent cost comparison across two harnesses",
+    });
     const cluster = storyCluster(story, evidence);
     const citation: ReaderSummaryCitation = {
       citationId: "citation-reddit",
@@ -89,10 +101,58 @@ describe("reader summary top read source lineage", () => {
     );
 
     expect(topRead.matchedRules).toContain(readerSummaryEditorialCurationRule);
+    expect(topRead.matchedRules).not.toContain(
+      readerSummaryUnverifiedLegalSafetyDemotionRule,
+    );
+  });
+
+  it("rejects an inherited safety marker without builder confirmation", () => {
+    const story: TopReadCandidate = {
+      storyClusterId: "story:ordinary-comparison",
+      title: "Developers compare coding-agent costs",
+      summary:
+        "A detailed discussion compares two coding-agent workflows and their cost trade-offs for engineering teams.",
+      interestIds: ["ai-agents"],
+      providerKeys: ["reddit"],
+      citationIds: ["citation-reddit"],
+    };
+    const evidence = redditEvidence({
+      feedItemId: "feed-reddit-ordinary",
+      sourceItemId: "source-reddit-ordinary",
+      canonicalUrl: "https://reddit.com/r/ai/ordinary-comparison",
+      title: "Developers compare coding-agent costs",
+      matchedRules: [readerSummaryUnverifiedLegalSafetyDemotionRule],
+    });
+    const cluster = storyCluster(story, evidence);
+    const citation: ReaderSummaryCitation = {
+      citationId: "citation-reddit",
+      feedItemId: evidence.feedItemId,
+      sourceItemId: evidence.sourceItemId,
+      providerKey: evidence.providerKey,
+      field: "title",
+      canonicalUrl: evidence.canonicalUrl,
+    };
+    const evidenceByFeedItemId = new Map([
+      [evidence.feedItemId, evidence] as const,
+    ]);
+
+    const topRead = storyToTopRead(
+      story,
+      new Map([[citation.citationId, citation]]),
+      evidenceByFeedItemId,
+      new Map([[cluster.id, cluster]]),
+      evidenceClusterMap([cluster], evidenceByFeedItemId),
+    );
+
+    expect(topRead.matchedRules).not.toContain(
+      readerSummaryUnverifiedLegalSafetyDemotionRule,
+    );
   });
 });
 
-const redditEvidence = (): SummaryEvidenceItem => ({
+const redditEvidence = (
+  overrides: Partial<SummaryEvidenceItem> = {},
+): SummaryEvidenceItem => ({
   feedItemId: "feed-reddit-lawsuit",
   sourceItemId: "source-reddit-lawsuit",
   sourceBindingId: "binding-ai",
@@ -106,6 +166,7 @@ const redditEvidence = (): SummaryEvidenceItem => ({
   observedAt: new Date("2026-07-12T09:05:00.000Z"),
   score: 2.4,
   whyImportant: [],
+  ...overrides,
 });
 
 const storyCluster = (

--- a/libs/summary/domain/services/reader-summary-top-read-builder.ts
+++ b/libs/summary/domain/services/reader-summary-top-read-builder.ts
@@ -14,7 +14,10 @@ import {
   readerItemConfidence,
   storyProviderMetricLabels,
 } from "./reader-summary-support";
-import { groundedTopReadTitle } from "./reader-summary-headline-policy";
+import {
+  groundedTopReadTitle,
+  isUnverifiedLegalTopRead,
+} from "./reader-summary-headline-policy";
 import {
   buildMatchedRules,
   buildWhyNow,
@@ -23,7 +26,11 @@ import {
 import { isTopReadEligibleEvidence } from "../policies/top-read-eligibility-policy";
 import { hasFirstPartyOfficialEvidence } from "../policies/reader-summary-source-authority-policy";
 import { compareRepresentativeEvidenceItems } from "../policies/representative-evidence-selection-policy";
-import { readerSummaryEditorialCurationRules } from "../policies/reader-summary-editorial-curation-policy";
+import {
+  readerSummaryEditorialCurationRules,
+  readerSummaryUnverifiedLegalSafetyDemotionRules,
+  withoutReaderSummaryUnverifiedLegalSafetyDemotionRule,
+} from "../policies/reader-summary-editorial-curation-policy";
 import {
   isFallbackReaderReason,
   isReaderTitleReasonDuplicate,
@@ -181,6 +188,13 @@ export const storyToTopRead = (
     whyImportant,
     confidence,
   });
+  const builderConfirmedUnverifiedLegalSafetyDemotion =
+    isUnverifiedLegalTopRead({
+      title,
+      reason,
+      whyImportant,
+      confidence,
+    });
 
   return {
     title,
@@ -191,12 +205,17 @@ export const storyToTopRead = (
     matchedInterestIds:
       matchedInterestIds.length > 0 ? matchedInterestIds : ["unknown-interest"],
     matchedRules: compactUnique([
-      ...buildMatchedRules(
-        supportEvidence,
-        matchedInterestIds,
-        readerProviderKey,
+      ...withoutReaderSummaryUnverifiedLegalSafetyDemotionRule(
+        buildMatchedRules(
+          supportEvidence,
+          matchedInterestIds,
+          readerProviderKey,
+        ),
       ),
       ...readerSummaryEditorialCurationRules(story),
+      ...readerSummaryUnverifiedLegalSafetyDemotionRules(
+        builderConfirmedUnverifiedLegalSafetyDemotion,
+      ),
     ]),
     signalScore,
     confidence,

--- a/scripts/check-reader-summary-quality-dashboard.ts
+++ b/scripts/check-reader-summary-quality-dashboard.ts
@@ -19,6 +19,7 @@ import {
 } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-records";
 import {
   presentReaderSummaryArtifact,
+  readerSummaryContentForArtifact,
   type ReaderSummaryArtifactView,
 } from "@social-monitor/summary/features/shared/reader-summary-artifact-presenter";
 
@@ -521,14 +522,22 @@ async function buildDayReport(
     scope,
     collectionDate,
   );
-  const view =
+  const artifact =
     artifactRecord === null
       ? undefined
+      : readerSummaryArtifactFromPrisma(artifactRecord);
+  const view =
+    artifact === undefined
+      ? undefined
       : presentReaderSummaryArtifact(
-          readerSummaryArtifactFromPrisma(artifactRecord),
+          artifact,
           { status: "fresh", checkedAt: new Date() },
           { collectedCoverage },
         );
+  const domainContent =
+    artifact === undefined
+      ? undefined
+      : readerSummaryContentForArtifact(artifact);
   const providerCounts = countBy(feedItems, (item) => item.providerKey);
   const strategy = await buildCollectionStrategy({
     pool,
@@ -544,7 +553,10 @@ async function buildDayReport(
     feedItems,
   });
   const summary = buildSummaryMetrics(view, artifactRecord);
-  const topReadQuality = buildTopReadQuality(view);
+  const topReadQuality = buildTopReadQuality(
+    view,
+    domainContent?.topReads,
+  );
   const feed = {
     collectedFeedItemCount: feedItems.length,
     providerCounts,
@@ -786,6 +798,9 @@ function buildSummaryMetrics(
 
 function buildTopReadQuality(
   view: ReaderSummaryArtifactView | undefined,
+  persistedTopReads:
+    | ReturnType<typeof readerSummaryContentForArtifact>["topReads"]
+    | undefined,
 ): TopReadQualityReport {
   if (view === undefined) {
     return {
@@ -852,6 +867,7 @@ function buildTopReadQuality(
     weakTopReadOutrankingStrongSocialRows({
       rows,
       topReads: view.content.topReads,
+      persistedTopReads,
     }).length;
 
   return {

--- a/scripts/check-reader-summary-top-read-ranking.ts
+++ b/scripts/check-reader-summary-top-read-ranking.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname } from "node:path";
 
 import { Pool } from "pg";
@@ -12,7 +19,10 @@ import {
   isFallbackReaderReason,
   isUnpolishedReaderTitle,
 } from "@social-monitor/summary/domain/policies/reader-summary-reader-facing-text-policy";
-import { presentReaderSummaryArtifact } from "@social-monitor/summary/features/shared/reader-summary-artifact-presenter";
+import {
+  presentReaderSummaryArtifact,
+  readerSummaryContentForArtifact,
+} from "@social-monitor/summary/features/shared/reader-summary-artifact-presenter";
 import { readerSummaryProviderIdentity } from "@social-monitor/summary/domain/value-objects/reader-summary-provider-identity";
 
 import {
@@ -89,16 +99,25 @@ type SignalInversion = {
   readonly laterFingerprint: string;
 };
 
+export type AtomicTopReadRankingReportOperations = {
+  readonly makeDirectory: (path: string) => void;
+  readonly writeFile: (path: string, value: string) => void;
+  readonly renameFile: (sourcePath: string, targetPath: string) => void;
+  readonly removeFile: (path: string) => void;
+};
+
 const outputPath = "ops/evals/reader-summary-top-read-ranking.v1.json";
 const update = process.argv.includes("--update");
+const writeFailedReport = process.argv.includes("--write-failed-report");
 const artifactOnly = process.argv.includes("--artifact-only");
 const { collectionDate } = collectionDateOptionOrDefault(previousUtcDate());
-const databaseUrl = yesterdaySocialQualityDatabaseUrl();
 const materialSignalGap = 0.3;
 const supportExplanationMargin = 0.4;
 const configuredTopReadLimit = 10;
 
-void main();
+if (require.main === module) {
+  void main();
+}
 
 async function main(): Promise<void> {
   if (artifactOnly) {
@@ -120,12 +139,18 @@ async function main(): Promise<void> {
   const serialized = `${JSON.stringify(report, null, 2)}\n`;
   if (!report.blockingPassed) {
     console.error(serialized);
-    throw new Error("Reader summary top-read ranking gates failed");
+    failTopReadRankingReport({
+      update,
+      writeFailedReport,
+      persistFailedReport: () => {
+        writeSanitizedReportAtomically(report, serialized);
+        console.log(`Updated failed report ${outputPath}`);
+      },
+    });
   }
 
   if (update) {
-    mkdirSync(dirname(outputPath), { recursive: true });
-    writeFileSync(outputPath, serialized);
+    writeSanitizedReportAtomically(report, serialized);
     console.log(`Updated ${outputPath}`);
     return;
   }
@@ -147,8 +172,9 @@ async function main(): Promise<void> {
 }
 
 async function tryBuildReport(): Promise<TopReadRankingReport | undefined> {
+  const databaseUrl = yesterdaySocialQualityDatabaseUrl();
   let fallbackError: unknown;
-  for (const candidateUrl of candidateDatabaseUrls()) {
+  for (const candidateUrl of candidateDatabaseUrls(databaseUrl)) {
     try {
       return await buildReportFromDatabase(candidateUrl);
     } catch (error) {
@@ -194,12 +220,14 @@ async function buildReportFromDatabase(
       );
     }
 
+    const artifact = readerSummaryArtifactFromPrisma(record);
     const view = presentReaderSummaryArtifact(
-      readerSummaryArtifactFromPrisma(record),
+      artifact,
       { status: "fresh", checkedAt: new Date() },
     );
-    const topReads = view.content.topReads;
-    const selectedPosts = view.content.selectedPosts;
+    const domainContent = readerSummaryContentForArtifact(artifact);
+    const topReads = domainContent.topReads;
+    const selectedPosts = domainContent.selectedPosts ?? domainContent.topReads;
     const providerCounts = topReadProviderCounts(topReads);
     const dominantProviderTopReadCount = Math.max(
       0,
@@ -343,7 +371,7 @@ async function buildReportFromDatabase(
   }
 }
 
-function candidateDatabaseUrls(): readonly string[] {
+function candidateDatabaseUrls(databaseUrl: string): readonly string[] {
   return [...new Set([databaseUrl, defaultYesterdaySocialQualityDatabaseUrl])];
 }
 
@@ -400,6 +428,8 @@ function unexplainedMaterialSignalInversions(
         inversion.laterSupportScore &&
       !isEditorialSafetyExplainedLeadInversion({
         earlierRank: inversion.earlierRank,
+        laterRank: inversion.laterRank,
+        earlier: topReads[inversion.earlierRank - 1],
         later: topReads[inversion.laterRank - 1],
       }),
   );
@@ -460,13 +490,73 @@ function isPublishedInsideWindow(
   startInclusive: string,
   endExclusive: string,
 ): boolean {
-  const publishedAt = item.publishedAt;
-  if (publishedAt === undefined) {
+  const publishedAt =
+    item.publishedAt instanceof Date
+      ? item.publishedAt.toISOString()
+      : item.publishedAt;
+  if (publishedAt === undefined || publishedAt.trim().length === 0) {
     return false;
   }
 
   return publishedAt >= startInclusive && publishedAt < endExclusive;
 }
+
+export const shouldPersistFailedTopReadRankingReport = (params: {
+  readonly update: boolean;
+  readonly writeFailedReport: boolean;
+}): boolean => params.update && params.writeFailedReport;
+
+export function failTopReadRankingReport(params: {
+  readonly update: boolean;
+  readonly writeFailedReport: boolean;
+  readonly persistFailedReport: () => void;
+}): never {
+  if (shouldPersistFailedTopReadRankingReport(params)) {
+    params.persistFailedReport();
+  }
+
+  throw new Error("Reader summary top-read ranking gates failed");
+}
+
+function writeSanitizedReportAtomically(
+  report: TopReadRankingReport,
+  serialized: string,
+): void {
+  if (
+    report.model.rawPostTextPersistedInReport !== false ||
+    !noRawSecretFragments(report)
+  ) {
+    throw new Error(
+      "Reader summary top-read ranking report failed sanitization; refusing to persist it.",
+    );
+  }
+
+  writeTopReadRankingReportAtomically({ outputPath, serialized });
+}
+
+export function writeTopReadRankingReportAtomically(params: {
+  readonly outputPath: string;
+  readonly serialized: string;
+  readonly operations?: AtomicTopReadRankingReportOperations;
+}): void {
+  const operations = params.operations ?? defaultAtomicReportOperations;
+  operations.makeDirectory(dirname(params.outputPath));
+  const temporaryPath = `${params.outputPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    operations.writeFile(temporaryPath, params.serialized);
+    operations.renameFile(temporaryPath, params.outputPath);
+  } finally {
+    operations.removeFile(temporaryPath);
+  }
+}
+
+const defaultAtomicReportOperations: AtomicTopReadRankingReportOperations = {
+  makeDirectory: (path) => mkdirSync(path, { recursive: true }),
+  writeFile: (path, value) => writeFileSync(path, value, { flag: "wx" }),
+  renameFile: (sourcePath, targetPath) =>
+    renameSync(sourcePath, targetPath),
+  removeFile: (path) => rmSync(path, { force: true }),
+};
 
 function rounded(value: number): number {
   return Number(value.toFixed(3));

--- a/scripts/lib/reader-summary-ranking-audit.spec.ts
+++ b/scripts/lib/reader-summary-ranking-audit.spec.ts
@@ -1,4 +1,16 @@
 import {
+  readerSummaryEditorialCurationRule,
+  readerSummaryUnverifiedLegalSafetyDemotionRule,
+} from "@social-monitor/summary/domain/policies/reader-summary-editorial-curation-policy";
+import { publicReaderSummaryMatchedRules } from "@social-monitor/summary/features/shared/reader-summary-artifact-presenter";
+
+import {
+  type AtomicTopReadRankingReportOperations,
+  failTopReadRankingReport,
+  writeTopReadRankingReportAtomically,
+} from "../check-reader-summary-top-read-ranking";
+
+import {
   type RankingAuditTopRead,
   isEditorialSafetyExplainedLeadInversion,
   materialSameProviderMissedCandidates,
@@ -110,7 +122,12 @@ describe("reader summary ranking audit", () => {
     ).toHaveLength(0);
   });
 
-  it("explains a lead inversion when the stronger story is unverified legal reporting", () => {
+  it("rejects forged legal wording without the builder safety marker", () => {
+    const safeLead = item({
+      title: "Claude Code token overhead compared with OpenCode",
+      providerKey: "hacker-news",
+      signalScore: 2.2,
+    });
     const legalReport = item({
       title: "Reports say Apple sued OpenAI over alleged trade secret theft",
       providerKey: "reddit",
@@ -121,15 +138,178 @@ describe("reader summary ranking audit", () => {
     expect(
       isEditorialSafetyExplainedLeadInversion({
         earlierRank: 1,
-        later: legalReport,
-      }),
-    ).toBe(true);
-    expect(
-      isEditorialSafetyExplainedLeadInversion({
-        earlierRank: 2,
+        laterRank: 2,
+        earlier: safeLead,
         later: legalReport,
       }),
     ).toBe(false);
+  });
+
+  it("accepts only the marker on the stronger later safety-demoted candidate", () => {
+    const safeLead = item({
+      title: "Claude Code token overhead compared with OpenCode",
+      providerKey: "hacker-news",
+      signalScore: 2.2,
+    });
+    const safetyDemotedLegalReport = item({
+      title: "Reports say Apple sued OpenAI over alleged trade secret theft",
+      providerKey: "reddit",
+      signalScore: 2.9,
+      matchedRules: [readerSummaryUnverifiedLegalSafetyDemotionRule],
+    });
+
+    expect(
+      isEditorialSafetyExplainedLeadInversion({
+        earlierRank: 1,
+        laterRank: 2,
+        earlier: safeLead,
+        later: safetyDemotedLegalReport,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat generic editorial provenance as a safety demotion", () => {
+    const safeLead = item({
+      title: "Claude Code token overhead compared with OpenCode",
+      providerKey: "hacker-news",
+      signalScore: 2.2,
+    });
+    const curatedRead = item({
+      title: "Developers compare coding-agent costs",
+      providerKey: "reddit",
+      signalScore: 2.9,
+      matchedRules: [readerSummaryEditorialCurationRule],
+    });
+
+    expect(
+      isEditorialSafetyExplainedLeadInversion({
+        earlierRank: 1,
+        laterRank: 2,
+        earlier: safeLead,
+        later: curatedRead,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects the safety marker in the wrong direction, rank, or strength", () => {
+    const markedLead = item({
+      title: "Marked first read",
+      providerKey: "reddit",
+      signalScore: 2.9,
+      matchedRules: [readerSummaryUnverifiedLegalSafetyDemotionRule],
+    });
+    const ordinaryLaterRead = item({
+      title: "Ordinary later read",
+      providerKey: "hacker-news",
+      signalScore: 3.2,
+    });
+    const markedWeakerLaterRead = item({
+      title: "Marked weaker later read",
+      providerKey: "reddit",
+      signalScore: 1.9,
+      matchedRules: [readerSummaryUnverifiedLegalSafetyDemotionRule],
+    });
+
+    expect(
+      isEditorialSafetyExplainedLeadInversion({
+        earlierRank: 1,
+        laterRank: 2,
+        earlier: markedLead,
+        later: ordinaryLaterRead,
+      }),
+    ).toBe(false);
+    expect(
+      isEditorialSafetyExplainedLeadInversion({
+        earlierRank: 2,
+        laterRank: 3,
+        earlier: ordinaryLaterRead,
+        later: markedLead,
+      }),
+    ).toBe(false);
+    expect(
+      isEditorialSafetyExplainedLeadInversion({
+        earlierRank: 1,
+        laterRank: 2,
+        earlier: markedLead,
+        later: markedWeakerLaterRead,
+      }),
+    ).toBe(false);
+  });
+
+  it("strips the reserved safety marker from public reader content", () => {
+    expect(
+      publicReaderSummaryMatchedRules([
+        readerSummaryUnverifiedLegalSafetyDemotionRule,
+        readerSummaryEditorialCurationRule,
+        "reader-visible-topic",
+      ]),
+    ).toEqual(["reader-visible-topic"]);
+  });
+});
+
+describe("reader summary top-read ranking failed-report CLI", () => {
+  it.each([
+    { label: "neither flag", update: false, writeFailedReport: false },
+    { label: "--update only", update: true, writeFailedReport: false },
+    { label: "--write-failed-report only", update: false, writeFailedReport: true },
+  ])("does not write a failed report with $label", (flags) => {
+    const persistFailedReport = jest.fn();
+
+    expect(() =>
+      failTopReadRankingReport({ ...flags, persistFailedReport }),
+    ).toThrow("Reader summary top-read ranking gates failed");
+    expect(persistFailedReport).not.toHaveBeenCalled();
+  });
+
+  it("writes with both flags and still fails the ranking gate", () => {
+    const persistFailedReport = jest.fn();
+
+    expect(() =>
+      failTopReadRankingReport({
+        update: true,
+        writeFailedReport: true,
+        persistFailedReport,
+      }),
+    ).toThrow("Reader summary top-read ranking gates failed");
+    expect(persistFailedReport).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates temporary-write errors and does not rename", () => {
+    const writeError = new Error("temporary write failed");
+    const operations = atomicOperations({
+      writeFile: jest.fn(() => {
+        throw writeError;
+      }),
+    });
+
+    expect(() =>
+      writeTopReadRankingReportAtomically({
+        outputPath: "ops/evals/test-report.json",
+        serialized: "{}\n",
+        operations,
+      }),
+    ).toThrow(writeError);
+    expect(operations.renameFile).not.toHaveBeenCalled();
+    expect(operations.removeFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates rename errors and removes the temporary file", () => {
+    const renameError = new Error("rename failed");
+    const operations = atomicOperations({
+      renameFile: jest.fn(() => {
+        throw renameError;
+      }),
+    });
+
+    expect(() =>
+      writeTopReadRankingReportAtomically({
+        outputPath: "ops/evals/test-report.json",
+        serialized: "{}\n",
+        operations,
+      }),
+    ).toThrow(renameError);
+    expect(operations.writeFile).toHaveBeenCalledTimes(1);
+    expect(operations.removeFile).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -144,6 +324,18 @@ function item(
     confidence: { level: "medium" },
     confirmedProviderKeys: [overrides.providerKey],
     citationIds: [],
+    ...overrides,
+  };
+}
+
+function atomicOperations(
+  overrides: Partial<AtomicTopReadRankingReportOperations> = {},
+): AtomicTopReadRankingReportOperations {
+  return {
+    makeDirectory: jest.fn(),
+    writeFile: jest.fn(),
+    renameFile: jest.fn(),
+    removeFile: jest.fn(),
     ...overrides,
   };
 }

--- a/scripts/lib/reader-summary-ranking-audit.ts
+++ b/scripts/lib/reader-summary-ranking-audit.ts
@@ -1,5 +1,5 @@
 import { fingerprint } from "./yesterday-social-replay-support";
-import { isUnverifiedLegalTopRead } from "@social-monitor/summary/domain/services/reader-summary-headline-policy";
+import { hasReaderSummaryUnverifiedLegalSafetyDemotionRule } from "@social-monitor/summary/domain/policies/reader-summary-editorial-curation-policy";
 
 export type RankingAuditTopRead = {
   readonly title: string;
@@ -13,7 +13,7 @@ export type RankingAuditTopRead = {
   readonly reason?: string;
   readonly whyImportant?: readonly string[];
   readonly matchedRules?: readonly string[];
-  readonly publishedAt?: string;
+  readonly publishedAt?: string | Date;
   readonly canonicalUrl?: string;
 };
 
@@ -126,23 +126,35 @@ export function rankingSupportScore(item: RankingAuditTopRead): number {
 }
 
 export function rankingItemFingerprint(item: RankingAuditTopRead): string {
+  const publishedAt =
+    item.publishedAt instanceof Date
+      ? item.publishedAt.toISOString()
+      : (item.publishedAt ?? "");
+
   return fingerprint(
     [
       item.providerKey,
       item.canonicalUrl ?? "",
       item.title,
-      item.publishedAt ?? "",
+      publishedAt,
     ].join("|"),
   );
 }
 
 export const isEditorialSafetyExplainedLeadInversion = (params: {
   readonly earlierRank: number;
+  readonly laterRank: number;
+  readonly earlier: RankingAuditTopRead | undefined;
   readonly later: RankingAuditTopRead | undefined;
 }): boolean =>
   params.earlierRank === 1 &&
+  params.laterRank > params.earlierRank &&
+  params.earlier !== undefined &&
   params.later !== undefined &&
-  isUnverifiedLegalTopRead(params.later);
+  params.later.signalScore > params.earlier.signalScore &&
+  hasReaderSummaryUnverifiedLegalSafetyDemotionRule(
+    params.later.matchedRules,
+  );
 
 const groupByProvider = (
   items: readonly RankingAuditTopRead[],

--- a/scripts/lib/reader-summary-top-read-order-audit.spec.ts
+++ b/scripts/lib/reader-summary-top-read-order-audit.spec.ts
@@ -1,4 +1,9 @@
 import {
+  readerSummaryEditorialCurationRule,
+  readerSummaryUnverifiedLegalSafetyDemotionRule,
+} from "@social-monitor/summary/domain/policies/reader-summary-editorial-curation-policy";
+
+import {
   type TopReadOrderAuditRow,
   weakTopReadOutrankingStrongSocialRows,
 } from "./reader-summary-top-read-order-audit";
@@ -6,6 +11,57 @@ import type { RankingAuditTopRead } from "./reader-summary-ranking-audit";
 
 describe("reader summary top-read order audit", () => {
   it("does not penalize a safe lead placed above unverified legal reporting", () => {
+    const rows = [
+      row(1, "hacker-news", 2.2, "low"),
+      row(2, "reddit", 2.96, "medium"),
+    ];
+    const persistedTopReads = [
+      read("Claude Code token overhead compared with OpenCode", "hacker-news"),
+      read(
+        "Reports say Apple sued OpenAI over alleged trade secret theft",
+        "reddit",
+        "The evidence does not include a primary court filing.",
+        [readerSummaryUnverifiedLegalSafetyDemotionRule],
+      ),
+    ];
+    const topReads = persistedTopReads.map((read) => ({
+      ...read,
+      matchedRules: [],
+    }));
+
+    expect(
+      weakTopReadOutrankingStrongSocialRows({
+        rows,
+        topReads,
+        persistedTopReads,
+      }),
+    ).toHaveLength(0);
+  });
+
+  it("fails closed on a marker forged through the public-only channel", () => {
+    const rows = [
+      row(1, "hacker-news", 2.2, "low"),
+      row(2, "reddit", 2.96, "medium"),
+    ];
+    const publicTopReads = [
+      read("Claude Code token overhead compared with OpenCode", "hacker-news"),
+      read(
+        "Reports say Apple sued OpenAI over alleged trade secret theft",
+        "reddit",
+        "The evidence does not include a primary court filing.",
+        [readerSummaryUnverifiedLegalSafetyDemotionRule],
+      ),
+    ];
+
+    expect(
+      weakTopReadOutrankingStrongSocialRows({
+        rows,
+        topReads: publicTopReads,
+      }),
+    ).toEqual([rows[0]]);
+  });
+
+  it("rejects forged legal wording without the builder safety marker", () => {
     const rows = [
       row(1, "hacker-news", 2.2, "low"),
       row(2, "reddit", 2.96, "medium"),
@@ -20,22 +76,59 @@ describe("reader summary top-read order audit", () => {
     ];
 
     expect(
-      weakTopReadOutrankingStrongSocialRows({ rows, topReads }),
-    ).toHaveLength(0);
+      weakTopReadOutrankingStrongSocialRows({
+        rows,
+        topReads,
+        persistedTopReads: topReads,
+      }),
+    ).toHaveLength(1);
   });
 
-  it("still rejects an unexplained weak read above a stronger social read", () => {
+  it("does not accept generic editorial provenance as safety demotion", () => {
     const rows = [
       row(1, "hacker-news", 2.2, "low"),
       row(2, "reddit", 2.96, "medium"),
     ];
     const topReads = [
       read("Claude Code token overhead compared with OpenCode", "hacker-news"),
-      read("Developers compare coding agent costs", "reddit"),
+      read(
+        "Developers compare coding agent costs",
+        "reddit",
+        "Detailed source-backed reason.",
+        [readerSummaryEditorialCurationRule],
+      ),
     ];
 
     expect(
-      weakTopReadOutrankingStrongSocialRows({ rows, topReads }),
+      weakTopReadOutrankingStrongSocialRows({
+        rows,
+        topReads,
+        persistedTopReads: topReads,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("rejects the safety marker when it points in the wrong direction", () => {
+    const rows = [
+      row(1, "hacker-news", 2.2, "low"),
+      row(2, "reddit", 2.96, "medium"),
+    ];
+    const topReads = [
+      read(
+        "Marked weak lead",
+        "hacker-news",
+        "Detailed source-backed reason.",
+        [readerSummaryUnverifiedLegalSafetyDemotionRule],
+      ),
+      read("Stronger later discussion", "reddit"),
+    ];
+
+    expect(
+      weakTopReadOutrankingStrongSocialRows({
+        rows,
+        topReads,
+        persistedTopReads: topReads,
+      }),
     ).toHaveLength(1);
   });
 
@@ -52,12 +145,60 @@ describe("reader summary top-read order audit", () => {
         "Reports say Apple sued OpenAI over alleged trade secret theft",
         "reddit",
         "The evidence does not include a primary court filing.",
+        [readerSummaryUnverifiedLegalSafetyDemotionRule],
       ),
     ];
 
-    expect(weakTopReadOutrankingStrongSocialRows({ rows, topReads })).toEqual([
-      rows[1],
-    ]);
+    expect(
+      weakTopReadOutrankingStrongSocialRows({
+        rows,
+        topReads,
+        persistedTopReads: topReads,
+      }),
+    ).toEqual([rows[1]]);
+  });
+
+  it("uses explicit row indexes when audit rows arrive reordered", () => {
+    const rows = [
+      row(2, "reddit", 2.96, "medium"),
+      row(1, "hacker-news", 2.2, "low"),
+    ];
+    const topReads = [
+      read("Weak first read", "hacker-news"),
+      read("Stronger later discussion", "reddit"),
+    ];
+
+    expect(
+      weakTopReadOutrankingStrongSocialRows({
+        rows,
+        topReads,
+        persistedTopReads: topReads,
+      }),
+    ).toEqual([rows[1]]);
+  });
+
+  it("fails closed when a sparse candidate index has no persisted read", () => {
+    const rows = [
+      row(1, "hacker-news", 2.2, "low"),
+      row(3, "reddit", 2.96, "medium"),
+    ];
+    const topReads = [
+      read("Weak first read", "hacker-news"),
+      read(
+        "Unrelated second read carrying a marker",
+        "rss",
+        "Detailed source-backed reason.",
+        [readerSummaryUnverifiedLegalSafetyDemotionRule],
+      ),
+    ];
+
+    expect(
+      weakTopReadOutrankingStrongSocialRows({
+        rows,
+        topReads,
+        persistedTopReads: topReads,
+      }),
+    ).toEqual([rows[0]]);
   });
 });
 
@@ -81,6 +222,7 @@ const read = (
   title: string,
   providerKey: string,
   reason = "Detailed source-backed reason.",
+  matchedRules: readonly string[] = [],
 ): RankingAuditTopRead => ({
   title,
   providerKey,
@@ -89,4 +231,5 @@ const read = (
   confidence: { level: "medium" },
   confirmedProviderKeys: [providerKey],
   citationIds: ["c1"],
+  matchedRules,
 });

--- a/scripts/lib/reader-summary-top-read-order-audit.ts
+++ b/scripts/lib/reader-summary-top-read-order-audit.ts
@@ -1,4 +1,4 @@
-import { isUnverifiedLegalTopRead } from "@social-monitor/summary/domain/services/reader-summary-headline-policy";
+import { hasReaderSummaryUnverifiedLegalSafetyDemotionRule } from "@social-monitor/summary/domain/policies/reader-summary-editorial-curation-policy";
 import type { RankingAuditTopRead } from "./reader-summary-ranking-audit";
 
 export type TopReadOrderAuditRow = {
@@ -15,20 +15,48 @@ export type TopReadOrderAuditRow = {
 export const weakTopReadOutrankingStrongSocialRows = (params: {
   readonly rows: readonly TopReadOrderAuditRow[];
   readonly topReads: readonly RankingAuditTopRead[];
+  readonly persistedTopReads?: readonly RankingAuditTopRead[];
 }): readonly TopReadOrderAuditRow[] =>
-  params.rows.filter((row, index) => {
+  params.rows.filter((row) => {
     if (!isWeakTopReadWithoutClearReason(row)) {
       return false;
     }
 
-    return params.rows.slice(index + 1).some((candidate) =>
-      isStrongSocialReadBelowWeakRead({
-        candidate,
-        candidateRead: params.topReads[candidate.index - 1],
-        weakRow: row,
-      }),
+    return params.rows.some(
+      (candidate) =>
+        candidate.index > row.index &&
+        isStrongSocialReadBelowWeakRead({
+          candidate,
+          candidateRank: candidate.index,
+          candidateRead: alignedPersistedTopRead({
+            candidate,
+            persistedRead: params.persistedTopReads?.[candidate.index - 1],
+            presentedRead: params.topReads[candidate.index - 1],
+          }),
+          weakRank: row.index,
+          weakRow: row,
+        }),
     );
   });
+
+const alignedPersistedTopRead = (params: {
+  readonly candidate: TopReadOrderAuditRow;
+  readonly persistedRead: RankingAuditTopRead | undefined;
+  readonly presentedRead: RankingAuditTopRead | undefined;
+}): RankingAuditTopRead | undefined => {
+  if (
+    params.persistedRead === undefined ||
+    params.presentedRead === undefined ||
+    params.persistedRead.providerKey !== params.candidate.providerKey ||
+    params.presentedRead.providerKey !== params.candidate.providerKey ||
+    params.persistedRead.signalScore !== params.presentedRead.signalScore ||
+    params.persistedRead.title !== params.presentedRead.title
+  ) {
+    return undefined;
+  }
+
+  return params.persistedRead;
+};
 
 const isWeakTopReadWithoutClearReason = (
   row: TopReadOrderAuditRow,
@@ -49,7 +77,9 @@ const isWeakTopReadWithoutClearReason = (
 
 const isStrongSocialReadBelowWeakRead = (params: {
   readonly candidate: TopReadOrderAuditRow;
+  readonly candidateRank: number;
   readonly candidateRead: RankingAuditTopRead | undefined;
+  readonly weakRank: number;
   readonly weakRow: TopReadOrderAuditRow;
 }): boolean =>
   ["reddit", "x-twitter", "rss"].includes(params.candidate.providerKey) &&
@@ -58,7 +88,10 @@ const isStrongSocialReadBelowWeakRead = (params: {
   params.candidate.confidenceLevel !== "low" &&
   !params.candidate.riskSignals.includes("low_signal_score") &&
   !(
-    params.weakRow.index === 1 &&
+    params.weakRank === 1 &&
+    params.candidateRank > params.weakRank &&
     params.candidateRead !== undefined &&
-    isUnverifiedLegalTopRead(params.candidateRead)
+    hasReaderSummaryUnverifiedLegalSafetyDemotionRule(
+      params.candidateRead.matchedRules,
+    )
   );

--- a/scripts/run-reader-summary-production-day.ts
+++ b/scripts/run-reader-summary-production-day.ts
@@ -322,6 +322,7 @@ async function main(): Promise<void> {
       "--update",
       "--date",
       collectionDate,
+      "--write-failed-report",
     ]),
   );
   steps.push(


### PR DESCRIPTION
## Summary
- make top-read order audits fail closed using persisted ranking evidence
- safely demote unverified legal-reporting candidates without exposing internal markers
- preserve persisted top-read evidence in the production quality dashboard

## Verification
- 3 focused suites, 26 ranking tests
- dashboard order-audit suite, 8 tests
- exact ESLint
- architecture and source-line-cap
- TypeScript build
- git diff --check and secret scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards for identifying and handling unverified legal-safety signals in reader summaries.
  * Improved ranking audits by validating persisted top-read data and safety markers.
  * Added atomic report writing and failed-report output for ranking checks.

* **Bug Fixes**
  * Improved date handling and ranking comparisons.
  * Prevented forged, misplaced, or unsupported safety markers from affecting rankings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->