### PR TITLE
fix(deploy): require validated pre-migration postgres backup

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -198,6 +198,7 @@ jobs:
             ops/deploy/social-monitor-production-deploy.sh
           )
           final_publication_assets=(
+            ops/deploy/postgres-backup-deploy-lib.sh
             ops/deploy/reader-summary-publication-deploy-lib.sh
             ops/deploy/reader-summary-publication-migrator-validation.test.sh
             ops/deploy/reader-summary-publication-signal-regression.test.sh
@@ -284,6 +285,7 @@ jobs:
             deploy_shell_files+=(ops/deploy/daily-deploy-lock-race.test.sh)
           fi
           final_publication_shell_files=(
+            ops/deploy/postgres-backup-deploy-lib.sh
             ops/deploy/reader-summary-publication-deploy-lib.sh
             ops/deploy/reader-summary-publication-migrator-validation.test.sh
             ops/deploy/reader-summary-publication-signal-regression.test.sh

--- a/ops/deploy/README.md
+++ b/ops/deploy/README.md
@@ -28,9 +28,23 @@ cannot silently skip an earlier component change.
 - deploy owns its singleton, daily owns a separate singleton, and both use one
   shared PostgreSQL admission `flock`;
 - integration advances only by fast-forward from a clean worktree;
-- backend deploys create and validate a managed PostgreSQL custom-format backup first;
-- every live PostgreSQL base table must appear in the new dump TOC, while CI
-  separately keeps the reviewed backup/restore contract aligned with Prisma;
+- backend deploys create and validate a managed PostgreSQL custom-format backup
+  before any migration;
+- pre-migration coverage is derived from two matching live-schema snapshots and
+  two byte-identical lifecycle snapshots of Prisma migration
+  `20260716170000_reader_summary_fail_closed_publication`: every public base
+  table that exists before migration must appear exactly once in the dump TOC,
+  and a full `pg_restore` stream must read the archive before its `.partial`
+  file is promoted;
+- the publication-table pair may be absent together on its first deployment
+  only when that exact migration has no history row. If the pair already
+  exists, both tables must be in the dump and the reviewed-checksum migration
+  row must be exactly one completed, non-rolled-back lifecycle. Partial schema,
+  failed, rolled-back, in-progress, duplicate, contradictory,
+  checksum-mismatched and raced states fail closed;
+- CI separately keeps the reviewed target-schema backup/restore contract aligned
+  with Prisma; that target contract does not claim a pre-migration archive
+  already contains tables created by the following migration;
 - only the 10 newest verified `pre-autodeploy` dumps are retained; manual,
   incident, partial and unknown backup artifacts are never pruned automatically;
 - previous container image IDs are retained and restored on runtime failure;
@@ -124,7 +138,13 @@ fast-forwards integration. A backend-classified target is then required to
 provide a reviewed, regular, non-symlink publication library inside the
 fast-forwarded integration tree. The bridge verifies that file against the
 target Git blob, sources it, and requires its publication-migration entrypoint
-before any runtime-control snapshot or activation. Runtime-control changes
+before any runtime-control snapshot or activation. While the target SHA remains
+dynamically scoped, that authenticated publication wrapper rejects a preloaded
+backup entrypoint and independently binds the target PostgreSQL backup library
+to its fixed canonical path, root owner, exact Git/filesystem mode and reviewed
+Git-blob digest before sourcing it. It then replaces the installed controller's
+legacy inline backup function, so the first migration release uses the hardened
+contract without changing any installed bridge file. Runtime-control changes
 therefore use an explicit two-release sequence:
 
 1. Deploy a bridge release containing the final entrypoint and deploy-control

--- a/ops/deploy/postgres-backup-deploy-lib.sh
+++ b/ops/deploy/postgres-backup-deploy-lib.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+# Sourced only by the authenticated target-publication wrapper after this exact
+# target blob passes canonical-path, ownership, mode, type, and digest checks.
+# The caller owns deploy/admission locks and supplies ROOT, REPO, STATE,
+# COMPOSE, deploy-control digest helpers, and fail().
+
+READER_SUMMARY_PUBLICATION_MIGRATION_ID=20260716170000_reader_summary_fail_closed_publication
+
+# Called through backup_database() after the publication wrapper returns to the
+# installed controller.
+# shellcheck disable=SC2329
+create_pre_migration_database_backup() (
+  local sha=$1
+  local output partial env_file listing schema_tables migration_state
+  local post_dump_schema_tables post_dump_migration_state
+  local api_id database_url database_name migration_checksum
+  local migration_path=prisma/migrations/$READER_SUMMARY_PUBLICATION_MIGRATION_ID/migration.sql
+  local backup_image=postgres@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+  local -a cleanup_paths=()
+
+  [[ $sha =~ ^[0-9a-f]{40}$ ]] || \
+    fail 'database backup target SHA is invalid'
+  migration_checksum=$(
+    deploy_control_git_blob_digest "$sha" "$migration_path"
+  ) || fail 'target commit is missing the reviewed publication migration'
+  [[ $migration_checksum =~ ^[0-9a-f]{64}$ ]] || \
+    fail 'reviewed reader-summary publication migration checksum is unavailable'
+
+  output=$ROOT/backups/pre-autodeploy-${sha:0:12}-$(date -u +%Y%m%dT%H%M%SZ).dump
+  partial=$output.partial
+  [[ ! -e $output && ! -L $output && ! -e $partial && ! -L $partial ]] || \
+    fail 'database backup output already exists'
+  cleanup_paths+=("$partial")
+
+  umask 077
+  trap 'rm -f -- "${cleanup_paths[@]}"' EXIT
+  env_file=$(mktemp "$STATE/database-backup.XXXXXX.env") || \
+    fail 'database backup credential file cannot be created'
+  cleanup_paths+=("$env_file")
+  listing=$(mktemp "$STATE/database-backup.XXXXXX.list") || \
+    fail 'database backup listing file cannot be created'
+  cleanup_paths+=("$listing")
+  schema_tables=$(mktemp "$STATE/database-backup.XXXXXX.tables") || \
+    fail 'database backup schema snapshot cannot be created'
+  cleanup_paths+=("$schema_tables")
+  migration_state=$(mktemp "$STATE/database-backup.XXXXXX.migration-state") || \
+    fail 'database backup migration snapshot cannot be created'
+  cleanup_paths+=("$migration_state")
+  post_dump_schema_tables=$(mktemp \
+    "$STATE/database-backup.XXXXXX.post-dump.tables") || \
+    fail 'database backup post-dump schema snapshot cannot be created'
+  cleanup_paths+=("$post_dump_schema_tables")
+  post_dump_migration_state=$(mktemp \
+    "$STATE/database-backup.XXXXXX.post-dump.migration-state") || \
+    fail 'database backup post-dump migration snapshot cannot be created'
+  cleanup_paths+=("$post_dump_migration_state")
+
+  api_id=$("${COMPOSE[@]}" --profile app ps -q api)
+  [[ -n $api_id ]] || \
+    fail 'production API container is unavailable for database discovery'
+  database_url=$(docker inspect "$api_id" \
+    --format '{{range .Config.Env}}{{println .}}{{end}}' | \
+    awk -F= '$1 == "DATABASE_URL" {sub(/^[^=]*=/, ""); print; exit}')
+  [[ -n $database_url ]] || \
+    fail 'production API has no effective database URL'
+
+  printf 'DATABASE_URL=%s\n' "$database_url" > "$env_file"
+
+  # shellcheck disable=SC2016 # Expansion occurs in the child shell.
+  database_name=$(docker run --rm \
+    --env-file "$env_file" \
+    -v "$ROOT/secrets/db/ca-certificate.crt:/run/social-monitor-db/ca-certificate.crt:ro" \
+    "$backup_image" \
+    sh -lc 'psql "$DATABASE_URL" -X -A -t -v ON_ERROR_STOP=1 -c "SELECT current_database()"')
+  [[ $database_name == social_monitor ]] || \
+    fail 'effective production database is not social_monitor'
+
+  capture_pre_migration_schema_tables "$env_file" "$backup_image" \
+    > "$schema_tables"
+  capture_reader_summary_publication_migration_state \
+    "$env_file" "$backup_image" "$migration_checksum" > "$migration_state"
+  bash "$REPO/ops/deploy/verify-postgres-backup-coverage.sh" \
+    "$schema_tables" "$migration_state"
+
+  # shellcheck disable=SC2016 # Expansion occurs in the child shell.
+  docker run --rm \
+    --env-file "$env_file" \
+    -v "$ROOT/secrets/db/ca-certificate.crt:/run/social-monitor-db/ca-certificate.crt:ro" \
+    "$backup_image" \
+    sh -lc 'pg_dump --format=custom --no-owner --no-privileges "$DATABASE_URL"' \
+    > "$partial"
+  [[ -s $partial ]] || fail 'database backup archive is empty'
+  docker run --rm \
+    -v "$ROOT/backups:/backups:ro" \
+    "$backup_image" \
+    pg_restore --file=/dev/null --no-owner --no-privileges \
+      "/backups/$(basename "$partial")"
+  docker run --rm \
+    -v "$ROOT/backups:/backups:ro" \
+    "$backup_image" \
+    pg_restore -l "/backups/$(basename "$partial")" > "$listing"
+
+  capture_pre_migration_schema_tables "$env_file" "$backup_image" \
+    > "$post_dump_schema_tables"
+  capture_reader_summary_publication_migration_state \
+    "$env_file" "$backup_image" "$migration_checksum" \
+    > "$post_dump_migration_state"
+  bash "$REPO/ops/deploy/verify-postgres-backup-coverage.sh" \
+    "$schema_tables" "$migration_state" "$listing" \
+    "$post_dump_schema_tables" "$post_dump_migration_state"
+
+  chmod 600 "$partial"
+  mv -T -- "$partial" "$output"
+  bash "$REPO/ops/deploy/prune-pre-autodeploy-backups.sh" \
+    "$ROOT/backups" 10 "$output"
+  printf 'database-backup=%s\n' "$output"
+)
+
+capture_pre_migration_schema_tables() {
+  local env_file=$1
+  local backup_image=$2
+
+  # shellcheck disable=SC2016 # Expansion occurs in the child shell.
+  docker run --rm \
+    --env-file "$env_file" \
+    -v "$ROOT/secrets/db/ca-certificate.crt:/run/social-monitor-db/ca-certificate.crt:ro" \
+    "$backup_image" \
+    sh -c 'exec psql "$DATABASE_URL" -X -A -t -v ON_ERROR_STOP=1 -c "$1"' _ \
+    "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE' ORDER BY table_name"
+}
+
+capture_reader_summary_publication_migration_state() {
+  local env_file=$1
+  local backup_image=$2
+  local migration_checksum=$3
+  local migration_id=$READER_SUMMARY_PUBLICATION_MIGRATION_ID
+  local sql
+
+  # The summary classifies every Prisma lifecycle. The second record is a
+  # canonical hex encoding of every target row, including logs and timestamps,
+  # so a mutation that remains nominally completed is still detected as a race.
+  read -r -d '' sql <<'SQL' || :
+WITH target AS MATERIALIZED (
+  SELECT
+    id,
+    checksum,
+    finished_at,
+    migration_name,
+    logs,
+    rolled_back_at,
+    started_at,
+    applied_steps_count
+  FROM public."_prisma_migrations"
+  WHERE migration_name = :'migration_id'
+), summary AS (
+  SELECT
+    count(*) AS total,
+    count(*) FILTER (
+      WHERE started_at IS NOT NULL
+        AND finished_at IS NOT NULL
+        AND rolled_back_at IS NULL
+        AND applied_steps_count = 1
+        AND id <> ''
+        AND checksum = :'migration_checksum'
+        AND finished_at >= started_at
+        AND (logs IS NULL OR btrim(logs) = '')
+    ) AS completed,
+    count(*) FILTER (
+      WHERE finished_at IS NULL
+        AND rolled_back_at IS NULL
+        AND logs IS NOT NULL
+        AND btrim(logs) <> ''
+    ) AS failed,
+    count(*) FILTER (
+      WHERE finished_at IS NULL
+        AND rolled_back_at IS NOT NULL
+    ) AS rolled_back,
+    count(*) FILTER (
+      WHERE finished_at IS NULL
+        AND rolled_back_at IS NULL
+        AND (logs IS NULL OR btrim(logs) = '')
+    ) AS in_progress
+  FROM target
+), classified AS (
+  SELECT
+    total,
+    completed,
+    failed,
+    rolled_back,
+    in_progress,
+    total - completed - failed - rolled_back - in_progress AS contradictory
+  FROM summary
+), exact_state AS (
+  SELECT encode(
+    convert_to(
+      COALESCE(
+        jsonb_agg(to_jsonb(target) ORDER BY started_at, id)::text,
+        '[]'
+      ),
+      'UTF8'
+    ),
+    'hex'
+  ) AS exact_hex
+  FROM target
+)
+SELECT concat_ws(
+  E'\t',
+  'reader-summary-publication-migration-state-v1',
+  total,
+  completed,
+  failed,
+  rolled_back,
+  in_progress,
+  contradictory
+)
+FROM classified
+UNION ALL
+SELECT 'exact-hex=' || exact_hex
+FROM exact_state;
+SQL
+
+  # shellcheck disable=SC2016 # Expansion occurs in the child shell.
+  docker run --rm \
+    --env-file "$env_file" \
+    -v "$ROOT/secrets/db/ca-certificate.crt:/run/social-monitor-db/ca-certificate.crt:ro" \
+    "$backup_image" \
+    sh -c 'exec psql "$DATABASE_URL" -X -A -t -v ON_ERROR_STOP=1 -v "migration_id=$1" -v "migration_checksum=$2" -c "$3"' \
+      _ "$migration_id" "$migration_checksum" "$sql"
+}

--- a/ops/deploy/reader-summary-publication-bridge-transition.test.sh
+++ b/ops/deploy/reader-summary-publication-bridge-transition.test.sh
@@ -3,305 +3,128 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
-LEGACY_BACKEND=c071bcbe2b0ef1ecab48db5bcfab281c4745f778
-LEGACY_FRONTEND=a6c4f0019d8a95875837bae251c379c45f40074d
-LEGACY_CONTROLLER=7185a5d02366437b5ad9146c3ae178d62c50101d
+INSTALLED_CONTROLLER=c59a0b54099c78eda2a8a3b022f438f6a30d2a46
+PUBLICATION_LIBRARY=ops/deploy/reader-summary-publication-deploy-lib.sh
+BACKUP_LIBRARY=ops/deploy/postgres-backup-deploy-lib.sh
+BRIDGE_PATHS=(
+  ops/deploy/deploy-control-lib.sh
+  ops/deploy/social-monitor-production-deploy.sh
+  ops/deploy/postgres-runtime-deploy-lib.sh
+)
 FIXTURE=$(mktemp -d \
-  "${TMPDIR:-/tmp}/reader-summary-publication-bridge.XXXXXX")
+  "${TMPDIR:-/tmp}/reader-summary-publication-c59-transition.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
 
 ORIGIN=$FIXTURE/origin.git
-REPO=$FIXTURE/integration
-ROOT=$FIXTURE/root
-CONTROL=$ROOT/control
-STATE=$CONTROL/deploy-state
-INSTALLED=$CONTROL/github-production-deploy.sh
-LEGACY_ENTRYPOINT=$FIXTURE/legacy-7185-controller.sh
-PUBLICATION_LIBRARY=ops/deploy/reader-summary-publication-deploy-lib.sh
-BRIDGE_PATHS=(
-  ops/deploy/social-monitor-production-deploy.sh
-  ops/deploy/deploy-control-lib.sh
-  ops/deploy/postgres-runtime-deploy-lib.sh
-)
-LEGACY_FRONTEND_PATHS=(
-  apps/frontend
-  libs/contracts/rest
-)
-LEGACY_BACKEND_PATHS=(
-  Dockerfile
-  .dockerignore
-  docker-compose.yml
-  package.json
-  package-lock.json
-  tsconfig.json
-  tsconfig.build.json
-  prisma.config.ts
-  prisma
-  vendor
-  libs
-  apps/api-gateway
-  apps/agent-runtime
-  apps/ingestion-worker
-  apps/intelligence-worker
-  apps/delivery-service
-  apps/event-relay
-  apps/x-collector
-  apps/social-research-runtime
-  apps/social-research-grpc
-  apps/social-research-mcp
-  scripts
-  ops/evals
-  test
-)
-LEGACY_CONTROL_PATHS=(
-  .github/workflows/production-deploy.yml
-  ops/deploy
-  ops/recovery/backup-restore-contract.json
-)
-BRIDGE_RELEASE_PATHS=(
-  "${BRIDGE_PATHS[@]}"
-  .github/workflows/production-deploy.yml
-  ops/deploy/README.md
-  ops/deploy/deploy-control-lib.test.sh
-  ops/deploy/reader-summary-publication-bridge-transition.test.sh
-)
+SYNTHESIS_REPO=$FIXTURE/synthesis
+INSTALLED_ENTRYPOINT=$FIXTURE/installed-c59-entrypoint.sh
 
-git -C "$PROJECT_ROOT" cat-file -e "$LEGACY_BACKEND^{commit}"
-git -C "$PROJECT_ROOT" cat-file -e "$LEGACY_FRONTEND^{commit}"
-git -C "$PROJECT_ROOT" cat-file -e "$LEGACY_CONTROLLER^{commit}"
-git -C "$PROJECT_ROOT" show \
-  "$LEGACY_CONTROLLER:ops/deploy/social-monitor-production-deploy.sh" \
-  > "$LEGACY_ENTRYPOINT"
-
-git clone --bare --shared -q "$PROJECT_ROOT" "$ORIGIN"
-git --git-dir="$ORIGIN" update-ref refs/heads/main "$LEGACY_CONTROLLER"
-git --git-dir="$ORIGIN" symbolic-ref HEAD refs/heads/main
-git clone --no-checkout --shared -q "$ORIGIN" "$REPO"
-git -C "$REPO" config user.name 'Publication Bridge Contract'
-git -C "$REPO" config user.email publication-bridge@example.invalid
-git -C "$REPO" sparse-checkout init --cone
-git -C "$REPO" sparse-checkout set \
-  .github ops/deploy apps/api-gateway apps/frontend libs/contracts/rest
-git -C "$REPO" checkout -q -B main "$LEGACY_CONTROLLER"
-
-# Production B starts from the deployed controller tree. That commit already
-# descends from the older backend/frontend markers and is byte-identical to
-# them on their component paths.
-
-# Release B contains the final controller bridge and its admitted CI/docs/test
-# support. It does not carry the target-only publication library or change
-# either daily runtime asset inherited from 7185.
-cp "$SCRIPT_DIR/social-monitor-production-deploy.sh" \
-  "$SCRIPT_DIR/deploy-control-lib.sh" \
-  "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" \
-  "$REPO/ops/deploy/"
-install -d "$REPO/.github/workflows"
-cp "$PROJECT_ROOT/.github/workflows/production-deploy.yml" \
-  "$REPO/.github/workflows/production-deploy.yml"
-cp "$SCRIPT_DIR/README.md" \
-  "$SCRIPT_DIR/deploy-control-lib.test.sh" \
-  "$SCRIPT_DIR/reader-summary-publication-bridge-transition.test.sh" \
-  "$REPO/ops/deploy/"
-git -C "$REPO" add "${BRIDGE_RELEASE_PATHS[@]}"
-git -C "$REPO" commit -qm 'test: control-only publication bridge B'
-BRIDGE_SHA=$(git -C "$REPO" rev-parse HEAD)
-
-expected_bridge_paths=$(printf '%s\n' "${BRIDGE_RELEASE_PATHS[@]}" | LC_ALL=C sort)
-actual_bridge_paths=$(git -C "$REPO" diff --name-only \
-  "$LEGACY_CONTROLLER" "$BRIDGE_SHA" -- | LC_ALL=C sort)
-[[ $actual_bridge_paths == "$expected_bridge_paths" ]] || {
-  echo 'Release B changed paths outside its exact manifest' >&2
-  diff -u <(printf '%s\n' "$expected_bridge_paths") \
-    <(printf '%s\n' "$actual_bridge_paths") || true
-  exit 1
-}
-grep -F \
-  "legacy_publication_bridge_base=$LEGACY_CONTROLLER" \
-  "$REPO/.github/workflows/production-deploy.yml" >/dev/null
-for bridge_path in "${BRIDGE_RELEASE_PATHS[@]}"; do
-  grep -F "$bridge_path" \
-    "$REPO/.github/workflows/production-deploy.yml" >/dev/null
-done
-
-# Bind the synthetic bridge to the exact component markers currently deployed
-# in production. This proves the real divergent-marker plan, not a simplified
-# all-components-at-c071 history.
-git -C "$REPO" diff --quiet "$LEGACY_BACKEND" "$BRIDGE_SHA" -- \
-  "${LEGACY_BACKEND_PATHS[@]}"
-git -C "$REPO" diff --quiet "$LEGACY_FRONTEND" "$BRIDGE_SHA" -- \
-  "${LEGACY_FRONTEND_PATHS[@]}"
-if git -C "$REPO" diff --quiet "$LEGACY_CONTROLLER" "$BRIDGE_SHA" -- \
-  "${LEGACY_CONTROL_PATHS[@]}"; then
-  echo 'Release B does not change the deployed control component' >&2
-  exit 1
-fi
-git -C "$REPO" diff --quiet "$LEGACY_CONTROLLER" "$BRIDGE_SHA" -- \
-  ops/deploy/production-runtime/daily-run.sh \
-  ops/deploy/production-runtime/social-monitor-daily.service
-
-if git -C "$REPO" cat-file -e "$BRIDGE_SHA:$PUBLICATION_LIBRARY" \
-  2>/dev/null; then
-  echo 'Release B unexpectedly contains the publication library' >&2
-  exit 1
-fi
-git -C "$REPO" diff --quiet "$LEGACY_BACKEND" "$BRIDGE_SHA" -- \
-  ops/deploy/production-runtime/daily-run.sh \
-  ops/deploy/production-runtime/social-monitor-daily.service
-git -C "$REPO" diff --quiet "$LEGACY_BACKEND" "$BRIDGE_SHA" -- \
-  apps/frontend libs/contracts/rest
-
-# Bad intermediate targets exercise target-tree validation without becoming
-# deployable releases. Release F is synthesized last so this test remains
-# runnable in B, where none of these final-only assets exist yet.
-install -d "$REPO/ops/deploy/production-runtime"
-printf '%s\n' '-- fixture publication pre-migration' \
-  > "$REPO/ops/deploy/reader-summary-publication-pre-migration.sql"
-printf '%s\n' '-- fixture publication post-migration' \
-  > "$REPO/ops/deploy/reader-summary-publication-post-migration.sql"
-cat > "$REPO/ops/deploy/production-runtime/daily-run.sh" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' 'fixture final daily runtime'
-EOF
-cat > "$REPO/ops/deploy/production-runtime/social-monitor-daily.service" <<'EOF'
-[Unit]
-Description=Fixture final daily runtime
-EOF
-printf '%s\n' 'fixture final backend path' \
-  > "$REPO/apps/api-gateway/publication-bridge-final.txt"
-git -C "$REPO" add \
-  ops/deploy/reader-summary-publication-pre-migration.sql \
-  ops/deploy/reader-summary-publication-post-migration.sql \
-  ops/deploy/production-runtime/daily-run.sh \
-  ops/deploy/production-runtime/social-monitor-daily.service \
-  apps/api-gateway/publication-bridge-final.txt
-git -C "$REPO" commit -qm 'test: rejected target missing publication blob'
-MISSING_BLOB_SHA=$(git -C "$REPO" rev-parse HEAD)
-
-ln -s ../../README.md "$REPO/$PUBLICATION_LIBRARY"
-git -C "$REPO" add "$PUBLICATION_LIBRARY"
-git -C "$REPO" commit -qm 'test: rejected symlink publication blob'
-SYMLINK_BLOB_SHA=$(git -C "$REPO" rev-parse HEAD)
-
-rm "$REPO/$PUBLICATION_LIBRARY"
-cat > "$REPO/$PUBLICATION_LIBRARY" <<'EOF'
-#!/usr/bin/env bash
-
-# Intentionally lacks deploy_reader_summary_publication_migrations.
-EOF
-git -C "$REPO" add "$PUBLICATION_LIBRARY"
-git -C "$REPO" commit -qm 'test: rejected publication library entrypoint'
-MISSING_ENTRYPOINT_SHA=$(git -C "$REPO" rev-parse HEAD)
-
-cat > "$REPO/$PUBLICATION_LIBRARY" <<'EOF'
-#!/usr/bin/env bash
-
-deploy_reader_summary_publication_migrations() {
-  :
-}
-EOF
-git -C "$REPO" add "$PUBLICATION_LIBRARY"
-git -C "$REPO" commit -qm 'test: final publication and runtime release F'
-FINAL_SHA=$(git -C "$REPO" rev-parse HEAD)
-git -C "$REPO" push -q origin HEAD:main
-
+git -C "$PROJECT_ROOT" cat-file -e "$INSTALLED_CONTROLLER^{commit}"
 for bridge_path in "${BRIDGE_PATHS[@]}"; do
-  bridge_digest=$(
-    git -C "$REPO" show "$BRIDGE_SHA:$bridge_path" | sha256sum | \
-      awk '{print $1}'
-  )
-  final_digest=$(
-    git -C "$REPO" show "$FINAL_SHA:$bridge_path" | sha256sum | \
-      awk '{print $1}'
-  )
-  [[ $bridge_digest == "$final_digest" ]] || {
-    echo "B/F bridge digest changed: $bridge_path" >&2
+  cmp -s "$PROJECT_ROOT/$bridge_path" \
+    <(git -C "$PROJECT_ROOT" show "$INSTALLED_CONTROLLER:$bridge_path") || {
+    echo "current bridge differs from c59: $bridge_path" >&2
     exit 1
   }
 done
-git -C "$REPO" cat-file -e "$FINAL_SHA:$PUBLICATION_LIBRARY"
-git -C "$REPO" cat-file -e \
-  "$FINAL_SHA:ops/deploy/production-runtime/daily-run.sh"
-git -C "$REPO" cat-file -e \
-  "$FINAL_SHA:ops/deploy/production-runtime/social-monitor-daily.service"
+git -C "$PROJECT_ROOT" show \
+  "$INSTALLED_CONTROLLER:ops/deploy/social-monitor-production-deploy.sh" \
+  > "$INSTALLED_ENTRYPOINT"
 
-# Run the actual recorded 7185 controller against c071. Its component policy
-# must classify B as control-only, advance to it, and install the new bridge
-# without touching backend/frontend markers or runtime activation.
-git -C "$REPO" checkout -q --detach "$LEGACY_BACKEND"
-install -d "$CONTROL" "$STATE" "$ROOT/runtime/deploy-staging"
-printf '%s\n' "$LEGACY_FRONTEND" > "$STATE/frontend.sha"
-printf '%s\n' "$LEGACY_BACKEND" > "$STATE/backend.sha"
-printf '%s\n' "$LEGACY_CONTROLLER" > "$STATE/control.sha"
-LEGACY_EVENTS=$FIXTURE/legacy-events
-# shellcheck disable=SC2016
-bridge_output=$(
-  LEGACY_ENTRYPOINT="$LEGACY_ENTRYPOINT" \
-  BRIDGE_SHA="$BRIDGE_SHA" LEGACY_EVENTS="$LEGACY_EVENTS" \
-  SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 \
-  SOCIAL_MONITOR_DEPLOY_ROOT="$ROOT" \
-  SOCIAL_MONITOR_DEPLOY_REPO="$REPO" \
-  SOCIAL_MONITOR_DEPLOY_CONTROL="$CONTROL" \
-  SOCIAL_MONITOR_DEPLOY_STATE="$STATE" \
-    bash -c '
-      source "$LEGACY_ENTRYPOINT"
-      verify_compose_scope() { printf "compose\n" >> "$LEGACY_EVENTS"; }
-      sync_control_script() {
-        install -m 0755 \
-          "$REPO/ops/deploy/social-monitor-production-deploy.sh" \
-          "$CONTROL/github-production-deploy.sh"
-        printf "sync\n" >> "$LEGACY_EVENTS"
-      }
-      commit_postgres_pool_bootstrap() { :; }
-      snapshot_postgres_runtime_control() {
-        printf "snapshot\n" >> "$LEGACY_EVENTS"
-        return 91
-      }
-      activate_postgres_runtime_control() {
-        printf "activation\n" >> "$LEGACY_EVENTS"
-        return 92
-      }
-      deploy_backend() {
-        printf "backend\n" >> "$LEGACY_EVENTS"
-        return 93
-      }
-      deploy_release "$BRIDGE_SHA"
-    '
-)
-grep -F "deployed=$BRIDGE_SHA frontend=false backend=false control=true" \
-  <<< "$bridge_output" >/dev/null
-[[ $(git -C "$REPO" rev-parse HEAD) == "$BRIDGE_SHA" ]]
-[[ $(cat "$STATE/backend.sha") == "$LEGACY_BACKEND" ]]
-[[ $(cat "$STATE/frontend.sha") == "$LEGACY_FRONTEND" ]]
-[[ $(cat "$STATE/control.sha") == "$BRIDGE_SHA" ]]
-cmp -s "$INSTALLED" "$REPO/ops/deploy/social-monitor-production-deploy.sh"
-[[ $(cat "$LEGACY_EVENTS") == $'sync\ncompose' ]]
+git clone --bare --shared -q "$PROJECT_ROOT" "$ORIGIN"
+git --git-dir="$ORIGIN" update-ref refs/heads/main "$INSTALLED_CONTROLLER"
+git --git-dir="$ORIGIN" symbolic-ref HEAD refs/heads/main
+git clone --no-checkout --shared -q "$ORIGIN" "$SYNTHESIS_REPO"
+git -C "$SYNTHESIS_REPO" config user.name 'c59 Backup Transition Contract'
+git -C "$SYNTHESIS_REPO" config user.email c59-backup@example.invalid
+git -C "$SYNTHESIS_REPO" sparse-checkout init --cone
+git -C "$SYNTHESIS_REPO" sparse-checkout set \
+  .github ops/deploy apps/api-gateway prisma
+git -C "$SYNTHESIS_REPO" checkout -q -B main "$INSTALLED_CONTROLLER"
 
-# The installed B bridge must also be runnable while the publication library is
-# absent. A backend=false reconciliation cannot source final-only logic.
-BRIDGE_RECONCILE=$FIXTURE/bridge-reconcile
-# shellcheck disable=SC2016
-reconcile_output=$(
-  BRIDGE_SHA="$BRIDGE_SHA" BRIDGE_RECONCILE="$BRIDGE_RECONCILE" \
-  SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 \
-  SOCIAL_MONITOR_DEPLOY_ROOT="$ROOT" \
-  SOCIAL_MONITOR_DEPLOY_REPO="$REPO" \
-  SOCIAL_MONITOR_DEPLOY_CONTROL="$CONTROL" \
-  SOCIAL_MONITOR_DEPLOY_STATE="$STATE" \
-    bash -c '
-      source "$SOCIAL_MONITOR_DEPLOY_CONTROL/github-production-deploy.sh"
-      ! declare -F deploy_reader_summary_publication_migrations >/dev/null
-      sync_control_script() { :; }
-      commit_postgres_pool_bootstrap() { :; }
-      deploy_release_runtime_transaction() {
-        ! declare -F deploy_reader_summary_publication_migrations >/dev/null
-        printf "%s %s\n" "$2" "$3" > "$BRIDGE_RECONCILE"
-      }
-      deploy_release "$BRIDGE_SHA"
-    '
+# Every synthetic target is backend/runtime-control classified, while the
+# installed entrypoint and both installed bridge libraries stay literal c59.
+printf '\n# target runtime activation\n' >> \
+  "$SYNTHESIS_REPO/ops/deploy/production-runtime/daily-run.sh"
+printf '%s\n' 'target backend activation' \
+  > "$SYNTHESIS_REPO/apps/api-gateway/pre-migration-backup-target.txt"
+git -C "$SYNTHESIS_REPO" rm -q "$PUBLICATION_LIBRARY"
+git -C "$SYNTHESIS_REPO" add \
+  ops/deploy/production-runtime/daily-run.sh \
+  apps/api-gateway/pre-migration-backup-target.txt
+git -C "$SYNTHESIS_REPO" commit -qm \
+  'test: target missing publication blob'
+PUBLICATION_MISSING_BLOB_SHA=$(git -C "$SYNTHESIS_REPO" rev-parse HEAD)
+
+ln -s ../../README.md "$SYNTHESIS_REPO/$PUBLICATION_LIBRARY"
+git -C "$SYNTHESIS_REPO" add "$PUBLICATION_LIBRARY"
+git -C "$SYNTHESIS_REPO" commit -qm \
+  'test: target publication symlink blob'
+PUBLICATION_SYMLINK_BLOB_SHA=$(git -C "$SYNTHESIS_REPO" rev-parse HEAD)
+
+rm "$SYNTHESIS_REPO/$PUBLICATION_LIBRARY"
+cat > "$SYNTHESIS_REPO/$PUBLICATION_LIBRARY" <<'LIBRARY'
+#!/usr/bin/env bash
+
+# Intentionally lacks deploy_reader_summary_publication_migrations.
+LIBRARY
+git -C "$SYNTHESIS_REPO" add "$PUBLICATION_LIBRARY"
+git -C "$SYNTHESIS_REPO" commit -qm \
+  'test: target publication entrypoint missing'
+PUBLICATION_MISSING_ENTRYPOINT_SHA=$(git -C "$SYNTHESIS_REPO" rev-parse HEAD)
+
+cp "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" \
+  "$SYNTHESIS_REPO/$PUBLICATION_LIBRARY"
+git -C "$SYNTHESIS_REPO" add "$PUBLICATION_LIBRARY"
+git -C "$SYNTHESIS_REPO" commit -qm \
+  'test: target missing PostgreSQL backup blob'
+BACKUP_MISSING_BLOB_SHA=$(git -C "$SYNTHESIS_REPO" rev-parse HEAD)
+
+ln -s ../../README.md "$SYNTHESIS_REPO/$BACKUP_LIBRARY"
+git -C "$SYNTHESIS_REPO" add "$BACKUP_LIBRARY"
+git -C "$SYNTHESIS_REPO" commit -qm \
+  'test: target PostgreSQL backup symlink blob'
+BACKUP_SYMLINK_BLOB_SHA=$(git -C "$SYNTHESIS_REPO" rev-parse HEAD)
+
+rm "$SYNTHESIS_REPO/$BACKUP_LIBRARY"
+cat > "$SYNTHESIS_REPO/$BACKUP_LIBRARY" <<'LIBRARY'
+#!/usr/bin/env bash
+
+# Intentionally lacks create_pre_migration_database_backup.
+LIBRARY
+git -C "$SYNTHESIS_REPO" add "$BACKUP_LIBRARY"
+git -C "$SYNTHESIS_REPO" commit -qm \
+  'test: target PostgreSQL backup entrypoint missing'
+BACKUP_MISSING_ENTRYPOINT_SHA=$(git -C "$SYNTHESIS_REPO" rev-parse HEAD)
+
+cp "$SCRIPT_DIR/postgres-backup-deploy-lib.sh" \
+  "$SYNTHESIS_REPO/$BACKUP_LIBRARY"
+git -C "$SYNTHESIS_REPO" add "$BACKUP_LIBRARY"
+git -C "$SYNTHESIS_REPO" commit -qm \
+  'test: authenticated target publication and backup wrapper'
+FINAL_SHA=$(git -C "$SYNTHESIS_REPO" rev-parse HEAD)
+git -C "$SYNTHESIS_REPO" push -q origin HEAD:main
+
+TARGET_SHAS=(
+  "$PUBLICATION_MISSING_BLOB_SHA"
+  "$PUBLICATION_SYMLINK_BLOB_SHA"
+  "$PUBLICATION_MISSING_ENTRYPOINT_SHA"
+  "$BACKUP_MISSING_BLOB_SHA"
+  "$BACKUP_SYMLINK_BLOB_SHA"
+  "$BACKUP_MISSING_ENTRYPOINT_SHA"
+  "$FINAL_SHA"
 )
-grep -F "deployed=$BRIDGE_SHA frontend=false backend=false control=false" \
-  <<< "$reconcile_output" >/dev/null
-[[ $(cat "$BRIDGE_RECONCILE") == 'false false' ]]
+for target_sha in "${TARGET_SHAS[@]}"; do
+  for bridge_path in "${BRIDGE_PATHS[@]}"; do
+    cmp -s \
+      <(git -C "$SYNTHESIS_REPO" show \
+        "$INSTALLED_CONTROLLER:$bridge_path") \
+      <(git -C "$SYNTHESIS_REPO" show "$target_sha:$bridge_path") || {
+      echo "target $target_sha changes installed c59 bridge: $bridge_path" >&2
+      exit 1
+    }
+  done
+done
 
 create_case_checkout() {
   local name=$1
@@ -312,72 +135,100 @@ create_case_checkout() {
   git clone --no-checkout --shared -q "$ORIGIN" "$case_repo"
   git -C "$case_repo" sparse-checkout init --cone
   git -C "$case_repo" sparse-checkout set \
-    .github ops/deploy apps/api-gateway apps/frontend libs/contracts/rest
-  git -C "$case_repo" checkout -q --detach "$BRIDGE_SHA"
+    .github ops/deploy apps/api-gateway prisma
+  git -C "$case_repo" checkout -q --detach "$INSTALLED_CONTROLLER"
   printf '%s\n' "$case_root"
 }
 
-run_final_case() {
+install_post_merge_mutation_hook() {
+  local case_repo=$1
+  local hook=$case_repo/.git/hooks/post-merge
+
+  cat > "$hook" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(git rev-parse --show-toplevel)
+publication=$root/ops/deploy/reader-summary-publication-deploy-lib.sh
+backup=$root/ops/deploy/postgres-backup-deploy-lib.sh
+printf 'advance %s\n' "$(git rev-parse HEAD)" >> "$BRIDGE_EVENTS"
+case ${BRIDGE_MUTATION:-correct} in
+  correct|publication-preloaded|publication-missing-entrypoint|helper-outside|helper-non-root|helper-preloaded|helper-missing-entrypoint)
+    ;;
+  publication-target-missing|publication-target-symlink)
+    rm -f "$publication"
+    cat > "$publication" <<'LIBRARY'
+#!/usr/bin/env bash
+deploy_reader_summary_publication_migrations() { :; }
+LIBRARY
+    ;;
+  publication-worktree-missing)
+    rm -f "$publication"
+    ;;
+  publication-filesystem-symlink)
+    rm -f "$publication"
+    ln -s "$root/README.md" "$publication"
+    ;;
+  publication-outside)
+    external=$root/../outside-deploy
+    rm -rf "$external"
+    mv "$root/ops/deploy" "$external"
+    ln -s "$external" "$root/ops/deploy"
+    ;;
+  publication-unreadable)
+    chmod 000 "$publication"
+    ;;
+  publication-mutated)
+    printf '%s\n' '# mutation after reviewed checkout' >> "$publication"
+    ;;
+  helper-target-missing|helper-target-symlink)
+    rm -f "$backup"
+    cat > "$backup" <<'LIBRARY'
+#!/usr/bin/env bash
+create_pre_migration_database_backup() { :; }
+LIBRARY
+    ;;
+  helper-worktree-missing)
+    rm -f "$backup"
+    ;;
+  helper-filesystem-symlink)
+    rm -f "$backup"
+    ln -s "$root/README.md" "$backup"
+    ;;
+  helper-wrong-mode)
+    chmod 600 "$backup"
+    ;;
+  helper-mutated)
+    printf '%s\n' '# mutation after reviewed checkout' >> "$backup"
+    ;;
+  *)
+    exit 94
+    ;;
+esac
+HOOK
+  chmod 0755 "$hook"
+}
+
+run_target_case() {
   local target_sha=$1
   local mutation=$2
   local expected_error=$3
   local expected_status=$4
   local case_root case_repo case_control case_state case_events case_output
-  local case_status hook
+  local case_status
 
   case_root=$(create_case_checkout "${mutation}-${target_sha:0:12}")
   case_repo=$case_root/integration
   case_control=$case_root/control
   case_state=$case_control/deploy-state
   case_events=$case_root/events
-  install -d "$case_control" "$case_state" "$case_root/runtime/deploy-staging"
-  cp "$case_repo/ops/deploy/social-monitor-production-deploy.sh" \
-    "$case_control/github-production-deploy.sh"
+  install -d "$case_control" "$case_state" \
+    "$case_root/runtime/deploy-staging"
+  cp "$INSTALLED_ENTRYPOINT" "$case_control/github-production-deploy.sh"
   chmod 0755 "$case_control/github-production-deploy.sh"
-  printf '%s\n' "$LEGACY_BACKEND" > "$case_state/backend.sha"
-  printf '%s\n' "$LEGACY_FRONTEND" > "$case_state/frontend.sha"
-  printf '%s\n' "$BRIDGE_SHA" > "$case_state/control.sha"
-
-  hook=$case_repo/.git/hooks/post-merge
-  cat > "$hook" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-root=$(git rev-parse --show-toplevel)
-publication=$root/ops/deploy/reader-summary-publication-deploy-lib.sh
-printf 'advance %s\n' "$(git rev-parse HEAD)" >> "$BRIDGE_EVENTS"
-case ${BRIDGE_MUTATION:-correct} in
-  correct) ;;
-  target-missing)
-    cat > "$publication" <<'LIBRARY'
-#!/usr/bin/env bash
-deploy_reader_summary_publication_migrations() { :; }
-LIBRARY
-    ;;
-  target-symlink)
-    rm -f "$publication"
-    cat > "$publication" <<'LIBRARY'
-#!/usr/bin/env bash
-deploy_reader_summary_publication_migrations() { :; }
-LIBRARY
-    ;;
-  missing) rm -f "$publication" ;;
-  symlink)
-    rm -f "$publication"
-    ln -s "$root/README.md" "$publication"
-    ;;
-  outside)
-    external=$root/../outside-deploy
-    rm -rf "$external"
-    mv "$root/ops/deploy" "$external"
-    ln -s "$external" "$root/ops/deploy"
-    ;;
-  unreadable) chmod 000 "$publication" ;;
-  mutated) printf '%s\n' '# mutation after reviewed checkout' >> "$publication" ;;
-  preloaded) ;;
-  *) exit 94 ;;
-esac
-EOF
-  chmod 0755 "$hook"
+  for component in frontend backend control; do
+    printf '%s\n' "$INSTALLED_CONTROLLER" > "$case_state/$component.sha"
+  done
+  install_post_merge_mutation_hook "$case_repo"
 
   set +e
   # shellcheck disable=SC2016
@@ -391,22 +242,50 @@ EOF
     SOCIAL_MONITOR_DEPLOY_STATE="$case_state" \
       bash -c '
         source "$SOCIAL_MONITOR_DEPLOY_CONTROL/github-production-deploy.sh"
-        if [[ $BRIDGE_MUTATION == preloaded ]]; then
+        helper_path=$SOCIAL_MONITOR_DEPLOY_REPO/ops/deploy/postgres-backup-deploy-lib.sh
+        if [[ $BRIDGE_MUTATION == publication-preloaded ]]; then
           deploy_reader_summary_publication_migrations() { :; }
-        else
-          ! declare -F deploy_reader_summary_publication_migrations >/dev/null
+        elif [[ $BRIDGE_MUTATION == helper-preloaded ]]; then
+          create_pre_migration_database_backup() { :; }
         fi
+        readlink() {
+          local last_argument=${!#}
+          if [[ $BRIDGE_MUTATION == helper-outside &&
+                $last_argument == "$helper_path" ]]; then
+            printf "%s\n" "$SOCIAL_MONITOR_DEPLOY_REPO/../outside-backup-library.sh"
+          else
+            command readlink "$@"
+          fi
+        }
+        stat() {
+          local last_argument=${!#}
+          local owner mode
+          if [[ $1 == -c && $2 == "%u %a" &&
+                $last_argument == "$helper_path" ]]; then
+            owner=0
+            [[ $BRIDGE_MUTATION != helper-non-root ]] || owner=65534
+            mode=$(command stat -c "%a" "$last_argument")
+            printf "%s %s\n" "$owner" "$mode"
+          else
+            command stat "$@"
+          fi
+        }
         sync_control_script() {
           declare -F deploy_reader_summary_publication_migrations >/dev/null
+          declare -F create_pre_migration_database_backup >/dev/null
+          declare -f backup_database |
+            grep -F "create_pre_migration_database_backup \"\$@\"" >/dev/null
+          create_pre_migration_database_backup() {
+            printf "backup\n" >> "$BRIDGE_EVENTS"
+          }
           printf "sync\n" >> "$BRIDGE_EVENTS"
         }
         commit_postgres_pool_bootstrap() { :; }
         snapshot_postgres_runtime_control() {
-          declare -F deploy_reader_summary_publication_migrations >/dev/null
-          local backup=$SOCIAL_MONITOR_DEPLOY_STATE/snapshot
-          install -d "$backup"
+          local snapshot=$SOCIAL_MONITOR_DEPLOY_STATE/runtime-snapshot
+          install -d "$snapshot"
           printf "snapshot\n" >> "$BRIDGE_EVENTS"
-          printf "%s\n" "$backup"
+          printf "%s\n" "$snapshot"
         }
         activate_postgres_runtime_control() {
           printf "activation\n" >> "$BRIDGE_EVENTS"
@@ -414,13 +293,10 @@ EOF
         verify_compose_scope() {
           printf "verify\n" >> "$BRIDGE_EVENTS"
         }
-        backup_database() {
-          printf "backup\n" >> "$BRIDGE_EVENTS"
-        }
         deploy_backend() {
-          declare -F deploy_reader_summary_publication_migrations >/dev/null
           printf "backend\n" >> "$BRIDGE_EVENTS"
           backup_database "$1"
+          printf "%s\n" "$1" > "$SOCIAL_MONITOR_DEPLOY_STATE/backend.sha"
         }
         restore_postgres_runtime_control() {
           printf "restore\n" >> "$BRIDGE_EVENTS"
@@ -437,60 +313,100 @@ EOF
   set -e
 
   if [[ $expected_status == success ]]; then
-    ((case_status == 0))
+    ((case_status == 0)) || {
+      printf 'success case failed: %s\n' "$case_output" >&2
+      exit 1
+    }
     grep -F \
       "deployed=$target_sha frontend=false backend=true control=true" \
       <<< "$case_output" >/dev/null
     [[ $(cat "$case_events") == \
       $'advance '"$target_sha"$'\nsync\nsnapshot\nactivation\nverify\nbackend\nbackup' ]]
-    [[ $(git -C "$case_repo" rev-parse HEAD) == "$target_sha" ]]
-    [[ $(cat "$case_state/frontend.sha") == "$LEGACY_FRONTEND" ]]
+    [[ $(cat "$case_state/backend.sha") == "$target_sha" ]]
+    [[ $(cat "$case_state/control.sha") == "$target_sha" ]]
   else
-    ((case_status != 0))
-    grep -F "$expected_error" <<< "$case_output" >/dev/null
-    grep -Fx "advance $target_sha" "$case_events" >/dev/null
-    if grep -E '^(sync|snapshot|activation|verify|backend|backup|restore|rollback)$' \
-      "$case_events" >/dev/null; then
-      echo "$mutation reached snapshot, activation, or backend work" >&2
+    ((case_status != 0)) || {
+      echo "$mutation unexpectedly succeeded" >&2
       exit 1
-    fi
-    [[ $(cat "$case_state/backend.sha") == "$LEGACY_BACKEND" ]]
-    [[ $(cat "$case_state/frontend.sha") == "$LEGACY_FRONTEND" ]]
-    [[ $(cat "$case_state/control.sha") == "$BRIDGE_SHA" ]]
+    }
+    grep -F "$expected_error" <<< "$case_output" >/dev/null || {
+      printf 'missing expected error for %s: %s\n' \
+        "$mutation" "$case_output" >&2
+      exit 1
+    }
+    [[ $(cat "$case_events") == "advance $target_sha" ]] || {
+      printf '%s reached work after advance: %q\n' \
+        "$mutation" "$(cat "$case_events")" >&2
+      exit 1
+    }
+    [[ $(cat "$case_state/backend.sha") == "$INSTALLED_CONTROLLER" ]]
+    [[ $(cat "$case_state/control.sha") == "$INSTALLED_CONTROLLER" ]]
   fi
 }
 
-run_final_case "$MISSING_BLOB_SHA" target-missing \
+# Existing publication-library target/worktree mutation and preload boundaries
+# remain fail-closed under the literal installed c59 bridge.
+run_target_case "$PUBLICATION_MISSING_BLOB_SHA" publication-target-missing \
   'target commit publication deploy library is not a regular blob' failure
-run_final_case "$SYMLINK_BLOB_SHA" target-symlink \
+run_target_case "$PUBLICATION_SYMLINK_BLOB_SHA" publication-target-symlink \
   'target commit publication deploy library is not a regular blob' failure
-run_final_case "$MISSING_ENTRYPOINT_SHA" correct \
+run_target_case "$PUBLICATION_MISSING_ENTRYPOINT_SHA" \
+  publication-missing-entrypoint \
   'target publication deploy library is missing its migration entrypoint' failure
-run_final_case "$FINAL_SHA" missing \
+run_target_case "$FINAL_SHA" publication-worktree-missing \
   'target publication deploy library is not a regular non-symlink file' failure
-run_final_case "$FINAL_SHA" symlink \
+run_target_case "$FINAL_SHA" publication-filesystem-symlink \
   'target publication deploy library is not a regular non-symlink file' failure
-run_final_case "$FINAL_SHA" outside \
+run_target_case "$FINAL_SHA" publication-outside \
   'target publication deploy library is outside integration' failure
-run_final_case "$FINAL_SHA" unreadable \
+run_target_case "$FINAL_SHA" publication-unreadable \
   'target publication deploy library is unreadable' failure
-run_final_case "$FINAL_SHA" mutated \
+run_target_case "$FINAL_SHA" publication-mutated \
   'target publication deploy library differs from reviewed target' failure
-run_final_case "$FINAL_SHA" preloaded \
+run_target_case "$FINAL_SHA" publication-preloaded \
   'publication migration entrypoint was loaded before target validation' failure
-run_final_case "$FINAL_SHA" correct '' success
 
+# Every helper failure must stop immediately after c59 advances integration;
+# no sync, snapshot, activation, verification, backend, backup, or marker write.
+run_target_case "$BACKUP_MISSING_BLOB_SHA" helper-target-missing \
+  'target commit PostgreSQL backup deploy library is not a regular blob' failure
+run_target_case "$BACKUP_SYMLINK_BLOB_SHA" helper-target-symlink \
+  'target commit PostgreSQL backup deploy library is not a regular blob' failure
+run_target_case "$FINAL_SHA" helper-worktree-missing \
+  'target PostgreSQL backup deploy library is not a regular non-symlink file' failure
+run_target_case "$FINAL_SHA" helper-filesystem-symlink \
+  'target PostgreSQL backup deploy library is not a regular non-symlink file' failure
+run_target_case "$FINAL_SHA" helper-outside \
+  'target PostgreSQL backup deploy library is outside its canonical integration path' failure
+run_target_case "$FINAL_SHA" helper-wrong-mode \
+  'target PostgreSQL backup deploy library mode does not match its target Git mode' failure
+run_target_case "$FINAL_SHA" helper-non-root \
+  'target PostgreSQL backup deploy library is not root-owned' failure
+run_target_case "$FINAL_SHA" helper-mutated \
+  'target PostgreSQL backup deploy library differs from reviewed target' failure
+run_target_case "$BACKUP_MISSING_ENTRYPOINT_SHA" helper-missing-entrypoint \
+  'target PostgreSQL backup deploy library is missing its backup entrypoint' failure
+run_target_case "$FINAL_SHA" helper-preloaded \
+  'PostgreSQL backup entrypoint was loaded before target validation' failure
+run_target_case "$FINAL_SHA" correct '' success
+
+# The literal c59 sequence is the authenticated seam: advance, source target,
+# then sync and enter the runtime transaction.
 # shellcheck disable=SC2016
 advance_line=$(grep -nF 'advance_integration "$sha"' \
-  "$SCRIPT_DIR/deploy-control-lib.sh" | tail -1 | cut -d: -f1)
+  "$PROJECT_ROOT/ops/deploy/deploy-control-lib.sh" | tail -1 | cut -d: -f1)
 # shellcheck disable=SC2016
 load_line=$(grep -nF \
   'load_target_reader_summary_publication_deploy_library "$sha"' \
-  "$SCRIPT_DIR/deploy-control-lib.sh" | tail -1 | cut -d: -f1)
+  "$PROJECT_ROOT/ops/deploy/deploy-control-lib.sh" | tail -1 | cut -d: -f1)
+# shellcheck disable=SC2016
+sync_line=$(grep -nF 'sync_control_script "$sha"' \
+  "$PROJECT_ROOT/ops/deploy/deploy-control-lib.sh" | tail -1 | cut -d: -f1)
 # shellcheck disable=SC2016
 transaction_line=$(grep -nF \
   'deploy_release_runtime_transaction "$sha" "$backend" "$runtime_control"' \
-  "$SCRIPT_DIR/deploy-control-lib.sh" | tail -1 | cut -d: -f1)
-((advance_line < load_line && load_line < transaction_line))
+  "$PROJECT_ROOT/ops/deploy/deploy-control-lib.sh" | tail -1 | cut -d: -f1)
+((advance_line < load_line && load_line < sync_line && \
+  sync_line < transaction_line))
 
-echo 'Reader-summary publication B-to-F bridge transition tests passed'
+echo 'Literal c59 pre-migration backup bridge transition tests passed'

--- a/ops/deploy/reader-summary-publication-deploy-lib.sh
+++ b/ops/deploy/reader-summary-publication-deploy-lib.sh
@@ -14,6 +14,72 @@ READER_SUMMARY_PUBLICATION_DATABASE_PORT=25060
 READER_SUMMARY_PUBLICATION_VALIDATION_ATTEMPTS=3
 READER_SUMMARY_PUBLICATION_VALIDATION_RETRY_SECONDS=2
 
+# This file is the authenticated target-publication wrapper loaded by the
+# installed c59 deploy-control bridge. The bridge's local target SHA remains
+# Bash-dynamically scoped while this file is sourced, so validate the adjacent
+# target-only backup implementation here before returning to installed code.
+! declare -F create_pre_migration_database_backup >/dev/null || \
+  fail 'PostgreSQL backup entrypoint was loaded before target validation'
+
+load_target_postgres_backup_deploy_library() {
+  local target_sha=$1
+  local relative_path=ops/deploy/postgres-backup-deploy-lib.sh
+  local backup_library=$REPO/$relative_path
+  local backup_real metadata owner permissions reviewed_digest actual_digest
+  local target_entry target_mode target_type target_object target_path extra
+
+  [[ $target_sha =~ ^[0-9a-f]{40}$ ]] || \
+    fail 'target PostgreSQL backup deploy library SHA is invalid'
+  [[ -f $backup_library && ! -L $backup_library ]] || \
+    fail 'target PostgreSQL backup deploy library is not a regular non-symlink file'
+  backup_real=$(readlink -f -- "$backup_library") || \
+    fail 'target PostgreSQL backup deploy library path cannot be resolved'
+  [[ $backup_real == "$REPO/$relative_path" ]] || \
+    fail 'target PostgreSQL backup deploy library is outside its canonical integration path'
+  metadata=$(stat -c '%u %a' "$backup_real") || \
+    fail 'target PostgreSQL backup deploy library ownership and mode cannot be read'
+  read -r owner permissions extra <<< "$metadata"
+  [[ -z ${extra:-} && $owner == 0 ]] || \
+    fail 'target PostgreSQL backup deploy library is not root-owned'
+
+  target_entry=$(git -C "$REPO" ls-tree "$target_sha" -- "$relative_path") || \
+    fail 'target commit PostgreSQL backup deploy library cannot be inspected'
+  read -r target_mode target_type target_object target_path extra \
+    <<< "$target_entry"
+  [[ -z ${extra:-} && \
+     ($target_mode == 100644 || $target_mode == 100755) && \
+     $target_type == blob && $target_object =~ ^[0-9a-f]{40}$ && \
+     $target_path == "$relative_path" ]] || \
+    fail 'target commit PostgreSQL backup deploy library is not a regular blob'
+  if [[ $target_mode == 100644 ]]; then
+    [[ $permissions == 644 ]] || \
+      fail 'target PostgreSQL backup deploy library mode does not match its target Git mode'
+  else
+    [[ $permissions == 755 ]] || \
+      fail 'target PostgreSQL backup deploy library mode does not match its target Git mode'
+  fi
+
+  reviewed_digest=$(
+    deploy_control_git_blob_digest "$target_sha" "$relative_path"
+  ) || fail 'target commit is missing the PostgreSQL backup deploy library'
+  actual_digest=$(deploy_control_file_digest "$backup_real") || \
+    fail 'target PostgreSQL backup deploy library digest cannot be read'
+  [[ $actual_digest == "$reviewed_digest" ]] || \
+    fail 'target PostgreSQL backup deploy library differs from reviewed target'
+
+  # shellcheck source=/dev/null
+  source "$backup_real" || \
+    fail 'target PostgreSQL backup deploy library could not be loaded'
+  declare -F create_pre_migration_database_backup >/dev/null || \
+    fail 'target PostgreSQL backup deploy library is missing its backup entrypoint'
+}
+
+load_target_postgres_backup_deploy_library "${sha:-}"
+
+backup_database() {
+  create_pre_migration_database_backup "$@"
+}
+
 reader_summary_publication_migrator_preflight() {
   local secret=$ROOT/secrets/db/reader-summary-publication-admin-url
   local ca_certificate=$ROOT/secrets/db/ca-certificate.crt

--- a/ops/deploy/reader-summary-publication-migrator-validation.test.sh
+++ b/ops/deploy/reader-summary-publication-migrator-validation.test.sh
@@ -38,6 +38,13 @@ printf '%s\n' 'test-only-ca-certificate' > "$CA_CERTIFICATE"
 cp "$SCRIPT_DIR/deploy-control-lib.sh" "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" "$REPO/ops/deploy/"
 cp "$DEPLOY_ENTRYPOINT" "$REPO/ops/deploy/"
+cp "$SCRIPT_DIR/postgres-backup-deploy-lib.sh" "$REPO/ops/deploy/"
+git init -q -b main "$REPO"
+git -C "$REPO" config user.name 'Publication Migrator Validation'
+git -C "$REPO" config user.email publication-validation@example.invalid
+git -C "$REPO" add ops/deploy
+git -C "$REPO" commit -qm 'test: reviewed target backup helper'
+TARGET_LIBRARY_SHA=$(git -C "$REPO" rev-parse HEAD)
 
 cat > "$FAKE_BIN/psql" <<'SH'
 #!/usr/bin/env bash
@@ -74,8 +81,30 @@ fail() {
   exit 1
 }
 
+deploy_control_file_digest() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+deploy_control_git_blob_digest() {
+  git -C "$REPO" show "$1:$2" | sha256sum | awk '{print $1}'
+}
+
+stat() {
+  local last_argument=${!#}
+  if [[ $1 == -c && $2 == '%u %a' && \
+        $last_argument == "$REPO/ops/deploy/postgres-backup-deploy-lib.sh" ]]; then
+    printf '0 %s\n' "$(command stat -c '%a' "$last_argument")"
+  else
+    command stat "$@"
+  fi
+}
+
+sha=$TARGET_LIBRARY_SHA
 # shellcheck source=ops/deploy/reader-summary-publication-deploy-lib.sh
 source "$LIBRARY"
+declare -F create_pre_migration_database_backup >/dev/null
+declare -f backup_database | \
+  grep -F 'create_pre_migration_database_backup "$@"' >/dev/null
 
 reader_summary_publication_admin_secret_metadata() {
   local mode
@@ -501,10 +530,25 @@ assert_deploy_backend_preflight_order() {
     ORCHESTRATION_LOG="$orchestration_log" \
     ORCHESTRATION_COUNTER="$counter" \
     ORCHESTRATION_MODE="$mode" \
+    TARGET_LIBRARY_SHA="$TARGET_LIBRARY_SHA" \
       bash -c '
       set -euo pipefail
       source "$1"
+      helper_path=$SOCIAL_MONITOR_DEPLOY_REPO/ops/deploy/postgres-backup-deploy-lib.sh
+      stat() {
+        local last_argument=${!#}
+        if [[ $1 == -c && $2 == "%u %a" && \
+              $last_argument == "$helper_path" ]]; then
+          printf "0 %s\n" "$(command stat -c "%a" "$last_argument")"
+        else
+          command stat "$@"
+        fi
+      }
+      sha=$TARGET_LIBRARY_SHA
       source "$2"
+      declare -F create_pre_migration_database_backup >/dev/null
+      declare -f backup_database | \
+        grep -F "create_pre_migration_database_backup \"\$@\"" >/dev/null
       backend_services() { printf "%s\n" migrate; }
       marker_value() { printf "%s\n" 0123456789abcdef0123456789abcdef01234567; }
       capture_previous_images() { printf "%s\n" capture >> "$ORCHESTRATION_LOG"; }

--- a/ops/deploy/social-monitor-production-deploy.test.sh
+++ b/ops/deploy/social-monitor-production-deploy.test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ENTRYPOINT=$SCRIPT_DIR/social-monitor-production-deploy.sh
+BACKUP_LIBRARY=$SCRIPT_DIR/postgres-backup-deploy-lib.sh
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/social-monitor-deploy-test.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
 
@@ -20,6 +21,7 @@ git -C "$REPO" config user.email deploy-contract@example.invalid
 git -C "$REPO" remote add origin "$ORIGIN"
 install -d "$REPO/apps/frontend" "$REPO/apps/api-gateway" \
   "$REPO/apps/x-collector" "$REPO/ops/deploy" "$REPO/ops/recovery" \
+  "$REPO/prisma/migrations/20260716170000_reader_summary_fail_closed_publication" \
   "$STATE" "$STAGING"
 cp "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/deploy-control-lib.sh" "$REPO/ops/deploy/"
@@ -27,11 +29,17 @@ cp "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" \
   "$SCRIPT_DIR/reader-summary-publication-pre-migration.sql" \
   "$SCRIPT_DIR/reader-summary-publication-post-migration.sql" \
   "$REPO/ops/deploy/"
+cp "$SCRIPT_DIR/verify-postgres-backup-coverage.sh" \
+  "$SCRIPT_DIR/prune-pre-autodeploy-backups.sh" \
+  "$BACKUP_LIBRARY" \
+  "$REPO/ops/deploy/"
 cp "$ENTRYPOINT" "$REPO/ops/deploy/"
+cp "$SCRIPT_DIR/../../prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql" \
+  "$REPO/prisma/migrations/20260716170000_reader_summary_fail_closed_publication/"
 cp "$SCRIPT_DIR/verify-postgres-runtime-topology.py" "$REPO/ops/deploy/"
 cp -R "$SCRIPT_DIR/production-runtime" "$REPO/ops/deploy/"
 printf 'base\n' > "$REPO/README.md"
-git -C "$REPO" add README.md ops/deploy
+git -C "$REPO" add README.md ops/deploy prisma/migrations
 git -C "$REPO" commit -qm 'test: base'
 git -C "$REPO" push -q -u origin main
 BASE_SHA=$(git -C "$REPO" rev-parse HEAD)
@@ -125,17 +133,177 @@ grep -F 'http://127.0.0.1:13080/auth/session' \
   "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" >/dev/null
 # shellcheck disable=SC2016
 grep -F '[[ ! -e $output && ! -L $output && ! -e $partial && ! -L $partial ]]' \
-  "$ENTRYPOINT" >/dev/null
+  "$BACKUP_LIBRARY" >/dev/null
 # shellcheck disable=SC2016
 grep -F '"$ROOT/backups" 10 "$output"' \
-  "$ENTRYPOINT" >/dev/null
-grep -F 'verify-postgres-backup-coverage.sh' "$ENTRYPOINT" >/dev/null
+  "$BACKUP_LIBRARY" >/dev/null
+grep -F 'verify-postgres-backup-coverage.sh' "$BACKUP_LIBRARY" >/dev/null
 # shellcheck disable=SC2016
-backup_move_line=$(grep -nF 'mv "$partial" "$output"' "$ENTRYPOINT" | cut -d: -f1)
+backup_move_line=$(grep -nF 'mv -T -- "$partial" "$output"' \
+  "$BACKUP_LIBRARY" | cut -d: -f1)
 # shellcheck disable=SC2016
 backup_prune_line=$(grep -nF 'prune-pre-autodeploy-backups.sh' \
-  "$ENTRYPOINT" | cut -d: -f1)
+  "$BACKUP_LIBRARY" | cut -d: -f1)
 ((backup_move_line < backup_prune_line))
+backup_integrity_line=$(grep -nF \
+  'pg_restore --file=/dev/null --no-owner --no-privileges' \
+  "$BACKUP_LIBRARY" | cut -d: -f1)
+backup_listing_line=$(grep -nF 'pg_restore -l ' \
+  "$BACKUP_LIBRARY" | cut -d: -f1)
+post_dump_snapshot_line=$(grep -nF \
+  '"$post_dump_migration_state"' "$BACKUP_LIBRARY" | tail -1 | cut -d: -f1)
+((backup_integrity_line < backup_listing_line))
+((backup_listing_line < post_dump_snapshot_line))
+((post_dump_snapshot_line < backup_move_line))
+
+# Exercise the real target wrapper and backup transaction with a fake
+# PostgreSQL client container. Empty, corrupt, failed, wrong-database, and
+# raced archives never escape their partial name or retain credential files.
+BACKUP_SCHEMA=$FIXTURE/backup-schema.txt
+BACKUP_LISTING=$FIXTURE/backup-listing.txt
+BACKUP_MIGRATION_STATE=$FIXTURE/backup-migration-state.txt
+BACKUP_DOCKER_LOG=$FIXTURE/backup-docker.log
+install -d "$ROOT/backups" "$ROOT/secrets/db"
+printf '%s\n' fixture-ca > "$ROOT/secrets/db/ca-certificate.crt"
+cat > "$BACKUP_SCHEMA" <<'TEXT'
+_prisma_migrations
+tenants
+workspaces
+source_items
+feed_items
+reader_summary_artifacts
+outbox_events
+inbox_records
+idempotency_keys
+TEXT
+cat > "$BACKUP_LISTING" <<'TEXT'
+1; 0 1 TABLE DATA public _prisma_migrations owner
+2; 0 2 TABLE DATA public tenants owner
+3; 0 3 TABLE DATA public workspaces owner
+4; 0 4 TABLE DATA public source_items owner
+5; 0 5 TABLE DATA public feed_items owner
+6; 0 6 TABLE DATA public reader_summary_artifacts owner
+7; 0 7 TABLE DATA public outbox_events owner
+8; 0 8 TABLE DATA public inbox_records owner
+9; 0 9 TABLE DATA public idempotency_keys owner
+TEXT
+printf 'reader-summary-publication-migration-state-v1\t0\t0\t0\t0\t0\t0\nexact-hex=5b5d\n' \
+  > "$BACKUP_MIGRATION_STATE"
+
+run_backup_fixture() {
+  local dump_mode=$1
+  local backup_timestamp=$2
+  # Fixture values expand only inside this isolated child shell.
+  # shellcheck disable=SC2016
+  BACKUP_DUMP_MODE=$dump_mode BACKUP_SHA=$BASE_SHA \
+  BACKUP_TIMESTAMP=$backup_timestamp BACKUP_SCHEMA=$BACKUP_SCHEMA \
+  BACKUP_LISTING=$BACKUP_LISTING BACKUP_DOCKER_LOG=$BACKUP_DOCKER_LOG \
+  BACKUP_MIGRATION_STATE=$BACKUP_MIGRATION_STATE \
+  SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 \
+  SOCIAL_MONITOR_DEPLOY_ROOT="$ROOT" \
+  SOCIAL_MONITOR_DEPLOY_REPO="$REPO" \
+  SOCIAL_MONITOR_DEPLOY_CONTROL="$CONTROL" \
+  SOCIAL_MONITOR_DEPLOY_STATE="$STATE" \
+  SOCIAL_MONITOR_DEPLOY_STAGING="$STAGING" \
+  ENTRYPOINT=$ENTRYPOINT bash -c '
+    source "$ENTRYPOINT"
+    helper_path=$SOCIAL_MONITOR_DEPLOY_REPO/ops/deploy/postgres-backup-deploy-lib.sh
+    stat() {
+      local last_argument=${!#}
+      if [[ $1 == -c && $2 == "%u %a" && \
+            $last_argument == "$helper_path" ]]; then
+        printf "0 %s\n" "$(command stat -c "%a" "$last_argument")"
+      else
+        command stat "$@"
+      fi
+    }
+    sha=$BACKUP_SHA
+    source "$SOCIAL_MONITOR_DEPLOY_REPO/ops/deploy/reader-summary-publication-deploy-lib.sh"
+    declare -F create_pre_migration_database_backup >/dev/null
+    declare -f backup_database | \
+      grep -F "create_pre_migration_database_backup \"\$@\"" >/dev/null
+    COMPOSE=(fake_compose)
+    fake_compose() {
+      [[ $* == "--profile app ps -q api" ]] || return 90
+      printf "%s\n" fixture-api
+    }
+    date() {
+      [[ $* == "-u +%Y%m%dT%H%M%SZ" ]] || return 91
+      printf "%s\n" "$BACKUP_TIMESTAMP"
+    }
+    docker() {
+      printf "%s\n" "$*" >> "$BACKUP_DOCKER_LOG"
+      if [[ $1 == inspect ]]; then
+        printf "%s\n" \
+          "DATABASE_URL=postgresql://fixture@db.invalid/social_monitor"
+      elif [[ $* == *"SELECT current_database()"* ]]; then
+        if [[ $BACKUP_DUMP_MODE == wrong-database ]]; then
+          printf "%s\n" postgres
+        else
+          printf "%s\n" social_monitor
+        fi
+      elif [[ $* == *"information_schema.tables"* ]]; then
+        command cat "$BACKUP_SCHEMA"
+      elif [[ $* == *"reader-summary-publication-migration-state-v1"* ]]; then
+        command cat "$BACKUP_MIGRATION_STATE"
+      elif [[ $* == *"pg_dump --format=custom"* ]]; then
+        [[ $BACKUP_DUMP_MODE != dump-failure ]] || return 72
+        [[ $BACKUP_DUMP_MODE != empty ]] && printf "%s\n" fixture-archive
+      elif [[ $* == *"pg_restore --file=/dev/null"* ]]; then
+        [[ $BACKUP_DUMP_MODE != corrupt ]] || return 73
+      elif [[ $* == *"pg_restore -l"* ]]; then
+        command cat "$BACKUP_LISTING"
+      else
+        return 92
+      fi
+    }
+    backup_database "$BACKUP_SHA"
+  '
+}
+
+: > "$BACKUP_DOCKER_LOG"
+valid_backup_output=$(run_backup_fixture valid 20260719T120000Z)
+BACKUP_PREFIX=${BASE_SHA:0:12}
+VALID_BACKUP=$ROOT/backups/pre-autodeploy-${BACKUP_PREFIX}-20260719T120000Z.dump
+[[ -s $VALID_BACKUP ]]
+[[ $(stat -c '%a' "$VALID_BACKUP") == 600 ]]
+grep -F "database-backup=$VALID_BACKUP" <<< "$valid_backup_output" >/dev/null
+grep -F 'pg_restore --file=/dev/null --no-owner --no-privileges' \
+  "$BACKUP_DOCKER_LOG" >/dev/null
+grep -F '20260716170000_reader_summary_fail_closed_publication' \
+  "$BACKUP_DOCKER_LOG" >/dev/null
+grep -F "checksum = :'migration_checksum'" "$BACKUP_DOCKER_LOG" >/dev/null
+mapfile -t migration_snapshot_lines < <(
+  grep -nF 'reader-summary-publication-migration-state-v1' \
+    "$BACKUP_DOCKER_LOG" | cut -d: -f1
+)
+((${#migration_snapshot_lines[@]} == 2))
+dump_capture_line=$(grep -nF 'pg_dump --format=custom' \
+  "$BACKUP_DOCKER_LOG" | cut -d: -f1)
+((migration_snapshot_lines[0] < dump_capture_line && \
+  dump_capture_line < migration_snapshot_lines[1]))
+
+assert_backup_failure_clean() {
+  local mode=$1 timestamp=$2
+  local expected=$ROOT/backups/pre-autodeploy-${BACKUP_PREFIX}-${timestamp}.dump
+  local status
+  set +e
+  run_backup_fixture "$mode" "$timestamp" >/dev/null 2>&1
+  status=$?
+  set -e
+  ((status != 0))
+  [[ ! -e $expected && ! -L $expected ]]
+  [[ ! -e $expected.partial && ! -L $expected.partial ]]
+  if compgen -G "$STATE/database-backup.*" >/dev/null; then
+    echo "$mode retained a temporary or credential-bearing backup file" >&2
+    exit 1
+  fi
+}
+
+assert_backup_failure_clean corrupt 20260719T120001Z
+assert_backup_failure_clean empty 20260719T120002Z
+assert_backup_failure_clean dump-failure 20260719T120003Z
+assert_backup_failure_clean wrong-database 20260719T120004Z
 grep -F 'ops/deploy/host/refresh-codex-auth.sh' "$ENTRYPOINT" >/dev/null
 # shellcheck disable=SC2016
 grep -F 'install -m 0700 -o root -g root "$auth_refresh_source" "$auth_refresh_destination.next"' \

--- a/ops/deploy/verify-postgres-backup-coverage.sh
+++ b/ops/deploy/verify-postgres-backup-coverage.sh
@@ -2,54 +2,226 @@
 set -euo pipefail
 
 schema_tables_path=${1:?schema table list path is required}
-listing_path=${2:-}
+migration_state_path=${2:?publication migration state path is required}
+listing_path=${3:-}
+post_dump_schema_tables_path=${4:-}
+post_dump_migration_state_path=${5:-}
 
-[[ -f $schema_tables_path && ! -L $schema_tables_path ]] || {
-  echo 'backup-coverage-error: schema table list must be a regular file' >&2
-  exit 1
+require_regular_file() {
+  local path=$1
+  local description=$2
+
+  [[ -f $path && ! -L $path ]] || {
+    echo "backup-coverage-error: $description must be a regular file" >&2
+    exit 1
+  }
 }
-if [[ -n $listing_path && (! -f $listing_path || -L $listing_path) ]]; then
-  echo 'backup-coverage-error: pg_restore listing must be a regular file' >&2
+
+require_regular_file "$schema_tables_path" 'schema table list'
+require_regular_file "$migration_state_path" 'publication migration state'
+if [[ -n $listing_path ]]; then
+  require_regular_file "$listing_path" 'pg_restore listing'
+  [[ -n $post_dump_schema_tables_path && \
+     -n $post_dump_migration_state_path ]] || {
+    echo 'backup-coverage-error: completed dump verification requires both post-dump snapshots' >&2
+    exit 1
+  }
+  require_regular_file "$post_dump_schema_tables_path" \
+    'post-dump schema table list'
+  require_regular_file "$post_dump_migration_state_path" \
+    'post-dump publication migration state'
+elif [[ -n $post_dump_schema_tables_path || \
+        -n $post_dump_migration_state_path ]]; then
+  echo 'backup-coverage-error: post-dump snapshots require a pg_restore listing' >&2
   exit 1
 fi
 
+read_publication_migration_state() {
+  local path=$1
+  local context=$2
+  local -a lines=()
+  local version total completed failed rolled_back in_progress contradictory
+  local extra count exact_hex
+
+  mapfile -t lines < "$path"
+  ((${#lines[@]} == 2)) || {
+    echo "backup-coverage-error: $context migration state has an invalid record count" >&2
+    return 1
+  }
+  IFS=$'\t' read -r version total completed failed rolled_back in_progress \
+    contradictory extra <<< "${lines[0]}"
+  [[ $version == reader-summary-publication-migration-state-v1 && \
+     -z ${extra:-} ]] || {
+    echo "backup-coverage-error: $context migration state header is invalid" >&2
+    return 1
+  }
+  for count in \
+    "$total" "$completed" "$failed" "$rolled_back" "$in_progress" \
+    "$contradictory"; do
+    [[ $count =~ ^(0|[1-9][0-9]{0,5})$ ]] || {
+      echo "backup-coverage-error: $context migration state count is invalid" >&2
+      return 1
+    }
+  done
+  ((completed + failed + rolled_back + in_progress + contradictory == total)) || {
+    echo "backup-coverage-error: $context migration state counts contradict each other" >&2
+    return 1
+  }
+  [[ ${lines[1]} =~ ^exact-hex=([0-9a-f]+)$ ]] || {
+    echo "backup-coverage-error: $context exact migration state is invalid" >&2
+    return 1
+  }
+  exact_hex=${BASH_REMATCH[1]}
+  ((${#exact_hex} % 2 == 0)) || {
+    echo "backup-coverage-error: $context exact migration state is truncated" >&2
+    return 1
+  }
+  if ((total == 0)); then
+    [[ $exact_hex == 5b5d ]] || {
+      echo "backup-coverage-error: $context absent migration has contradictory exact state" >&2
+      return 1
+    }
+  else
+    [[ $exact_hex != 5b5d ]] || {
+      echo "backup-coverage-error: $context present migration has empty exact state" >&2
+      return 1
+    }
+  fi
+
+  MIGRATION_TOTAL=$total
+  MIGRATION_COMPLETED=$completed
+  MIGRATION_FAILED=$failed
+  MIGRATION_ROLLED_BACK=$rolled_back
+  MIGRATION_IN_PROGRESS=$in_progress
+  MIGRATION_CONTRADICTORY=$contradictory
+}
+
+require_publication_schema_migration_match() {
+  local context=$1
+
+  case $publication_schema in
+    absent)
+      ((MIGRATION_TOTAL == 0 && MIGRATION_COMPLETED == 0 && \
+        MIGRATION_FAILED == 0 && MIGRATION_ROLLED_BACK == 0 && \
+        MIGRATION_IN_PROGRESS == 0 && MIGRATION_CONTRADICTORY == 0)) || {
+        echo "backup-coverage-error: $context publication tables are absent but the exact migration is not unapplied" >&2
+        return 1
+      }
+      publication_migration_state=not-applied
+      ;;
+    present)
+      ((MIGRATION_TOTAL == 1 && MIGRATION_COMPLETED == 1 && \
+        MIGRATION_FAILED == 0 && MIGRATION_ROLLED_BACK == 0 && \
+        MIGRATION_IN_PROGRESS == 0 && MIGRATION_CONTRADICTORY == 0)) || {
+        echo "backup-coverage-error: $context publication tables exist without one exact completed migration" >&2
+        return 1
+      }
+      publication_migration_state=completed
+      ;;
+  esac
+}
+
 required_relations=()
+declare -A required_relation_set=()
 while IFS= read -r relation; do
   [[ -n $relation ]] || continue
   [[ $relation =~ ^_?[a-z][a-z0-9_]*$ ]] || {
     echo 'backup-coverage-error: live schema contains an unsafe relation name' >&2
     exit 1
   }
+  [[ -z ${required_relation_set[$relation]+present} ]] || {
+    echo "backup-coverage-error: duplicate live schema relation: $relation" >&2
+    exit 1
+  }
   required_relations+=("$relation")
+  required_relation_set[$relation]=present
 done < "$schema_tables_path"
 
 ((${#required_relations[@]} > 0)) || {
   echo 'backup-coverage-error: live schema table list is empty' >&2
   exit 1
 }
-duplicate=$(printf '%s\n' "${required_relations[@]}" | LC_ALL=C sort | uniq -d | head -1)
-[[ -z $duplicate ]] || {
-  echo "backup-coverage-error: duplicate live schema relation: $duplicate" >&2
-  exit 1
-}
 for core_relation in \
   _prisma_migrations tenants workspaces source_items feed_items \
-  reader_summary_artifacts reader_summary_publications \
-  reader_summary_publication_slots outbox_events inbox_records \
-  idempotency_keys; do
-  printf '%s\n' "${required_relations[@]}" | grep -Fx "$core_relation" >/dev/null || {
+  reader_summary_artifacts outbox_events inbox_records idempotency_keys; do
+  [[ -n ${required_relation_set[$core_relation]+present} ]] || {
     echo "backup-coverage-error: live schema fingerprint is missing: $core_relation" >&2
     exit 1
   }
 done
 
+publication_relation_count=0
+for publication_relation in \
+  reader_summary_publications reader_summary_publication_slots; do
+  if [[ -n ${required_relation_set[$publication_relation]+present} ]]; then
+    publication_relation_count=$((publication_relation_count + 1))
+  fi
+done
+case $publication_relation_count in
+  0) publication_schema=absent ;;
+  2) publication_schema=present ;;
+  *)
+    echo 'backup-coverage-error: live publication schema is only partially present' >&2
+    exit 1
+    ;;
+esac
+
+read_publication_migration_state "$migration_state_path" pre-dump
+require_publication_schema_migration_match pre-dump
+
 if [[ -n $listing_path ]]; then
+  declare -A dump_relation_set=()
+  dump_relation_count=0
+  while IFS= read -r relation; do
+    [[ $relation =~ ^_?[a-z][a-z0-9_]*$ ]] || {
+      echo 'backup-coverage-error: dump contains an unsafe public relation name' >&2
+      exit 1
+    }
+    [[ -z ${dump_relation_set[$relation]+present} ]] || {
+      echo "backup-coverage-error: dump contains duplicate relation data: $relation" >&2
+      exit 1
+    }
+    dump_relation_set[$relation]=present
+    dump_relation_count=$((dump_relation_count + 1))
+  done < <(
+    awk '$4 == "TABLE" && $5 == "DATA" && $6 == "public" { print $7 }' \
+      "$listing_path"
+  )
+
   for relation in "${required_relations[@]}"; do
-    grep -Eq "TABLE DATA public $relation( |$)" "$listing_path" || {
+    [[ -n ${dump_relation_set[$relation]+present} ]] || {
       echo "backup-coverage-error: dump is missing live relation data: $relation" >&2
       exit 1
     }
   done
-fi
+  for relation in "${!dump_relation_set[@]}"; do
+    [[ -n ${required_relation_set[$relation]+present} ]] || {
+      echo "backup-coverage-error: dump schema differs from captured live schema: $relation" >&2
+      exit 1
+    }
+  done
+  ((dump_relation_count == ${#required_relations[@]})) || {
+    echo 'backup-coverage-error: dump relation count differs from captured live schema' >&2
+    exit 1
+  }
 
-printf 'database-backup-relations-verified=%s\n' "${#required_relations[@]}"
+  cmp -s "$schema_tables_path" "$post_dump_schema_tables_path" || {
+    echo 'backup-coverage-error: live schema changed while backup was captured' >&2
+    exit 1
+  }
+  read_publication_migration_state \
+    "$post_dump_migration_state_path" post-dump
+  require_publication_schema_migration_match post-dump
+  cmp -s "$migration_state_path" "$post_dump_migration_state_path" || {
+    echo 'backup-coverage-error: exact publication migration state changed while backup was captured' >&2
+    exit 1
+  }
+
+  printf 'database-backup-relations-verified=%s publication-schema=%s publication-migration=%s\n' \
+    "${#required_relations[@]}" "$publication_schema" \
+    "$publication_migration_state"
+else
+  printf 'database-backup-schema-verified=%s publication-schema=%s publication-migration=%s\n' \
+    "${#required_relations[@]}" "$publication_schema" \
+    "$publication_migration_state"
+fi

--- a/ops/deploy/verify-postgres-backup-coverage.test.sh
+++ b/ops/deploy/verify-postgres-backup-coverage.test.sh
@@ -6,98 +6,211 @@ ENTRYPOINT=$SCRIPT_DIR/verify-postgres-backup-coverage.sh
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/social-monitor-backup-coverage-test.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
 
-cat > "$FIXTURE/schema.txt" <<'TEXT'
+cat > "$FIXTURE/first-deploy-schema.txt" <<'TEXT'
 _prisma_migrations
 tenants
 workspaces
 source_items
 feed_items
 reader_summary_artifacts
-reader_summary_publications
-reader_summary_publication_slots
 outbox_events
 inbox_records
 idempotency_keys
 TEXT
-cat > "$FIXTURE/listing.txt" <<'TEXT'
+cat > "$FIXTURE/first-deploy-listing.txt" <<'TEXT'
+;
+; Archive created by pg_dump
+;
 1; 0 1 TABLE DATA public _prisma_migrations owner
 2; 0 2 TABLE DATA public tenants owner
 3; 0 3 TABLE DATA public workspaces owner
 4; 0 4 TABLE DATA public source_items owner
 5; 0 5 TABLE DATA public feed_items owner
 6; 0 6 TABLE DATA public reader_summary_artifacts owner
-7; 0 7 TABLE DATA public reader_summary_publications owner
-8; 0 8 TABLE DATA public reader_summary_publication_slots owner
-9; 0 9 TABLE DATA public outbox_events owner
-10; 0 10 TABLE DATA public inbox_records owner
-11; 0 11 TABLE DATA public idempotency_keys owner
+7; 0 7 TABLE DATA public outbox_events owner
+8; 0 8 TABLE DATA public inbox_records owner
+9; 0 9 TABLE DATA public idempotency_keys owner
 TEXT
 
-output=$(bash "$ENTRYPOINT" "$FIXTURE/schema.txt" "$FIXTURE/listing.txt")
-grep -Fx 'database-backup-relations-verified=11' <<< "$output" >/dev/null
+write_migration_state() {
+  local path=$1 total=$2 completed=$3 failed=$4 rolled_back=$5
+  local in_progress=$6 contradictory=$7 exact_hex=$8
+  printf 'reader-summary-publication-migration-state-v1\t%s\t%s\t%s\t%s\t%s\t%s\nexact-hex=%s\n' \
+    "$total" "$completed" "$failed" "$rolled_back" "$in_progress" \
+    "$contradictory" "$exact_hex" > "$path"
+}
 
-grep -v '^feed_items$' "$FIXTURE/schema.txt" > "$FIXTURE/schema-missing.txt"
-if bash "$ENTRYPOINT" "$FIXTURE/schema-missing.txt" >/dev/null 2>&1; then
-  echo 'wrong live schema identity was accepted' >&2
-  exit 1
-fi
+NOT_APPLIED_STATE=$FIXTURE/migration-not-applied.txt
+COMPLETED_STATE=$FIXTURE/migration-completed.txt
+write_migration_state "$NOT_APPLIED_STATE" 0 0 0 0 0 0 5b5d
+write_migration_state "$COMPLETED_STATE" 1 1 0 0 0 0 \
+  7b22636f6d706c65746564223a747275657d
 
-grep -v 'TABLE DATA public feed_items ' "$FIXTURE/listing.txt" > "$FIXTURE/listing-missing.txt"
-if bash "$ENTRYPOINT" "$FIXTURE/schema.txt" \
-  "$FIXTURE/listing-missing.txt" >/dev/null 2>&1; then
-  echo 'missing dump relation was accepted' >&2
-  exit 1
-fi
-
-for publication_relation in \
-  reader_summary_publications reader_summary_publication_slots; do
-  grep -v "^${publication_relation}$" "$FIXTURE/schema.txt" \
-    > "$FIXTURE/schema-missing-${publication_relation}.txt"
-  if bash "$ENTRYPOINT" \
-    "$FIXTURE/schema-missing-${publication_relation}.txt" >/dev/null 2>&1; then
-    echo "schema without $publication_relation was accepted" >&2
+assert_pre_state_rejected() {
+  local name=$1 schema=$2 state=$3
+  if bash "$ENTRYPOINT" "$schema" "$state" >/dev/null 2>&1; then
+    echo "$name publication migration state was accepted" >&2
     exit 1
   fi
+}
 
-  grep -v "TABLE DATA public ${publication_relation} " \
-    "$FIXTURE/listing.txt" \
-    > "$FIXTURE/listing-missing-${publication_relation}.txt"
-  if bash "$ENTRYPOINT" "$FIXTURE/schema.txt" \
-    "$FIXTURE/listing-missing-${publication_relation}.txt" \
-    >/dev/null 2>&1; then
-    echo "dump without $publication_relation was accepted" >&2
-    exit 1
-  fi
-done
+schema_output=$(bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
+  "$NOT_APPLIED_STATE")
+grep -Fx \
+  'database-backup-schema-verified=9 publication-schema=absent publication-migration=not-applied' \
+  <<< "$schema_output" >/dev/null
+output=$(bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
+  "$NOT_APPLIED_STATE" "$FIXTURE/first-deploy-listing.txt" \
+  "$FIXTURE/first-deploy-schema.txt" "$NOT_APPLIED_STATE")
+grep -Fx \
+  'database-backup-relations-verified=9 publication-schema=absent publication-migration=not-applied' \
+  <<< "$output" >/dev/null
 
-cp "$FIXTURE/schema.txt" "$FIXTURE/duplicate.txt"
-printf 'feed_items\n' >> "$FIXTURE/duplicate.txt"
-if bash "$ENTRYPOINT" "$FIXTURE/duplicate.txt" \
-  "$FIXTURE/listing.txt" >/dev/null 2>&1; then
-  echo 'duplicate live schema relation was accepted' >&2
+cp "$FIXTURE/first-deploy-schema.txt" "$FIXTURE/upgrade-schema.txt"
+printf '%s\n' reader_summary_publications \
+  reader_summary_publication_slots >> "$FIXTURE/upgrade-schema.txt"
+cp "$FIXTURE/first-deploy-listing.txt" "$FIXTURE/upgrade-listing.txt"
+cat >> "$FIXTURE/upgrade-listing.txt" <<'TEXT'
+10; 0 10 TABLE DATA public reader_summary_publications owner
+11; 0 11 TABLE DATA public reader_summary_publication_slots owner
+TEXT
+output=$(bash "$ENTRYPOINT" "$FIXTURE/upgrade-schema.txt" \
+  "$COMPLETED_STATE" "$FIXTURE/upgrade-listing.txt" \
+  "$FIXTURE/upgrade-schema.txt" "$COMPLETED_STATE")
+grep -Fx \
+  'database-backup-relations-verified=11 publication-schema=present publication-migration=completed' \
+  <<< "$output" >/dev/null
+
+FAILED_STATE=$FIXTURE/migration-failed.txt
+ROLLED_BACK_STATE=$FIXTURE/migration-rolled-back.txt
+IN_PROGRESS_STATE=$FIXTURE/migration-in-progress.txt
+DUPLICATE_STATE=$FIXTURE/migration-duplicate.txt
+CONTRADICTORY_STATE=$FIXTURE/migration-contradictory.txt
+CHECKSUM_MISMATCH_STATE=$FIXTURE/migration-checksum-mismatch.txt
+write_migration_state "$FAILED_STATE" 1 0 1 0 0 0 \
+  7b226661696c6564223a747275657d
+write_migration_state "$ROLLED_BACK_STATE" 1 0 0 1 0 0 \
+  7b22726f6c6c6564223a747275657d
+write_migration_state "$IN_PROGRESS_STATE" 1 0 0 0 1 0 \
+  7b2272756e6e696e67223a747275657d
+write_migration_state "$DUPLICATE_STATE" 2 2 0 0 0 0 5b7b7d2c7b7d5d
+write_migration_state "$CONTRADICTORY_STATE" 1 0 0 0 0 1 \
+  7b2266696e6973686564416e64526f6c6c65644261636b223a747275657d
+write_migration_state "$CHECKSUM_MISMATCH_STATE" 1 0 0 0 0 1 \
+  7b22636865636b73756d223a2277726f6e67227d
+assert_pre_state_rejected failed "$FIXTURE/upgrade-schema.txt" "$FAILED_STATE"
+assert_pre_state_rejected rolled-back "$FIXTURE/upgrade-schema.txt" \
+  "$ROLLED_BACK_STATE"
+assert_pre_state_rejected in-progress "$FIXTURE/upgrade-schema.txt" \
+  "$IN_PROGRESS_STATE"
+assert_pre_state_rejected duplicate "$FIXTURE/upgrade-schema.txt" \
+  "$DUPLICATE_STATE"
+assert_pre_state_rejected contradictory "$FIXTURE/upgrade-schema.txt" \
+  "$CONTRADICTORY_STATE"
+assert_pre_state_rejected checksum-mismatch "$FIXTURE/upgrade-schema.txt" \
+  "$CHECKSUM_MISMATCH_STATE"
+assert_pre_state_rejected completed-without-tables \
+  "$FIXTURE/first-deploy-schema.txt" "$COMPLETED_STATE"
+assert_pre_state_rejected tables-without-migration \
+  "$FIXTURE/upgrade-schema.txt" "$NOT_APPLIED_STATE"
+
+cp "$FIXTURE/first-deploy-schema.txt" "$FIXTURE/partial-schema.txt"
+printf '%s\n' reader_summary_publications >> "$FIXTURE/partial-schema.txt"
+assert_pre_state_rejected partial "$FIXTURE/partial-schema.txt" \
+  "$NOT_APPLIED_STATE"
+
+grep -v '^feed_items$' "$FIXTURE/first-deploy-schema.txt" \
+  > "$FIXTURE/schema-missing-critical.txt"
+assert_pre_state_rejected missing-critical \
+  "$FIXTURE/schema-missing-critical.txt" "$NOT_APPLIED_STATE"
+grep -v 'TABLE DATA public feed_items ' "$FIXTURE/first-deploy-listing.txt" \
+  > "$FIXTURE/listing-missing-critical.txt"
+if bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
+  "$NOT_APPLIED_STATE" "$FIXTURE/listing-missing-critical.txt" \
+  "$FIXTURE/first-deploy-schema.txt" "$NOT_APPLIED_STATE" \
+  >/dev/null 2>&1; then
+  echo 'dump missing an existing critical table was accepted' >&2
   exit 1
 fi
 
-cp "$FIXTURE/schema.txt" "$FIXTURE/unsafe.txt"
-printf '../unsafe\n' >> "$FIXTURE/unsafe.txt"
-if bash "$ENTRYPOINT" "$FIXTURE/unsafe.txt" \
-  "$FIXTURE/listing.txt" >/dev/null 2>&1; then
-  echo 'unsafe live schema relation was accepted' >&2
+grep -v 'TABLE DATA public reader_summary_publication_slots ' \
+  "$FIXTURE/upgrade-listing.txt" > "$FIXTURE/upgrade-listing-missing.txt"
+if bash "$ENTRYPOINT" "$FIXTURE/upgrade-schema.txt" \
+  "$COMPLETED_STATE" "$FIXTURE/upgrade-listing-missing.txt" \
+  "$FIXTURE/upgrade-schema.txt" "$COMPLETED_STATE" >/dev/null 2>&1; then
+  echo 'upgrade dump missing an existing publication table was accepted' >&2
   exit 1
 fi
 
+cp "$FIXTURE/first-deploy-listing.txt" "$FIXTURE/listing-extra.txt"
+printf '%s\n' '10; 0 10 TABLE DATA public unexpected_table owner' \
+  >> "$FIXTURE/listing-extra.txt"
+if bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
+  "$NOT_APPLIED_STATE" "$FIXTURE/listing-extra.txt" \
+  "$FIXTURE/first-deploy-schema.txt" "$NOT_APPLIED_STATE" \
+  >/dev/null 2>&1; then
+  echo 'dump with a mismatched public table set was accepted' >&2
+  exit 1
+fi
+cp "$FIXTURE/first-deploy-listing.txt" "$FIXTURE/listing-duplicate.txt"
+printf '%s\n' '10; 0 10 TABLE DATA public feed_items owner' \
+  >> "$FIXTURE/listing-duplicate.txt"
+if bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
+  "$NOT_APPLIED_STATE" "$FIXTURE/listing-duplicate.txt" \
+  "$FIXTURE/first-deploy-schema.txt" "$NOT_APPLIED_STATE" \
+  >/dev/null 2>&1; then
+  echo 'dump with duplicate public table data was accepted' >&2
+  exit 1
+fi
+printf '%s\n' 'not a PostgreSQL archive listing' \
+  > "$FIXTURE/corrupt-listing.txt"
+if bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
+  "$NOT_APPLIED_STATE" "$FIXTURE/corrupt-listing.txt" \
+  "$FIXTURE/first-deploy-schema.txt" "$NOT_APPLIED_STATE" \
+  >/dev/null 2>&1; then
+  echo 'corrupt archive listing was accepted' >&2
+  exit 1
+fi
+
+cp "$FIXTURE/first-deploy-schema.txt" "$FIXTURE/post-dump-schema-changed.txt"
+printf '%s\n' concurrent_table >> "$FIXTURE/post-dump-schema-changed.txt"
+if bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
+  "$NOT_APPLIED_STATE" "$FIXTURE/first-deploy-listing.txt" \
+  "$FIXTURE/post-dump-schema-changed.txt" "$NOT_APPLIED_STATE" \
+  >/dev/null 2>&1; then
+  echo 'live schema race during backup was accepted' >&2
+  exit 1
+fi
+
+COMPLETED_STATE_CHANGED=$FIXTURE/migration-completed-changed.txt
+write_migration_state "$COMPLETED_STATE_CHANGED" 1 1 0 0 0 0 \
+  7b22636f6d706c65746564223a747275652c226964223a226368616e676564227d
+if bash "$ENTRYPOINT" "$FIXTURE/upgrade-schema.txt" "$COMPLETED_STATE" \
+  "$FIXTURE/upgrade-listing.txt" "$FIXTURE/upgrade-schema.txt" \
+  "$COMPLETED_STATE_CHANGED" >/dev/null 2>&1; then
+  echo 'exact publication migration state race was accepted' >&2
+  exit 1
+fi
+
+cp "$FIXTURE/first-deploy-schema.txt" "$FIXTURE/duplicate-schema.txt"
+printf 'feed_items\n' >> "$FIXTURE/duplicate-schema.txt"
+assert_pre_state_rejected duplicate-schema "$FIXTURE/duplicate-schema.txt" \
+  "$NOT_APPLIED_STATE"
+cp "$FIXTURE/first-deploy-schema.txt" "$FIXTURE/unsafe-schema.txt"
+printf '../unsafe\n' >> "$FIXTURE/unsafe-schema.txt"
+assert_pre_state_rejected unsafe "$FIXTURE/unsafe-schema.txt" \
+  "$NOT_APPLIED_STATE"
 printf 'feed_items\n' > "$FIXTURE/no-migrations.txt"
-if bash "$ENTRYPOINT" "$FIXTURE/no-migrations.txt" \
-  "$FIXTURE/listing.txt" >/dev/null 2>&1; then
-  echo 'schema without migration history was accepted' >&2
-  exit 1
-fi
-
+assert_pre_state_rejected no-migrations "$FIXTURE/no-migrations.txt" \
+  "$NOT_APPLIED_STATE"
 : > "$FIXTURE/empty.txt"
-if bash "$ENTRYPOINT" "$FIXTURE/empty.txt" \
-  "$FIXTURE/listing.txt" >/dev/null 2>&1; then
-  echo 'empty live schema was accepted' >&2
-  exit 1
-fi
+assert_pre_state_rejected empty "$FIXTURE/empty.txt" "$NOT_APPLIED_STATE"
+printf '%s\n' 'reader-summary-publication-migration-state-v1' \
+  > "$FIXTURE/corrupt-migration-state.txt"
+assert_pre_state_rejected corrupt "$FIXTURE/first-deploy-schema.txt" \
+  "$FIXTURE/corrupt-migration-state.txt"
+write_migration_state "$FIXTURE/empty-exact-state.txt" 0 0 0 0 0 0 7b7d
+assert_pre_state_rejected absent-exact-contradiction \
+  "$FIXTURE/first-deploy-schema.txt" "$FIXTURE/empty-exact-state.txt"
 
-echo 'PostgreSQL backup coverage tests passed'
+echo 'PostgreSQL pre-migration backup coverage tests passed'


### PR DESCRIPTION
## Summary
- require a validated custom-format PostgreSQL backup before publication migrations
- verify live schema and migration state before and after dump
- retain only verified backups and clean all partial credential artifacts
- preserve the installed c59 publication bridge byte-for-byte

## Verification
- independent security/correctness review: approved
- 8 broker-controlled integration checks: passed
- production deploy contract and 68 migrator cases: passed
- source line cap, secret scan and diff check: passed