### PR TITLE
fix(collection): make X account attribution fail closed

### DIFF
--- a/apps/x-collector/src/x_collector/account_usage.py
+++ b/apps/x-collector/src/x_collector/account_usage.py
@@ -15,6 +15,11 @@ class AccountUsageEventType(str, Enum):
     COOLDOWN_OBSERVED = "cooldown_observed"
 
 
+class AccountUsageAttributionStatus(str, Enum):
+    KNOWN = "known"
+    UNKNOWN = "unknown"
+
+
 @dataclass(frozen=True)
 class AccountUsageEvent:
     event_id: str
@@ -43,6 +48,7 @@ class AccountUsageEvent:
     failure_kind: str | None = None
     cooldown_reason: str | None = None
     reset_at: datetime | None = None
+    attribution_status: AccountUsageAttributionStatus | None = None
 
 
 @dataclass(frozen=True)
@@ -52,15 +58,21 @@ class AccountUsageDelta:
 
     @property
     def request_delta(self) -> int:
+        if self.before is None:
+            return 0
+
         return max(
-            self.after.daily_requests - (self.before.daily_requests if self.before else 0),
+            self.after.daily_requests - self.before.daily_requests,
             0,
         )
 
     @property
     def tweet_delta(self) -> int:
+        if self.before is None:
+            return 0
+
         return max(
-            self.after.daily_tweets - (self.before.daily_tweets if self.before else 0),
+            self.after.daily_tweets - self.before.daily_tweets,
             0,
         )
 
@@ -86,13 +98,13 @@ def account_usage_deltas(
     before: AccountPoolSnapshot | None,
     after: AccountPoolSnapshot | None,
 ) -> tuple[AccountUsageDelta, ...]:
-    if after is None:
+    if before is None or after is None:
         return ()
 
     before_by_id = {
         account.account_id: account
         for account in before.accounts
-    } if before is not None else {}
+    }
 
     deltas: list[AccountUsageDelta] = []
     for after_account in after.accounts:

--- a/apps/x-collector/src/x_collector/account_usage_observer.py
+++ b/apps/x-collector/src/x_collector/account_usage_observer.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from .account_pool import AccountCapacity, AccountPoolSnapshot
 from .account_usage import (
+    AccountUsageAttributionStatus,
     AccountUsageDelta,
     AccountUsageEvent,
     AccountUsageEventType,
@@ -196,34 +197,22 @@ class AccountUsageObserver:
     ) -> tuple[AccountUsageEvent, ...]:
         after_snapshot = self._snapshot()
         deltas = account_usage_deltas(usage.before_snapshot, after_snapshot)
+        # Shared pool counters can change in another gRPC request and do not
+        # prove which account executed this pass.
+        events = [
+            self._event(
+                request,
+                event_type,
+                usage=usage,
+                fetched_count=fetched_count,
+                accepted_count=accepted_count,
+                failure_kind=failure_kind,
+                reset_at=reset_at,
+                attribution_status=AccountUsageAttributionStatus.UNKNOWN,
+            ),
+        ]
 
-        if not deltas:
-            return (
-                self._event(
-                    request,
-                    event_type,
-                    usage=usage,
-                    fetched_count=fetched_count,
-                    accepted_count=accepted_count,
-                    failure_kind=failure_kind,
-                    reset_at=reset_at,
-                ),
-            )
-
-        events: list[AccountUsageEvent] = []
         for delta in deltas:
-            events.append(
-                self._event_for_delta(
-                    request,
-                    usage,
-                    delta,
-                    event_type=event_type,
-                    fetched_count=fetched_count,
-                    accepted_count=accepted_count,
-                    failure_kind=failure_kind,
-                    reset_at=reset_at,
-                ),
-            )
             if delta.cooldown_observed:
                 events.append(
                     self._event_for_delta(
@@ -249,6 +238,7 @@ class AccountUsageObserver:
         accepted_count: int | None = None,
         failure_kind: str | None = None,
         reset_at: datetime | None = None,
+        attribution_status: AccountUsageAttributionStatus | None = None,
     ) -> AccountUsageEvent:
         before = delta.before
         after = delta.after
@@ -271,6 +261,7 @@ class AccountUsageObserver:
             failure_kind=failure_kind,
             cooldown_reason=after.cooldown_reason,
             reset_at=reset_at or after.available_at,
+            attribution_status=attribution_status,
         )
 
     def _event(
@@ -293,6 +284,7 @@ class AccountUsageObserver:
         failure_kind: str | None = None,
         cooldown_reason: str | None = None,
         reset_at: datetime | None = None,
+        attribution_status: AccountUsageAttributionStatus | None = None,
     ) -> AccountUsageEvent:
         return AccountUsageEvent(
             event_id=self._event_id_factory(),
@@ -332,6 +324,7 @@ class AccountUsageObserver:
             failure_kind=failure_kind,
             cooldown_reason=cooldown_reason,
             reset_at=reset_at,
+            attribution_status=attribution_status,
         )
 
     def _append_safely(

--- a/apps/x-collector/src/x_collector/account_usage_observer.py
+++ b/apps/x-collector/src/x_collector/account_usage_observer.py
@@ -195,7 +195,7 @@ class AccountUsageObserver:
         failure_kind: str | None = None,
         reset_at: datetime | None = None,
     ) -> tuple[AccountUsageEvent, ...]:
-        after_snapshot = self._snapshot()
+        after_snapshot = self._snapshot_safely()
         deltas = account_usage_deltas(usage.before_snapshot, after_snapshot)
         # Shared pool counters can change in another gRPC request and do not
         # prove which account executed this pass.

--- a/apps/x-collector/src/x_collector/sqlite_account_usage_event_repository.py
+++ b/apps/x-collector/src/x_collector/sqlite_account_usage_event_repository.py
@@ -48,8 +48,9 @@ class SqliteAccountUsageEventRepository:
                   returned_count,
                   failure_kind,
                   cooldown_reason,
-                  reset_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                  reset_at,
+                  attribution_status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [event_to_row(event) for event in events],
             )
@@ -65,6 +66,7 @@ def ensure_account_usage_events_schema(connection: sqlite3.Connection) -> None:
         "daily_requests_limit": "INTEGER",
         "daily_tweets_limit": "INTEGER",
         "account_priority": "INTEGER",
+        "attribution_status": "TEXT",
     }.items():
         if column not in columns:
             connection.execute(
@@ -100,7 +102,8 @@ def account_usage_events_schema() -> str:
       returned_count INTEGER,
       failure_kind TEXT,
       cooldown_reason TEXT,
-      reset_at TEXT
+      reset_at TEXT,
+      attribution_status TEXT
     )
     """
 
@@ -150,4 +153,5 @@ def event_to_row(event: AccountUsageEvent) -> tuple[Any, ...]:
         event.failure_kind,
         event.cooldown_reason,
         event.reset_at.isoformat() if event.reset_at else None,
+        event.attribution_status.value if event.attribution_status else None,
     )

--- a/apps/x-collector/tests/test_account_usage_attribution.py
+++ b/apps/x-collector/tests/test_account_usage_attribution.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from threading import Barrier, Lock
+from typing import Callable
+
+from x_collector.account_pool import (
+    AccountCapacity,
+    AccountPoolLimits,
+    AccountPoolSnapshot,
+)
+from x_collector.account_usage import (
+    AccountUsageAttributionStatus,
+    AccountUsageDelta,
+    AccountUsageEvent,
+    AccountUsageEventType,
+    account_usage_deltas,
+)
+from x_collector.account_usage_observer import AccountUsageObserver
+from x_collector.domain import DailySearchRequest, SearchProduct
+from x_collector.search_plan import ScweetSearchPass
+
+
+@dataclass(frozen=True)
+class FixedClock:
+    value: datetime
+
+    def now(self) -> datetime:
+        return self.value
+
+
+class SnapshotLedger:
+    def __init__(
+        self,
+        snapshots: tuple[AccountPoolSnapshot | None, ...],
+    ) -> None:
+        self._snapshots = snapshots
+        self._index = 0
+
+    def snapshot(self, now: datetime) -> AccountPoolSnapshot | None:
+        del now
+        snapshot = self._snapshots[min(self._index, len(self._snapshots) - 1)]
+        self._index += 1
+        return snapshot
+
+
+class CapturingRepository:
+    def __init__(self) -> None:
+        self.events: list[AccountUsageEvent] = []
+
+    def append_events(self, events: tuple[AccountUsageEvent, ...]) -> None:
+        self.events.extend(events)
+
+
+class ConcurrentMutationLedger:
+    def __init__(self, initial: AccountPoolSnapshot) -> None:
+        self._current = initial
+        self._lock = Lock()
+
+    def snapshot(self, now: datetime) -> AccountPoolSnapshot:
+        del now
+        with self._lock:
+            return self._current
+
+    def replace(self, current: AccountPoolSnapshot) -> None:
+        with self._lock:
+            self._current = current
+
+
+class AccountUsageAttributionTest(unittest.TestCase):
+    def test_does_not_infer_known_from_unique_shared_counter_delta(self) -> None:
+        before = snapshot(account(1), account(2))
+        after = snapshot(
+            replace(
+                account(1),
+                daily_requests=1,
+                daily_tweets=3,
+                remaining_requests=29,
+                remaining_tweets=597,
+            ),
+            replace(account(2), busy=True),
+        )
+
+        results = observe_success(before, after)
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].account_id)
+        self.assertEqual(
+            results[0].attribution_status,
+            AccountUsageAttributionStatus.UNKNOWN,
+        )
+        self.assertEqual(results[0].fetched_count, 3)
+
+    def test_concurrent_unrelated_account_delta_remains_unknown(self) -> None:
+        before = snapshot(account(1), account(2))
+        ledger = ConcurrentMutationLedger(before)
+        repository = CapturingRepository()
+        observer = AccountUsageObserver(
+            ledger,
+            repository,
+            FixedClock(before.observed_at),
+            event_id_factory=event_id_factory(),
+        )
+        usage = observer.begin_pass(request(), search_pass(), 1)
+        mutation_barrier = Barrier(2)
+
+        def mutate_unrelated_account() -> None:
+            mutation_barrier.wait()
+            ledger.replace(
+                snapshot(
+                    account(1),
+                    replace(
+                        account(2),
+                        daily_requests=1,
+                        daily_tweets=7,
+                        remaining_requests=29,
+                        remaining_tweets=593,
+                    ),
+                ),
+            )
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            unrelated_request = executor.submit(mutate_unrelated_account)
+            mutation_barrier.wait()
+            unrelated_request.result(timeout=1)
+
+        observer.complete_pass_success(
+            request(),
+            usage,
+            fetched_count=3,
+            accepted_count=2,
+        )
+        results = [
+            event
+            for event in repository.events
+            if event.event_type is AccountUsageEventType.PASS_SUCCEEDED
+        ]
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].account_id)
+        self.assertEqual(
+            results[0].attribution_status,
+            AccountUsageAttributionStatus.UNKNOWN,
+        )
+        self.assertEqual(results[0].fetched_count, 3)
+
+    def test_uses_explicit_unknown_when_snapshot_has_no_identity_delta(
+        self,
+    ) -> None:
+        unchanged = snapshot(account(1), account(2))
+
+        results = observe_success(unchanged, unchanged)
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].account_id)
+        self.assertEqual(
+            results[0].attribution_status,
+            AccountUsageAttributionStatus.UNKNOWN,
+        )
+        self.assertEqual(results[0].accepted_count, 2)
+
+    def test_does_not_duplicate_result_when_multiple_accounts_have_usage(
+        self,
+    ) -> None:
+        before = snapshot(account(1), account(2))
+        after = snapshot(
+            replace(
+                account(1),
+                daily_requests=1,
+                daily_tweets=2,
+                remaining_requests=29,
+                remaining_tweets=598,
+            ),
+            replace(
+                account(2),
+                daily_requests=1,
+                daily_tweets=1,
+                remaining_requests=29,
+                remaining_tweets=599,
+            ),
+        )
+
+        results = observe_success(before, after)
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].account_id)
+        self.assertEqual(
+            results[0].attribution_status,
+            AccountUsageAttributionStatus.UNKNOWN,
+        )
+
+    def test_missing_baseline_does_not_treat_historical_counters_as_usage(
+        self,
+    ) -> None:
+        after = snapshot(
+            replace(
+                account(1),
+                daily_requests=24,
+                daily_tweets=137,
+                remaining_requests=6,
+                remaining_tweets=463,
+            ),
+        )
+
+        self.assertEqual(account_usage_deltas(None, after), ())
+        delta = AccountUsageDelta(before=None, after=after.accounts[0])
+        self.assertEqual(delta.request_delta, 0)
+        self.assertEqual(delta.tweet_delta, 0)
+
+        results = observe_success(None, after)
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].account_id)
+        self.assertEqual(
+            results[0].attribution_status,
+            AccountUsageAttributionStatus.UNKNOWN,
+        )
+
+    def test_busy_only_change_does_not_select_known_attribution(self) -> None:
+        before = snapshot(account(1), account(2))
+        after = snapshot(account(1), replace(account(2), busy=True))
+
+        results = observe_success(before, after)
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].account_id)
+        self.assertEqual(
+            results[0].attribution_status,
+            AccountUsageAttributionStatus.UNKNOWN,
+        )
+
+
+def observe_success(
+    before: AccountPoolSnapshot | None,
+    after: AccountPoolSnapshot,
+) -> list[AccountUsageEvent]:
+    repository = CapturingRepository()
+    observer = AccountUsageObserver(
+        SnapshotLedger((before, after)),
+        repository,
+        FixedClock(after.observed_at),
+        event_id_factory=event_id_factory(),
+    )
+    usage = observer.begin_pass(request(), search_pass(), 1)
+    observer.complete_pass_success(
+        request(),
+        usage,
+        fetched_count=3,
+        accepted_count=2,
+    )
+
+    return [
+        event
+        for event in repository.events
+        if event.event_type is AccountUsageEventType.PASS_SUCCEEDED
+    ]
+
+
+def snapshot(*accounts: AccountCapacity) -> AccountPoolSnapshot:
+    return AccountPoolSnapshot(
+        observed_at=datetime(2026, 7, 18, 0, 5, tzinfo=UTC),
+        limits=AccountPoolLimits(daily_requests=30, daily_tweets=600),
+        accounts=accounts,
+    )
+
+
+def account(account_id: int) -> AccountCapacity:
+    return AccountCapacity(
+        account_id=account_id,
+        username=f"research-{account_id}",
+        status=1,
+        daily_requests=0,
+        daily_tweets=0,
+        daily_requests_limit=30,
+        daily_tweets_limit=600,
+        priority=account_id,
+        remaining_requests=30,
+        remaining_tweets=600,
+        available_at=None,
+        lease_id=None,
+        lease_expires_at=None,
+        busy=False,
+        cooldown_reason=None,
+    )
+
+
+def request() -> DailySearchRequest:
+    return DailySearchRequest(
+        request_id="request-1",
+        tenant_id="tenant-1",
+        workspace_id="workspace-1",
+        source_binding_id="binding-1",
+        scan_job_id="scan-1",
+        correlation_id="correlation-1",
+        query="AI agents",
+        language="en",
+        window_hours=24,
+        window_end=datetime(2026, 7, 18, tzinfo=UTC),
+        search_products=(SearchProduct.TOP,),
+        limit_per_product=10,
+        max_items=5,
+        min_likes=None,
+        min_retweets=None,
+        min_replies=None,
+        cursor=None,
+    )
+
+
+def search_pass() -> ScweetSearchPass:
+    return ScweetSearchPass(
+        label="top_base",
+        product=SearchProduct.TOP,
+        limit=10,
+        min_likes=None,
+        min_retweets=None,
+        min_replies=None,
+    )
+
+
+def event_id_factory() -> Callable[[], str]:
+    next_id = 0
+
+    def create() -> str:
+        nonlocal next_id
+        next_id += 1
+        return f"event-{next_id}"
+
+    return create
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/x-collector/tests/test_account_usage_attribution.py
+++ b/apps/x-collector/tests/test_account_usage_attribution.py
@@ -70,7 +70,83 @@ class ConcurrentMutationLedger:
             self._current = current
 
 
+class CompletionSnapshotFailureLedger:
+    def __init__(self, before: AccountPoolSnapshot) -> None:
+        self._before = before
+        self._snapshot_count = 0
+
+    def snapshot(self, now: datetime) -> AccountPoolSnapshot:
+        del now
+        self._snapshot_count += 1
+        if self._snapshot_count == 1:
+            return self._before
+        raise RuntimeError("completion snapshot unavailable")
+
+
 class AccountUsageAttributionTest(unittest.TestCase):
+    def test_success_persists_unknown_when_completion_snapshot_fails(
+        self,
+    ) -> None:
+        before = snapshot(account(1))
+        repository = CapturingRepository()
+        observer = AccountUsageObserver(
+            CompletionSnapshotFailureLedger(before),
+            repository,
+            FixedClock(before.observed_at),
+            event_id_factory=event_id_factory(),
+        )
+        usage = observer.begin_pass(request(), search_pass(), 1)
+
+        observer.complete_pass_success(
+            request(),
+            usage,
+            fetched_count=3,
+            accepted_count=2,
+        )
+
+        results = [
+            event
+            for event in repository.events
+            if event.event_type is AccountUsageEventType.PASS_SUCCEEDED
+        ]
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].account_id)
+        self.assertEqual(
+            results[0].attribution_status,
+            AccountUsageAttributionStatus.UNKNOWN,
+        )
+
+    def test_failure_persists_unknown_when_completion_snapshot_fails(
+        self,
+    ) -> None:
+        before = snapshot(account(1))
+        repository = CapturingRepository()
+        observer = AccountUsageObserver(
+            CompletionSnapshotFailureLedger(before),
+            repository,
+            FixedClock(before.observed_at),
+            event_id_factory=event_id_factory(),
+        )
+        usage = observer.begin_pass(request(), search_pass(), 1)
+
+        observer.complete_pass_failure(
+            request(),
+            usage,
+            failure_kind="provider_error",
+        )
+
+        results = [
+            event
+            for event in repository.events
+            if event.event_type is AccountUsageEventType.PASS_FAILED
+        ]
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].account_id)
+        self.assertEqual(
+            results[0].attribution_status,
+            AccountUsageAttributionStatus.UNKNOWN,
+        )
+
     def test_does_not_infer_known_from_unique_shared_counter_delta(self) -> None:
         before = snapshot(account(1), account(2))
         after = snapshot(

--- a/apps/x-collector/tests/test_account_usage_observability.py
+++ b/apps/x-collector/tests/test_account_usage_observability.py
@@ -49,16 +49,17 @@ def test_collect_daily_search_records_audit_only_account_usage_events(
         row for row in rows
         if row["event_type"] == "pass_succeeded"
     ]
-    assert succeeded[0]["account_id"] == 1
-    assert succeeded[0]["requests_before"] == 0
-    assert succeeded[0]["requests_after"] == 1
-    assert succeeded[0]["daily_requests_limit"] == 30
-    assert succeeded[0]["daily_tweets_limit"] == 600
-    assert succeeded[0]["account_priority"] == 100
-    assert succeeded[0]["tweets_before"] == 0
-    assert succeeded[0]["tweets_after"] == 2
+    assert succeeded[0]["account_id"] is None
+    assert succeeded[0]["requests_before"] is None
+    assert succeeded[0]["requests_after"] is None
+    assert succeeded[0]["daily_requests_limit"] is None
+    assert succeeded[0]["daily_tweets_limit"] is None
+    assert succeeded[0]["account_priority"] is None
+    assert succeeded[0]["tweets_before"] is None
+    assert succeeded[0]["tweets_after"] is None
     assert succeeded[0]["fetched_count"] == 2
     assert succeeded[0]["accepted_count"] == 2
+    assert succeeded[0]["attribution_status"] == "unknown"
 
 
 def test_account_usage_observer_failures_do_not_break_collection(
@@ -115,12 +116,69 @@ def test_collect_daily_search_records_rate_limit_cooldown_events(
         row for row in rows
         if row["event_type"] == "cooldown_observed"
     ]
-    assert failed[0]["account_id"] == 1
+    assert failed[0]["account_id"] is None
     assert failed[0]["failure_kind"] == "rate_limited"
-    assert failed[0]["cooldown_reason"] == "rate_limit"
+    assert failed[0]["cooldown_reason"] is None
     assert failed[0]["reset_at"] == reset_at.isoformat()
+    assert failed[0]["attribution_status"] == "unknown"
     assert cooldowns[0]["account_id"] == 1
     assert cooldowns[0]["cooldown_reason"] == "rate_limit"
+
+
+def test_pass_result_is_unknown_when_two_account_states_change(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "scweet_state.db"
+    create_scweet_accounts_table(db_path)
+    insert_scweet_account(db_path, daily_requests=0, daily_tweets=0)
+    insert_scweet_account(
+        db_path,
+        account_id=2,
+        username="research-2",
+        daily_requests=0,
+        daily_tweets=0,
+    )
+    clock = FixedClock(datetime(2026, 6, 27, 12, tzinfo=UTC))
+    collector = collector_with_observability(
+        db_path,
+        TwoAccountStateChangeScweet(db_path),
+        clock,
+    )
+
+    collector.collect_daily_search(request(max_items=2))
+
+    succeeded = [
+        row for row in account_usage_event_rows(db_path)
+        if row["event_type"] == "pass_succeeded"
+    ]
+    assert {row["account_id"] for row in succeeded} == {None}
+    assert {row["attribution_status"] for row in succeeded} == {"unknown"}
+    assert sum(row["fetched_count"] for row in succeeded) == 6
+
+
+def test_pass_result_records_explicit_unknown_when_no_account_delta_exists(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "scweet_state.db"
+    create_scweet_accounts_table(db_path)
+    insert_scweet_account(db_path, daily_requests=0, daily_tweets=0)
+    clock = FixedClock(datetime(2026, 6, 27, 12, tzinfo=UTC))
+    collector = collector_with_observability(
+        db_path,
+        NoStateChangeScweet(),
+        clock,
+    )
+
+    result = collector.collect_daily_search(request(max_items=1))
+
+    assert [post.tweet_id for post in result.posts] == ["300"]
+    succeeded = [
+        row for row in account_usage_event_rows(db_path)
+        if row["event_type"] == "pass_succeeded"
+    ]
+    assert len(succeeded) == 3
+    assert {row["account_id"] for row in succeeded} == {None}
+    assert {row["attribution_status"] for row in succeeded} == {"unknown"}
 
 
 class DbUpdatingScweet:
@@ -134,6 +192,33 @@ class DbUpdatingScweet:
         increment_account_usage(self._db_path, request_count=1, tweet_count=len(records))
 
         return records
+
+
+class TwoAccountStateChangeScweet:
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._changed_secondary = False
+
+    def search(self, *_: object, **kwargs: object) -> list[dict[str, object]]:
+        records = tweets_for_product(str(kwargs["display_type"]))
+        increment_account_usage(
+            self._db_path,
+            request_count=1,
+            tweet_count=len(records),
+        )
+        if not self._changed_secondary:
+            with sqlite3.connect(self._db_path) as connection:
+                connection.execute(
+                    "UPDATE accounts SET busy = 1 WHERE id = 2",
+                )
+            self._changed_secondary = True
+
+        return records
+
+
+class NoStateChangeScweet:
+    def search(self, *_: object, **kwargs: object) -> list[dict[str, object]]:
+        return tweets_for_product(str(kwargs["display_type"]))
 
 
 class RateLimitedAfterFirstPassScweet:
@@ -281,6 +366,8 @@ def create_scweet_accounts_table(db_path: Path) -> None:
 def insert_scweet_account(
     db_path: Path,
     *,
+    account_id: int = 1,
+    username: str = "research-1",
     daily_requests: int,
     daily_tweets: int,
 ) -> None:
@@ -302,8 +389,8 @@ def insert_scweet_account(
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                1,
-                "research-1",
+                account_id,
+                username,
                 1,
                 0.0,
                 0.0,

--- a/scripts/check-source-line-cap.mjs
+++ b/scripts/check-source-line-cap.mjs
@@ -56,7 +56,6 @@ const legacyLineCapDebt = new Map([
   ["scripts/check-staging-reliability-evidence.mjs", 2203],
   ["scripts/check-summary-feedback-hardening.mjs", 1328],
   ["scripts/check-yesterday-reader-summary-artifact-quality.ts", 1225],
-  ["scripts/check-yesterday-social-collection-quality.ts", 1647],
   ["scripts/external-beta-evidence-runner.mjs", 2113],
   ["scripts/lib/docker-backend-evidence-harness.mjs", 1174],
   ["test/e2e/feed.items.list.e2e-spec.ts", 1117],

--- a/scripts/check-yesterday-social-collection-quality.ts
+++ b/scripts/check-yesterday-social-collection-quality.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
@@ -19,7 +18,29 @@ import {
   type XAccountPoolReport,
   type XCollectorLedgerReport,
 } from "./lib/x-collector-quality-report-support";
+import { finalizeXAccountAttributionWarningOnly } from "./lib/x-account-attribution-warning-policy";
 import { productionCollectionThresholds } from "./lib/production-collection-quality-policy";
+import {
+  average,
+  averageValues,
+  countBy,
+  errorMessage,
+  fingerprints,
+  groupBy,
+  hashText,
+  noRawSecretFragments,
+  normalizeLineEndings,
+  percentile,
+  providerFeedItemCountAtLeast,
+  ratio,
+  readJson,
+  roundMetric,
+  runRateAtLeast,
+  statusCounts,
+  sumCounts,
+  tokenize,
+  visibleRows,
+} from "./lib/yesterday-social-collection-quality-helpers";
 
 type FeedRow = {
   readonly interestId: string;
@@ -182,6 +203,14 @@ type Report = {
     readonly xCollectorInvalidJsonFieldCount: number;
     readonly xAccountPoolUsageEventCount: number;
     readonly xAccountPoolLimitProfileObservedCount: number;
+    readonly xAccountAttributionStatus: "known" | "partial" | "unknown";
+    readonly xAccountAttributionPolicy: "warning_only";
+    readonly xAccountAttributionGateReason: string;
+    readonly xAccountAttributionWarningCount: number;
+    readonly xAccountAttributionWarnings: readonly {
+      readonly code: string;
+      readonly accountFingerprint: string;
+    }[];
     readonly publishedOutsideWindowFeedItemCount: number;
     readonly lowRelevanceFeedItemCount: number;
   };
@@ -423,6 +452,10 @@ async function tryBuildReport(): Promise<Report | undefined> {
       collectionIntegrityCleanForEval: collectionIntegrity.status === "clean",
       noRawSecretFragments: true,
     };
+    const attributionVerdict = finalizeXAccountAttributionWarningOnly({
+      qualityGates,
+      attribution: xAccountPool,
+    });
     const reportWithoutSecretGate = {
       schemaVersion: 1,
       artifactFormat: "yesterday-social-collection-quality-report-v1",
@@ -475,6 +508,7 @@ async function tryBuildReport(): Promise<Report | undefined> {
         xAccountPoolUsageEventCount: xAccountPool.eventCount,
         xAccountPoolLimitProfileObservedCount:
           xAccountPool.accountLimitProfileObservedCount,
+        ...attributionVerdict.operationalWarnings,
         publishedOutsideWindowFeedItemCount:
           dayWindowAudit.observedButPublishedOutsideWindowFeedItemCount,
         lowRelevanceFeedItemCount: dayWindowAudit.lowRelevanceFeedItemCount,
@@ -492,15 +526,20 @@ async function tryBuildReport(): Promise<Report | undefined> {
     } satisfies Report;
     const finalQualityGates = {
       ...reportWithoutSecretGate.qualityGates,
-      noRawSecretFragments: noRawSecretFragments(reportWithoutSecretGate),
+      noRawSecretFragments: noRawSecretFragments(
+        reportWithoutSecretGate,
+        forbiddenSerializedFragments,
+      ),
     };
+    const finalVerdict = finalizeXAccountAttributionWarningOnly({
+      qualityGates: finalQualityGates,
+      attribution: xAccountPool,
+    });
 
     return {
       ...reportWithoutSecretGate,
       qualityGates: finalQualityGates,
-      collectionBlockingPassed: Object.values(finalQualityGates).every(
-        (value) => value === true,
-      ),
+      collectionBlockingPassed: finalVerdict.collectionBlockingPassed,
     };
   } catch (error) {
     console.warn(
@@ -863,7 +902,7 @@ function validateExistingReport(expectedCollectionDate: string): void {
     primarySources.every((source) =>
       report.primarySourceCoverage.includes(source),
     ) &&
-    noRawSecretFragments(report);
+    noRawSecretFragments(report, forbiddenSerializedFragments);
 
   if (!valid) {
     throw new Error(`${outputPath} failed existing artifact validation`);
@@ -927,191 +966,4 @@ function rankInputReadinessScore(
       freshnessScore,
     ]),
   );
-}
-
-function tokenize(value: string): readonly string[] {
-  const stopWords = new Set([
-    "about",
-    "after",
-    "and",
-    "before",
-    "for",
-    "from",
-    "how",
-    "into",
-    "that",
-    "the",
-    "this",
-    "what",
-    "when",
-    "where",
-    "which",
-    "with",
-    "your",
-  ]);
-
-  return [
-    ...new Set(
-      value
-        .toLowerCase()
-        .replace(/[^a-z0-9+#.]+/g, " ")
-        .split(/\s+/)
-        .filter((term) => term.length >= 3 && !stopWords.has(term)),
-    ),
-  ];
-}
-
-function statusCounts(
-  rows: readonly SummaryCountRow[],
-): Record<string, number> {
-  return Object.fromEntries(
-    rows.map((row) => [
-      row.status ?? "unknown",
-      Number.parseInt(row.count, 10),
-    ]),
-  );
-}
-
-function sumCounts(rows: readonly SummaryCountRow[]): number {
-  return rows.reduce((sum, row) => sum + Number.parseInt(row.count, 10), 0);
-}
-
-function groupBy<TKey, TValue>(
-  values: readonly TValue[],
-  keyOf: (value: TValue) => TKey,
-): Map<TKey, TValue[]> {
-  const grouped = new Map<TKey, TValue[]>();
-
-  for (const value of values) {
-    const key = keyOf(value);
-    const bucket = grouped.get(key) ?? [];
-
-    bucket.push(value);
-    grouped.set(key, bucket);
-  }
-
-  return grouped;
-}
-
-function countBy<TValue>(
-  values: readonly TValue[],
-  keyOf: (value: TValue) => string,
-): Record<string, number> {
-  const counts = new Map<string, number>();
-
-  for (const value of values) {
-    const key = keyOf(value);
-
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-
-  return Object.fromEntries(
-    [...counts.entries()].sort(([left], [right]) => left.localeCompare(right)),
-  );
-}
-
-function ratio<TValue>(
-  values: readonly TValue[],
-  predicate: (value: TValue) => boolean,
-): number {
-  if (values.length === 0) {
-    return 0;
-  }
-
-  return roundMetric(
-    values.filter((value) => predicate(value)).length / values.length,
-  );
-}
-
-function average<TValue>(
-  values: readonly TValue[],
-  valueOf: (value: TValue) => number,
-): number {
-  if (values.length === 0) {
-    return 0;
-  }
-
-  return averageValues(values.map((value) => valueOf(value)));
-}
-
-function averageValues(values: readonly number[]): number {
-  if (values.length === 0) {
-    return 0;
-  }
-
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
-}
-
-function percentile(values: readonly number[], percent: number): number {
-  if (values.length === 0) {
-    return 0;
-  }
-
-  const sorted = [...values].sort((left, right) => left - right);
-  const index = Math.min(
-    sorted.length - 1,
-    Math.max(0, Math.ceil(sorted.length * percent) - 1),
-  );
-
-  return sorted[index] ?? 0;
-}
-
-function readJson<TValue>(path: string): TValue {
-  return JSON.parse(readFileSync(path, "utf8")) as TValue;
-}
-
-function hashText(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function fingerprints(values: readonly string[]): readonly string[] {
-  return [...new Set(values.map((value) => hashText(value).slice(0, 12)))]
-    .sort()
-    .slice(0, 20);
-}
-
-function noRawSecretFragments(value: unknown): boolean {
-  const serialized = JSON.stringify(value).toLowerCase();
-
-  return forbiddenSerializedFragments.every(
-    (fragment) => !serialized.includes(fragment),
-  );
-}
-
-function providerFeedItemCountAtLeast(
-  reports: readonly ProviderReport[],
-  providerKey: string,
-  threshold: number,
-): boolean {
-  return (
-    (reports.find((item) => item.providerKey === providerKey)
-      ?.visibleFeedItemCount ?? 0) >= threshold
-  );
-}
-
-function runRateAtLeast(
-  acceptedRunCount: number,
-  totalRunCount: number,
-  thresholdPercent: number,
-): boolean {
-  return (
-    totalRunCount > 0 &&
-    acceptedRunCount * 100 >= totalRunCount * thresholdPercent
-  );
-}
-
-function visibleRows(rows: readonly FeedRow[]): readonly FeedRow[] {
-  return rows.filter((row) => row.status === "VISIBLE");
-}
-
-function normalizeLineEndings(value: string): string {
-  return value.replace(/\r\n/g, "\n");
-}
-
-function roundMetric(value: number): number {
-  return Number(value.toFixed(3));
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/scripts/check-yesterday-social-collection-quality.ts
+++ b/scripts/check-yesterday-social-collection-quality.ts
@@ -21,6 +21,9 @@ import {
 import { finalizeXAccountAttributionWarningOnly } from "./lib/x-account-attribution-warning-policy";
 import { productionCollectionThresholds } from "./lib/production-collection-quality-policy";
 import {
+  isValidExistingYesterdaySocialCollectionQualityReport,
+} from "./lib/yesterday-social-collection-quality-report-validation";
+import {
   average,
   averageValues,
   countBy,
@@ -371,6 +374,7 @@ async function tryBuildReport(): Promise<Report | undefined> {
       return report === undefined ? [] : [report];
     });
     const qualityGates = {
+      globalXCollectionSucceeded: true as const,
       postgresFeedItemsAvailable: summaryWindowRows.length > 0,
       allExpectedPrimarySourcesPresent:
         primarySourceCoverage.length === primarySources.length,
@@ -894,15 +898,12 @@ function validateExistingReport(expectedCollectionDate: string): void {
   }
 
   const report = readJson<Report>(outputPath);
-  const valid =
-    report.schemaVersion === 1 &&
-    report.artifactFormat === "yesterday-social-collection-quality-report-v1" &&
-    report.collectionDate === expectedCollectionDate &&
-    report.collectionBlockingPassed === true &&
-    primarySources.every((source) =>
-      report.primarySourceCoverage.includes(source),
-    ) &&
-    noRawSecretFragments(report, forbiddenSerializedFragments);
+  const valid = isValidExistingYesterdaySocialCollectionQualityReport({
+    report,
+    expectedCollectionDate,
+    requiredPrimarySources: primarySources,
+    forbiddenSerializedFragments,
+  });
 
   if (!valid) {
     throw new Error(`${outputPath} failed existing artifact validation`);

--- a/scripts/lib/reader-summary-production-day-report.spec.ts
+++ b/scripts/lib/reader-summary-production-day-report.spec.ts
@@ -4,6 +4,7 @@ import {
 } from "./reader-summary-production-day-collection-barrier";
 import {
   buildProductionDayReport,
+  type ProductionDayCollectionQuality,
   validateLiveProductionDayReport,
 } from "./reader-summary-production-day-report";
 import {
@@ -163,6 +164,116 @@ describe("production-day report", () => {
     ).toContain("model must exactly identify the subscription runtime");
   });
 
+  it("preserves snapshot dates and explicit unknown account attribution", () => {
+    const collectionQuality = {
+      collectionDate,
+      dayWindowAudit: {
+        publishedInsideWindowFeedItemCount: 10,
+        providerBreakdown: [],
+      },
+      xAccountPool: {
+        totalAccountCount: 1,
+        eligibleAccountCount: 1,
+        attributionStatus: "unknown",
+        attributionPolicy: "warning_only",
+        attributionGateReason:
+          "unknown_attribution_global_collection_succeeded_warning_only",
+        eligibleAccountZeroAttributableOutputWarningCount: 0,
+        attributionWarnings: [],
+        accounts: [
+          {
+            accountFingerprint: "account-fingerprint",
+            priorityRank: 1,
+            dailyRequests: 24,
+            dailyTweets: 0,
+            observedAccountSnapshot: {
+              observedAt: "2026-07-16T00:05:00.000Z",
+              dailyRequests: 24,
+              dailyTweets: 0,
+              counterResetDate: "2026-07-16",
+              counterResetDateMatchesTargetDate: false,
+            },
+            targetWindowAttribution: {
+              collectionDate,
+              status: "unknown",
+              requestDelta: null,
+              tweetDelta: null,
+              fetchedCount: null,
+              acceptedCount: null,
+              returnedCount: null,
+              passSucceededCount: null,
+              passFailedCount: null,
+            },
+          },
+        ],
+      },
+    } satisfies ProductionDayCollectionQuality;
+
+    const report = buildReport(
+      passedSteps(),
+      evidenceFixture(),
+      collectionQuality,
+    );
+
+    expect(report.stats.xAccounts[0]).toMatchObject({
+      dailyRequests: 24,
+      dailyTweets: 0,
+      passSucceededCount: null,
+      passFailedCount: null,
+      attributionStatus: "unknown",
+      observedAccountSnapshot: {
+        counterResetDate: "2026-07-16",
+        counterResetDateMatchesTargetDate: false,
+      },
+      targetWindowAttribution: {
+        collectionDate,
+        status: "unknown",
+        requestDelta: null,
+        acceptedCount: null,
+      },
+    });
+    expect(report.stats.xAccountAttribution).toEqual({
+      status: "unknown",
+      policy: "warning_only",
+      gateReason:
+        "unknown_attribution_global_collection_succeeded_warning_only",
+      warningCount: 0,
+      warnings: [],
+    });
+  });
+
+  it("persists pool-level attribution warnings in durable stats", () => {
+    const warning = {
+      code: "eligible_account_requests_without_attributable_output",
+      accountFingerprint: "account-fingerprint",
+    };
+    const report = buildReport(passedSteps(), evidenceFixture(), {
+      collectionDate,
+      dayWindowAudit: {
+        publishedInsideWindowFeedItemCount: 10,
+        providerBreakdown: [],
+      },
+      xAccountPool: {
+        totalAccountCount: 2,
+        eligibleAccountCount: 2,
+        attributionStatus: "known",
+        attributionPolicy: "warning_only",
+        attributionGateReason:
+          "known_attribution_zero_output_warning_only",
+        eligibleAccountZeroAttributableOutputWarningCount: 1,
+        attributionWarnings: [warning],
+      },
+    });
+
+    expect(report.stats.xAccountAttribution).toEqual({
+      status: "known",
+      policy: "warning_only",
+      gateReason: "known_attribution_zero_output_warning_only",
+      warningCount: 1,
+      warnings: [warning],
+    });
+  });
+
   it.each([true, undefined, "false"])(
     "validator rejects nonLive=%p for a live report",
     (nonLive) => {
@@ -195,6 +306,14 @@ function liveReport() {
 function buildReport(
   steps: readonly ProductionDayStepReport[],
   artifact = evidenceFixture(),
+  collectionQuality: ProductionDayCollectionQuality = {
+    collectionDate,
+    dayWindowAudit: {
+      publishedInsideWindowFeedItemCount: 10,
+      providerBreakdown: [],
+    },
+    xAccountPool: { totalAccountCount: 1, eligibleAccountCount: 1 },
+  },
 ) {
   return buildProductionDayReport({
     executionMode: "live-production",
@@ -209,14 +328,7 @@ function buildReport(
       tenantId: "33333333-3333-4333-8333-333333333333",
       workspaceId: "44444444-4444-4444-8444-444444444444",
     },
-    collectionQuality: {
-      collectionDate,
-      dayWindowAudit: {
-        publishedInsideWindowFeedItemCount: 10,
-        providerBreakdown: [],
-      },
-      xAccountPool: { totalAccountCount: 1, eligibleAccountCount: 1 },
-    },
+    collectionQuality,
     durableEvidence: artifact.evidence,
     evidenceBinding: artifact.binding,
     liveCaptureExecution: artifact.binding.captureExecution,

--- a/scripts/lib/reader-summary-production-day-report.spec.ts
+++ b/scripts/lib/reader-summary-production-day-report.spec.ts
@@ -274,6 +274,113 @@ describe("production-day report", () => {
     });
   });
 
+  it("normalizes partial nested X account attribution per field", () => {
+    const report = buildReport(passedSteps(), evidenceFixture(), {
+      collectionDate,
+      dayWindowAudit: {
+        publishedInsideWindowFeedItemCount: 10,
+        providerBreakdown: [],
+      },
+      xAccountPool: {
+        totalAccountCount: 1,
+        eligibleAccountCount: 1,
+        attributionStatus: "partial",
+        attributionPolicy: "warning_only",
+        attributionGateReason:
+          "partial_attribution_global_collection_succeeded_warning_only",
+        eligibleAccountZeroAttributableOutputWarningCount: 0,
+        attributionWarnings: [],
+        accounts: [
+          {
+            accountFingerprint: "account-fingerprint",
+            priorityRank: 1,
+            dailyRequests: 24,
+            dailyTweets: 5,
+            lastResetDate: "2026-07-16",
+            observedAccountSnapshot: {
+              observedAt: "2026-07-16T00:05:00.000Z",
+            },
+            targetWindowAttribution: {
+              status: "partial",
+              requestDelta: 2,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(report.stats.xAccounts[0]?.observedAccountSnapshot).toStrictEqual({
+      observedAt: "2026-07-16T00:05:00.000Z",
+      dailyRequests: 24,
+      dailyTweets: 5,
+      counterResetDate: "2026-07-16",
+      counterResetDateMatchesTargetDate: false,
+    });
+    expect(report.stats.xAccounts[0]?.targetWindowAttribution).toStrictEqual({
+      collectionDate: undefined,
+      status: "partial",
+      requestDelta: 2,
+      tweetDelta: null,
+      fetchedCount: null,
+      acceptedCount: null,
+      returnedCount: null,
+      passSucceededCount: null,
+      passFailedCount: null,
+    });
+  });
+
+  it.each([
+    ["status", undefined],
+    ["status", "future"],
+    ["policy", undefined],
+    ["policy", "blocking"],
+    ["gateReason", undefined],
+    ["gateReason", "   "],
+    ["warningCount", undefined],
+    ["warningCount", 0.5],
+    ["warnings", undefined],
+    ["warnings", {}],
+  ] as const)(
+    "validator rejects an incomplete attribution contract with %s=%p",
+    (field, value) => {
+      const { report, binding } = liveReport();
+      const candidate = structuredClone(report);
+      const mutable = candidate as unknown as {
+        stats: { xAccountAttribution: Record<string, unknown> };
+      };
+      mutable.stats.xAccountAttribution[field] = value;
+
+      expect(
+        validateLiveProductionDayReport({
+          report: candidate,
+          binding,
+          expectedDate: collectionDate,
+        }),
+      ).toContain(
+        "stats.xAccountAttribution must contain a complete warning-only attribution contract",
+      );
+    },
+  );
+
+  it("validator rejects an attribution warning count inconsistent with warnings", () => {
+    const { report, binding } = liveReport();
+    const candidate = structuredClone(report);
+    const mutable = candidate as unknown as {
+      stats: { xAccountAttribution: { warningCount: number } };
+    };
+    mutable.stats.xAccountAttribution.warningCount = 1;
+
+    expect(
+      validateLiveProductionDayReport({
+        report: candidate,
+        binding,
+        expectedDate: collectionDate,
+      }),
+    ).toContain(
+      "stats.xAccountAttribution must contain a complete warning-only attribution contract",
+    );
+  });
+
   it.each([true, undefined, "false"])(
     "validator rejects nonLive=%p for a live report",
     (nonLive) => {
@@ -312,7 +419,16 @@ function buildReport(
       publishedInsideWindowFeedItemCount: 10,
       providerBreakdown: [],
     },
-    xAccountPool: { totalAccountCount: 1, eligibleAccountCount: 1 },
+    xAccountPool: {
+      totalAccountCount: 1,
+      eligibleAccountCount: 1,
+      attributionStatus: "unknown",
+      attributionPolicy: "warning_only",
+      attributionGateReason:
+        "unknown_attribution_global_collection_succeeded_warning_only",
+      eligibleAccountZeroAttributableOutputWarningCount: 0,
+      attributionWarnings: [],
+    },
   },
 ) {
   return buildProductionDayReport({

--- a/scripts/lib/reader-summary-production-day-report.ts
+++ b/scripts/lib/reader-summary-production-day-report.ts
@@ -53,6 +53,14 @@ export type ProductionDayCollectionQuality = {
     readonly totalAccountCount?: number;
     readonly eligibleAccountCount?: number;
     readonly eventCount?: number;
+    readonly attributionStatus?: "known" | "partial" | "unknown";
+    readonly attributionPolicy?: "warning_only";
+    readonly attributionGateReason?: string;
+    readonly eligibleAccountZeroAttributableOutputWarningCount?: number;
+    readonly attributionWarnings?: readonly {
+      readonly code: string;
+      readonly accountFingerprint: string;
+    }[];
     readonly accounts?: readonly ProductionDayXAccount[];
   };
 };
@@ -65,12 +73,32 @@ type ProductionDayXAccount = {
   readonly ineligibilityReasonCodes?: readonly string[];
   readonly dailyRequests?: number;
   readonly dailyTweets?: number;
-  readonly passSucceededCount?: number;
-  readonly passFailedCount?: number;
+  readonly lastResetDate?: string | null;
+  readonly attributionStatus?: "known" | "partial" | "unknown";
+  readonly passSucceededCount?: number | null;
+  readonly passFailedCount?: number | null;
   readonly rateLimitCount?: number;
   readonly cooldownObservedCount?: number;
   readonly lastUsedAt?: string | null;
   readonly cooldownUntil?: string | null;
+  readonly observedAccountSnapshot?: {
+    readonly observedAt?: string;
+    readonly dailyRequests?: number | null;
+    readonly dailyTweets?: number | null;
+    readonly counterResetDate?: string | null;
+    readonly counterResetDateMatchesTargetDate?: boolean;
+  };
+  readonly targetWindowAttribution?: {
+    readonly collectionDate?: string;
+    readonly status?: "known" | "partial" | "unknown";
+    readonly requestDelta?: number | null;
+    readonly tweetDelta?: number | null;
+    readonly fetchedCount?: number | null;
+    readonly acceptedCount?: number | null;
+    readonly returnedCount?: number | null;
+    readonly passSucceededCount?: number | null;
+    readonly passFailedCount?: number | null;
+  };
 };
 
 export type ProductionDayDurableEvidence = {
@@ -514,6 +542,16 @@ function buildStats(
     xAccountTotalCount: pool?.totalAccountCount ?? null,
     xAccountEligibleCount: pool?.eligibleAccountCount ?? null,
     xAccountUsageEventCount: pool?.eventCount ?? null,
+    xAccountAttribution: {
+      status: pool?.attributionStatus ?? "unknown",
+      policy: pool?.attributionPolicy ?? "warning_only",
+      gateReason:
+        pool?.attributionGateReason ??
+        "attribution_not_reported_warning_only",
+      warningCount:
+        pool?.eligibleAccountZeroAttributableOutputWarningCount ?? null,
+      warnings: pool?.attributionWarnings ?? [],
+    },
     xAccounts:
       pool?.accounts?.flatMap((account) =>
         account.accountFingerprint === undefined ||
@@ -525,6 +563,25 @@ function buildStats(
 }
 
 function normalizedXAccount(account: ProductionDayXAccount) {
+  const observedAccountSnapshot = account.observedAccountSnapshot ?? {
+    observedAt: undefined,
+    dailyRequests: account.dailyRequests ?? null,
+    dailyTweets: account.dailyTweets ?? null,
+    counterResetDate: account.lastResetDate ?? null,
+    counterResetDateMatchesTargetDate: false,
+  };
+  const targetWindowAttribution = account.targetWindowAttribution ?? {
+    collectionDate: undefined,
+    status: account.attributionStatus ?? ("unknown" as const),
+    requestDelta: null,
+    tweetDelta: null,
+    fetchedCount: null,
+    acceptedCount: null,
+    returnedCount: null,
+    passSucceededCount: null,
+    passFailedCount: null,
+  };
+
   return {
     accountFingerprint: account.accountFingerprint as string,
     priorityRank: account.priorityRank as number,
@@ -533,12 +590,16 @@ function normalizedXAccount(account: ProductionDayXAccount) {
     ineligibilityReasonCodes: account.ineligibilityReasonCodes ?? [],
     dailyRequests: account.dailyRequests ?? 0,
     dailyTweets: account.dailyTweets ?? 0,
-    passSucceededCount: account.passSucceededCount ?? 0,
-    passFailedCount: account.passFailedCount ?? 0,
+    lastResetDate: account.lastResetDate ?? null,
+    passSucceededCount: account.passSucceededCount ?? null,
+    passFailedCount: account.passFailedCount ?? null,
     rateLimitCount: account.rateLimitCount ?? 0,
     cooldownObservedCount: account.cooldownObservedCount ?? 0,
     lastUsedAt: account.lastUsedAt ?? null,
     cooldownUntil: account.cooldownUntil ?? null,
+    attributionStatus: targetWindowAttribution.status ?? "unknown",
+    observedAccountSnapshot,
+    targetWindowAttribution,
   };
 }
 

--- a/scripts/lib/reader-summary-production-day-report.ts
+++ b/scripts/lib/reader-summary-production-day-report.ts
@@ -371,6 +371,11 @@ export function validateLiveProductionDayReport(params: {
   if (!allQualityGatesPass(report.qualityGates)) {
     violations.push("all quality gates must exist and pass");
   }
+  if (!validXAccountAttributionContract(report.stats)) {
+    violations.push(
+      "stats.xAccountAttribution must contain a complete warning-only attribution contract",
+    );
+  }
   return violations;
 }
 
@@ -563,23 +568,39 @@ function buildStats(
 }
 
 function normalizedXAccount(account: ProductionDayXAccount) {
-  const observedAccountSnapshot = account.observedAccountSnapshot ?? {
-    observedAt: undefined,
-    dailyRequests: account.dailyRequests ?? null,
-    dailyTweets: account.dailyTweets ?? null,
-    counterResetDate: account.lastResetDate ?? null,
-    counterResetDateMatchesTargetDate: false,
+  const observedAccountSnapshot = {
+    observedAt: account.observedAccountSnapshot?.observedAt,
+    dailyRequests:
+      account.observedAccountSnapshot?.dailyRequests ??
+      account.dailyRequests ??
+      null,
+    dailyTweets:
+      account.observedAccountSnapshot?.dailyTweets ??
+      account.dailyTweets ??
+      null,
+    counterResetDate:
+      account.observedAccountSnapshot?.counterResetDate ??
+      account.lastResetDate ??
+      null,
+    counterResetDateMatchesTargetDate:
+      account.observedAccountSnapshot?.counterResetDateMatchesTargetDate ??
+      false,
   };
-  const targetWindowAttribution = account.targetWindowAttribution ?? {
-    collectionDate: undefined,
-    status: account.attributionStatus ?? ("unknown" as const),
-    requestDelta: null,
-    tweetDelta: null,
-    fetchedCount: null,
-    acceptedCount: null,
-    returnedCount: null,
-    passSucceededCount: null,
-    passFailedCount: null,
+  const targetWindowAttribution = {
+    collectionDate: account.targetWindowAttribution?.collectionDate,
+    status:
+      account.targetWindowAttribution?.status ??
+      account.attributionStatus ??
+      ("unknown" as const),
+    requestDelta: account.targetWindowAttribution?.requestDelta ?? null,
+    tweetDelta: account.targetWindowAttribution?.tweetDelta ?? null,
+    fetchedCount: account.targetWindowAttribution?.fetchedCount ?? null,
+    acceptedCount: account.targetWindowAttribution?.acceptedCount ?? null,
+    returnedCount: account.targetWindowAttribution?.returnedCount ?? null,
+    passSucceededCount:
+      account.targetWindowAttribution?.passSucceededCount ?? null,
+    passFailedCount:
+      account.targetWindowAttribution?.passFailedCount ?? null,
   };
 
   return {
@@ -731,6 +752,28 @@ function allQualityGatesPass(value: unknown): boolean {
     isRecord(value) &&
     Object.keys(value).length > 0 &&
     Object.values(value).every((gate) => gate === true)
+  );
+}
+
+function validXAccountAttributionContract(stats: unknown): boolean {
+  if (!isRecord(stats) || !isRecord(stats.xAccountAttribution)) {
+    return false;
+  }
+  const attribution = stats.xAccountAttribution;
+  const statusValid =
+    attribution.status === "known" ||
+    attribution.status === "partial" ||
+    attribution.status === "unknown";
+  return (
+    statusValid &&
+    attribution.policy === "warning_only" &&
+    typeof attribution.gateReason === "string" &&
+    attribution.gateReason.trim().length > 0 &&
+    typeof attribution.warningCount === "number" &&
+    Number.isInteger(attribution.warningCount) &&
+    attribution.warningCount >= 0 &&
+    Array.isArray(attribution.warnings) &&
+    attribution.warnings.length === attribution.warningCount
   );
 }
 

--- a/scripts/lib/x-account-attribution-report.spec.ts
+++ b/scripts/lib/x-account-attribution-report.spec.ts
@@ -1,0 +1,208 @@
+import {
+  buildXAccountAttributionSummary,
+  buildXAccountReport,
+  type XAccountStateRow,
+  type XAccountUsageEventRow,
+} from "./x-account-attribution-report";
+
+describe("X account attribution reporting", () => {
+  it("separates post-midnight snapshots from target-window deltas", () => {
+    const observedAt = new Date("2026-07-18T00:05:00.000Z");
+    const events = [knownResult(1, 2, 7)];
+    const account = buildXAccountReport({
+      accountKey: "id:1",
+      state: accountState(1, 11, 40, "2026-07-18"),
+      events,
+      allEvents: events,
+      collectionDate: "2026-07-17",
+      observedAt,
+    });
+
+    expect(account.observedAccountSnapshot).toEqual({
+      observedAt: observedAt.toISOString(),
+      dailyRequests: 11,
+      dailyTweets: 40,
+      counterResetDate: "2026-07-18",
+      counterResetDateMatchesTargetDate: false,
+    });
+    expect(account.targetWindowAttribution).toMatchObject({
+      collectionDate: "2026-07-17",
+      status: "known",
+      requestDelta: 2,
+      tweetDelta: 7,
+      acceptedCount: 7,
+    });
+  });
+
+  it("counts each known pass once and warns on eligible zero output", () => {
+    const observedAt = new Date("2026-07-18T00:05:00.000Z");
+    const events = [knownResult(1, 1, 5), knownResult(2, 24, 0)];
+    const accounts = [
+      buildXAccountReport({
+        accountKey: "id:1",
+        state: accountState(1, 1, 5, "2026-07-18"),
+        events: [events[0] as XAccountUsageEventRow],
+        allEvents: events,
+        collectionDate: "2026-07-17",
+        observedAt,
+      }),
+      buildXAccountReport({
+        accountKey: "id:2",
+        state: accountState(2, 24, 0, "2026-07-18"),
+        events: [events[1] as XAccountUsageEventRow],
+        allEvents: events,
+        collectionDate: "2026-07-17",
+        observedAt,
+      }),
+    ];
+    const summary = buildXAccountAttributionSummary({
+      collectionDate: "2026-07-17",
+      events,
+      accounts,
+      globalCollectionSucceeded: true,
+    });
+
+    expect(summary).toMatchObject({
+      status: "known",
+      requestDelta: 25,
+      tweetDelta: 5,
+      fetchedCount: 5,
+      acceptedCount: 5,
+      knownPassResultCount: 2,
+      unknownPassResultCount: 0,
+      eligibleAccountZeroAttributableOutputWarningCount: 1,
+      attributionPolicy: "warning_only",
+      gateReason: "known_attribution_zero_output_warning_only",
+    });
+    expect(accounts[1]?.warningCodes).toEqual([
+      "eligible_account_requests_without_attributable_output",
+    ]);
+  });
+
+  it("keeps unknown attribution nullable and non-blocking after global success", () => {
+    const observedAt = new Date("2026-07-18T00:05:00.000Z");
+    const events = [unknownResult()];
+    const accounts = [
+      buildXAccountReport({
+        accountKey: "id:1",
+        state: accountState(1, 24, 0, "2026-07-18"),
+        events: [],
+        allEvents: events,
+        collectionDate: "2026-07-17",
+        observedAt,
+      }),
+    ];
+    const summary = buildXAccountAttributionSummary({
+      collectionDate: "2026-07-17",
+      events,
+      accounts,
+      globalCollectionSucceeded: true,
+    });
+
+    expect(accounts[0]?.targetWindowAttribution).toMatchObject({
+      status: "unknown",
+      requestDelta: null,
+      tweetDelta: null,
+      fetchedCount: null,
+      acceptedCount: null,
+    });
+    expect(accounts[0]?.warningCodes).toEqual([]);
+    expect(summary).toMatchObject({
+      status: "unknown",
+      requestDelta: null,
+      tweetDelta: null,
+      eligibleAccountZeroAttributableOutputWarningCount: 0,
+      attributionPolicy: "warning_only",
+      gateReason: "unknown_attribution_global_collection_succeeded_warning_only",
+    });
+  });
+
+  it("preserves known lower bounds and explicit partial semantics", () => {
+    const observedAt = new Date("2026-07-18T00:05:00.000Z");
+    const events = [knownResult(1, 3, 9), unknownResult()];
+    const account = buildXAccountReport({
+      accountKey: "id:1",
+      state: accountState(1, 3, 9, "2026-07-18"),
+      events: [events[0] as XAccountUsageEventRow],
+      allEvents: events,
+      collectionDate: "2026-07-17",
+      observedAt,
+    });
+    const summary = buildXAccountAttributionSummary({
+      collectionDate: "2026-07-17",
+      events,
+      accounts: [account],
+      globalCollectionSucceeded: true,
+    });
+
+    expect(account.targetWindowAttribution).toMatchObject({
+      status: "partial",
+      requestDelta: 3,
+      tweetDelta: 9,
+      fetchedCount: 9,
+      acceptedCount: 9,
+      passSucceededCount: 1,
+    });
+    expect(account.warningCodes).toEqual([]);
+    expect(summary).toMatchObject({
+      status: "partial",
+      requestDelta: 3,
+      tweetDelta: 9,
+      fetchedCount: 9,
+      acceptedCount: 9,
+      knownPassResultCount: 1,
+      unknownPassResultCount: 1,
+      attributionPolicy: "warning_only",
+      gateReason: "partial_attribution_global_collection_succeeded_warning_only",
+    });
+  });
+});
+
+function accountState(
+  id: number,
+  dailyRequests: number,
+  dailyTweets: number,
+  resetDate: string,
+): XAccountStateRow {
+  return {
+    id,
+    username: `research-${id}`,
+    status: 1,
+    busy: 0,
+    daily_requests: dailyRequests,
+    daily_tweets: dailyTweets,
+    last_reset_date: resetDate,
+  };
+}
+
+function knownResult(
+  accountId: number,
+  requestDelta: number,
+  acceptedCount: number,
+): XAccountUsageEventRow {
+  return {
+    event_id: `known-${accountId}`,
+    event_type: "pass_succeeded",
+    account_id: accountId,
+    username: `research-${accountId}`,
+    attribution_status: "known",
+    requests_before: 0,
+    requests_after: requestDelta,
+    tweets_before: 0,
+    tweets_after: acceptedCount,
+    fetched_count: acceptedCount,
+    accepted_count: acceptedCount,
+  };
+}
+
+function unknownResult(): XAccountUsageEventRow {
+  return {
+    event_id: "unknown-1",
+    event_type: "pass_succeeded",
+    account_id: null,
+    username: null,
+    attribution_status: "unknown",
+    fetched_count: 12,
+    accepted_count: 5,
+  };
+}

--- a/scripts/lib/x-account-attribution-report.ts
+++ b/scripts/lib/x-account-attribution-report.ts
@@ -1,0 +1,371 @@
+import { createHash } from "node:crypto";
+
+import { evaluateXAccountHealth } from "./x-account-pool-health";
+
+export type XAccountAttributionStatus = "known" | "partial" | "unknown";
+
+export type XAccountUsageEventRow = {
+  readonly event_id?: string;
+  readonly event_type?: string;
+  readonly occurred_at?: string;
+  readonly account_id?: number | null;
+  readonly username?: string | null;
+  readonly estimated_request_cost?: number | null;
+  readonly daily_requests_limit?: number | null;
+  readonly daily_tweets_limit?: number | null;
+  readonly account_priority?: number | null;
+  readonly requests_before?: number | null;
+  readonly requests_after?: number | null;
+  readonly tweets_before?: number | null;
+  readonly tweets_after?: number | null;
+  readonly fetched_count?: number | null;
+  readonly accepted_count?: number | null;
+  readonly returned_count?: number | null;
+  readonly failure_kind?: string | null;
+  readonly cooldown_reason?: string | null;
+  readonly reset_at?: string | null;
+  readonly attribution_status?: string | null;
+};
+
+export type XAccountStateRow = {
+  readonly id?: number;
+  readonly username?: string;
+  readonly status?: number;
+  readonly daily_requests?: number;
+  readonly daily_tweets?: number;
+  readonly last_reset_date?: string | null;
+  readonly available_until?: string | null;
+  readonly last_used_at?: string | null;
+  readonly cooldown_reason?: string | null;
+  readonly busy?: number;
+};
+
+type TargetWindowMetrics = {
+  readonly requestDelta: number;
+  readonly tweetDelta: number;
+  readonly fetchedCount: number;
+  readonly acceptedCount: number;
+  readonly returnedCount: number;
+  readonly passSucceededCount: number;
+  readonly passFailedCount: number;
+};
+
+const zeroOutputWarning =
+  "eligible_account_requests_without_attributable_output";
+
+export function xAccountAttributionStatus(
+  events: readonly XAccountUsageEventRow[],
+): XAccountAttributionStatus {
+  const results = events.filter(isPassResultEvent);
+  const knownCount = results.filter(isKnownAttributionEvent).length;
+  if (results.length === 0 || knownCount === 0) {
+    return "unknown";
+  }
+
+  return knownCount === results.length ? "known" : "partial";
+}
+
+export function buildXAccountAttributionSummary(params: {
+  readonly collectionDate: string;
+  readonly events: readonly XAccountUsageEventRow[];
+  readonly accounts: readonly ReturnType<typeof buildXAccountReport>[];
+  readonly globalCollectionSucceeded: boolean;
+}) {
+  const resultEvents = params.events.filter(isPassResultEvent);
+  const knownEvents = resultEvents.filter(isKnownAttributionEvent);
+  const status = xAccountAttributionStatus(params.events);
+  const metrics = metricsForAttribution(status, knownEvents);
+  const warnings = params.accounts.flatMap((account) =>
+    account.warningCodes.map((code) => ({
+      code,
+      accountFingerprint: account.accountFingerprint,
+    })),
+  );
+  const gateReason = warningOnlyGateReason({
+    status,
+    warningCount: warnings.length,
+    globalCollectionSucceeded: params.globalCollectionSucceeded,
+  });
+
+  return {
+    collectionDate: params.collectionDate,
+    status,
+    knownPassResultCount: knownEvents.length,
+    unknownPassResultCount: resultEvents.length - knownEvents.length,
+    ...metrics,
+    eligibleAccountZeroAttributableOutputWarningCount: warnings.length,
+    warnings,
+    attributionPolicy: "warning_only",
+    gateReason,
+  } as const;
+}
+
+export function buildXAccountReport(params: {
+  readonly accountKey: string;
+  readonly state: XAccountStateRow | undefined;
+  readonly events: readonly XAccountUsageEventRow[];
+  readonly allEvents: readonly XAccountUsageEventRow[];
+  readonly collectionDate: string;
+  readonly observedAt: Date;
+}) {
+  const username = params.state?.username ?? params.events[0]?.username ?? "";
+  const accountId = params.state?.id ?? params.events[0]?.account_id ?? null;
+  const eventTimes = params.events
+    .map((event) => event.occurred_at)
+    .filter((value): value is string => value !== undefined);
+  const latestEventAt = eventTimes.sort().at(-1) ?? null;
+  const latestDailyRequestsLimit = latestNumber(
+    params.events,
+    (event) => event.daily_requests_limit,
+  );
+  const latestDailyTweetsLimit = latestNumber(
+    params.events,
+    (event) => event.daily_tweets_limit,
+  );
+  const latestAccountPriority = latestNumber(
+    params.events,
+    (event) => event.account_priority,
+  );
+  const status = params.state?.status ?? null;
+  const busy =
+    params.state?.busy === undefined ? null : params.state.busy === 1;
+  const dailyRequests = params.state?.daily_requests ?? null;
+  const dailyTweets = params.state?.daily_tweets ?? null;
+  const lastResetDate = params.state?.last_reset_date ?? null;
+  const cooldownUntil = params.state?.available_until ?? null;
+  const health = evaluateXAccountHealth(
+    {
+      stateAvailable: params.state !== undefined,
+      status,
+      busy,
+      dailyRequests,
+      dailyTweets,
+      dailyRequestsLimit: latestDailyRequestsLimit,
+      dailyTweetsLimit: latestDailyTweetsLimit,
+      lastResetDate,
+      cooldownUntil,
+    },
+    params.observedAt,
+  );
+  const attributionStatus = xAccountAttributionStatus(params.allEvents);
+  const knownEvents = params.events.filter(isKnownAttributionEvent);
+  const metrics = metricsForAttribution(attributionStatus, knownEvents);
+  const warningCodes =
+    health.eligible &&
+    attributionStatus === "known" &&
+    metrics.requestDelta !== null &&
+    metrics.requestDelta > 0 &&
+    metrics.acceptedCount === 0
+      ? [zeroOutputWarning]
+      : [];
+  const accountFingerprint = fingerprint(
+    `x-account:${accountId ?? params.accountKey}`,
+  );
+
+  return {
+    accountFingerprint,
+    usernameFingerprint:
+      username.trim().length === 0 ? null : fingerprint(`x-user:${username}`),
+    priorityRank: latestAccountPriority ?? accountId ?? 9999,
+    prioritySource:
+      latestAccountPriority === null ? "account_order" : "account_profile",
+    ...health,
+    status,
+    busy,
+    dailyRequests,
+    dailyTweets,
+    dailyRequestsLimit: latestDailyRequestsLimit,
+    dailyTweetsLimit: latestDailyTweetsLimit,
+    lastResetDate,
+    attributionStatus,
+    observedAccountSnapshot: {
+      observedAt: params.observedAt.toISOString(),
+      dailyRequests,
+      dailyTweets,
+      counterResetDate: lastResetDate,
+      counterResetDateMatchesTargetDate:
+        lastResetDate === params.collectionDate,
+    },
+    targetWindowAttribution: {
+      collectionDate: params.collectionDate,
+      status: attributionStatus,
+      ...metrics,
+    },
+    lastUsedAt: params.state?.last_used_at ?? latestEventAt,
+    latestEventAt,
+    cooldownUntil,
+    cooldownReasonFingerprint:
+      params.state?.cooldown_reason === null ||
+      params.state?.cooldown_reason === undefined
+        ? null
+        : fingerprint(params.state.cooldown_reason),
+    eventCount: params.events.length,
+    passStartedCount: countEvents(params.events, "pass_started"),
+    passSucceededCount: metrics.passSucceededCount,
+    passFailedCount: metrics.passFailedCount,
+    cooldownObservedCount: countEvents(params.events, "cooldown_observed"),
+    rateLimitCount: params.events.filter(isRateLimitEvent).length,
+    estimatedRequestCost: sumEventNumbers(
+      params.events,
+      (event) => event.estimated_request_cost,
+    ),
+    requestDelta: metrics.requestDelta,
+    tweetDelta: metrics.tweetDelta,
+    fetchedCount: metrics.fetchedCount,
+    acceptedCount: metrics.acceptedCount,
+    returnedCount: metrics.returnedCount,
+    warningCodes,
+  } as const;
+}
+
+function metricsForAttribution(
+  status: XAccountAttributionStatus,
+  events: readonly XAccountUsageEventRow[],
+): { readonly [Key in keyof TargetWindowMetrics]: number | null } {
+  if (status === "unknown") {
+    return {
+      requestDelta: null,
+      tweetDelta: null,
+      fetchedCount: null,
+      acceptedCount: null,
+      returnedCount: null,
+      passSucceededCount: null,
+      passFailedCount: null,
+    };
+  }
+
+  return {
+    requestDelta: sumEventNumbers(events, requestDelta),
+    tweetDelta: sumEventNumbers(events, tweetDelta),
+    fetchedCount: sumEventNumbers(events, (event) => event.fetched_count),
+    acceptedCount: sumEventNumbers(events, (event) => event.accepted_count),
+    returnedCount: sumEventNumbersOrNull(
+      events,
+      (event) => event.returned_count,
+    ),
+    passSucceededCount: countEvents(events, "pass_succeeded"),
+    passFailedCount: countEvents(events, "pass_failed"),
+  };
+}
+
+function warningOnlyGateReason(params: {
+  readonly status: XAccountAttributionStatus;
+  readonly warningCount: number;
+  readonly globalCollectionSucceeded: boolean;
+}): string {
+  if (params.status === "known") {
+    return params.warningCount === 0
+      ? "known_attribution_healthy"
+      : "known_attribution_zero_output_warning_only";
+  }
+
+  const collectionResult = params.globalCollectionSucceeded
+    ? "global_collection_succeeded"
+    : "without_global_success";
+  return `${params.status}_attribution_${collectionResult}_warning_only`;
+}
+
+function isPassResultEvent(event: XAccountUsageEventRow): boolean {
+  return (
+    event.event_type === "pass_succeeded" || event.event_type === "pass_failed"
+  );
+}
+
+function isKnownAttributionEvent(event: XAccountUsageEventRow): boolean {
+  return (
+    isPassResultEvent(event) &&
+    event.attribution_status === "known" &&
+    (event.account_id !== null && event.account_id !== undefined ||
+      (event.username?.trim().length ?? 0) > 0)
+  );
+}
+
+function countEvents(
+  events: readonly XAccountUsageEventRow[],
+  eventType: string,
+): number {
+  return events.filter((event) => event.event_type === eventType).length;
+}
+
+function isRateLimitEvent(event: XAccountUsageEventRow): boolean {
+  const text = `${event.failure_kind ?? ""} ${event.cooldown_reason ?? ""}`
+    .trim()
+    .toLowerCase();
+
+  return (
+    text.includes("rate") ||
+    text.includes("limit") ||
+    text.includes("429") ||
+    text.includes("cooldown")
+  );
+}
+
+function sumEventNumbers(
+  events: readonly XAccountUsageEventRow[],
+  valueOf: (event: XAccountUsageEventRow) => number | null | undefined,
+): number {
+  return events.reduce((sum, event) => {
+    const value = valueOf(event);
+    return (
+      sum + (typeof value === "number" && Number.isFinite(value) ? value : 0)
+    );
+  }, 0);
+}
+
+function sumEventNumbersOrNull(
+  events: readonly XAccountUsageEventRow[],
+  valueOf: (event: XAccountUsageEventRow) => number | null | undefined,
+): number | null {
+  const values = events
+    .map(valueOf)
+    .filter(
+      (value): value is number =>
+        typeof value === "number" && Number.isFinite(value),
+    );
+
+  return values.length === 0
+    ? null
+    : values.reduce((sum, value) => sum + value, 0);
+}
+
+function latestNumber(
+  events: readonly XAccountUsageEventRow[],
+  valueOf: (event: XAccountUsageEventRow) => number | null | undefined,
+): number | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const value = valueOf(events[index] as XAccountUsageEventRow);
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function requestDelta(event: XAccountUsageEventRow): number {
+  return counterDelta(event.requests_before, event.requests_after);
+}
+
+function tweetDelta(event: XAccountUsageEventRow): number {
+  return counterDelta(event.tweets_before, event.tweets_after);
+}
+
+function counterDelta(
+  before: number | null | undefined,
+  after: number | null | undefined,
+): number {
+  if (
+    typeof before !== "number" ||
+    typeof after !== "number" ||
+    !Number.isFinite(before) ||
+    !Number.isFinite(after)
+  ) {
+    return 0;
+  }
+
+  return Math.max(after - before, 0);
+}
+
+function fingerprint(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}

--- a/scripts/lib/x-account-attribution-warning-policy.spec.ts
+++ b/scripts/lib/x-account-attribution-warning-policy.spec.ts
@@ -58,7 +58,10 @@ describe("X account attribution warning-only production verdict", () => {
 
   it("still honors unrelated blocking collection gates", () => {
     const result = finalizeXAccountAttributionWarningOnly({
-      qualityGates: { globalXCollectionSucceeded: false },
+      qualityGates: {
+        globalXCollectionSucceeded: true,
+        durableCollectionEvidencePassed: false,
+      },
       attribution: {
         attributionStatus: "unknown",
         attributionPolicy: "warning_only",
@@ -71,4 +74,28 @@ describe("X account attribution warning-only production verdict", () => {
 
     expect(result.collectionBlockingPassed).toBe(false);
   });
+
+  it.each([
+    ["missing", {}],
+    ["false", { globalXCollectionSucceeded: false }],
+  ] as const)(
+    "fails closed when global X collection success is %s at runtime",
+    (_case, runtimeQualityGates) => {
+      const result = finalizeXAccountAttributionWarningOnly({
+        qualityGates: runtimeQualityGates as unknown as Parameters<
+          typeof finalizeXAccountAttributionWarningOnly
+        >[0]["qualityGates"],
+        attribution: {
+          attributionStatus: "unknown",
+          attributionPolicy: "warning_only",
+          attributionGateReason:
+            "unknown_attribution_without_global_success_warning_only",
+          eligibleAccountZeroAttributableOutputWarningCount: 0,
+          attributionWarnings: [],
+        },
+      });
+
+      expect(result.collectionBlockingPassed).toBe(false);
+    },
+  );
 });

--- a/scripts/lib/x-account-attribution-warning-policy.spec.ts
+++ b/scripts/lib/x-account-attribution-warning-policy.spec.ts
@@ -1,0 +1,74 @@
+import { finalizeXAccountAttributionWarningOnly } from "./x-account-attribution-warning-policy";
+
+describe("X account attribution warning-only production verdict", () => {
+  it("keeps a known zero-output warning operational and nonblocking", () => {
+    const result = finalizeXAccountAttributionWarningOnly({
+      qualityGates: { globalXCollectionSucceeded: true },
+      attribution: {
+        attributionStatus: "known",
+        attributionPolicy: "warning_only",
+        attributionGateReason:
+          "known_attribution_zero_output_warning_only",
+        eligibleAccountZeroAttributableOutputWarningCount: 1,
+        attributionWarnings: [
+          {
+            code: "eligible_account_requests_without_attributable_output",
+            accountFingerprint: "account-fingerprint",
+          },
+        ],
+      },
+    });
+
+    expect(result.collectionBlockingPassed).toBe(true);
+    expect(result.operationalWarnings).toEqual({
+      xAccountAttributionStatus: "known",
+      xAccountAttributionPolicy: "warning_only",
+      xAccountAttributionGateReason:
+        "known_attribution_zero_output_warning_only",
+      xAccountAttributionWarningCount: 1,
+      xAccountAttributionWarnings: [
+        {
+          code: "eligible_account_requests_without_attributable_output",
+          accountFingerprint: "account-fingerprint",
+        },
+      ],
+    });
+  });
+
+  it("keeps unknown attribution nonblocking after global success", () => {
+    const result = finalizeXAccountAttributionWarningOnly({
+      qualityGates: { globalXCollectionSucceeded: true },
+      attribution: {
+        attributionStatus: "unknown",
+        attributionPolicy: "warning_only",
+        attributionGateReason:
+          "unknown_attribution_global_collection_succeeded_warning_only",
+        eligibleAccountZeroAttributableOutputWarningCount: 0,
+        attributionWarnings: [],
+      },
+    });
+
+    expect(result.collectionBlockingPassed).toBe(true);
+    expect(result.operationalWarnings).toMatchObject({
+      xAccountAttributionStatus: "unknown",
+      xAccountAttributionWarningCount: 0,
+      xAccountAttributionWarnings: [],
+    });
+  });
+
+  it("still honors unrelated blocking collection gates", () => {
+    const result = finalizeXAccountAttributionWarningOnly({
+      qualityGates: { globalXCollectionSucceeded: false },
+      attribution: {
+        attributionStatus: "unknown",
+        attributionPolicy: "warning_only",
+        attributionGateReason:
+          "unknown_attribution_without_global_success_warning_only",
+        eligibleAccountZeroAttributableOutputWarningCount: 0,
+        attributionWarnings: [],
+      },
+    });
+
+    expect(result.collectionBlockingPassed).toBe(false);
+  });
+});

--- a/scripts/lib/x-account-attribution-warning-policy.ts
+++ b/scripts/lib/x-account-attribution-warning-policy.ts
@@ -12,13 +12,15 @@ type XAccountAttributionReport = {
 };
 
 export function finalizeXAccountAttributionWarningOnly(params: {
-  readonly qualityGates: Readonly<Record<string, boolean>>;
+  readonly qualityGates: Readonly<Record<string, boolean>> & {
+    readonly globalXCollectionSucceeded: true;
+  };
   readonly attribution: XAccountAttributionReport;
 }) {
   return {
-    collectionBlockingPassed: Object.values(params.qualityGates).every(
-      (value) => value === true,
-    ),
+    collectionBlockingPassed:
+      params.qualityGates.globalXCollectionSucceeded === true &&
+      Object.values(params.qualityGates).every((value) => value === true),
     operationalWarnings: {
       xAccountAttributionStatus: params.attribution.attributionStatus,
       xAccountAttributionPolicy: params.attribution.attributionPolicy,

--- a/scripts/lib/x-account-attribution-warning-policy.ts
+++ b/scripts/lib/x-account-attribution-warning-policy.ts
@@ -1,0 +1,33 @@
+export type XAccountAttributionWarning = {
+  readonly code: string;
+  readonly accountFingerprint: string;
+};
+
+type XAccountAttributionReport = {
+  readonly attributionStatus: "known" | "partial" | "unknown";
+  readonly attributionPolicy: "warning_only";
+  readonly attributionGateReason: string;
+  readonly eligibleAccountZeroAttributableOutputWarningCount: number;
+  readonly attributionWarnings: readonly XAccountAttributionWarning[];
+};
+
+export function finalizeXAccountAttributionWarningOnly(params: {
+  readonly qualityGates: Readonly<Record<string, boolean>>;
+  readonly attribution: XAccountAttributionReport;
+}) {
+  return {
+    collectionBlockingPassed: Object.values(params.qualityGates).every(
+      (value) => value === true,
+    ),
+    operationalWarnings: {
+      xAccountAttributionStatus: params.attribution.attributionStatus,
+      xAccountAttributionPolicy: params.attribution.attributionPolicy,
+      xAccountAttributionGateReason:
+        params.attribution.attributionGateReason,
+      xAccountAttributionWarningCount:
+        params.attribution
+          .eligibleAccountZeroAttributableOutputWarningCount,
+      xAccountAttributionWarnings: params.attribution.attributionWarnings,
+    },
+  } as const;
+}

--- a/scripts/lib/x-collector-quality-report-support.spec.ts
+++ b/scripts/lib/x-collector-quality-report-support.spec.ts
@@ -7,6 +7,7 @@ import {
   buildXAccountPoolReport,
   buildXCollectorLedgerReport,
 } from "./x-collector-quality-report-support";
+import { finalizeXAccountAttributionWarningOnly } from "./x-account-attribution-warning-policy";
 
 jest.mock("node:child_process", () => {
   const actual = jest.requireActual("node:child_process") as Record<
@@ -206,11 +207,21 @@ describe("x collector quality report support", () => {
       expect(accountPool.eventCount).toBe(3);
       expect(accountPool.accountCount).toBe(1);
       expect(accountPool.passStartedCount).toBe(1);
-      expect(accountPool.passSucceededCount).toBe(1);
-      expect(accountPool.passFailedCount).toBe(1);
+      expect(accountPool.passSucceededCount).toBeNull();
+      expect(accountPool.passFailedCount).toBeNull();
       expect(accountPool.accountLimitProfileObservedCount).toBe(0);
+      expect(accountPool.attributionStatus).toBe("unknown");
+      expect(accountPool.totalRequestDelta).toBeNull();
+      expect(accountPool.totalTweetDelta).toBeNull();
+      expect(accountPool.attributionPolicy).toBe("warning_only");
+      expect(accountPool.attributionGateReason).toBe(
+        "unknown_attribution_global_collection_succeeded_warning_only",
+      );
       expect(accountPool.accounts[0]?.passStartedCount).toBe(1);
-      expect(accountPool.accounts[0]?.fetchedCount).toBe(31);
+      expect(accountPool.accounts[0]?.fetchedCount).toBeNull();
+      expect(accountPool.accounts[0]?.targetWindowAttribution.status).toBe(
+        "unknown",
+      );
       expect(accountPool.accounts[0]?.dailyRequestsLimit).toBeNull();
       expect(accountPool.accounts[0]?.dailyTweetsLimit).toBeNull();
       expect(jest.mocked(execFileSync)).toHaveBeenCalled();
@@ -522,7 +533,8 @@ describe("x collector quality report support", () => {
             product text, estimated_request_cost integer, requests_before integer,
             requests_after integer, tweets_before integer, tweets_after integer,
             fetched_count integer, accepted_count integer, returned_count integer,
-            failure_kind text, cooldown_reason text, reset_at text
+            failure_kind text, cooldown_reason text, reset_at text,
+            attribution_status text
           );
         `,
       );
@@ -545,6 +557,17 @@ describe("x collector quality report support", () => {
           ) values
             (1, 'active_account', 1, null, 0, 1, 10, '2026-07-14', null, null),
             (2, 'manually_disabled_account', 0, null, 0, 0, 0, '2026-07-14', null, null);
+          insert into account_usage_events (
+            event_id, event_type, provider, occurred_at, account_id, username,
+            request_id, scan_job_id, source_binding_id, query, pass_label,
+            product, requests_before, requests_after, tweets_before,
+            tweets_after, fetched_count, accepted_count, attribution_status
+          ) values (
+            'event-known', 'pass_succeeded', 'x-twitter',
+            '2026-07-14T00:01:30.000Z', 1, 'active_account', 'request-1',
+            'scan-1', 'binding-1', 'AI agents', 'top_base', 'search',
+            0, 1, 0, 0, 0, 0, 'known'
+          );
         `,
       );
 
@@ -560,18 +583,49 @@ describe("x collector quality report support", () => {
         eligibleAccountCount: 1,
         ineligibleAccountCount: 1,
         observedAt: "2026-07-14T00:03:00.000Z",
+        attributionStatus: "known",
+        totalRequestDelta: 1,
+        totalTweetDelta: 0,
+        attributionPolicy: "warning_only",
+        attributionGateReason:
+          "known_attribution_zero_output_warning_only",
+        eligibleAccountZeroAttributableOutputWarningCount: 1,
       });
       expect(
         accountPool.accounts.find((account) => account.status === 1),
       ).toMatchObject({
         eligible: true,
         ineligibilityReasonCodes: [],
+        observedAccountSnapshot: {
+          counterResetDate: "2026-07-14",
+          counterResetDateMatchesTargetDate: false,
+        },
+        targetWindowAttribution: {
+          collectionDate: "2026-07-13",
+          status: "known",
+          requestDelta: 1,
+          acceptedCount: 0,
+        },
       });
       expect(
         accountPool.accounts.find((account) => account.status === 0),
       ).toMatchObject({
         eligible: false,
         ineligibilityReasonCodes: ["status_not_reusable"],
+      });
+      const verdict = finalizeXAccountAttributionWarningOnly({
+        qualityGates: { globalXCollectionSucceeded: true },
+        attribution: accountPool,
+      });
+      expect(verdict.collectionBlockingPassed).toBe(true);
+      expect(verdict.operationalWarnings).toMatchObject({
+        xAccountAttributionStatus: "known",
+        xAccountAttributionWarningCount: 1,
+        xAccountAttributionWarnings: [
+          {
+            code: "eligible_account_requests_without_attributable_output",
+          },
+        ],
       });
     } finally {
       rmSync(directory, { recursive: true, force: true });

--- a/scripts/lib/x-collector-quality-report-support.ts
+++ b/scripts/lib/x-collector-quality-report-support.ts
@@ -2,7 +2,12 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 
-import { evaluateXAccountHealth } from "./x-account-pool-health";
+import {
+  buildXAccountAttributionSummary,
+  buildXAccountReport,
+  type XAccountStateRow,
+  type XAccountUsageEventRow,
+} from "./x-account-attribution-report";
 
 type XRunRow = {
   readonly run_id?: string;
@@ -34,41 +39,6 @@ type XCollectorJsonWarning = {
   readonly runId: string | null;
   readonly field: "input_json" | "stats_json";
   readonly reason: string;
-};
-
-type XAccountUsageEventRow = {
-  readonly event_id?: string;
-  readonly event_type?: string;
-  readonly occurred_at?: string;
-  readonly account_id?: number | null;
-  readonly username?: string | null;
-  readonly estimated_request_cost?: number | null;
-  readonly daily_requests_limit?: number | null;
-  readonly daily_tweets_limit?: number | null;
-  readonly account_priority?: number | null;
-  readonly requests_before?: number | null;
-  readonly requests_after?: number | null;
-  readonly tweets_before?: number | null;
-  readonly tweets_after?: number | null;
-  readonly fetched_count?: number | null;
-  readonly accepted_count?: number | null;
-  readonly returned_count?: number | null;
-  readonly failure_kind?: string | null;
-  readonly cooldown_reason?: string | null;
-  readonly reset_at?: string | null;
-};
-
-type XAccountStateRow = {
-  readonly id?: number;
-  readonly username?: string;
-  readonly status?: number;
-  readonly daily_requests?: number;
-  readonly daily_tweets?: number;
-  readonly last_reset_date?: string | null;
-  readonly available_until?: string | null;
-  readonly last_used_at?: string | null;
-  readonly cooldown_reason?: string | null;
-  readonly busy?: number;
 };
 
 type BuildParams = {
@@ -227,12 +197,29 @@ export function buildXAccountPoolReport(params: BuildParams) {
       "ledger_file_missing",
       [],
       observedAt,
+      params.collectionDate,
     );
   }
+  const targetRunsResult = readXRunRows(params.ledgerPath);
+  const targetRuns = targetRunsResult.ok
+    ? targetRunsResult.rows.filter((row) =>
+        runTargetsCollectionDate(row, params.collectionDate),
+      )
+    : [];
+  const globalCollectionSucceeded =
+    targetRuns.some((row) => row.status === "completed") &&
+    targetRuns.some((row) => normalizedTweetCount(row.tweets_count) > 0);
 
   const stateResult = readXAccountStateRows(params.ledgerPath);
   if (!stateResult.ok) {
-    return emptyXAccountPoolReport(false, stateResult.error, [], observedAt);
+    return emptyXAccountPoolReport(
+      false,
+      stateResult.error,
+      [],
+      observedAt,
+      params.collectionDate,
+      globalCollectionSucceeded,
+    );
   }
 
   const eventResult = readXAccountUsageEventRows(params);
@@ -242,6 +229,8 @@ export function buildXAccountPoolReport(params: BuildParams) {
       eventResult.error,
       stateResult.rows,
       observedAt,
+      params.collectionDate,
+      globalCollectionSucceeded,
     );
   }
 
@@ -276,6 +265,8 @@ export function buildXAccountPoolReport(params: BuildParams) {
         accountKey,
         state: stateByAccount.get(accountKey),
         events: eventsByAccount.get(accountKey) ?? [],
+        allEvents: events,
+        collectionDate: params.collectionDate,
         observedAt,
       }),
     )
@@ -284,6 +275,12 @@ export function buildXAccountPoolReport(params: BuildParams) {
         left.priorityRank - right.priorityRank ||
         left.accountFingerprint.localeCompare(right.accountFingerprint),
     );
+  const attribution = buildXAccountAttributionSummary({
+    collectionDate: params.collectionDate,
+    events,
+    accounts,
+    globalCollectionSucceeded,
+  });
 
   return {
     available: true,
@@ -295,8 +292,8 @@ export function buildXAccountPoolReport(params: BuildParams) {
     observedAt: observedAt.toISOString(),
     eventCount: events.length,
     passStartedCount: countEvents(events, "pass_started"),
-    passSucceededCount: countEvents(events, "pass_succeeded"),
-    passFailedCount: countEvents(events, "pass_failed"),
+    passSucceededCount: attribution.passSucceededCount,
+    passFailedCount: attribution.passFailedCount,
     cooldownObservedCount: countEvents(events, "cooldown_observed"),
     rateLimitCount: events.filter(isRateLimitEvent).length,
     accountLimitProfileObservedCount: accounts.filter(
@@ -308,12 +305,16 @@ export function buildXAccountPoolReport(params: BuildParams) {
       events,
       (event) => event.estimated_request_cost,
     ),
-    totalRequestDelta: sumEventNumbers(events, requestDelta),
-    totalTweetDelta: sumEventNumbers(events, tweetDelta),
-    totalReturnedCount: sumEventNumbers(
-      events,
-      (event) => event.returned_count,
-    ),
+    totalRequestDelta: attribution.requestDelta,
+    totalTweetDelta: attribution.tweetDelta,
+    totalReturnedCount: attribution.returnedCount,
+    attributionStatus: attribution.status,
+    attributionPolicy: attribution.attributionPolicy,
+    attributionGateReason: attribution.gateReason,
+    eligibleAccountZeroAttributableOutputWarningCount:
+      attribution.eligibleAccountZeroAttributableOutputWarningCount,
+    attributionWarnings: attribution.warnings,
+    targetWindowAttribution: attribution,
     accounts,
     readError: null,
   } as const;
@@ -361,15 +362,25 @@ function emptyXAccountPoolReport(
   readError: string | null,
   stateRows: readonly XAccountStateRow[] = [],
   observedAt: Date = new Date(),
+  collectionDate = "unknown",
+  globalCollectionSucceeded = false,
 ) {
   const accounts = stateRows.map((state) =>
     buildXAccountReport({
       accountKey: accountBucketKey(state.id, state.username),
       state,
       events: [],
+      allEvents: [],
+      collectionDate,
       observedAt,
     }),
   );
+  const attribution = buildXAccountAttributionSummary({
+    collectionDate,
+    events: [],
+    accounts,
+    globalCollectionSucceeded,
+  });
   return {
     available,
     accountCount: stateRows.length,
@@ -380,115 +391,24 @@ function emptyXAccountPoolReport(
     observedAt: observedAt.toISOString(),
     eventCount: 0,
     passStartedCount: 0,
-    passSucceededCount: 0,
-    passFailedCount: 0,
+    passSucceededCount: attribution.passSucceededCount,
+    passFailedCount: attribution.passFailedCount,
     cooldownObservedCount: 0,
     rateLimitCount: 0,
     accountLimitProfileObservedCount: 0,
     totalEstimatedRequestCost: 0,
-    totalRequestDelta: 0,
-    totalTweetDelta: 0,
-    totalReturnedCount: 0,
+    totalRequestDelta: attribution.requestDelta,
+    totalTweetDelta: attribution.tweetDelta,
+    totalReturnedCount: attribution.returnedCount,
+    attributionStatus: attribution.status,
+    attributionPolicy: attribution.attributionPolicy,
+    attributionGateReason: attribution.gateReason,
+    eligibleAccountZeroAttributableOutputWarningCount:
+      attribution.eligibleAccountZeroAttributableOutputWarningCount,
+    attributionWarnings: attribution.warnings,
+    targetWindowAttribution: attribution,
     accounts,
     readError,
-  } as const;
-}
-
-function buildXAccountReport(params: {
-  readonly accountKey: string;
-  readonly state: XAccountStateRow | undefined;
-  readonly events: readonly XAccountUsageEventRow[];
-  readonly observedAt: Date;
-}) {
-  const username = params.state?.username ?? params.events[0]?.username ?? "";
-  const accountId = params.state?.id ?? params.events[0]?.account_id ?? null;
-  const eventTimes = params.events
-    .map((event) => event.occurred_at)
-    .filter((value): value is string => value !== undefined);
-  const latestEventAt = eventTimes.sort().at(-1) ?? null;
-  const latestDailyRequestsLimit = latestNumber(
-    params.events,
-    (event) => event.daily_requests_limit,
-  );
-  const latestDailyTweetsLimit = latestNumber(
-    params.events,
-    (event) => event.daily_tweets_limit,
-  );
-  const latestAccountPriority = latestNumber(
-    params.events,
-    (event) => event.account_priority,
-  );
-  const status = params.state?.status ?? null;
-  const busy =
-    params.state?.busy === undefined ? null : params.state.busy === 1;
-  const dailyRequests = params.state?.daily_requests ?? null;
-  const dailyTweets = params.state?.daily_tweets ?? null;
-  const lastResetDate = params.state?.last_reset_date ?? null;
-  const cooldownUntil = params.state?.available_until ?? null;
-  const health = evaluateXAccountHealth(
-    {
-      stateAvailable: params.state !== undefined,
-      status,
-      busy,
-      dailyRequests,
-      dailyTweets,
-      dailyRequestsLimit: latestDailyRequestsLimit,
-      dailyTweetsLimit: latestDailyTweetsLimit,
-      lastResetDate,
-      cooldownUntil,
-    },
-    params.observedAt,
-  );
-
-  return {
-    accountFingerprint: fingerprint(
-      `x-account:${accountId ?? params.accountKey}`,
-    ),
-    usernameFingerprint:
-      username.trim().length === 0 ? null : fingerprint(`x-user:${username}`),
-    priorityRank: latestAccountPriority ?? accountId ?? 9999,
-    prioritySource:
-      latestAccountPriority === null ? "account_order" : "account_profile",
-    ...health,
-    status,
-    busy,
-    dailyRequests,
-    dailyTweets,
-    dailyRequestsLimit: latestDailyRequestsLimit,
-    dailyTweetsLimit: latestDailyTweetsLimit,
-    lastResetDate,
-    lastUsedAt: params.state?.last_used_at ?? latestEventAt,
-    latestEventAt,
-    cooldownUntil,
-    cooldownReasonFingerprint:
-      params.state?.cooldown_reason === null ||
-      params.state?.cooldown_reason === undefined
-        ? null
-        : fingerprint(params.state.cooldown_reason),
-    eventCount: params.events.length,
-    passStartedCount: countEvents(params.events, "pass_started"),
-    passSucceededCount: countEvents(params.events, "pass_succeeded"),
-    passFailedCount: countEvents(params.events, "pass_failed"),
-    cooldownObservedCount: countEvents(params.events, "cooldown_observed"),
-    rateLimitCount: params.events.filter(isRateLimitEvent).length,
-    estimatedRequestCost: sumEventNumbers(
-      params.events,
-      (event) => event.estimated_request_cost,
-    ),
-    requestDelta: sumEventNumbers(params.events, requestDelta),
-    tweetDelta: sumEventNumbers(params.events, tweetDelta),
-    fetchedCount: sumEventNumbers(
-      params.events,
-      (event) => event.fetched_count,
-    ),
-    acceptedCount: sumEventNumbers(
-      params.events,
-      (event) => event.accepted_count,
-    ),
-    returnedCount: sumEventNumbers(
-      params.events,
-      (event) => event.returned_count,
-    ),
   } as const;
 }
 
@@ -546,6 +466,9 @@ function readXAccountUsageEventRows(params: BuildParams):
   const accountPriority = columns.columns.has("account_priority")
     ? "account_priority"
     : "null as account_priority";
+  const attributionStatus = columns.columns.has("attribution_status")
+    ? "attribution_status"
+    : "null as attribution_status";
   const sql = `
     select
       event_id,
@@ -566,7 +489,8 @@ function readXAccountUsageEventRows(params: BuildParams):
       returned_count,
       failure_kind,
       cooldown_reason,
-      reset_at
+      reset_at,
+      ${attributionStatus}
     from account_usage_events
     order by occurred_at asc, event_id asc
   `;
@@ -834,44 +758,6 @@ function sumEventNumbers(
   }, 0);
 }
 
-function latestNumber(
-  events: readonly XAccountUsageEventRow[],
-  valueOf: (event: XAccountUsageEventRow) => number | null | undefined,
-): number | null {
-  for (let index = events.length - 1; index >= 0; index -= 1) {
-    const value = valueOf(events[index] as XAccountUsageEventRow);
-    if (typeof value === "number" && Number.isFinite(value)) {
-      return value;
-    }
-  }
-
-  return null;
-}
-
-function requestDelta(event: XAccountUsageEventRow): number {
-  return counterDelta(event.requests_before, event.requests_after);
-}
-
-function tweetDelta(event: XAccountUsageEventRow): number {
-  return counterDelta(event.tweets_before, event.tweets_after);
-}
-
-function counterDelta(
-  before: number | null | undefined,
-  after: number | null | undefined,
-): number {
-  if (
-    typeof before !== "number" ||
-    typeof after !== "number" ||
-    !Number.isFinite(before) ||
-    !Number.isFinite(after)
-  ) {
-    return 0;
-  }
-
-  return Math.max(after - before, 0);
-}
-
 function groupBy<TKey, TValue>(
   values: readonly TValue[],
   keyOf: (value: TValue) => TKey,
@@ -935,10 +821,6 @@ function parseJsonStrict<TValue>(
 
 function hashText(value: string): string {
   return createHash("sha256").update(value).digest("hex");
-}
-
-function fingerprint(value: string): string {
-  return hashText(value).slice(0, 12);
 }
 
 function roundMetric(value: number): number {

--- a/scripts/lib/yesterday-social-collection-quality-helpers.ts
+++ b/scripts/lib/yesterday-social-collection-quality-helpers.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+export function tokenize(value: string): readonly string[] {
+  const stopWords = new Set([
+    "about",
+    "after",
+    "and",
+    "before",
+    "for",
+    "from",
+    "how",
+    "into",
+    "that",
+    "the",
+    "this",
+    "what",
+    "when",
+    "where",
+    "which",
+    "with",
+    "your",
+  ]);
+
+  return [
+    ...new Set(
+      value
+        .toLowerCase()
+        .replace(/[^a-z0-9+#.]+/g, " ")
+        .split(/\s+/)
+        .filter((term) => term.length >= 3 && !stopWords.has(term)),
+    ),
+  ];
+}
+
+export function statusCounts<TValue extends { readonly status: string | null }>(
+  rows: readonly (TValue & { readonly count: string })[],
+): Record<string, number> {
+  return Object.fromEntries(
+    rows.map((row) => [
+      row.status ?? "unknown",
+      Number.parseInt(row.count, 10),
+    ]),
+  );
+}
+
+export function sumCounts<TValue extends { readonly count: string }>(
+  rows: readonly TValue[],
+): number {
+  return rows.reduce((sum, row) => sum + Number.parseInt(row.count, 10), 0);
+}
+
+export function groupBy<TKey, TValue>(
+  values: readonly TValue[],
+  keyOf: (value: TValue) => TKey,
+): Map<TKey, TValue[]> {
+  const grouped = new Map<TKey, TValue[]>();
+
+  for (const value of values) {
+    const key = keyOf(value);
+    const bucket = grouped.get(key) ?? [];
+    bucket.push(value);
+    grouped.set(key, bucket);
+  }
+
+  return grouped;
+}
+
+export function countBy<TValue>(
+  values: readonly TValue[],
+  keyOf: (value: TValue) => string,
+): Record<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const value of values) {
+    const key = keyOf(value);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  return Object.fromEntries(
+    [...counts.entries()].sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+export function ratio<TValue>(
+  values: readonly TValue[],
+  predicate: (value: TValue) => boolean,
+): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  return roundMetric(
+    values.filter((value) => predicate(value)).length / values.length,
+  );
+}
+
+export function average<TValue>(
+  values: readonly TValue[],
+  valueOf: (value: TValue) => number,
+): number {
+  return values.length === 0
+    ? 0
+    : averageValues(values.map((value) => valueOf(value)));
+}
+
+export function averageValues(values: readonly number[]): number {
+  return values.length === 0
+    ? 0
+    : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function percentile(values: readonly number[], percent: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * percent) - 1),
+  );
+
+  return sorted[index] ?? 0;
+}
+
+export function readJson<TValue>(path: string): TValue {
+  return JSON.parse(readFileSync(path, "utf8")) as TValue;
+}
+
+export function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function fingerprints(values: readonly string[]): readonly string[] {
+  return [...new Set(values.map((value) => hashText(value).slice(0, 12)))]
+    .sort()
+    .slice(0, 20);
+}
+
+export function noRawSecretFragments(
+  value: unknown,
+  forbiddenFragments: readonly string[],
+): boolean {
+  const serialized = JSON.stringify(value).toLowerCase();
+  return forbiddenFragments.every((fragment) => !serialized.includes(fragment));
+}
+
+export function providerFeedItemCountAtLeast<
+  TValue extends {
+    readonly providerKey: string;
+    readonly visibleFeedItemCount: number;
+  },
+>(
+  reports: readonly TValue[],
+  providerKey: string,
+  threshold: number,
+): boolean {
+  return (
+    (reports.find((item) => item.providerKey === providerKey)
+      ?.visibleFeedItemCount ?? 0) >= threshold
+  );
+}
+
+export function runRateAtLeast(
+  acceptedRunCount: number,
+  totalRunCount: number,
+  thresholdPercent: number,
+): boolean {
+  return (
+    totalRunCount > 0 &&
+    acceptedRunCount * 100 >= totalRunCount * thresholdPercent
+  );
+}
+
+export function visibleRows<TValue extends { readonly status: string }>(
+  rows: readonly TValue[],
+): readonly TValue[] {
+  return rows.filter((row) => row.status === "VISIBLE");
+}
+
+export function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/g, "\n");
+}
+
+export function roundMetric(value: number): number {
+  return Number(value.toFixed(3));
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/lib/yesterday-social-collection-quality-report-validation.spec.ts
+++ b/scripts/lib/yesterday-social-collection-quality-report-validation.spec.ts
@@ -1,0 +1,80 @@
+import { isValidExistingYesterdaySocialCollectionQualityReport } from "./yesterday-social-collection-quality-report-validation";
+
+const collectionDate = "2026-07-18";
+const requiredPrimarySources = ["reddit", "x-twitter"];
+const forbiddenSerializedFragments = ["access_token", "postgres://"];
+
+describe("existing yesterday social collection quality report validation", () => {
+  it("accepts a schema-v1 artifact with a complete durable attribution contract", () => {
+    expect(validateArtifact(artifact())).toBe(true);
+  });
+
+  it("rejects a schema-v1 artifact missing operational warnings", () => {
+    const candidate = artifact() as Record<string, unknown>;
+    delete candidate.operationalWarnings;
+
+    expect(validateArtifact(candidate)).toBe(false);
+  });
+
+  it.each([
+    ["attribution status", contract({ xAccountAttributionStatus: undefined })],
+    ["valid attribution status", contract({ xAccountAttributionStatus: "future" })],
+    ["warning-only policy", contract({ xAccountAttributionPolicy: undefined })],
+    ["valid warning-only policy", contract({ xAccountAttributionPolicy: "blocking" })],
+    ["gate reason", contract({ xAccountAttributionGateReason: undefined })],
+    ["nonempty gate reason", contract({ xAccountAttributionGateReason: "   " })],
+    ["warning count", contract({ xAccountAttributionWarningCount: undefined })],
+    ["integer warning count", contract({ xAccountAttributionWarningCount: 0.5 })],
+    ["warnings array", contract({ xAccountAttributionWarnings: undefined })],
+    ["valid warnings array", contract({ xAccountAttributionWarnings: {} })],
+  ] as const)(
+    "rejects a schema-v1 artifact missing a %s",
+    (_case, operationalWarnings) => {
+      expect(validateArtifact(artifact(operationalWarnings))).toBe(false);
+    },
+  );
+
+  it("rejects a schema-v1 artifact with an inconsistent attribution warning count", () => {
+    expect(
+      validateArtifact(
+        artifact(
+          contract({
+            xAccountAttributionWarningCount: 1,
+            xAccountAttributionWarnings: [],
+          }),
+        ),
+      ),
+    ).toBe(false);
+  });
+});
+
+function artifact(operationalWarnings: unknown = contract()) {
+  return {
+    schemaVersion: 1,
+    artifactFormat: "yesterday-social-collection-quality-report-v1",
+    collectionDate,
+    collectionBlockingPassed: true,
+    primarySourceCoverage: requiredPrimarySources,
+    operationalWarnings,
+  };
+}
+
+function contract(overrides: Readonly<Record<string, unknown>> = {}) {
+  return {
+    xAccountAttributionStatus: "known",
+    xAccountAttributionPolicy: "warning_only",
+    xAccountAttributionGateReason: "known_attribution_warning_only",
+    xAccountAttributionWarningCount: 0,
+    xAccountAttributionWarnings: [],
+    ...overrides,
+  };
+}
+
+function validateArtifact(report: unknown): boolean {
+  return isValidExistingYesterdaySocialCollectionQualityReport({
+    report,
+    expectedCollectionDate: collectionDate,
+    requiredPrimarySources,
+    forbiddenSerializedFragments,
+  });
+}

--- a/scripts/lib/yesterday-social-collection-quality-report-validation.ts
+++ b/scripts/lib/yesterday-social-collection-quality-report-validation.ts
@@ -1,0 +1,57 @@
+import { noRawSecretFragments } from "./yesterday-social-collection-quality-helpers";
+
+export function isValidExistingYesterdaySocialCollectionQualityReport(params: {
+  readonly report: unknown;
+  readonly expectedCollectionDate: string;
+  readonly requiredPrimarySources: readonly string[];
+  readonly forbiddenSerializedFragments: readonly string[];
+}): boolean {
+  const report = recordValue(params.report);
+  if (report === undefined) {
+    return false;
+  }
+  const primarySourceCoverage = report.primarySourceCoverage;
+
+  return (
+    report.schemaVersion === 1 &&
+    report.artifactFormat ===
+      "yesterday-social-collection-quality-report-v1" &&
+    report.collectionDate === params.expectedCollectionDate &&
+    report.collectionBlockingPassed === true &&
+    Array.isArray(primarySourceCoverage) &&
+    params.requiredPrimarySources.every((source) =>
+      primarySourceCoverage.includes(source),
+    ) &&
+    hasCompleteXAccountAttributionContract(report.operationalWarnings) &&
+    noRawSecretFragments(report, params.forbiddenSerializedFragments)
+  );
+}
+
+function hasCompleteXAccountAttributionContract(value: unknown): boolean {
+  const operationalWarnings = recordValue(value);
+  if (operationalWarnings === undefined) {
+    return false;
+  }
+
+  const status = operationalWarnings.xAccountAttributionStatus;
+  const warningCount = operationalWarnings.xAccountAttributionWarningCount;
+  const warnings = operationalWarnings.xAccountAttributionWarnings;
+
+  return (
+    (status === "known" || status === "partial" || status === "unknown") &&
+    operationalWarnings.xAccountAttributionPolicy === "warning_only" &&
+    typeof operationalWarnings.xAccountAttributionGateReason === "string" &&
+    operationalWarnings.xAccountAttributionGateReason.trim().length > 0 &&
+    typeof warningCount === "number" &&
+    Number.isInteger(warningCount) &&
+    warningCount >= 0 &&
+    Array.isArray(warnings) &&
+    warnings.length === warningCount
+  );
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}


### PR DESCRIPTION
## What changed

- stop inferring account ownership from shared pool counters
- persist explicit known, partial, or unknown attribution
- keep unknown attribution nonblocking after globally successful collection
- add concurrent regression and durable production reporting

## Verification

- independent review approved
- Python attribution and observability checks: 11 passed
- focused Jest: 45 passed
- source line cap, secret scan, diff check: passed

No collection or production write was triggered by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account-attribution reporting with known, partial, and unknown outcomes.
  * Added per-account usage, snapshot, target-window, and attribution details to collection reports.
  * Added operational warnings for ambiguous attribution and eligible activity without attributable output.
  * Preserved non-blocking collection results when attribution is unknown but overall collection succeeds.

* **Bug Fixes**
  * Prevented missing baselines or ambiguous account changes from being incorrectly attributed.
  * Avoided duplicate pass-result events and excluded historical counters from new usage deltas.

* **Tests**
  * Expanded coverage for attribution, warnings, snapshots, and collection-quality reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->