### PR TITLE
fix(reporting): verify persisted summary coverage

### DIFF
--- a/scripts/check-source-line-cap.mjs
+++ b/scripts/check-source-line-cap.mjs
@@ -55,7 +55,6 @@ const legacyLineCapDebt = new Map([
   ["scripts/check-source-provider-runtime-contract.ts", 1475],
   ["scripts/check-staging-reliability-evidence.mjs", 2203],
   ["scripts/check-summary-feedback-hardening.mjs", 1328],
-  ["scripts/check-yesterday-reader-summary-artifact-quality.ts", 1225],
   ["scripts/external-beta-evidence-runner.mjs", 2113],
   ["scripts/lib/docker-backend-evidence-harness.mjs", 1174],
   ["test/e2e/feed.items.list.e2e-spec.ts", 1117],

--- a/scripts/check-yesterday-reader-summary-artifact-quality.ts
+++ b/scripts/check-yesterday-reader-summary-artifact-quality.ts
@@ -5,23 +5,15 @@ import { Pool } from "pg";
 
 import { SourceContentQualityPolicy } from "@social-monitor/relevance/domain";
 import type { JsonObject } from "@social-monitor/shared-kernel";
-import { isDefaultReaderSummaryEvidenceProvider } from "@social-monitor/summary/adapters/evidence/reader-summary-evidence-provider-filter";
-import {
-  readerSummaryArtifactFromPrisma,
-  type PrismaReaderSummaryArtifactRecord,
-} from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-records";
+import { readerSummaryArtifactFromPrisma } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-records";
 import { presentReaderSummaryArtifact } from "@social-monitor/summary/features/shared/reader-summary-artifact-presenter";
-import type {
-  ReaderSummaryCollectedFeedItemCoverage,
-  ReaderSummaryFreshness,
-} from "@social-monitor/summary/ports";
+import type { ReaderSummaryFreshness } from "@social-monitor/summary/ports";
 
 import {
   collectionDateOptionOrDefault,
   type CollectionIntegrityStatus,
   fingerprint,
   message,
-  nextDate,
   noRawSecretFragments,
   normalizeLineEndings,
   readCollectionIntegrityStatus,
@@ -33,27 +25,15 @@ import {
   dailyPeriodKey,
   isLocalDataSourceUnavailable,
 } from "./lib/reader-summary-quality-eval-support";
-import { selectedCoverageMatchesProviderBreakdown } from "./lib/reader-summary-artifact-coverage";
-
-type ProviderCountRow = {
-  readonly providerKey: string;
-  readonly collectedFeedItemCount: string;
-};
-
-type TopReadFeedItemQualityRow = {
-  readonly id: string;
-  readonly providerKey: string;
-  readonly canonicalUrl: string;
-  readonly authorHandle: string | null;
-  readonly title: string;
-  readonly bodyPreview: string | null;
-  readonly providerMetadata: unknown;
-};
-
-type ArtifactStatusCountRow = {
-  readonly status: string;
-  readonly count: string;
-};
+import {
+  selectedCoverageMatchesProviderBreakdown,
+  selectedFeedItemProvenanceMatchesScope,
+} from "./lib/reader-summary-artifact-coverage";
+import {
+  artifactQualityFeedWindow,
+  type TopReadFeedItemQualityRow,
+  YesterdayReaderSummaryArtifactQualityStore,
+} from "./lib/yesterday-reader-summary-artifact-quality-store";
 
 type ArtifactQualityReport = {
   readonly schemaVersion: 1;
@@ -277,36 +257,28 @@ async function buildReport(): Promise<ArtifactQualityReport> {
     max: 1,
     connectionTimeoutMillis: 2_000,
   });
+  const artifactScope = {
+    tenantId: String(scope.tenantId),
+    workspaceId: String(scope.workspaceId),
+  };
+  const artifactStore = new YesterdayReaderSummaryArtifactQualityStore(
+    pool,
+    collectionDate,
+    badGamingFalsePositiveNeedle,
+  );
 
   try {
-    const record = await readLatestArtifact(pool, {
-      tenantId: String(scope.tenantId),
-      workspaceId: String(scope.workspaceId),
-    });
-    const latestVisible = await readLatestVisibleArtifact(pool, {
-      tenantId: String(scope.tenantId),
-      workspaceId: String(scope.workspaceId),
-    });
+    const record = await artifactStore.readLatestArtifact(artifactScope);
+    const latestVisible =
+      await artifactStore.readLatestVisibleArtifact(artifactScope);
     const visibleBadGamingArtifactCount =
-      await readVisibleBadGamingArtifactCount(pool, {
-        tenantId: String(scope.tenantId),
-        workspaceId: String(scope.workspaceId),
-      });
-    const badGamingStatusCounts = await readBadGamingArtifactStatusCounts(
-      pool,
-      {
-        tenantId: String(scope.tenantId),
-        workspaceId: String(scope.workspaceId),
-      },
-    );
-    const periodStatusCounts = await readPeriodArtifactStatusCounts(pool, {
-      tenantId: String(scope.tenantId),
-      workspaceId: String(scope.workspaceId),
-    });
-    const collectedCoverage = await readCollectedCoverage(pool, {
-      tenantId: String(scope.tenantId),
-      workspaceId: String(scope.workspaceId),
-    });
+      await artifactStore.readVisibleBadGamingArtifactCount(artifactScope);
+    const badGamingStatusCounts =
+      await artifactStore.readBadGamingArtifactStatusCounts(artifactScope);
+    const periodStatusCounts =
+      await artifactStore.readPeriodArtifactStatusCounts(artifactScope);
+    const collectedCoverage =
+      await artifactStore.readCollectedCoverage(artifactScope);
     const artifact = readerSummaryArtifactFromPrisma(record);
     const freshness: ReaderSummaryFreshness = {
       status: "fresh",
@@ -315,6 +287,20 @@ async function buildReport(): Promise<ArtifactQualityReport> {
     const view = presentReaderSummaryArtifact(artifact, freshness, {
       collectedCoverage,
     });
+    const selectedFeedItemProvenance =
+      await artifactStore.readSelectedFeedItemProvenance({
+        ...artifactScope,
+        feedItemIds: view.sourceWindow.selectedFeedItemIds,
+      });
+    const selectedFeedItemScopeEvidence = {
+      selectedFeedItemIds: view.sourceWindow.selectedFeedItemIds,
+      feedItems: selectedFeedItemProvenance,
+      scope: {
+        tenantId: record.tenantId,
+        workspaceId: record.workspaceId,
+        summaryScope: view.scope,
+      },
+    };
     const content = view.content;
     const coverage = view.coverage;
     const citationById = new Map(
@@ -330,9 +316,8 @@ async function buildReport(): Promise<ArtifactQualityReport> {
           .filter((value): value is string => value !== undefined),
       ),
     );
-    const topReadFeedItems = await readFeedItemsByIds(pool, {
-      tenantId: String(scope.tenantId),
-      workspaceId: String(scope.workspaceId),
+    const topReadFeedItems = await artifactStore.readFeedItemsByIds({
+      ...artifactScope,
       feedItemIds: topReadCitationFeedItemIds,
     });
     const sourceQuality = buildTopReadSourceQuality({
@@ -446,7 +431,7 @@ async function buildReport(): Promise<ArtifactQualityReport> {
       },
       inputs: {
         database: "local-postgres",
-        period: feedWindow(),
+        period: artifactQualityFeedWindow(collectionDate),
         scope: {
           tenantFingerprint: fingerprint(String(scope.tenantId)),
           workspaceFingerprint: fingerprint(String(scope.workspaceId)),
@@ -545,8 +530,15 @@ async function buildReport(): Promise<ArtifactQualityReport> {
         coverageSelectedMatchesSourceWindow:
           coverage.selectedFeedItemCount ===
           view.sourceWindow.selectedFeedItemIds.length,
+        selectedFeedItemProvenanceMatchesArtifactScope:
+          selectedFeedItemProvenanceMatchesScope(
+            selectedFeedItemScopeEvidence,
+          ),
         coverageSelectedMatchesProviderBreakdown:
-          selectedCoverageMatchesProviderBreakdown(coverage, selectedPosts),
+          selectedCoverageMatchesProviderBreakdown(coverage, {
+            ...selectedFeedItemScopeEvidence,
+            citations: view.citations,
+          }),
         selectedPostsMismatchIsExplained: selectedPostsMismatchDocumented,
         topReadsHaveCanonicalUrls:
           topReads.length > 0 &&
@@ -677,292 +669,6 @@ function validateExistingReport(): void {
   console.log(
     `Persisted reader summary artifact quality artifact OK (${report.collectionDate})`,
   );
-}
-
-async function readLatestArtifact(
-  pool: Pool,
-  scope: {
-    readonly tenantId: string;
-    readonly workspaceId: string;
-  },
-): Promise<PrismaReaderSummaryArtifactRecord> {
-  const result = await pool.query<PrismaReaderSummaryArtifactRecord>(
-    `
-      select
-        id::text as "id",
-        tenant_id::text as "tenantId",
-        workspace_id::text as "workspaceId",
-        scope_type as "scopeType",
-        scope_key as "scopeKey",
-        interest_id::text as "interestId",
-        cadence as "cadence",
-        period_started_at as "periodStartedAt",
-        period_ended_at as "periodEndedAt",
-        period_timezone as "periodTimezone",
-        period_key as "periodKey",
-        user_id::text as "userId",
-        subscription_id::text as "subscriptionId",
-        status::text as "status",
-        schema_version as "schemaVersion",
-        model_version as "modelVersion",
-        prompt_version as "promptVersion",
-        headline as "headline",
-        summary_text as "summaryText",
-        artifact_payload as "artifactPayload",
-        citations as "citations",
-        quality_signals as "qualitySignals",
-        created_at as "createdAt",
-        updated_at as "updatedAt"
-      from reader_summary_artifacts
-      where tenant_id = $1::uuid
-        and workspace_id = $2::uuid
-        and status in ('COMPLETED', 'NO_SIGNAL')
-        and scope_type = 'workspace'
-        and cadence = 'daily'
-        and period_key = $3
-      order by created_at desc, id desc
-      limit 1
-    `,
-    [scope.tenantId, scope.workspaceId, dailyPeriodKey(collectionDate)],
-  );
-  const row = result.rows[0];
-
-  if (row === undefined) {
-    throw new Error(
-      `No persisted reader summary artifact found for ${collectionDate}`,
-    );
-  }
-
-  return row;
-}
-
-async function readLatestVisibleArtifact(
-  pool: Pool,
-  scope: {
-    readonly tenantId: string;
-    readonly workspaceId: string;
-  },
-): Promise<PrismaReaderSummaryArtifactRecord> {
-  const result = await pool.query<PrismaReaderSummaryArtifactRecord>(
-    `
-      select
-        id::text as "id",
-        tenant_id::text as "tenantId",
-        workspace_id::text as "workspaceId",
-        scope_type as "scopeType",
-        scope_key as "scopeKey",
-        interest_id::text as "interestId",
-        cadence as "cadence",
-        period_started_at as "periodStartedAt",
-        period_ended_at as "periodEndedAt",
-        period_timezone as "periodTimezone",
-        period_key as "periodKey",
-        user_id::text as "userId",
-        subscription_id::text as "subscriptionId",
-        status::text as "status",
-        schema_version as "schemaVersion",
-        model_version as "modelVersion",
-        prompt_version as "promptVersion",
-        headline as "headline",
-        summary_text as "summaryText",
-        artifact_payload as "artifactPayload",
-        citations as "citations",
-        quality_signals as "qualitySignals",
-        created_at as "createdAt",
-        updated_at as "updatedAt"
-      from reader_summary_artifacts
-      where tenant_id = $1::uuid
-        and workspace_id = $2::uuid
-        and scope_type = 'workspace'
-        and cadence = 'daily'
-        and status in ('COMPLETED', 'NO_SIGNAL')
-      order by period_started_at desc, created_at desc, id desc
-      limit 1
-    `,
-    [scope.tenantId, scope.workspaceId],
-  );
-  const row = result.rows[0];
-
-  if (row === undefined) {
-    throw new Error("No persisted latest reader summary artifact found");
-  }
-
-  return row;
-}
-
-async function readPeriodArtifactStatusCounts(
-  pool: Pool,
-  scope: {
-    readonly tenantId: string;
-    readonly workspaceId: string;
-  },
-): Promise<Record<string, number>> {
-  const result = await pool.query<ArtifactStatusCountRow>(
-    `
-      select status::text as status, count(*)::text as count
-      from reader_summary_artifacts
-      where tenant_id = $1::uuid
-        and workspace_id = $2::uuid
-        and scope_type = 'workspace'
-        and cadence = 'daily'
-        and period_key = $3
-      group by status
-      order by status
-    `,
-    [scope.tenantId, scope.workspaceId, dailyPeriodKey(collectionDate)],
-  );
-
-  return Object.fromEntries(
-    result.rows.map((row) => [row.status, Number.parseInt(row.count, 10)]),
-  );
-}
-
-async function readBadGamingArtifactStatusCounts(
-  pool: Pool,
-  scope: {
-    readonly tenantId: string;
-    readonly workspaceId: string;
-  },
-): Promise<Record<string, number>> {
-  const result = await pool.query<ArtifactStatusCountRow>(
-    `
-      select status::text as status, count(*)::text as count
-      from reader_summary_artifacts
-      where tenant_id = $1::uuid
-        and workspace_id = $2::uuid
-        and artifact_payload::text ilike $3
-      group by status
-      order by status
-    `,
-    [scope.tenantId, scope.workspaceId, `%${badGamingFalsePositiveNeedle}%`],
-  );
-
-  return Object.fromEntries(
-    result.rows.map((row) => [row.status, Number.parseInt(row.count, 10)]),
-  );
-}
-
-async function readCollectedCoverage(
-  pool: Pool,
-  scope: {
-    readonly tenantId: string;
-    readonly workspaceId: string;
-  },
-): Promise<ReaderSummaryCollectedFeedItemCoverage> {
-  const result = await pool.query<ProviderCountRow>(
-    `
-      select
-        provider_key as "providerKey",
-        count(*)::text as "collectedFeedItemCount"
-      from feed_items
-      where tenant_id = $1::uuid
-        and workspace_id = $2::uuid
-        and published_at >= $3::timestamptz
-        and published_at < $4::timestamptz
-      group by provider_key
-      order by provider_key
-    `,
-    [
-      scope.tenantId,
-      scope.workspaceId,
-      feedWindow().startInclusive,
-      feedWindow().endExclusive,
-    ],
-  );
-  const providerBreakdown = result.rows
-    .filter((item) => isDefaultReaderSummaryEvidenceProvider(item.providerKey))
-    .map((item) => ({
-      providerKey: item.providerKey,
-      collectedFeedItemCount: Number.parseInt(item.collectedFeedItemCount, 10),
-      lowRelevanceFeedItemCount: 0,
-      mutedFeedItemCount: 0,
-      userRatedFeedItemCount: 0,
-    }))
-    .sort((left, right) => {
-      const countDiff =
-        right.collectedFeedItemCount - left.collectedFeedItemCount;
-      return countDiff === 0
-        ? left.providerKey.localeCompare(right.providerKey)
-        : countDiff;
-    });
-
-  return {
-    collectedFeedItemCount: providerBreakdown.reduce(
-      (sum, item) => sum + item.collectedFeedItemCount,
-      0,
-    ),
-    lowRelevanceFeedItemCount: 0,
-    mutedFeedItemCount: 0,
-    userRatedFeedItemCount: 0,
-    providerBreakdown,
-    topicBreakdown: [],
-    queryBreakdown: [],
-  };
-}
-
-async function readVisibleBadGamingArtifactCount(
-  pool: Pool,
-  scope: {
-    readonly tenantId: string;
-    readonly workspaceId: string;
-  },
-): Promise<number> {
-  const result = await pool.query<{ readonly count: string }>(
-    `
-      select count(*)::text as count
-      from reader_summary_artifacts
-      where tenant_id = $1::uuid
-        and workspace_id = $2::uuid
-        and status in ('COMPLETED', 'NO_SIGNAL')
-        and artifact_payload::text ilike $3
-    `,
-    [scope.tenantId, scope.workspaceId, `%${badGamingFalsePositiveNeedle}%`],
-  );
-
-  return Number.parseInt(result.rows[0]?.count ?? "0", 10);
-}
-
-async function readFeedItemsByIds(
-  pool: Pool,
-  params: {
-    readonly tenantId: string;
-    readonly workspaceId: string;
-    readonly feedItemIds: readonly string[];
-  },
-): Promise<readonly TopReadFeedItemQualityRow[]> {
-  if (params.feedItemIds.length === 0) {
-    return [];
-  }
-
-  const result = await pool.query<TopReadFeedItemQualityRow>(
-    `
-      select
-        id::text as "id",
-        provider_key as "providerKey",
-        canonical_url as "canonicalUrl",
-        author_handle as "authorHandle",
-        title,
-        body_preview as "bodyPreview",
-        provider_metadata as "providerMetadata"
-      from feed_items
-      where tenant_id = $1::uuid
-        and workspace_id = $2::uuid
-        and id = any($3::uuid[])
-    `,
-    [params.tenantId, params.workspaceId, params.feedItemIds],
-  );
-
-  return result.rows;
-}
-
-function feedWindow(): {
-  readonly startInclusive: string;
-  readonly endExclusive: string;
-} {
-  return {
-    startInclusive: `${collectionDate}T00:00:00.000Z`,
-    endExclusive: new Date(nextDate(collectionDate)).toISOString(),
-  };
 }
 
 function previousUtcDate(): string {

--- a/scripts/lib/reader-summary-artifact-coverage.spec.ts
+++ b/scripts/lib/reader-summary-artifact-coverage.spec.ts
@@ -1,40 +1,409 @@
-import { selectedCoverageMatchesProviderBreakdown } from "./reader-summary-artifact-coverage";
+import {
+  isPrimaryReaderSummaryArticleProvider,
+  selectedCoverageMatchesProviderBreakdown,
+  selectedFeedItemProvenanceMatchesScope,
+  type SelectedCoverageScope,
+  type SelectedFeedItemCitation,
+  type SelectedFeedItemProvenance,
+} from "./reader-summary-artifact-coverage";
 
 describe("selectedCoverageMatchesProviderBreakdown", () => {
-  it("accounts for isolated GitHub Trending appendix posts", () => {
+  it("accepts the real 131 selected / 129 projected / 120 primary-provider case", () => {
+    const fixture = productionRegressionFixture();
+
+    expect(fixture.coverage.selectedFeedItemCount).toBe(131);
+    expect(fixture.selectedPosts).toHaveLength(129);
     expect(
-      selectedCoverageMatchesProviderBreakdown(
-        {
-          selectedFeedItemCount: 123,
+      fixture.coverage.providerBreakdown.reduce(
+        (sum, provider) => sum + provider.selectedFeedItemCount,
+        0,
+      ),
+    ).toBe(120);
+    expect(matches(fixture)).toBe(true);
+  });
+
+  it("fails closed when a primary provider count is understated", () => {
+    const fixture = productionRegressionFixture();
+
+    expect(
+      matches({
+        ...fixture,
+        coverage: {
+          ...fixture.coverage,
+          providerBreakdown: fixture.coverage.providerBreakdown.map(
+            (provider) =>
+              provider.providerKey === "reddit"
+                ? { ...provider, selectedFeedItemCount: 29 }
+                : provider,
+          ),
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed when supplemental evidence is counted as primary", () => {
+    const fixture = productionRegressionFixture();
+
+    expect(
+      matches({
+        ...fixture,
+        coverage: {
+          ...fixture.coverage,
+          providerBreakdown: fixture.coverage.providerBreakdown.map(
+            (provider) =>
+              provider.providerKey === "github-trending-page"
+                ? { ...provider, selectedFeedItemCount: 11 }
+                : provider,
+          ),
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed for an unknown zero-count breakdown provider", () => {
+    const fixture = singleRedditFixture();
+
+    expect(
+      matches({
+        ...fixture,
+        coverage: {
+          ...fixture.coverage,
           providerBreakdown: [
-            { providerKey: "reddit", selectedFeedItemCount: 30 },
-            { providerKey: "rss", selectedFeedItemCount: 30 },
-            { providerKey: "hacker-news", selectedFeedItemCount: 30 },
-            { providerKey: "x-twitter", selectedFeedItemCount: 30 },
-            { providerKey: "github-trending-page", selectedFeedItemCount: 0 },
+            ...fixture.coverage.providerBreakdown,
+            { providerKey: "github-issues", selectedFeedItemCount: 0 },
           ],
         },
-        Array.from({ length: 3 }, () => ({
-          providerKey: "github-trending-page",
-        })),
-      ),
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts the explicit zero-count supplemental breakdown provider", () => {
+    const fixture = singleRedditFixture();
+
+    expect(
+      matches({
+        ...fixture,
+        coverage: {
+          ...fixture.coverage,
+          providerBreakdown: [
+            ...fixture.coverage.providerBreakdown,
+            {
+              providerKey: "github-trending-page",
+              selectedFeedItemCount: 0,
+            },
+          ],
+        },
+      }),
     ).toBe(true);
   });
 
-  it("does not double count GitHub posts already present in breakdown", () => {
+  it("rejects self-consistent GitHub Issues citations and source-mix counts", () => {
+    const fixture = productionRegressionFixture();
+    const githubIssuesId = fixture.selectedFeedItemIds.at(-1)!;
+
     expect(
-      selectedCoverageMatchesProviderBreakdown(
-        {
-          selectedFeedItemCount: 123,
+      matches({
+        ...fixture,
+        coverage: {
+          ...fixture.coverage,
           providerBreakdown: [
-            { providerKey: "reddit", selectedFeedItemCount: 120 },
-            { providerKey: "github-trending-page", selectedFeedItemCount: 3 },
+            ...fixture.coverage.providerBreakdown,
+            { providerKey: "github-issues", selectedFeedItemCount: 1 },
           ],
         },
-        Array.from({ length: 3 }, () => ({
-          providerKey: "github-trending-page",
-        })),
-      ),
+        citations: fixture.citations.map((citation) =>
+          citation.feedItemId === githubIssuesId
+            ? { ...citation, providerKey: "github-issues" }
+            : citation,
+        ),
+        feedItems: fixture.feedItems.map((feedItem) =>
+          feedItem.feedItemId === githubIssuesId
+            ? { ...feedItem, providerKey: "github-issues" }
+            : feedItem,
+        ),
+      }),
+    ).toBe(false);
+    expect(isPrimaryReaderSummaryArticleProvider("github-issues")).toBe(
+      false,
+    );
+  });
+
+  it("uses DB selection provenance rather than requiring display citations", () => {
+    const fixture = productionRegressionFixture();
+
+    expect(
+      matches({ ...fixture, citations: fixture.citations.slice(0, -1) }),
     ).toBe(true);
   });
+
+  it("fails closed when a citation references outside the selected window", () => {
+    const fixture = productionRegressionFixture();
+
+    expect(
+      matches({
+        ...fixture,
+        citations: [
+          ...fixture.citations,
+          { feedItemId: "outside-selection", providerKey: "reddit" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed when one selected item maps to conflicting providers", () => {
+    const fixture = productionRegressionFixture();
+    const selectedFeedItemId = fixture.selectedFeedItemIds[0]!;
+
+    expect(
+      matches({
+        ...fixture,
+        citations: [
+          ...fixture.citations,
+          { feedItemId: selectedFeedItemId, providerKey: "rss" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed when citation and DB provider provenance disagree", () => {
+    const fixture = productionRegressionFixture();
+
+    expect(
+      matches({
+        ...fixture,
+        citations: fixture.citations.map((citation, index) =>
+          index === 0 ? { ...citation, providerKey: "rss" } : citation,
+        ),
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed on missing or duplicate DB provenance", () => {
+    const fixture = productionRegressionFixture();
+
+    expect(
+      matches({ ...fixture, feedItems: fixture.feedItems.slice(0, -1) }),
+    ).toBe(false);
+    expect(
+      matches({
+        ...fixture,
+        feedItems: [...fixture.feedItems, fixture.feedItems[0]!],
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed on cross-tenant or cross-workspace DB provenance", () => {
+    const fixture = productionRegressionFixture();
+
+    const crossTenant = {
+      ...fixture,
+      feedItems: fixture.feedItems.map((feedItem, index) =>
+        index === 0 ? { ...feedItem, tenantId: "tenant-other" } : feedItem,
+      ),
+    };
+    const crossWorkspace = {
+      ...fixture,
+      feedItems: fixture.feedItems.map((feedItem, index) =>
+        index === 0
+          ? { ...feedItem, workspaceId: "workspace-other" }
+          : feedItem,
+      ),
+    };
+
+    expect(provenanceMatches(crossTenant)).toBe(false);
+    expect(matches(crossTenant)).toBe(false);
+    expect(provenanceMatches(crossWorkspace)).toBe(false);
+    expect(matches(crossWorkspace)).toBe(false);
+  });
+
+  it("fails closed when interest provenance is missing or cross-scoped", () => {
+    const fixture = productionRegressionFixture();
+
+    const missingInterest = {
+      ...fixture,
+      feedItems: fixture.feedItems.map((feedItem, index) =>
+        index === 0 ? { ...feedItem, interestTenantId: null } : feedItem,
+      ),
+    };
+    const crossScopeInterest = {
+      ...fixture,
+      feedItems: fixture.feedItems.map((feedItem, index) =>
+        index === 0
+          ? { ...feedItem, interestWorkspaceId: "workspace-other" }
+          : feedItem,
+      ),
+    };
+
+    expect(provenanceMatches(missingInterest)).toBe(false);
+    expect(matches(missingInterest)).toBe(false);
+    expect(provenanceMatches(crossScopeInterest)).toBe(false);
+    expect(matches(crossScopeInterest)).toBe(false);
+  });
+
+  it("fails closed when an interest-scoped selection contains another interest", () => {
+    const fixture = productionRegressionFixture();
+
+    const crossInterest = {
+      ...fixture,
+      scope: {
+        ...fixture.scope,
+        summaryScope: {
+          type: "interest" as const,
+          interestId: "interest-ai",
+        },
+      },
+      feedItems: fixture.feedItems.map((feedItem, index) => ({
+        ...feedItem,
+        interestId: index === 0 ? "interest-other" : "interest-ai",
+      })),
+    };
+
+    expect(provenanceMatches(crossInterest)).toBe(false);
+    expect(matches(crossInterest)).toBe(false);
+  });
+
+  it("fails closed for duplicate source-window ids or a false selected total", () => {
+    const fixture = productionRegressionFixture();
+
+    expect(
+      matches({
+        ...fixture,
+        selectedFeedItemIds: [
+          ...fixture.selectedFeedItemIds.slice(0, -1),
+          fixture.selectedFeedItemIds[0]!,
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      matches({
+        ...fixture,
+        coverage: { ...fixture.coverage, selectedFeedItemCount: 130 },
+      }),
+    ).toBe(false);
+  });
 });
+
+type CoverageFixture = {
+  readonly coverage: Parameters<
+    typeof selectedCoverageMatchesProviderBreakdown
+  >[0];
+  readonly selectedFeedItemIds: readonly string[];
+  readonly citations: readonly SelectedFeedItemCitation[];
+  readonly feedItems: readonly SelectedFeedItemProvenance[];
+  readonly scope: SelectedCoverageScope;
+  readonly selectedPosts: readonly string[];
+};
+
+const matches = (fixture: CoverageFixture): boolean =>
+  selectedCoverageMatchesProviderBreakdown(fixture.coverage, {
+    selectedFeedItemIds: fixture.selectedFeedItemIds,
+    citations: fixture.citations,
+    feedItems: fixture.feedItems,
+    scope: fixture.scope,
+  });
+
+const provenanceMatches = (fixture: CoverageFixture): boolean =>
+  selectedFeedItemProvenanceMatchesScope({
+    selectedFeedItemIds: fixture.selectedFeedItemIds,
+    feedItems: fixture.feedItems,
+    scope: fixture.scope,
+  });
+
+function singleRedditFixture(): CoverageFixture {
+  const citation: SelectedFeedItemCitation = {
+    feedItemId: "reddit-1",
+    providerKey: "reddit",
+  };
+
+  return {
+    coverage: {
+      selectedFeedItemCount: 1,
+      providerBreakdown: [
+        { providerKey: "reddit", selectedFeedItemCount: 1 },
+      ],
+    },
+    selectedFeedItemIds: [citation.feedItemId],
+    citations: [citation],
+    feedItems: [
+      {
+        feedItemId: citation.feedItemId,
+        tenantId: "tenant-main",
+        workspaceId: "workspace-main",
+        interestId: "interest-ai",
+        interestTenantId: "tenant-main",
+        interestWorkspaceId: "workspace-main",
+        providerKey: citation.providerKey,
+      },
+    ],
+    scope: {
+      tenantId: "tenant-main",
+      workspaceId: "workspace-main",
+      summaryScope: { type: "workspace" },
+    },
+    selectedPosts: ["post-1"],
+  };
+}
+
+function productionRegressionFixture(): CoverageFixture {
+  const primaryProviders = [
+    "reddit",
+    "x-twitter",
+    "hacker-news",
+    "rss",
+  ] as const;
+  const primaryCitations = primaryProviders.flatMap((providerKey) =>
+    Array.from(
+      { length: 30 },
+      (_, index): SelectedFeedItemCitation => ({
+        feedItemId: `${providerKey}-${index + 1}`,
+        providerKey,
+      }),
+    ),
+  );
+  const supplementalCitations = Array.from(
+    { length: 11 },
+    (_, index): SelectedFeedItemCitation => ({
+      feedItemId: `github-trending-page-${index + 1}`,
+      providerKey: "github-trending-page",
+    }),
+  );
+  const citations = [...primaryCitations, ...supplementalCitations];
+  const feedItems = citations.map(
+    (citation): SelectedFeedItemProvenance => ({
+      feedItemId: citation.feedItemId,
+      tenantId: "tenant-main",
+      workspaceId: "workspace-main",
+      interestId: "interest-ai",
+      interestTenantId: "tenant-main",
+      interestWorkspaceId: "workspace-main",
+      providerKey: citation.providerKey,
+    }),
+  );
+
+  return {
+    coverage: {
+      selectedFeedItemCount: 131,
+      providerBreakdown: [
+        ...primaryProviders.map((providerKey) => ({
+          providerKey,
+          selectedFeedItemCount: 30,
+        })),
+        {
+          providerKey: "github-trending-page",
+          selectedFeedItemCount: 0,
+        },
+      ],
+    },
+    selectedFeedItemIds: citations.map((citation) => citation.feedItemId),
+    citations,
+    feedItems,
+    scope: {
+      tenantId: "tenant-main",
+      workspaceId: "workspace-main",
+      summaryScope: { type: "workspace" as const },
+    },
+    // One primary canonical identity is collapsed and only the GitHub Top 10
+    // is projected; neither presentation rule changes selection provenance.
+    selectedPosts: Array.from({ length: 129 }, (_, index) => `post-${index}`),
+  };
+}

--- a/scripts/lib/reader-summary-artifact-coverage.ts
+++ b/scripts/lib/reader-summary-artifact-coverage.ts
@@ -3,30 +3,278 @@ export type ProviderSelectedCount = {
   readonly selectedFeedItemCount: number;
 };
 
+export type SelectedFeedItemCitation = {
+  readonly feedItemId: string;
+  readonly providerKey: string;
+};
+
+export type SelectedFeedItemProvenance = {
+  readonly feedItemId: string;
+  readonly tenantId: string;
+  readonly workspaceId: string;
+  readonly interestId: string;
+  readonly interestTenantId: string | null;
+  readonly interestWorkspaceId: string | null;
+  readonly providerKey: string;
+};
+
+export type SelectedCoverageScope = {
+  readonly tenantId: string;
+  readonly workspaceId: string;
+  readonly summaryScope:
+    | { readonly type: "workspace" }
+    | { readonly type: "interest"; readonly interestId: string };
+};
+
+const primaryArticleProviderKeys = new Set([
+  "reddit",
+  "rss",
+  "hacker-news",
+  "x-twitter",
+]);
+
+export const isPrimaryReaderSummaryArticleProvider = (
+  providerKey: string,
+): boolean => {
+  const normalized = normalizedProviderKey(providerKey);
+  return (
+    normalized !== undefined && primaryArticleProviderKeys.has(normalized)
+  );
+};
+
+const isSupplementalReaderSummaryProvider = (providerKey: string): boolean =>
+  normalizedProviderKey(providerKey) === "github-trending-page";
+
+// The source window is the full scoped selection. The provider breakdown is
+// the source-mix projection: unique primary feed items grouped by provider.
+// Reader selectedPosts are identity-deduped and supplemental-display-capped,
+// so they are intentionally not evidence for this invariant.
 export const selectedCoverageMatchesProviderBreakdown = (
   coverage: {
     readonly selectedFeedItemCount: number;
     readonly providerBreakdown: readonly ProviderSelectedCount[];
   },
-  selectedPosts: readonly { readonly providerKey: string }[],
+  evidence: {
+    readonly selectedFeedItemIds: readonly string[];
+    readonly citations: readonly SelectedFeedItemCitation[];
+    readonly feedItems: readonly SelectedFeedItemProvenance[];
+    readonly scope: SelectedCoverageScope;
+  },
 ): boolean => {
-  const providerSelectedCount = coverage.providerBreakdown.reduce(
-    (sum, provider) => sum + provider.selectedFeedItemCount,
-    0,
-  );
-  const githubTrendingProviderCount =
-    coverage.providerBreakdown.find(
-      (provider) => provider.providerKey === "github-trending-page",
-    )?.selectedFeedItemCount ?? 0;
-  const githubTrendingSelectedPostCount = selectedPosts.filter(
-    (post) => post.providerKey === "github-trending-page",
-  ).length;
-  const appendixOnlyCount = Math.max(
-    0,
-    githubTrendingSelectedPostCount - githubTrendingProviderCount,
-  );
+  if (
+    !validCount(coverage.selectedFeedItemCount) ||
+    coverage.selectedFeedItemCount !== evidence.selectedFeedItemIds.length
+  ) {
+    return false;
+  }
 
+  const selectedFeedItemIds = normalizedUniqueIds(
+    evidence.selectedFeedItemIds,
+  );
+  if (selectedFeedItemIds === undefined) {
+    return false;
+  }
+
+  const selectedFeedItems = selectedFeedItemProvenanceById(
+    selectedFeedItemIds,
+    evidence.feedItems,
+    evidence.scope,
+  );
+  if (selectedFeedItems === undefined) {
+    return false;
+  }
+
+  const providerBySelectedFeedItemId = selectedCitationProviders(
+    selectedFeedItemIds,
+    evidence.citations,
+  );
+  if (providerBySelectedFeedItemId === undefined) {
+    return false;
+  }
+
+  for (const [feedItemId, providerKey] of providerBySelectedFeedItemId) {
+    if (selectedFeedItems.get(feedItemId)?.providerKey !== providerKey) {
+      return false;
+    }
+  }
+
+  const expectedPrimaryCounts = new Map<string, number>();
+  for (const feedItem of selectedFeedItems.values()) {
+    if (isSupplementalReaderSummaryProvider(feedItem.providerKey)) {
+      continue;
+    }
+    if (!isPrimaryReaderSummaryArticleProvider(feedItem.providerKey)) {
+      return false;
+    }
+    expectedPrimaryCounts.set(
+      feedItem.providerKey,
+      (expectedPrimaryCounts.get(feedItem.providerKey) ?? 0) + 1,
+    );
+  }
+
+  const breakdownCounts = normalizedBreakdownCounts(
+    coverage.providerBreakdown,
+  );
+  if (breakdownCounts === undefined) {
+    return false;
+  }
+
+  for (const [providerKey, expectedCount] of expectedPrimaryCounts) {
+    if (breakdownCounts.get(providerKey) !== expectedCount) {
+      return false;
+    }
+  }
+
+  return [...breakdownCounts].every(([providerKey, count]) => {
+    if (isPrimaryReaderSummaryArticleProvider(providerKey)) {
+      return count === (expectedPrimaryCounts.get(providerKey) ?? 0);
+    }
+
+    return isSupplementalReaderSummaryProvider(providerKey) && count === 0;
+  });
+};
+
+export const selectedFeedItemProvenanceMatchesScope = (evidence: {
+  readonly selectedFeedItemIds: readonly string[];
+  readonly feedItems: readonly SelectedFeedItemProvenance[];
+  readonly scope: SelectedCoverageScope;
+}): boolean => {
+  const selectedFeedItemIds = normalizedUniqueIds(
+    evidence.selectedFeedItemIds,
+  );
   return (
-    coverage.selectedFeedItemCount === providerSelectedCount + appendixOnlyCount
+    selectedFeedItemIds !== undefined &&
+    selectedFeedItemProvenanceById(
+      selectedFeedItemIds,
+      evidence.feedItems,
+      evidence.scope,
+    ) !== undefined
   );
 };
+
+const normalizedUniqueIds = (
+  values: readonly string[],
+): ReadonlySet<string> | undefined => {
+  const normalized = values.map((value) => value.trim());
+  if (normalized.some((value) => value.length === 0)) {
+    return undefined;
+  }
+
+  const unique = new Set(normalized);
+  return unique.size === normalized.length ? unique : undefined;
+};
+
+const selectedFeedItemProvenanceById = (
+  selectedFeedItemIds: ReadonlySet<string>,
+  feedItems: readonly SelectedFeedItemProvenance[],
+  scope: SelectedCoverageScope,
+): ReadonlyMap<string, { readonly providerKey: string }> | undefined => {
+  const expectedTenantId = normalizedId(scope.tenantId);
+  const expectedWorkspaceId = normalizedId(scope.workspaceId);
+  const expectedInterestId =
+    scope.summaryScope.type === "interest"
+      ? normalizedId(scope.summaryScope.interestId)
+      : undefined;
+  if (
+    expectedTenantId === undefined ||
+    expectedWorkspaceId === undefined ||
+    (scope.summaryScope.type === "interest" &&
+      expectedInterestId === undefined)
+  ) {
+    return undefined;
+  }
+
+  const provenanceByFeedItemId = new Map<
+    string,
+    { readonly providerKey: string }
+  >();
+  for (const feedItem of feedItems) {
+    const feedItemId = normalizedId(feedItem.feedItemId);
+    const tenantId = normalizedId(feedItem.tenantId);
+    const workspaceId = normalizedId(feedItem.workspaceId);
+    const interestId = normalizedId(feedItem.interestId);
+    const interestTenantId = normalizedNullableId(feedItem.interestTenantId);
+    const interestWorkspaceId = normalizedNullableId(
+      feedItem.interestWorkspaceId,
+    );
+    const providerKey = normalizedProviderKey(feedItem.providerKey);
+    if (
+      feedItemId === undefined ||
+      !selectedFeedItemIds.has(feedItemId) ||
+      provenanceByFeedItemId.has(feedItemId) ||
+      tenantId !== expectedTenantId ||
+      workspaceId !== expectedWorkspaceId ||
+      interestId === undefined ||
+      interestTenantId !== expectedTenantId ||
+      interestWorkspaceId !== expectedWorkspaceId ||
+      (expectedInterestId !== undefined && interestId !== expectedInterestId) ||
+      providerKey === undefined
+    ) {
+      return undefined;
+    }
+    provenanceByFeedItemId.set(feedItemId, { providerKey });
+  }
+
+  return provenanceByFeedItemId.size === selectedFeedItemIds.size
+    ? provenanceByFeedItemId
+    : undefined;
+};
+
+const selectedCitationProviders = (
+  selectedFeedItemIds: ReadonlySet<string>,
+  citations: readonly SelectedFeedItemCitation[],
+): ReadonlyMap<string, string> | undefined => {
+  const providerByFeedItemId = new Map<string, string>();
+  for (const citation of citations) {
+    const feedItemId = citation.feedItemId.trim();
+    if (!selectedFeedItemIds.has(feedItemId)) {
+      return undefined;
+    }
+    const providerKey = normalizedProviderKey(citation.providerKey);
+    const current = providerByFeedItemId.get(feedItemId);
+    if (
+      providerKey === undefined ||
+      (current !== undefined && current !== providerKey)
+    ) {
+      return undefined;
+    }
+    providerByFeedItemId.set(feedItemId, providerKey);
+  }
+
+  return providerByFeedItemId;
+};
+
+const normalizedBreakdownCounts = (
+  breakdown: readonly ProviderSelectedCount[],
+): ReadonlyMap<string, number> | undefined => {
+  const counts = new Map<string, number>();
+  for (const provider of breakdown) {
+    const providerKey = normalizedProviderKey(provider.providerKey);
+    if (
+      providerKey === undefined ||
+      !validCount(provider.selectedFeedItemCount) ||
+      counts.has(providerKey)
+    ) {
+      return undefined;
+    }
+    counts.set(providerKey, provider.selectedFeedItemCount);
+  }
+
+  return counts;
+};
+
+const normalizedProviderKey = (value: string): string | undefined => {
+  const normalized = value.trim().toLocaleLowerCase("en-US");
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizedId = (value: string): string | undefined => {
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizedNullableId = (value: string | null): string | undefined =>
+  value === null ? undefined : normalizedId(value);
+
+const validCount = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0;

--- a/scripts/lib/reader-summary-production-day-collection-barrier.spec.ts
+++ b/scripts/lib/reader-summary-production-day-collection-barrier.spec.ts
@@ -1,4 +1,6 @@
 import {
+  artifactQualityIsReadyForCleanDayE2e,
+  blockedCleanDayE2eStep,
   blockedProductionDaySteps,
   collectionIsReadyForProductionSummary,
   exactProductionDayStepsPassed,
@@ -66,6 +68,25 @@ describe("production-day collection barrier", () => {
     expect(
       steps.every((step) => step.command.includes("collection quality failed")),
     ).toBe(true);
+  });
+
+  it("does not diagnose a stale clean-day artifact after artifact quality fails", () => {
+    expect(artifactQualityIsReadyForCleanDayE2e("failed")).toBe(false);
+    expect(artifactQualityIsReadyForCleanDayE2e("skipped")).toBe(false);
+    expect(artifactQualityIsReadyForCleanDayE2e("passed")).toBe(true);
+
+    expect(
+      blockedCleanDayE2eStep(
+        "artifact-quality failed; no current-date artifact was written",
+      ),
+    ).toEqual({
+      id: "clean-day-e2e",
+      command:
+        "clean-day-e2e -- skipped: artifact-quality failed; no current-date artifact was written",
+      status: "skipped",
+      durationMs: 0,
+      exitCode: null,
+    });
   });
 
   it("passes only the exact nine executed production steps", () => {

--- a/scripts/lib/reader-summary-production-day-collection-barrier.ts
+++ b/scripts/lib/reader-summary-production-day-collection-barrier.ts
@@ -45,6 +45,20 @@ export const exactProductionDayStepsPassed = (
   });
 };
 
+export const artifactQualityIsReadyForCleanDayE2e = (
+  status: ProductionDayStepStatus,
+): boolean => status === "passed";
+
+export const blockedCleanDayE2eStep = (
+  reason: string,
+): ProductionDayStepReport => ({
+  id: "clean-day-e2e",
+  command: `clean-day-e2e -- skipped: ${reason}`,
+  status: "skipped",
+  durationMs: 0,
+  exitCode: null,
+});
+
 const blockedStepIds = [
   "durable-reader-summary",
   "artifact-quality",

--- a/scripts/lib/yesterday-reader-summary-artifact-quality-store.spec.ts
+++ b/scripts/lib/yesterday-reader-summary-artifact-quality-store.spec.ts
@@ -1,37 +1,263 @@
 import type { Pool } from "pg";
 
+import type { PrismaReaderSummaryArtifactRecord } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-records";
+
 import type { SelectedFeedItemProvenance } from "./reader-summary-artifact-coverage";
-import { YesterdayReaderSummaryArtifactQualityStore } from "./yesterday-reader-summary-artifact-quality-store";
+import {
+  type TopReadFeedItemQualityRow,
+  YesterdayReaderSummaryArtifactQualityStore,
+} from "./yesterday-reader-summary-artifact-quality-store";
+
+const tenantId = "00000000-0000-7000-8000-000000000201";
+const workspaceId = "00000000-0000-7000-8000-000000000301";
+const collectionDate = "2026-07-18";
+const periodKey =
+  "daily:2026-07-18T00:00:00.000Z:2026-07-19T00:00:00.000Z:UTC";
 
 describe("YesterdayReaderSummaryArtifactQualityStore", () => {
-  it("reads tenant-scoped DB and interest provenance for selected ids", async () => {
+  it("reads the latest visible artifact for the scoped UTC collection day", async () => {
+    const artifact = artifactRecord();
+    const query = jest.fn().mockResolvedValue({ rows: [artifact] });
+    const store = createStore(query);
+
+    await expect(
+      store.readLatestArtifact({ tenantId, workspaceId }),
+    ).resolves.toEqual(artifact);
+
+    const sql = querySql(query);
+    expect(sql).toContain("tenant_id = $1::uuid");
+    expect(sql).toContain("workspace_id = $2::uuid");
+    expect(sql).toContain("status in ('COMPLETED', 'NO_SIGNAL')");
+    expect(sql).toContain("scope_type = 'workspace'");
+    expect(sql).toContain("cadence = 'daily'");
+    expect(sql).toContain("period_key = $3");
+    expect(sql).toContain("order by created_at desc, id desc");
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      tenantId,
+      workspaceId,
+      periodKey,
+    ]);
+  });
+
+  it("reads the latest visible artifact across periods within tenant scope", async () => {
+    const artifact = artifactRecord({
+      id: "00000000-0000-7000-8000-000000000102",
+      status: "NO_SIGNAL",
+    });
+    const query = jest.fn().mockResolvedValue({ rows: [artifact] });
+    const store = createStore(query);
+
+    await expect(
+      store.readLatestVisibleArtifact({ tenantId, workspaceId }),
+    ).resolves.toEqual(artifact);
+
+    const sql = querySql(query);
+    expect(sql).toContain("tenant_id = $1::uuid");
+    expect(sql).toContain("workspace_id = $2::uuid");
+    expect(sql).toContain("scope_type = 'workspace'");
+    expect(sql).toContain("cadence = 'daily'");
+    expect(sql).toContain("status in ('COMPLETED', 'NO_SIGNAL')");
+    expect(sql).toContain(
+      "order by period_started_at desc, created_at desc, id desc",
+    );
+    expect(query.mock.calls[0]?.[1]).toEqual([tenantId, workspaceId]);
+  });
+
+  it("fails closed when either latest-artifact lookup has no row", async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const store = createStore(query);
+
+    await expect(
+      store.readLatestArtifact({ tenantId, workspaceId }),
+    ).rejects.toThrow(
+      "No persisted reader summary artifact found for 2026-07-18",
+    );
+    await expect(
+      store.readLatestVisibleArtifact({ tenantId, workspaceId }),
+    ).rejects.toThrow("No persisted latest reader summary artifact found");
+  });
+
+  it("maps scoped period artifact status counts", async () => {
+    const query = jest.fn().mockResolvedValue({
+      rows: [
+        { status: "COMPLETED", count: "4" },
+        { status: "FAILED", count: "2" },
+      ],
+    });
+    const store = createStore(query);
+
+    await expect(
+      store.readPeriodArtifactStatusCounts({ tenantId, workspaceId }),
+    ).resolves.toEqual({ COMPLETED: 4, FAILED: 2 });
+
+    const sql = querySql(query);
+    expect(sql).toContain("tenant_id = $1::uuid");
+    expect(sql).toContain("workspace_id = $2::uuid");
+    expect(sql).toContain("scope_type = 'workspace'");
+    expect(sql).toContain("cadence = 'daily'");
+    expect(sql).toContain("period_key = $3");
+    expect(sql).toContain("group by status");
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      tenantId,
+      workspaceId,
+      periodKey,
+    ]);
+  });
+
+  it("escapes the same literal needle in both bad-gaming queries", async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { status: "COMPLETED", count: "3" },
+          { status: "REJECTED", count: "1" },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ count: "3" }] });
+    const store = createStore(query, "bad\\path_100%");
+
+    await expect(
+      store.readBadGamingArtifactStatusCounts({ tenantId, workspaceId }),
+    ).resolves.toEqual({ COMPLETED: 3, REJECTED: 1 });
+    await expect(
+      store.readVisibleBadGamingArtifactCount({ tenantId, workspaceId }),
+    ).resolves.toBe(3);
+
+    const escapedPattern = "%bad\\\\path\\_100\\%%";
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      tenantId,
+      workspaceId,
+      escapedPattern,
+    ]);
+    expect(query.mock.calls[1]?.[1]).toEqual([
+      tenantId,
+      workspaceId,
+      escapedPattern,
+    ]);
+
+    const statusSql = querySql(query, 0);
+    const visibleSql = querySql(query, 1);
+    for (const sql of [statusSql, visibleSql]) {
+      expect(sql).toContain("tenant_id = $1::uuid");
+      expect(sql).toContain("workspace_id = $2::uuid");
+      expect(sql).toContain("artifact_payload::text ilike $3 escape E'\\\\'");
+    }
+    expect(visibleSql).toContain("status in ('COMPLETED', 'NO_SIGNAL')");
+  });
+
+  it("maps UTC collection coverage for eligible providers only", async () => {
+    const query = jest.fn().mockResolvedValue({
+      rows: [
+        { providerKey: "reddit", collectedFeedItemCount: "2" },
+        { providerKey: "rss", collectedFeedItemCount: "5" },
+        { providerKey: "github-issues", collectedFeedItemCount: "11" },
+        {
+          providerKey: "GITHUB-TRENDING-PAGE",
+          collectedFeedItemCount: "13",
+        },
+      ],
+    });
+    const store = createStore(query);
+
+    await expect(
+      store.readCollectedCoverage({ tenantId, workspaceId }),
+    ).resolves.toEqual({
+      collectedFeedItemCount: 7,
+      lowRelevanceFeedItemCount: 0,
+      mutedFeedItemCount: 0,
+      userRatedFeedItemCount: 0,
+      providerBreakdown: [
+        {
+          providerKey: "rss",
+          collectedFeedItemCount: 5,
+          lowRelevanceFeedItemCount: 0,
+          mutedFeedItemCount: 0,
+          userRatedFeedItemCount: 0,
+        },
+        {
+          providerKey: "reddit",
+          collectedFeedItemCount: 2,
+          lowRelevanceFeedItemCount: 0,
+          mutedFeedItemCount: 0,
+          userRatedFeedItemCount: 0,
+        },
+      ],
+      topicBreakdown: [],
+      queryBreakdown: [],
+    });
+
+    const sql = querySql(query);
+    expect(sql).toContain("tenant_id = $1::uuid");
+    expect(sql).toContain("workspace_id = $2::uuid");
+    expect(sql).toContain("published_at >= $3::timestamptz");
+    expect(sql).toContain("published_at < $4::timestamptz");
+    expect(sql).toContain("group by provider_key");
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      tenantId,
+      workspaceId,
+      "2026-07-18T00:00:00.000Z",
+      "2026-07-19T00:00:00.000Z",
+    ]);
+  });
+
+  it("reads tenant-scoped feed items by UUID", async () => {
+    const rows: readonly TopReadFeedItemQualityRow[] = [
+      {
+        id: "00000000-0000-7000-8000-000000000101",
+        providerKey: "reddit",
+        canonicalUrl: "https://example.test/posts/101",
+        authorHandle: "example-author",
+        title: "Example title",
+        bodyPreview: "Example preview",
+        providerMetadata: { score: 42 },
+      },
+    ];
+    const feedItemIds = rows.map((row) => row.id);
+    const query = jest.fn().mockResolvedValue({ rows });
+    const store = createStore(query);
+
+    await expect(
+      store.readFeedItemsByIds({ tenantId, workspaceId, feedItemIds }),
+    ).resolves.toEqual(rows);
+
+    const sql = querySql(query);
+    expect(sql).toContain('id::text as "id"');
+    expect(sql).toContain('provider_key as "providerKey"');
+    expect(sql).toContain("tenant_id = $1::uuid");
+    expect(sql).toContain("workspace_id = $2::uuid");
+    expect(sql).toContain("id = any($3::uuid[])");
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      tenantId,
+      workspaceId,
+      feedItemIds,
+    ]);
+  });
+
+  it("preserves tenant-scoped DB and interest provenance for selected UUIDs", async () => {
     const rows: readonly SelectedFeedItemProvenance[] = [
       {
         feedItemId: "00000000-0000-7000-8000-000000000101",
-        tenantId: "00000000-0000-7000-8000-000000000201",
-        workspaceId: "00000000-0000-7000-8000-000000000301",
+        tenantId,
+        workspaceId,
         interestId: "00000000-0000-7000-8000-000000000401",
-        interestTenantId: "00000000-0000-7000-8000-000000000201",
-        interestWorkspaceId: "00000000-0000-7000-8000-000000000301",
+        interestTenantId: tenantId,
+        interestWorkspaceId: workspaceId,
         providerKey: "reddit",
       },
     ];
+    const feedItemIds = rows.map((row) => row.feedItemId);
     const query = jest.fn().mockResolvedValue({ rows });
-    const store = new YesterdayReaderSummaryArtifactQualityStore(
-      { query } as unknown as Pool,
-      "2026-07-18",
-      "false-positive-needle",
-    );
+    const store = createStore(query);
 
     await expect(
       store.readSelectedFeedItemProvenance({
-        tenantId: rows[0]!.tenantId,
-        workspaceId: rows[0]!.workspaceId,
-        feedItemIds: [rows[0]!.feedItemId],
+        tenantId,
+        workspaceId,
+        feedItemIds,
       }),
     ).resolves.toEqual(rows);
 
-    const sql = String(query.mock.calls[0]?.[0]);
+    const sql = querySql(query);
     expect(sql).toContain('fi.tenant_id::text as "tenantId"');
     expect(sql).toContain('fi.workspace_id::text as "workspaceId"');
     expect(sql).toContain('fi.interest_id::text as "interestId"');
@@ -44,9 +270,68 @@ describe("YesterdayReaderSummaryArtifactQualityStore", () => {
     expect(sql).toContain("and fi.workspace_id = $2::uuid");
     expect(sql).toContain("and fi.id = any($3::uuid[])");
     expect(query.mock.calls[0]?.[1]).toEqual([
-      rows[0]!.tenantId,
-      rows[0]!.workspaceId,
-      [rows[0]!.feedItemId],
+      tenantId,
+      workspaceId,
+      feedItemIds,
     ]);
   });
+
+  it("short-circuits every empty UUID list without querying PostgreSQL", async () => {
+    const query = jest.fn();
+    const store = createStore(query);
+    const params = { tenantId, workspaceId, feedItemIds: [] };
+
+    await expect(store.readFeedItemsByIds(params)).resolves.toEqual([]);
+    await expect(
+      store.readSelectedFeedItemProvenance(params),
+    ).resolves.toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+  });
 });
+
+function createStore(
+  query: jest.Mock,
+  badGamingFalsePositiveNeedle = "false-positive-needle",
+): YesterdayReaderSummaryArtifactQualityStore {
+  return new YesterdayReaderSummaryArtifactQualityStore(
+    { query } as unknown as Pool,
+    collectionDate,
+    badGamingFalsePositiveNeedle,
+  );
+}
+
+function querySql(query: jest.Mock, callIndex = 0): string {
+  return String(query.mock.calls[callIndex]?.[0]);
+}
+
+function artifactRecord(
+  overrides: Partial<PrismaReaderSummaryArtifactRecord> = {},
+): PrismaReaderSummaryArtifactRecord {
+  return {
+    id: "00000000-0000-7000-8000-000000000101",
+    tenantId,
+    workspaceId,
+    scopeType: "workspace",
+    scopeKey: "workspace",
+    interestId: null,
+    cadence: "daily",
+    periodStartedAt: new Date("2026-07-18T00:00:00.000Z"),
+    periodEndedAt: new Date("2026-07-19T00:00:00.000Z"),
+    periodTimezone: "UTC",
+    periodKey,
+    userId: null,
+    subscriptionId: null,
+    status: "COMPLETED",
+    schemaVersion: 1,
+    modelVersion: "model-v1",
+    promptVersion: "prompt-v1",
+    headline: "Example headline",
+    summaryText: "Example summary",
+    artifactPayload: { schemaVersion: 1 },
+    citations: [],
+    qualitySignals: { grounded: true },
+    createdAt: new Date("2026-07-19T00:01:00.000Z"),
+    updatedAt: new Date("2026-07-19T00:02:00.000Z"),
+    ...overrides,
+  };
+}

--- a/scripts/lib/yesterday-reader-summary-artifact-quality-store.spec.ts
+++ b/scripts/lib/yesterday-reader-summary-artifact-quality-store.spec.ts
@@ -1,0 +1,52 @@
+import type { Pool } from "pg";
+
+import type { SelectedFeedItemProvenance } from "./reader-summary-artifact-coverage";
+import { YesterdayReaderSummaryArtifactQualityStore } from "./yesterday-reader-summary-artifact-quality-store";
+
+describe("YesterdayReaderSummaryArtifactQualityStore", () => {
+  it("reads tenant-scoped DB and interest provenance for selected ids", async () => {
+    const rows: readonly SelectedFeedItemProvenance[] = [
+      {
+        feedItemId: "00000000-0000-7000-8000-000000000101",
+        tenantId: "00000000-0000-7000-8000-000000000201",
+        workspaceId: "00000000-0000-7000-8000-000000000301",
+        interestId: "00000000-0000-7000-8000-000000000401",
+        interestTenantId: "00000000-0000-7000-8000-000000000201",
+        interestWorkspaceId: "00000000-0000-7000-8000-000000000301",
+        providerKey: "reddit",
+      },
+    ];
+    const query = jest.fn().mockResolvedValue({ rows });
+    const store = new YesterdayReaderSummaryArtifactQualityStore(
+      { query } as unknown as Pool,
+      "2026-07-18",
+      "false-positive-needle",
+    );
+
+    await expect(
+      store.readSelectedFeedItemProvenance({
+        tenantId: rows[0]!.tenantId,
+        workspaceId: rows[0]!.workspaceId,
+        feedItemIds: [rows[0]!.feedItemId],
+      }),
+    ).resolves.toEqual(rows);
+
+    const sql = String(query.mock.calls[0]?.[0]);
+    expect(sql).toContain('fi.tenant_id::text as "tenantId"');
+    expect(sql).toContain('fi.workspace_id::text as "workspaceId"');
+    expect(sql).toContain('fi.interest_id::text as "interestId"');
+    expect(sql).toContain('i.tenant_id::text as "interestTenantId"');
+    expect(sql).toContain('i.workspace_id::text as "interestWorkspaceId"');
+    expect(sql).toContain("on i.id = fi.interest_id");
+    expect(sql).toContain("and i.tenant_id = $1::uuid");
+    expect(sql).toContain("and i.workspace_id = $2::uuid");
+    expect(sql).toContain("where fi.tenant_id = $1::uuid");
+    expect(sql).toContain("and fi.workspace_id = $2::uuid");
+    expect(sql).toContain("and fi.id = any($3::uuid[])");
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      rows[0]!.tenantId,
+      rows[0]!.workspaceId,
+      [rows[0]!.feedItemId],
+    ]);
+  });
+});

--- a/scripts/lib/yesterday-reader-summary-artifact-quality-store.ts
+++ b/scripts/lib/yesterday-reader-summary-artifact-quality-store.ts
@@ -23,6 +23,12 @@ type ArtifactStatusCountRow = {
   readonly count: string;
 };
 
+const escapePostgresIlikeLiteral = (value: string): string =>
+  value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
+
 export type TopReadFeedItemQualityRow = {
   readonly id: string;
   readonly providerKey: string;
@@ -181,14 +187,14 @@ export class YesterdayReaderSummaryArtifactQualityStore {
         from reader_summary_artifacts
         where tenant_id = $1::uuid
           and workspace_id = $2::uuid
-          and artifact_payload::text ilike $3
+          and artifact_payload::text ilike $3 escape E'\\\\'
         group by status
         order by status
       `,
       [
         scope.tenantId,
         scope.workspaceId,
-        `%${this.badGamingFalsePositiveNeedle}%`,
+        `%${escapePostgresIlikeLiteral(this.badGamingFalsePositiveNeedle)}%`,
       ],
     );
 
@@ -265,12 +271,12 @@ export class YesterdayReaderSummaryArtifactQualityStore {
         where tenant_id = $1::uuid
           and workspace_id = $2::uuid
           and status in ('COMPLETED', 'NO_SIGNAL')
-          and artifact_payload::text ilike $3
+          and artifact_payload::text ilike $3 escape E'\\\\'
       `,
       [
         scope.tenantId,
         scope.workspaceId,
-        `%${this.badGamingFalsePositiveNeedle}%`,
+        `%${escapePostgresIlikeLiteral(this.badGamingFalsePositiveNeedle)}%`,
       ],
     );
 

--- a/scripts/lib/yesterday-reader-summary-artifact-quality-store.ts
+++ b/scripts/lib/yesterday-reader-summary-artifact-quality-store.ts
@@ -1,0 +1,361 @@
+import type { Pool } from "pg";
+
+import { isDefaultReaderSummaryEvidenceProvider } from "@social-monitor/summary/adapters/evidence/reader-summary-evidence-provider-filter";
+import type { PrismaReaderSummaryArtifactRecord } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-records";
+import type { ReaderSummaryCollectedFeedItemCoverage } from "@social-monitor/summary/ports";
+
+import type { SelectedFeedItemProvenance } from "./reader-summary-artifact-coverage";
+import { dailyPeriodKey } from "./reader-summary-quality-eval-support";
+import { nextDate } from "./yesterday-social-replay-support";
+
+type ArtifactQualityScope = {
+  readonly tenantId: string;
+  readonly workspaceId: string;
+};
+
+type ProviderCountRow = {
+  readonly providerKey: string;
+  readonly collectedFeedItemCount: string;
+};
+
+type ArtifactStatusCountRow = {
+  readonly status: string;
+  readonly count: string;
+};
+
+export type TopReadFeedItemQualityRow = {
+  readonly id: string;
+  readonly providerKey: string;
+  readonly canonicalUrl: string;
+  readonly authorHandle: string | null;
+  readonly title: string;
+  readonly bodyPreview: string | null;
+  readonly providerMetadata: unknown;
+};
+
+export class YesterdayReaderSummaryArtifactQualityStore {
+  constructor(
+    private readonly pool: Pool,
+    private readonly collectionDate: string,
+    private readonly badGamingFalsePositiveNeedle: string,
+  ) {}
+
+  async readLatestArtifact(
+    scope: ArtifactQualityScope,
+  ): Promise<PrismaReaderSummaryArtifactRecord> {
+    const result = await this.pool.query<PrismaReaderSummaryArtifactRecord>(
+      `
+        select
+          id::text as "id",
+          tenant_id::text as "tenantId",
+          workspace_id::text as "workspaceId",
+          scope_type as "scopeType",
+          scope_key as "scopeKey",
+          interest_id::text as "interestId",
+          cadence as "cadence",
+          period_started_at as "periodStartedAt",
+          period_ended_at as "periodEndedAt",
+          period_timezone as "periodTimezone",
+          period_key as "periodKey",
+          user_id::text as "userId",
+          subscription_id::text as "subscriptionId",
+          status::text as "status",
+          schema_version as "schemaVersion",
+          model_version as "modelVersion",
+          prompt_version as "promptVersion",
+          headline as "headline",
+          summary_text as "summaryText",
+          artifact_payload as "artifactPayload",
+          citations as "citations",
+          quality_signals as "qualitySignals",
+          created_at as "createdAt",
+          updated_at as "updatedAt"
+        from reader_summary_artifacts
+        where tenant_id = $1::uuid
+          and workspace_id = $2::uuid
+          and status in ('COMPLETED', 'NO_SIGNAL')
+          and scope_type = 'workspace'
+          and cadence = 'daily'
+          and period_key = $3
+        order by created_at desc, id desc
+        limit 1
+      `,
+      [
+        scope.tenantId,
+        scope.workspaceId,
+        dailyPeriodKey(this.collectionDate),
+      ],
+    );
+    const row = result.rows[0];
+
+    if (row === undefined) {
+      throw new Error(
+        `No persisted reader summary artifact found for ${this.collectionDate}`,
+      );
+    }
+
+    return row;
+  }
+
+  async readLatestVisibleArtifact(
+    scope: ArtifactQualityScope,
+  ): Promise<PrismaReaderSummaryArtifactRecord> {
+    const result = await this.pool.query<PrismaReaderSummaryArtifactRecord>(
+      `
+        select
+          id::text as "id",
+          tenant_id::text as "tenantId",
+          workspace_id::text as "workspaceId",
+          scope_type as "scopeType",
+          scope_key as "scopeKey",
+          interest_id::text as "interestId",
+          cadence as "cadence",
+          period_started_at as "periodStartedAt",
+          period_ended_at as "periodEndedAt",
+          period_timezone as "periodTimezone",
+          period_key as "periodKey",
+          user_id::text as "userId",
+          subscription_id::text as "subscriptionId",
+          status::text as "status",
+          schema_version as "schemaVersion",
+          model_version as "modelVersion",
+          prompt_version as "promptVersion",
+          headline as "headline",
+          summary_text as "summaryText",
+          artifact_payload as "artifactPayload",
+          citations as "citations",
+          quality_signals as "qualitySignals",
+          created_at as "createdAt",
+          updated_at as "updatedAt"
+        from reader_summary_artifacts
+        where tenant_id = $1::uuid
+          and workspace_id = $2::uuid
+          and scope_type = 'workspace'
+          and cadence = 'daily'
+          and status in ('COMPLETED', 'NO_SIGNAL')
+        order by period_started_at desc, created_at desc, id desc
+        limit 1
+      `,
+      [scope.tenantId, scope.workspaceId],
+    );
+    const row = result.rows[0];
+
+    if (row === undefined) {
+      throw new Error("No persisted latest reader summary artifact found");
+    }
+
+    return row;
+  }
+
+  async readPeriodArtifactStatusCounts(
+    scope: ArtifactQualityScope,
+  ): Promise<Record<string, number>> {
+    const result = await this.pool.query<ArtifactStatusCountRow>(
+      `
+        select status::text as status, count(*)::text as count
+        from reader_summary_artifacts
+        where tenant_id = $1::uuid
+          and workspace_id = $2::uuid
+          and scope_type = 'workspace'
+          and cadence = 'daily'
+          and period_key = $3
+        group by status
+        order by status
+      `,
+      [
+        scope.tenantId,
+        scope.workspaceId,
+        dailyPeriodKey(this.collectionDate),
+      ],
+    );
+
+    return statusCounts(result.rows);
+  }
+
+  async readBadGamingArtifactStatusCounts(
+    scope: ArtifactQualityScope,
+  ): Promise<Record<string, number>> {
+    const result = await this.pool.query<ArtifactStatusCountRow>(
+      `
+        select status::text as status, count(*)::text as count
+        from reader_summary_artifacts
+        where tenant_id = $1::uuid
+          and workspace_id = $2::uuid
+          and artifact_payload::text ilike $3
+        group by status
+        order by status
+      `,
+      [
+        scope.tenantId,
+        scope.workspaceId,
+        `%${this.badGamingFalsePositiveNeedle}%`,
+      ],
+    );
+
+    return statusCounts(result.rows);
+  }
+
+  async readCollectedCoverage(
+    scope: ArtifactQualityScope,
+  ): Promise<ReaderSummaryCollectedFeedItemCoverage> {
+    const window = artifactQualityFeedWindow(this.collectionDate);
+    const result = await this.pool.query<ProviderCountRow>(
+      `
+        select
+          provider_key as "providerKey",
+          count(*)::text as "collectedFeedItemCount"
+        from feed_items
+        where tenant_id = $1::uuid
+          and workspace_id = $2::uuid
+          and published_at >= $3::timestamptz
+          and published_at < $4::timestamptz
+        group by provider_key
+        order by provider_key
+      `,
+      [
+        scope.tenantId,
+        scope.workspaceId,
+        window.startInclusive,
+        window.endExclusive,
+      ],
+    );
+    const providerBreakdown = result.rows
+      .filter((item) =>
+        isDefaultReaderSummaryEvidenceProvider(item.providerKey),
+      )
+      .map((item) => ({
+        providerKey: item.providerKey,
+        collectedFeedItemCount: Number.parseInt(
+          item.collectedFeedItemCount,
+          10,
+        ),
+        lowRelevanceFeedItemCount: 0,
+        mutedFeedItemCount: 0,
+        userRatedFeedItemCount: 0,
+      }))
+      .sort((left, right) => {
+        const countDiff =
+          right.collectedFeedItemCount - left.collectedFeedItemCount;
+        return countDiff === 0
+          ? left.providerKey.localeCompare(right.providerKey)
+          : countDiff;
+      });
+
+    return {
+      collectedFeedItemCount: providerBreakdown.reduce(
+        (sum, item) => sum + item.collectedFeedItemCount,
+        0,
+      ),
+      lowRelevanceFeedItemCount: 0,
+      mutedFeedItemCount: 0,
+      userRatedFeedItemCount: 0,
+      providerBreakdown,
+      topicBreakdown: [],
+      queryBreakdown: [],
+    };
+  }
+
+  async readVisibleBadGamingArtifactCount(
+    scope: ArtifactQualityScope,
+  ): Promise<number> {
+    const result = await this.pool.query<{ readonly count: string }>(
+      `
+        select count(*)::text as count
+        from reader_summary_artifacts
+        where tenant_id = $1::uuid
+          and workspace_id = $2::uuid
+          and status in ('COMPLETED', 'NO_SIGNAL')
+          and artifact_payload::text ilike $3
+      `,
+      [
+        scope.tenantId,
+        scope.workspaceId,
+        `%${this.badGamingFalsePositiveNeedle}%`,
+      ],
+    );
+
+    return Number.parseInt(result.rows[0]?.count ?? "0", 10);
+  }
+
+  async readFeedItemsByIds(params: {
+    readonly tenantId: string;
+    readonly workspaceId: string;
+    readonly feedItemIds: readonly string[];
+  }): Promise<readonly TopReadFeedItemQualityRow[]> {
+    if (params.feedItemIds.length === 0) {
+      return [];
+    }
+
+    const result = await this.pool.query<TopReadFeedItemQualityRow>(
+      `
+        select
+          id::text as "id",
+          provider_key as "providerKey",
+          canonical_url as "canonicalUrl",
+          author_handle as "authorHandle",
+          title,
+          body_preview as "bodyPreview",
+          provider_metadata as "providerMetadata"
+        from feed_items
+        where tenant_id = $1::uuid
+          and workspace_id = $2::uuid
+          and id = any($3::uuid[])
+      `,
+      [params.tenantId, params.workspaceId, params.feedItemIds],
+    );
+
+    return result.rows;
+  }
+
+  async readSelectedFeedItemProvenance(params: {
+    readonly tenantId: string;
+    readonly workspaceId: string;
+    readonly feedItemIds: readonly string[];
+  }): Promise<readonly SelectedFeedItemProvenance[]> {
+    if (params.feedItemIds.length === 0) {
+      return [];
+    }
+
+    const result = await this.pool.query<SelectedFeedItemProvenance>(
+      `
+        select
+          fi.id::text as "feedItemId",
+          fi.tenant_id::text as "tenantId",
+          fi.workspace_id::text as "workspaceId",
+          fi.interest_id::text as "interestId",
+          i.tenant_id::text as "interestTenantId",
+          i.workspace_id::text as "interestWorkspaceId",
+          fi.provider_key as "providerKey"
+        from feed_items fi
+        left join interests i
+          on i.id = fi.interest_id
+         and i.tenant_id = $1::uuid
+         and i.workspace_id = $2::uuid
+        where fi.tenant_id = $1::uuid
+          and fi.workspace_id = $2::uuid
+          and fi.id = any($3::uuid[])
+        order by fi.id
+      `,
+      [params.tenantId, params.workspaceId, params.feedItemIds],
+    );
+
+    return result.rows;
+  }
+}
+
+export const artifactQualityFeedWindow = (
+  collectionDate: string,
+): {
+  readonly startInclusive: string;
+  readonly endExclusive: string;
+} => ({
+  startInclusive: `${collectionDate}T00:00:00.000Z`,
+  endExclusive: new Date(nextDate(collectionDate)).toISOString(),
+});
+
+const statusCounts = (
+  rows: readonly ArtifactStatusCountRow[],
+): Record<string, number> =>
+  Object.fromEntries(
+    rows.map((row) => [row.status, Number.parseInt(row.count, 10)]),
+  );

--- a/scripts/run-reader-summary-production-day.ts
+++ b/scripts/run-reader-summary-production-day.ts
@@ -25,6 +25,8 @@ import {
 import { loadDotenvIfPresent } from "./lib/env-file";
 import { READER_SUMMARY_PRODUCTION_RUNTIME_POLICY } from "./lib/reader-summary-production-runtime-policy";
 import {
+  artifactQualityIsReadyForCleanDayE2e,
+  blockedCleanDayE2eStep,
   blockedProductionDaySteps,
   collectionIsReadyForProductionSummary,
   type ProductionDayStepReport,
@@ -271,18 +273,17 @@ async function main(): Promise<void> {
   }
   steps.push(summaryStep);
 
-  steps.push(
-    runNpm("artifact-quality", [
-      "run",
-      "check:yesterday-reader-summary-artifact-quality",
-      "--",
-      "--update",
-      "--date",
-      collectionDate,
-      ...(allowDegraded ? ["--allow-dirty-collection"] : []),
-      ...(allowHistorical ? ["--allow-historical"] : []),
-    ]),
-  );
+  const artifactQualityStep = runNpm("artifact-quality", [
+    "run",
+    "check:yesterday-reader-summary-artifact-quality",
+    "--",
+    "--update",
+    "--date",
+    collectionDate,
+    ...(allowDegraded ? ["--allow-dirty-collection"] : []),
+    ...(allowHistorical ? ["--allow-historical"] : []),
+  ]);
+  steps.push(artifactQualityStep);
   steps.push(
     runNpm("quality-dashboard", [
       "run",
@@ -316,7 +317,13 @@ async function main(): Promise<void> {
       collectionDate,
     ]),
   );
-  if (shouldRunCleanDayE2e()) {
+  if (!artifactQualityIsReadyForCleanDayE2e(artifactQualityStep.status)) {
+    steps.push(
+      blockedCleanDayE2eStep(
+        "artifact-quality failed; no current-date artifact was written",
+      ),
+    );
+  } else if (shouldRunCleanDayE2e()) {
     steps.push(
       runNpm("clean-day-e2e", [
         "run",


### PR DESCRIPTION
## Summary
- validate source-window, rendered and primary-provider coverage separately
- enforce strict provider allowlisting and DB-backed scope/cardinality
- split the production artifact checker below the source line cap
- skip clean E2E after artifact-quality failure while preserving the failed overall gate

## Verification
- focused Jest: 45/45
- full TypeScript in reviewed worker
- exact-path ESLint
- source line cap
- secret scan
- git diff --check

Independently reviewed and integrated through the project controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stronger validation for selected feed-item coverage, citations, provider attribution, and scope consistency in artifact-quality reports.
  - Added tenant- and workspace-scoped provenance checks for selected feed items.

- **Bug Fixes**
  - Prevented clean-day end-to-end checks from running when artifact quality has failed or been skipped.
  - Improved reporting of blocked clean-day checks and missing current-date artifacts.
  - Standardized artifact-quality data collection and reporting across daily periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->