### PR TITLE
fix: restore publication release gates

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -114,10 +114,12 @@ jobs:
       - name: Prove fail-closed PostgreSQL and signal publication
         if: needs.plan.outputs.backend == 'true'
         env:
+          DATABASE_URL: postgresql://social_monitor_publication_ci_admin:social_monitor_local_password@127.0.0.1:5432/social_monitor_publication_ci_admin
           READER_SUMMARY_PUBLICATION_TEST_ADMIN_DATABASE_URL: postgresql://social_monitor_publication_ci_admin:social_monitor_local_password@127.0.0.1:5432/social_monitor_publication_ci_admin
         run: |
           set -euo pipefail
           npm ci
+          npm run prisma:generate
           npm run check:reader-summary-publication-postgres
           npm run check:reader-summary-publication-signal-regression
 

--- a/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
@@ -66,6 +66,14 @@ void main() {
       find.text('Top 10 repositories in GitHub Trending order'),
       findsOneWidget,
     );
+    expect(
+      find.byKey(const ValueKey('workspace-summary-toolbar-generate')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('workspace-summary-export')),
+      findsOneWidget,
+    );
     await tester.scrollUntilVisible(
       find.byKey(const ValueKey('reader-summary-top-post-0')),
       500,
@@ -77,14 +85,6 @@ void main() {
     expect(find.text('18K'), findsWidgets);
     expect(find.text('Single source'), findsWidgets);
     expect(find.text('Matching 1 interest'), findsWidgets);
-    expect(
-      find.byKey(const ValueKey('workspace-summary-toolbar-generate')),
-      findsOneWidget,
-    );
-    expect(
-      find.byKey(const ValueKey('workspace-summary-export')),
-      findsOneWidget,
-    );
   });
 
   testWidgets('does not show source-list summary headlines as the lead', (

--- a/apps/frontend/features/summaries/test/support/generated_summary_test_fixtures.dart
+++ b/apps/frontend/features/summaries/test/support/generated_summary_test_fixtures.dart
@@ -1,0 +1,83 @@
+import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
+import 'package:social_monitor_summaries/src/domain/entities/generated_summary.dart';
+import 'package:social_monitor_summaries/src/domain/entities/summary_citation.dart';
+import 'package:social_monitor_summaries/src/domain/value_objects/summary_generation_status.dart';
+import 'package:social_monitor_summaries/src/domain/value_objects/summary_id.dart';
+import 'package:social_monitor_summaries/src/infrastructure/api/summary_api_dto.dart';
+
+SummaryCitationApiDto summaryCitationApiDto({
+  String id = 'c-1',
+  String sourceLabel = 'Reddit thread',
+  String rawSnippet = 'Users compared competitor pricing tiers.',
+  String feedItemId = 'feed-c-1',
+  String sourceItemId = 'source-c-1',
+  String? providerKey,
+  String? canonicalUrl,
+}) {
+  return SummaryCitationApiDto(
+    id: id,
+    sourceLabel: sourceLabel,
+    rawSnippet: rawSnippet,
+    feedItemId: feedItemId,
+    sourceItemId: sourceItemId,
+    providerKey: providerKey,
+    canonicalUrl: canonicalUrl,
+  );
+}
+
+SummaryApiDto summaryApiDto({
+  String id = 's-1',
+  String title = 'Weekly risk summary',
+  String status = 'ready',
+  String bodyText =
+      'Pricing pressure increased while launch sentiment stayed stable.',
+  List<SummaryCitationApiDto>? citations,
+  String freshnessLabel = 'Today',
+  bool feedbackSubmitted = false,
+}) {
+  return SummaryApiDto(
+    id: id,
+    title: title,
+    status: status,
+    bodyText: bodyText,
+    citations: citations ?? [summaryCitationApiDto()],
+    freshnessLabel: freshnessLabel,
+    feedbackSubmitted: feedbackSubmitted,
+  );
+}
+
+GeneratedSummary generatedSummary({
+  String id = 's-1',
+  String title = 'Weekly risk summary',
+  String bodyPreview =
+      'Pricing pressure increased while launch sentiment stayed stable.',
+  SummaryGenerationStatus status = SummaryGenerationStatus.ready,
+  List<SummaryCitation> citations = const [
+    SummaryCitation(
+      id: 'c-1',
+      sourceLabel: 'Reddit thread',
+      safeSnippet: 'Users compared competitor pricing tiers.',
+      feedItemId: 'feed-c-1',
+      sourceItemId: 'source-c-1',
+    ),
+  ],
+  String freshnessLabel = 'Today',
+  bool feedbackSubmitted = false,
+}) {
+  return GeneratedSummary(
+    id: SummaryId(id),
+    title: title,
+    bodyPreview: bodyPreview,
+    status: status,
+    citations: citations,
+    freshnessLabel: freshnessLabel,
+    feedbackSubmitted: feedbackSubmitted,
+  );
+}
+
+PageResult<GeneratedSummary> generatedSummaryPage(
+  List<GeneratedSummary> items, {
+  PageRequest request = const PageRequest(),
+}) {
+  return PageResult<GeneratedSummary>(items: items, request: request);
+}

--- a/apps/frontend/features/summaries/test/support/github_trending_summary_test_fixtures.dart
+++ b/apps/frontend/features/summaries/test/support/github_trending_summary_test_fixtures.dart
@@ -1,0 +1,133 @@
+import 'package:social_monitor_summaries/src/infrastructure/api/summary_api_dto.dart';
+
+import 'generated_summary_test_fixtures.dart';
+
+const githubTrendingProviderKey = 'github-trending-page';
+
+const canonicalGitHubTrendingCitationIds = [
+  'bc-1',
+  'bc-2',
+  'bc-3',
+  'bc-4',
+  'bc-5',
+  'bc-6',
+  'bc-7',
+  'bc-8',
+  'bc-9',
+  'bc-10',
+];
+
+const _canonicalGitHubTrendingRepositories =
+    <({String repository, String stars, String starsToday})>[
+      (
+        repository: 'calesthio/OpenMontage',
+        stars: '18,398',
+        starsToday: '3,703',
+      ),
+      (repository: 'apple/container', stars: '41,719', starsToday: '1,746'),
+      (
+        repository: 'ZhuLinsen/daily_stock_analysis',
+        stars: '12,640',
+        starsToday: '984',
+      ),
+      (
+        repository: 'fixture-labs/trending-repo-4',
+        stars: '9,440',
+        starsToday: '812',
+      ),
+      (
+        repository: 'fixture-labs/trending-repo-5',
+        stars: '8,310',
+        starsToday: '744',
+      ),
+      (
+        repository: 'fixture-labs/trending-repo-6',
+        stars: '7,205',
+        starsToday: '681',
+      ),
+      (
+        repository: 'fixture-labs/trending-repo-7',
+        stars: '6,180',
+        starsToday: '594',
+      ),
+      (
+        repository: 'fixture-labs/trending-repo-8',
+        stars: '5,090',
+        starsToday: '512',
+      ),
+      (
+        repository: 'fixture-labs/trending-repo-9',
+        stars: '4,070',
+        starsToday: '436',
+      ),
+      (
+        repository: 'fixture-labs/trending-repo-10',
+        stars: '3,060',
+        starsToday: '371',
+      ),
+    ];
+
+List<TopReadApiDto> canonicalGitHubTrendingSelectedPostApiDtos() {
+  return List<TopReadApiDto>.generate(
+    _canonicalGitHubTrendingRepositories.length,
+    (index) {
+      final rank = index + 1;
+      final repository = _canonicalGitHubTrendingRepositories[index];
+
+      return TopReadApiDto(
+        title: repository.repository,
+        providerKey: githubTrendingProviderKey,
+        reason: '#$rank repository on github.com/trending today.',
+        matchedInterestIds: const ['ai-developer-tools'],
+        matchedRules: const [
+          'interest:ai-developer-tools',
+          'provider:github-trending-page',
+        ],
+        signalScore: 1 - index / 20,
+        confidence: const TopReadConfidenceApiDto(
+          level: 'medium',
+          score: 0.57,
+          rationale: 'Daily GitHub Trending signal with raw metrics.',
+        ),
+        confirmedProviderKeys: const [githubTrendingProviderKey],
+        providerMetrics: [
+          ProviderMetricApiDto(
+            label: 'GitHub Trending today',
+            value: '#$rank, +${repository.starsToday} stars today',
+          ),
+          ProviderMetricApiDto(label: 'Stars', value: repository.stars),
+        ],
+        whyImportant: [
+          'Repository #$rank is attracting attention on GitHub Trending.',
+        ],
+        whyNow: 'Current summary window includes GitHub Trending coverage.',
+        canonicalUrl: 'https://github.com/${repository.repository}',
+        citationIds: [canonicalGitHubTrendingCitationIds[index]],
+      );
+    },
+    growable: false,
+  );
+}
+
+List<SummaryCitationApiDto> canonicalGitHubTrendingCitationApiDtos() {
+  return List<SummaryCitationApiDto>.generate(
+    _canonicalGitHubTrendingRepositories.length,
+    (index) {
+      final rank = index + 1;
+      final repository = _canonicalGitHubTrendingRepositories[index];
+      final citationId = canonicalGitHubTrendingCitationIds[index];
+
+      return summaryCitationApiDto(
+        id: citationId,
+        sourceLabel: 'GitHub Trending [$rank] ${repository.repository}',
+        rawSnippet:
+            'Repository #$rank gained ${repository.starsToday} stars today.',
+        feedItemId: 'feed-$citationId',
+        sourceItemId: 'source-$citationId',
+        providerKey: githubTrendingProviderKey,
+        canonicalUrl: 'https://github.com/${repository.repository}',
+      );
+    },
+    growable: false,
+  );
+}

--- a/apps/frontend/features/summaries/test/support/mixed_source_summaries_test_fixtures.dart
+++ b/apps/frontend/features/summaries/test/support/mixed_source_summaries_test_fixtures.dart
@@ -3,6 +3,72 @@ import 'package:social_monitor_summaries/src/infrastructure/api/summary_api_dto.
 import 'summaries_test_fixtures.dart';
 
 ReaderSummaryApiDto mixedSourceReaderSummaryApiDto() {
+  const topReads = [
+    TopReadApiDto(
+      title: 'Reddit thread on agent reliability',
+      providerKey: 'reddit',
+      reason: 'High-engagement Reddit discussion with concrete failures.',
+      matchedInterestIds: ['ai-developer-tools'],
+      matchedRules: ['provider:reddit', 'interest:ai-developer-tools'],
+      signalScore: 0.94,
+      confirmedProviderKeys: ['reddit', githubTrendingProviderKey],
+      providerMetrics: [
+        ProviderMetricApiDto(
+          label: 'Reddit evidence',
+          value: '1,214 score, 246 comments, 71% upvoted',
+        ),
+        ProviderMetricApiDto(label: 'Score', value: '1,214'),
+      ],
+      whyImportant: ['Shows what practitioners are struggling with.'],
+      whyNow:
+          'Current summary window has cross-source Reddit and GitHub coverage.',
+      canonicalUrl: 'https://reddit.example/r/MachineLearning/comments/1',
+      citationIds: ['editorial-reddit-1', 'editorial-reddit-2'],
+    ),
+    TopReadApiDto(
+      title: 'calesthio/OpenMontage',
+      providerKey: githubTrendingProviderKey,
+      reason: 'Daily GitHub Trending repository in the AI workflow space.',
+      matchedInterestIds: ['ai-developer-tools'],
+      matchedRules: [
+        'provider:github-trending-page',
+        'interest:ai-developer-tools',
+      ],
+      signalScore: 0.89,
+      providerMetrics: [
+        ProviderMetricApiDto(label: 'Stars', value: '18,398'),
+        ProviderMetricApiDto(
+          label: 'GitHub Trending today',
+          value: '#1, +3,703 stars today',
+        ),
+      ],
+      whyImportant: ['Shows repository attention around AI workflows.'],
+      whyNow: 'Current summary window includes GitHub Trending coverage.',
+      canonicalUrl: 'https://github.com/calesthio/OpenMontage',
+      citationIds: ['bc-1'],
+    ),
+    TopReadApiDto(
+      title: 'HN discussion on model routing',
+      providerKey: 'hacker-news',
+      reason: 'Hacker News discussion adds technical review context.',
+      matchedInterestIds: ['ai-developer-tools'],
+      matchedRules: ['provider:hacker-news', 'interest:ai-developer-tools'],
+      signalScore: 0.83,
+      providerMetrics: [
+        ProviderMetricApiDto(label: 'HN points', value: '312'),
+        ProviderMetricApiDto(label: 'Comments', value: '74'),
+      ],
+      whyImportant: ['Adds engineering critique beyond repository metrics.'],
+      whyNow: 'Current summary window includes Hacker News discussion.',
+      canonicalUrl: 'https://news.ycombinator.com/item?id=1',
+      citationIds: ['editorial-hacker-news-1', 'editorial-hacker-news-2'],
+    ),
+  ];
+  final selectedPosts = [
+    ...topReads.where((item) => item.providerKey != githubTrendingProviderKey),
+    ...canonicalGitHubTrendingSelectedPostApiDtos(),
+  ];
+
   return readerSummaryApiDto(
     title: 'Mixed AI source summary',
     executiveSummary:
@@ -28,10 +94,10 @@ ReaderSummaryApiDto mixedSourceReaderSummaryApiDto() {
           interestIds: ['ai-developer-tools'],
         ),
         SourceMixEntryApiDto(
-          providerKey: 'github-trending-page',
-          itemCount: 2,
-          citationCount: 2,
-          storyClusterCount: 2,
+          providerKey: githubTrendingProviderKey,
+          itemCount: 10,
+          citationCount: 10,
+          storyClusterCount: 10,
           crossSourceClusterCount: 1,
           singleSourceOnly: false,
           interestIds: ['ai-developer-tools'],
@@ -46,98 +112,45 @@ ReaderSummaryApiDto mixedSourceReaderSummaryApiDto() {
           interestIds: ['ai-developer-tools'],
         ),
       ],
-      topReads: const [
-        TopReadApiDto(
-          title: 'Reddit thread on agent reliability',
-          providerKey: 'reddit',
-          reason: 'High-engagement Reddit discussion with concrete failures.',
-          matchedInterestIds: ['ai-developer-tools'],
-          matchedRules: ['provider:reddit', 'interest:ai-developer-tools'],
-          signalScore: 0.94,
-          confirmedProviderKeys: ['reddit', 'github-trending-page'],
-          providerMetrics: [
-            ProviderMetricApiDto(
-              label: 'Reddit evidence',
-              value: '1,214 score, 246 comments, 71% upvoted',
-            ),
-            ProviderMetricApiDto(label: 'Score', value: '1,214'),
-          ],
-          whyImportant: ['Shows what practitioners are struggling with.'],
-          whyNow:
-              'Current summary window has cross-source Reddit and GitHub coverage.',
-          canonicalUrl: 'https://reddit.example/r/MachineLearning/comments/1',
-          citationIds: ['bc-1', 'bc-2'],
-        ),
-        TopReadApiDto(
-          title: 'calesthio/OpenMontage',
-          providerKey: 'github-trending-page',
-          reason: 'Daily GitHub Trending repository in the AI workflow space.',
-          matchedInterestIds: ['ai-developer-tools'],
-          matchedRules: [
-            'provider:github-trending-page',
-            'interest:ai-developer-tools',
-          ],
-          signalScore: 0.89,
-          providerMetrics: [
-            ProviderMetricApiDto(label: 'Stars', value: '18,398'),
-            ProviderMetricApiDto(
-              label: 'GitHub Trending today',
-              value: '#1, +3,703 stars today',
-            ),
-          ],
-          whyImportant: ['Shows repository attention around AI workflows.'],
-          whyNow: 'Current summary window includes GitHub Trending coverage.',
-          canonicalUrl: 'https://github.com/calesthio/OpenMontage',
-          citationIds: ['bc-2'],
-        ),
-        TopReadApiDto(
-          title: 'HN discussion on model routing',
-          providerKey: 'hacker-news',
-          reason: 'Hacker News discussion adds technical review context.',
-          matchedInterestIds: ['ai-developer-tools'],
-          matchedRules: ['provider:hacker-news', 'interest:ai-developer-tools'],
-          signalScore: 0.83,
-          providerMetrics: [
-            ProviderMetricApiDto(label: 'HN points', value: '312'),
-            ProviderMetricApiDto(label: 'Comments', value: '74'),
-          ],
-          whyImportant: [
-            'Adds engineering critique beyond repository metrics.',
-          ],
-          whyNow: 'Current summary window includes Hacker News discussion.',
-          canonicalUrl: 'https://news.ycombinator.com/item?id=1',
-          citationIds: ['bc-3'],
-        ),
-      ],
+      topReads: topReads,
+      selectedPosts: selectedPosts,
     ),
     citations: [
       summaryCitationApiDto(
-        id: 'bc-1',
-        sourceLabel: 'Reddit - r/MachineLearning',
+        id: 'editorial-reddit-1',
+        sourceLabel: 'Reddit discussion evidence 1',
         rawSnippet: 'Practitioners compare agent reliability incidents.',
         providerKey: 'reddit',
         canonicalUrl: 'https://reddit.example/r/MachineLearning/comments/1',
       ),
       summaryCitationApiDto(
-        id: 'bc-2',
-        sourceLabel: 'GitHub Trending - calesthio/OpenMontage',
-        rawSnippet: 'Repository gained rapid daily attention.',
-        providerKey: 'github-trending-page',
-        canonicalUrl: 'https://github.com/calesthio/OpenMontage',
+        id: 'editorial-reddit-2',
+        sourceLabel: 'Reddit discussion evidence 2',
+        rawSnippet: 'The discussion includes concrete reliability failures.',
+        providerKey: 'reddit',
+        canonicalUrl: 'https://reddit.example/r/MachineLearning/comments/1',
       ),
       summaryCitationApiDto(
-        id: 'bc-3',
-        sourceLabel: 'Hacker News',
+        id: 'editorial-hacker-news-1',
+        sourceLabel: 'Hacker News discussion evidence 1',
         rawSnippet: 'Engineers discuss model routing tradeoffs.',
         providerKey: 'hacker-news',
         canonicalUrl: 'https://news.ycombinator.com/item?id=1',
       ),
+      summaryCitationApiDto(
+        id: 'editorial-hacker-news-2',
+        sourceLabel: 'Hacker News discussion evidence 2',
+        rawSnippet: 'The discussion adds technical review context.',
+        providerKey: 'hacker-news',
+        canonicalUrl: 'https://news.ycombinator.com/item?id=1',
+      ),
+      ...canonicalGitHubTrendingCitationApiDtos(),
     ],
     coverage: const ReaderSummaryCoverageApiDto(
       collectedFeedItemCount: 469,
-      selectedFeedItemCount: 60,
+      selectedFeedItemCount: 68,
       topReadCount: 3,
-      citationCount: 6,
+      citationCount: 14,
       providerBreakdown: [
         ReaderSummaryProviderCoverageApiDto(
           providerKey: 'hacker-news',
@@ -161,11 +174,11 @@ ReaderSummaryApiDto mixedSourceReaderSummaryApiDto() {
           citationCount: 2,
         ),
         ReaderSummaryProviderCoverageApiDto(
-          providerKey: 'github-trending-page',
+          providerKey: githubTrendingProviderKey,
           collectedFeedItemCount: 22,
-          selectedFeedItemCount: 2,
+          selectedFeedItemCount: 10,
           topReadCount: 1,
-          citationCount: 2,
+          citationCount: 10,
         ),
       ],
     ),

--- a/apps/frontend/features/summaries/test/support/summaries_test_fixtures.dart
+++ b/apps/frontend/features/summaries/test/support/summaries_test_fixtures.dart
@@ -1,58 +1,18 @@
 import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
 import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.dart';
-import 'package:social_monitor_summaries/src/domain/entities/generated_summary.dart';
-import 'package:social_monitor_summaries/src/domain/entities/summary_citation.dart';
-import 'package:social_monitor_summaries/src/domain/value_objects/summary_generation_status.dart';
-import 'package:social_monitor_summaries/src/domain/value_objects/summary_id.dart';
 import 'package:social_monitor_summaries/src/infrastructure/api/summary_api_dto.dart';
 
+import 'generated_summary_test_fixtures.dart';
+import 'github_trending_summary_test_fixtures.dart';
 import 'summaries_topic_map_test_fixtures.dart';
+
+export 'generated_summary_test_fixtures.dart';
+export 'github_trending_summary_test_fixtures.dart';
 
 const summaryWorkspaceScope = WorkspaceScope(
   tenantId: 'tenant-demo',
   workspaceId: 'workspace-demo',
 );
-
-SummaryCitationApiDto summaryCitationApiDto({
-  String id = 'c-1',
-  String sourceLabel = 'Reddit thread',
-  String rawSnippet = 'Users compared competitor pricing tiers.',
-  String feedItemId = 'feed-c-1',
-  String sourceItemId = 'source-c-1',
-  String? providerKey,
-  String? canonicalUrl,
-}) {
-  return SummaryCitationApiDto(
-    id: id,
-    sourceLabel: sourceLabel,
-    rawSnippet: rawSnippet,
-    feedItemId: feedItemId,
-    sourceItemId: sourceItemId,
-    providerKey: providerKey,
-    canonicalUrl: canonicalUrl,
-  );
-}
-
-SummaryApiDto summaryApiDto({
-  String id = 's-1',
-  String title = 'Weekly risk summary',
-  String status = 'ready',
-  String bodyText =
-      'Pricing pressure increased while launch sentiment stayed stable.',
-  List<SummaryCitationApiDto>? citations,
-  String freshnessLabel = 'Today',
-  bool feedbackSubmitted = false,
-}) {
-  return SummaryApiDto(
-    id: id,
-    title: title,
-    status: status,
-    bodyText: bodyText,
-    citations: citations ?? [summaryCitationApiDto()],
-    freshnessLabel: freshnessLabel,
-    feedbackSubmitted: feedbackSubmitted,
-  );
-}
 
 ReaderSummaryApiDto readerSummaryApiDto({
   String id = 'readerSummary-1',
@@ -199,6 +159,7 @@ ReaderSummaryContentApiDto readerSummaryContentApiDto({
       citationIds: ['bc-1'],
     ),
   ],
+  List<TopReadApiDto>? selectedPosts,
 }) {
   final primaryRead = topReads.isNotEmpty ? topReads.first : null;
   final primaryTitle = primaryRead?.title ?? 'source';
@@ -247,7 +208,7 @@ ReaderSummaryContentApiDto readerSummaryContentApiDto({
           ),
         ],
     topReads: topReads,
-    selectedPosts: topReads,
+    selectedPosts: selectedPosts ?? topReads,
     claimBoard: claimBoard,
     reliabilityReport: reliabilityReport,
     trendDelta: ReaderTrendDeltaApiDto(
@@ -291,35 +252,6 @@ ReaderSummaryContentApiDto readerSummaryContentApiDto({
   );
 }
 
-GeneratedSummary generatedSummary({
-  String id = 's-1',
-  String title = 'Weekly risk summary',
-  String bodyPreview =
-      'Pricing pressure increased while launch sentiment stayed stable.',
-  SummaryGenerationStatus status = SummaryGenerationStatus.ready,
-  List<SummaryCitation> citations = const [
-    SummaryCitation(
-      id: 'c-1',
-      sourceLabel: 'Reddit thread',
-      safeSnippet: 'Users compared competitor pricing tiers.',
-      feedItemId: 'feed-c-1',
-      sourceItemId: 'source-c-1',
-    ),
-  ],
-  String freshnessLabel = 'Today',
-  bool feedbackSubmitted = false,
-}) {
-  return GeneratedSummary(
-    id: SummaryId(id),
-    title: title,
-    bodyPreview: bodyPreview,
-    status: status,
-    citations: citations,
-    freshnessLabel: freshnessLabel,
-    feedbackSubmitted: feedbackSubmitted,
-  );
-}
-
 SummaryApiDto githubTrendingSummaryApiDto() {
   return summaryApiDto(
     title: 'GitHub Trending daily summary',
@@ -354,6 +286,8 @@ SummaryApiDto githubTrendingSummaryApiDto() {
 }
 
 ReaderSummaryApiDto githubTrendingReaderSummaryApiDto() {
+  final selectedPosts = canonicalGitHubTrendingSelectedPostApiDtos();
+
   return readerSummaryApiDto(
     title: 'AI signal summary',
     executiveSummary:
@@ -362,139 +296,45 @@ ReaderSummaryApiDto githubTrendingReaderSummaryApiDto() {
       headline: 'GitHub daily radar',
       oneLineTakeaway:
           'GitHub Trending is the daily radar for what is breaking out today; Repo Radar is the historical analytics layer for 7d, 30d and 90d growth.',
-      sourceProviderKey: 'github-trending-page',
-      newSignals: const ['3 GitHub Trending page items selected'],
-      topReads: const [
-        TopReadApiDto(
-          title: 'calesthio/OpenMontage',
-          providerKey: 'github-trending-page',
-          reason:
-              '#1 repository on github.com/trending today with +3.7k stars today.',
-          matchedInterestIds: ['ai-developer-tools'],
-          matchedRules: [
-            'interest:ai-developer-tools',
-            'provider:github-trending-page',
-          ],
-          signalScore: 1,
-          confidence: TopReadConfidenceApiDto(
-            level: 'medium',
-            score: 0.57,
-            rationale: 'Daily GitHub Trending signal with raw metrics.',
-          ),
-          confirmedProviderKeys: ['github-trending-page'],
-          providerMetrics: [
-            ProviderMetricApiDto(
-              label: 'GitHub Trending today',
-              value: '#1, +3,703 stars today',
-            ),
-            ProviderMetricApiDto(label: 'Stars', value: '18,398'),
-          ],
-          whyImportant: [
-            'It is the clearest daily breakout on the public GitHub Trending page.',
-          ],
-          whyNow:
-              'Current summary window has github.com/trending page coverage.',
-          canonicalUrl: 'https://github.com/calesthio/OpenMontage',
-          citationIds: ['bc-1'],
-        ),
-        TopReadApiDto(
-          title: 'apple/container',
-          providerKey: 'github-trending-page',
-          reason:
-              'Useful infrastructure follow-up from today\'s Trending page.',
-          matchedInterestIds: ['ai-developer-tools'],
-          matchedRules: [
-            'interest:ai-developer-tools',
-            'provider:github-trending-page',
-          ],
-          signalScore: 0.9,
-          providerMetrics: [
-            ProviderMetricApiDto(
-              label: 'GitHub Trending today',
-              value: '#2, +1,746 stars today',
-            ),
-            ProviderMetricApiDto(label: 'Stars', value: '41,719'),
-          ],
-          whyImportant: ['Useful infrastructure signal from Apple.'],
-          whyNow:
-              'Current summary window has github.com/trending page coverage.',
-          canonicalUrl: 'https://github.com/apple/container',
-          citationIds: ['bc-2'],
-        ),
-        TopReadApiDto(
-          title: 'ZhuLinsen/daily_stock_analysis',
-          providerKey: 'github-trending-page',
-          reason: 'Useful follow-up for LLM-assisted analysis workflows.',
-          matchedInterestIds: ['ai-developer-tools'],
-          matchedRules: [
-            'interest:ai-developer-tools',
-            'provider:github-trending-page',
-          ],
-          signalScore: 0.82,
-          providerMetrics: [
-            ProviderMetricApiDto(
-              label: 'GitHub Trending today',
-              value: '#3 daily signal',
-            ),
-            ProviderMetricApiDto(label: 'Source', value: 'github.com/trending'),
-          ],
-          whyImportant: [
-            'Shows LLM workflows breaking into daily GitHub attention.',
-          ],
-          whyNow:
-              'Current summary window has github.com/trending page coverage.',
-          canonicalUrl: 'https://github.com/ZhuLinsen/daily_stock_analysis',
-          citationIds: ['bc-3'],
+      sourceProviderKey: githubTrendingProviderKey,
+      newSignals: const ['10 GitHub Trending page items selected'],
+      sourceMix: const [
+        SourceMixEntryApiDto(
+          providerKey: githubTrendingProviderKey,
+          itemCount: 10,
+          citationCount: 10,
+          storyClusterCount: 10,
+          crossSourceClusterCount: 0,
+          singleSourceOnly: true,
+          interestIds: ['ai-developer-tools'],
         ),
       ],
+      topReads: const [],
+      selectedPosts: selectedPosts,
     ),
     topStories: const [
       SummaryStoryApiDto(
         title: 'OpenMontage leads today\'s GitHub Trending page',
         summary:
             'The daily radar is driven by the public github.com/trending page, not Repo Radar history.',
-        topicCount: 3,
+        topicCount: 10,
         providerCount: 1,
-        citationIds: ['bc-1', 'bc-2', 'bc-3'],
+        citationIds: canonicalGitHubTrendingCitationIds,
       ),
     ],
-    citations: [
-      summaryCitationApiDto(
-        id: 'bc-1',
-        sourceLabel:
-            'GitHub Trending - github.com/trending page [1] calesthio/OpenMontage',
-        rawSnippet: '18.4k stars, #1 today and +3.7k stars today.',
-        canonicalUrl: 'https://github.com/calesthio/OpenMontage',
-      ),
-      summaryCitationApiDto(
-        id: 'bc-2',
-        sourceLabel:
-            'GitHub Trending - github.com/trending page [2] apple/container',
-        rawSnippet:
-            'Apple container tooling is #2 today with +1.7k stars today.',
-        canonicalUrl: 'https://github.com/apple/container',
-      ),
-      summaryCitationApiDto(
-        id: 'bc-3',
-        sourceLabel:
-            'GitHub Trending - github.com/trending page [3] ZhuLinsen/daily_stock_analysis',
-        rawSnippet:
-            'LLM-powered stock analysis is a high-rank daily GitHub Trending project.',
-        canonicalUrl: 'https://github.com/ZhuLinsen/daily_stock_analysis',
-      ),
-    ],
+    citations: canonicalGitHubTrendingCitationApiDtos(),
     coverage: const ReaderSummaryCoverageApiDto(
       collectedFeedItemCount: 22,
-      selectedFeedItemCount: 3,
-      topReadCount: 3,
-      citationCount: 3,
+      selectedFeedItemCount: 10,
+      topReadCount: 0,
+      citationCount: 10,
       providerBreakdown: [
         ReaderSummaryProviderCoverageApiDto(
-          providerKey: 'github-trending-page',
+          providerKey: githubTrendingProviderKey,
           collectedFeedItemCount: 22,
-          selectedFeedItemCount: 3,
-          topReadCount: 3,
-          citationCount: 3,
+          selectedFeedItemCount: 10,
+          topReadCount: 0,
+          citationCount: 10,
         ),
       ],
     ),
@@ -549,11 +389,4 @@ ReaderSummaryApiDto repoRadarTopTenReaderSummaryApiDto() {
       );
     }),
   );
-}
-
-PageResult<GeneratedSummary> generatedSummaryPage(
-  List<GeneratedSummary> items, {
-  PageRequest request = const PageRequest(),
-}) {
-  return PageResult<GeneratedSummary>(items: items, request: request);
 }

--- a/libs/summary/domain/reader-summary-architecture.spec.ts
+++ b/libs/summary/domain/reader-summary-architecture.spec.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import ts from "typescript";
 
 const readerSummaryCoreFiles = [
   "aggregates/reader-summary.ts",
@@ -107,28 +108,31 @@ describe("ReaderSummary domain architecture", () => {
   });
 
   it("does not own provider display labels in the Summary domain", () => {
-    const forbiddenDisplayFragments = [
-      "providerLabel",
-      "Repo Radar",
-      "GitHub Trending",
-      "GitHub",
-      "Hacker News",
-      "Reddit",
-    ];
     const violations: string[] = [];
 
     for (const file of readerSummaryCoreFiles) {
-      const source = sourceFor(file);
-      for (const fragment of forbiddenDisplayFragments) {
-        if (source.includes(fragment)) {
-          violations.push(
-            `${file} contains provider display fragment ${fragment}`,
-          );
-        }
-      }
+      violations.push(...providerDisplayViolations(file, sourceFor(file)));
     }
 
     expect(violations).toEqual([]);
+  });
+
+  it("distinguishes provider identity from provider display-label ownership", () => {
+    expect(
+      providerDisplayViolations(
+        "canonical-provider-identity.ts",
+        "export const isGitHubTrendingProvider = true;",
+      ),
+    ).toEqual([]);
+    expect(
+      providerDisplayViolations(
+        "provider-display-label.ts",
+        'export const providerLabel = `GitHub ${providerKind}`;',
+      ),
+    ).toEqual([
+      "provider-display-label.ts contains provider display fragment providerLabel",
+      "provider-display-label.ts contains provider display fragment GitHub",
+    ]);
   });
 
   it("does not keep canonical ReaderSummary compatibility shims inside the domain", () => {
@@ -538,3 +542,47 @@ const sourceFor = (relativePath: string): string => {
 
 const importPaths = (source: string): readonly string[] =>
   [...source.matchAll(/from ['"]([^'"]+)['"]/g)].map((match) => match[1] ?? "");
+
+const providerDisplayViolations = (
+  file: string,
+  source: string,
+): readonly string[] => {
+  const forbiddenDisplayFragments = [
+    "providerLabel",
+    "Repo Radar",
+    "GitHub Trending",
+    "GitHub",
+    "Hacker News",
+    "Reddit",
+  ];
+  const foundFragments = new Set<string>();
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isIdentifier(node) && node.text === "providerLabel") {
+      foundFragments.add(node.text);
+    }
+
+    if (ts.isStringLiteralLike(node) || ts.isTemplateLiteralToken(node)) {
+      for (const fragment of forbiddenDisplayFragments) {
+        if (node.text.includes(fragment)) {
+          foundFragments.add(fragment);
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  return [...foundFragments].map(
+    (fragment) => `${file} contains provider display fragment ${fragment}`,
+  );
+};


### PR DESCRIPTION
Restores the publication release path after the merged CI regression.\n\n- generates Prisma client before backend architecture tests\n- makes the reader-summary architecture rule AST-aware\n- aligns exact GitHub Top10 and mixed-source frontend fixtures\n- keeps toolbar visibility assertions before the intentional Top10 scroll\n\nVerified on the production host:\n- backend architecture and integration release gates passed\n- Flutter analyze passed\n- 14 summary-page widget scenarios passed\n- 21 frontend architecture checks passed\n- source line cap, secret scan and git diff check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded summary test coverage with reusable fixtures for generated summaries and GitHub Trending content.
  * Updated mixed-source summary scenarios to reflect expanded selections, citations, and provider coverage.
  * Improved architecture checks for distinguishing provider identity from display labels.
  * Cleaned up duplicate toolbar control assertions.
* **Chores**
  * Deployment verification now generates the Prisma client before running database and publication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->