### PR TITLE
fix(feed): preserve first observed timestamp

### DIFF
--- a/libs/feed/adapters/persistence/prisma/prisma-feed-client.ts
+++ b/libs/feed/adapters/persistence/prisma/prisma-feed-client.ts
@@ -34,7 +34,6 @@ export type PrismaFeedClient = {
         readonly bodyPreview: string;
         readonly authorHandle?: string | null;
         readonly publishedAt: Date;
-        readonly observedAt: Date;
         readonly providerMetadata?: Readonly<Record<string, unknown>> | null;
       };
       readonly create: {
@@ -68,7 +67,6 @@ export type PrismaFeedClient = {
         readonly bodyPreview?: string;
         readonly authorHandle?: string | null;
         readonly publishedAt?: Date;
-        readonly observedAt?: Date;
         readonly providerMetadata?: Readonly<Record<string, unknown>> | null;
       };
     }): Promise<PrismaFeedItemRecord>;

--- a/libs/feed/adapters/persistence/prisma/prisma-feed-projection.adapter.spec.ts
+++ b/libs/feed/adapters/persistence/prisma/prisma-feed-projection.adapter.spec.ts
@@ -1,0 +1,322 @@
+import { SourceItem } from "@social-monitor/ingestion/domain";
+import type { ProjectFeedItemsCommand } from "@social-monitor/ingestion/ports";
+import type { IdGenerator, JsonObject } from "@social-monitor/shared-kernel";
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+
+import type {
+  PrismaFeedClient,
+  PrismaFeedSignalBaselineSampleRecord,
+} from "./prisma-feed-client";
+import type { PrismaFeedItemRecord } from "./prisma-feed-records";
+import { PrismaFeedProjectionAdapter } from "./prisma-feed-projection.adapter";
+
+const firstObservedAt = new Date("2026-07-16T00:01:33.681Z");
+const reprojectedAt = new Date("2026-07-16T01:07:20.000Z");
+
+type FeedItemUpsertArgs = Parameters<
+  PrismaFeedClient["feedItem"]["upsert"]
+>[0];
+type FeedItemUpdateArgs = Parameters<
+  NonNullable<PrismaFeedClient["feedItem"]["update"]>
+>[0];
+type FeedItemMutableData =
+  | FeedItemUpsertArgs["update"]
+  | FeedItemUpdateArgs["data"];
+type BaselineUpsertArgs = Parameters<
+  PrismaFeedClient["feedSignalBaselineSample"]["upsert"]
+>[0];
+
+describe("PrismaFeedProjectionAdapter", () => {
+  it.each([
+    ["explicit update", true],
+    ["upsert update fallback", false],
+  ])(
+    "keeps feed observedAt create-only through %s and refreshes the current baseline",
+    async (_path, supportsExplicitUpdate) => {
+      const prisma = new FakePrismaFeedClient(supportsExplicitUpdate);
+      const projection = new PrismaFeedProjectionAdapter(
+        prisma,
+        new SequenceIdGenerator([
+          "feed-1",
+          "sample-1",
+          "unused-feed-2",
+          "unused-sample-2",
+        ]),
+      );
+      const command = projectionCommand();
+
+      await projection.project({
+        ...command,
+        sourceItems: [
+          sourceItem({
+            title: "Initial title",
+            body: "Initial body",
+            authorHandle: "initial-author",
+            publishedAt: new Date("2026-07-15T23:55:00.000Z"),
+            ingestedAt: firstObservedAt,
+            metadata: {
+              subreddit: "startups",
+              score: 4,
+              numComments: 1,
+              upvoteRatio: 0.6,
+            },
+          }),
+        ],
+      });
+      await projection.project({
+        ...command,
+        sourceItems: [
+          sourceItem({
+            title: "Reprojected title",
+            body: "Reprojected body",
+            authorHandle: "updated-author",
+            publishedAt: new Date("2026-07-16T00:05:00.000Z"),
+            ingestedAt: reprojectedAt,
+            metadata: {
+              subreddit: "startups",
+              score: 400,
+              numComments: 20,
+              upvoteRatio: 0.95,
+            },
+          }),
+        ],
+      });
+
+      expect(prisma.feedCreateData).toHaveProperty(
+        "observedAt",
+        firstObservedAt,
+      );
+      expect(prisma.feedUpdateData).toMatchObject({
+        title: "Reprojected title",
+        bodyPreview: "Reprojected body",
+        authorHandle: "updated-author",
+        publishedAt: new Date("2026-07-16T00:05:00.000Z"),
+        providerMetadata: expect.objectContaining({
+          subreddit: "startups",
+          score: 400,
+          numComments: 20,
+          upvoteRatio: 0.95,
+        }),
+      });
+      expect(prisma.feedUpdateData).not.toHaveProperty("observedAt");
+      expect(prisma.feedItemRecord).toMatchObject({
+        title: "Reprojected title",
+        bodyPreview: "Reprojected body",
+        authorHandle: "updated-author",
+        publishedAt: new Date("2026-07-16T00:05:00.000Z"),
+        observedAt: firstObservedAt,
+        providerMetadata: expect.objectContaining({
+          score: 400,
+          numComments: 20,
+          upvoteRatio: 0.95,
+        }),
+      });
+      expect(prisma.explicitUpdateCount).toBe(
+        supportsExplicitUpdate ? 1 : 0,
+      );
+      expect(prisma.upsertUpdateCount).toBe(
+        supportsExplicitUpdate ? 0 : 1,
+      );
+
+      const baselineCreateData = prisma.baselineCreateData;
+      const baselineUpdateData = prisma.baselineUpdateData;
+      if (baselineCreateData === undefined || baselineUpdateData === undefined) {
+        throw new Error("Expected baseline create and update writes");
+      }
+
+      expect(baselineCreateData).toMatchObject({
+        feedItemId: "feed-1",
+        providerKey: "reddit",
+        sourceKey: "r/startups",
+        contentType: "post",
+        observedAt: firstObservedAt,
+      });
+      expect(baselineUpdateData).toMatchObject({
+        providerKey: "reddit",
+        sourceKey: "r/startups",
+        contentType: "post",
+        observedAt: reprojectedAt,
+      });
+      expect(baselineUpdateData.strength).toBeGreaterThan(
+        baselineCreateData.strength,
+      );
+      expect(prisma.baselineSampleRecord).toMatchObject({
+        feedItemId: "feed-1",
+        observedAt: reprojectedAt,
+        strength: baselineUpdateData.strength,
+      });
+    },
+  );
+});
+
+const sourceItem = (params: {
+  readonly title: string;
+  readonly body: string;
+  readonly authorHandle: string;
+  readonly publishedAt: Date;
+  readonly ingestedAt: Date;
+  readonly metadata: JsonObject;
+}): SourceItem =>
+  SourceItem.ingest({
+    id: "source-coverage-item",
+    tenantId: tenantId("tenant-1"),
+    workspaceId: workspaceId("workspace-1"),
+    sourceBindingId: "binding-1",
+    externalId: "reddit-coverage-item",
+    canonicalUrl: "https://example.test/reddit-coverage-item",
+    ...params,
+  });
+
+const projectionCommand = (): Omit<
+  ProjectFeedItemsCommand,
+  "sourceItems"
+> => ({
+  tenantId: tenantId("tenant-1"),
+  workspaceId: workspaceId("workspace-1"),
+  interestId: "topic-1",
+  sourceBindingId: "binding-1",
+  providerKey: "reddit",
+  snapshots: {
+    interestQuerySnapshot: {
+      interestId: "topic-1",
+      query: "AI developer tools",
+    },
+    sourceBindingSnapshot: {
+      sourceBindingId: "binding-1",
+      providerKey: "reddit",
+      sourceQuery: {
+        mode: "listing",
+        query: "startups:hot",
+      },
+    },
+    workspaceScopeSnapshot: {
+      tenantId: tenantId("tenant-1"),
+      workspaceId: workspaceId("workspace-1"),
+    },
+  },
+});
+
+class SequenceIdGenerator implements IdGenerator {
+  private index = 0;
+
+  constructor(private readonly values: readonly string[]) {}
+
+  generate(): string {
+    const value = this.values[this.index];
+    if (value === undefined) {
+      throw new Error("SequenceIdGenerator exhausted");
+    }
+    this.index += 1;
+
+    return value;
+  }
+}
+
+class FakePrismaFeedClient implements PrismaFeedClient {
+  feedItemRecord: PrismaFeedItemRecord | undefined;
+  baselineSampleRecord: PrismaFeedSignalBaselineSampleRecord | undefined;
+  feedCreateData: FeedItemUpsertArgs["create"] | undefined;
+  feedUpdateData: FeedItemMutableData | undefined;
+  baselineCreateData: BaselineUpsertArgs["create"] | undefined;
+  baselineUpdateData: BaselineUpsertArgs["update"] | undefined;
+  explicitUpdateCount = 0;
+  upsertUpdateCount = 0;
+
+  readonly feedItem: PrismaFeedClient["feedItem"];
+
+  constructor(supportsExplicitUpdate: boolean) {
+    const feedItemWithoutUpdate: Omit<
+      PrismaFeedClient["feedItem"],
+      "update"
+    > = {
+      upsert: (args) => this.upsertFeedItem(args),
+      findMany: async () => [],
+      count: async () => 0,
+      findFirst: async (args) => {
+        const record = this.feedItemRecord;
+        return record !== undefined &&
+          record.tenantId === args.where.tenantId &&
+          record.workspaceId === args.where.workspaceId &&
+          record.interestId === args.where.interestId &&
+          record.sourceItemId === args.where.sourceItemId &&
+          record.status === args.where.status
+          ? record
+          : null;
+      },
+    };
+    this.feedItem = supportsExplicitUpdate
+      ? {
+          ...feedItemWithoutUpdate,
+          update: (args) => this.updateFeedItem(args),
+        }
+      : feedItemWithoutUpdate;
+  }
+
+  readonly feedSignalBaselineSample: PrismaFeedClient["feedSignalBaselineSample"] =
+    {
+      upsert: async (args) => this.upsertBaselineSample(args),
+      findMany: async () => [],
+      deleteMany: async () => ({ count: 0 }),
+    };
+
+  private async upsertFeedItem(
+    args: FeedItemUpsertArgs,
+  ): Promise<PrismaFeedItemRecord> {
+    const existing = this.feedItemRecord;
+    if (
+      existing !== undefined &&
+      existing.tenantId ===
+        args.where.tenantId_interestId_dedupeKey.tenantId &&
+      existing.interestId ===
+        args.where.tenantId_interestId_dedupeKey.interestId &&
+      existing.dedupeKey ===
+        args.where.tenantId_interestId_dedupeKey.dedupeKey
+    ) {
+      this.upsertUpdateCount += 1;
+      this.feedUpdateData = args.update;
+      this.feedItemRecord = { ...existing, ...args.update };
+
+      return this.feedItemRecord;
+    }
+
+    this.feedCreateData = args.create;
+    this.feedItemRecord = {
+      ...args.create,
+      authorHandle: args.create.authorHandle ?? null,
+      providerMetadata: args.create.providerMetadata ?? null,
+      createdAt: firstObservedAt,
+    };
+
+    return this.feedItemRecord;
+  }
+
+  private async updateFeedItem(
+    args: FeedItemUpdateArgs,
+  ): Promise<PrismaFeedItemRecord> {
+    const existing = this.feedItemRecord;
+    if (existing === undefined || existing.id !== args.where.id) {
+      throw new Error(`Feed item ${args.where.id} does not exist`);
+    }
+
+    this.explicitUpdateCount += 1;
+    this.feedUpdateData = args.data;
+    this.feedItemRecord = { ...existing, ...args.data };
+
+    return this.feedItemRecord;
+  }
+
+  private async upsertBaselineSample(
+    args: BaselineUpsertArgs,
+  ): Promise<PrismaFeedSignalBaselineSampleRecord> {
+    const existing = this.baselineSampleRecord;
+    if (existing === undefined) {
+      this.baselineCreateData = args.create;
+      this.baselineSampleRecord = { ...args.create };
+    } else {
+      this.baselineUpdateData = args.update;
+      this.baselineSampleRecord = { ...existing, ...args.update };
+    }
+
+    return this.baselineSampleRecord;
+  }
+}

--- a/libs/feed/adapters/persistence/prisma/prisma-feed-projection.adapter.ts
+++ b/libs/feed/adapters/persistence/prisma/prisma-feed-projection.adapter.ts
@@ -70,7 +70,6 @@ export class PrismaFeedProjectionAdapter implements FeedProjectionPort {
           bodyPreview,
           authorHandle: snapshot.authorHandle ?? null,
           publishedAt: snapshot.publishedAt,
-          observedAt: snapshot.ingestedAt,
           providerMetadata,
         };
         const feedItem = existingFeedItem !== null && this.prisma.feedItem.update !== undefined
@@ -134,7 +133,7 @@ export class PrismaFeedProjectionAdapter implements FeedProjectionPort {
               contentType: signalSample.contentType,
               strength: signalSample.strength,
               publishedAt: signalSample.publishedAt,
-              observedAt: signalSample.observedAt,
+              observedAt: snapshot.ingestedAt,
             },
             create: {
               id: this.ids.generate(),
@@ -147,7 +146,7 @@ export class PrismaFeedProjectionAdapter implements FeedProjectionPort {
               contentType: signalSample.contentType,
               strength: signalSample.strength,
               publishedAt: signalSample.publishedAt,
-              observedAt: signalSample.observedAt,
+              observedAt: snapshot.ingestedAt,
             },
           });
         }

--- a/libs/feed/adapters/persistence/prisma/prisma-feed-signal-baseline.repository.spec.ts
+++ b/libs/feed/adapters/persistence/prisma/prisma-feed-signal-baseline.repository.spec.ts
@@ -377,7 +377,7 @@ class FakePrismaFeedClient implements PrismaFeedClient {
               bodyPreview: args.update.bodyPreview,
               authorHandle: args.update.authorHandle ?? null,
               publishedAt: args.update.publishedAt,
-              observedAt: args.update.observedAt,
+              observedAt: existing.observedAt,
               providerMetadata:
                 args.update.providerMetadata === undefined
                   ? existing.providerMetadata

--- a/scripts/check-ingestion-feed-prisma-persistence.ts
+++ b/scripts/check-ingestion-feed-prisma-persistence.ts
@@ -798,7 +798,7 @@ class FakePrismaIngestionFeedClient
               bodyPreview: args.update.bodyPreview,
               authorHandle: args.update.authorHandle ?? null,
               publishedAt: args.update.publishedAt,
-              observedAt: args.update.observedAt,
+              observedAt: existing.observedAt,
               providerMetadata:
                 args.update.providerMetadata === undefined
                   ? existing.providerMetadata


### PR DESCRIPTION
## Summary
- preserve feed item observedAt as the first-observation timestamp
- refresh mutable content and engagement without moving historical coverage outside the summary window
- keep signal baseline recency and strength current

## Verification
- focused projection and baseline tests
- feed persistence smoke
- exact ESLint
- build
- architecture and source line cap
- git diff --check
- independent review: no P0/P1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved feed item observation timestamps when existing items are refreshed.
  * Updated baseline signal timestamps to reflect the latest ingestion time.
  * Ensured feed metadata and signal strength continue to refresh correctly during re-projection.

* **Tests**
  * Added coverage for feed updates through both supported persistence paths.
  * Verified timestamp preservation, metadata refreshes, and baseline signal updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->