### PR TITLE
fix(reporting): harden collection quality validation

### DIFF
--- a/scripts/lib/yesterday-social-collection-quality-helpers.ts
+++ b/scripts/lib/yesterday-social-collection-quality-helpers.ts
@@ -143,7 +143,9 @@ export function noRawSecretFragments(
   forbiddenFragments: readonly string[],
 ): boolean {
   const serialized = JSON.stringify(value).toLowerCase();
-  return forbiddenFragments.every((fragment) => !serialized.includes(fragment));
+  return forbiddenFragments.every(
+    (fragment) => !serialized.includes(fragment.toLowerCase()),
+  );
 }
 
 export function providerFeedItemCountAtLeast<

--- a/scripts/lib/yesterday-social-collection-quality-report-validation.spec.ts
+++ b/scripts/lib/yesterday-social-collection-quality-report-validation.spec.ts
@@ -16,6 +16,20 @@ describe("existing yesterday social collection quality report validation", () =>
     expect(validateArtifact(candidate)).toBe(false);
   });
 
+  it("rejects a report containing a mixed-case configured forbidden fragment", () => {
+    const candidate = artifact() as Record<string, unknown>;
+    candidate.diagnostic = "aCcEsS_tOkEn";
+
+    expect(validateArtifact(candidate, ["AcCeSs_ToKeN"])).toBe(false);
+  });
+
+  it("rejects a report missing one required primary source", () => {
+    const candidate = artifact() as Record<string, unknown>;
+    candidate.primarySourceCoverage = ["reddit"];
+
+    expect(validateArtifact(candidate)).toBe(false);
+  });
+
   it.each([
     ["attribution status", contract({ xAccountAttributionStatus: undefined })],
     ["valid attribution status", contract({ xAccountAttributionStatus: "future" })],
@@ -70,11 +84,14 @@ function contract(overrides: Readonly<Record<string, unknown>> = {}) {
   };
 }
 
-function validateArtifact(report: unknown): boolean {
+function validateArtifact(
+  report: unknown,
+  configuredForbiddenFragments = forbiddenSerializedFragments,
+): boolean {
   return isValidExistingYesterdaySocialCollectionQualityReport({
     report,
     expectedCollectionDate: collectionDate,
     requiredPrimarySources,
-    forbiddenSerializedFragments,
+    forbiddenSerializedFragments: configuredForbiddenFragments,
   });
 }


### PR DESCRIPTION
## Summary
- reject mixed-case forbidden fragments in production quality reports
- verify every required primary provider is present

## Verification
- focused Jest: 15/15
- changed-file ESLint
- source line cap
- git diff --check

Patch was independently reviewed and integrated through the project controller.