### PR TITLE
fix(deploy): validate PostgreSQL 18 migrator contract

### DIFF
--- a/ops/deploy/reader-summary-publication-deploy-lib.sh
+++ b/ops/deploy/reader-summary-publication-deploy-lib.sh
@@ -8,6 +8,7 @@
 
 READER_SUMMARY_PUBLICATION_MIGRATOR_ROLE=social_monitor_publication_migrator
 READER_SUMMARY_PUBLICATION_RUNTIME_ROLE=social_monitor_app
+READER_SUMMARY_PUBLICATION_PROVISIONER_ROLE=doadmin
 READER_SUMMARY_PUBLICATION_DATABASE=social_monitor
 READER_SUMMARY_PUBLICATION_DATABASE_HOST=dbaas-db-8050451-do-user-39622063-0.e.db.ondigitalocean.com
 READER_SUMMARY_PUBLICATION_DATABASE_PORT=25060
@@ -157,7 +158,8 @@ validate_reader_summary_publication_migrator() (
   local is_superuser can_create_database can_replicate can_bypass_rls
   local server_version uses_tls membership_count membership_admin
   local membership_inherit membership_set protected_memberships_valid
-  local unexpected_membership_count outgoing_membership_count extra
+  local unexpected_membership_count outgoing_membership_count
+  local protected_creator_membership_valid extra
   local query_status availability_status
 
   [[ -f $secret && ! -L $secret && -s $secret ]] || return 64
@@ -196,14 +198,15 @@ validate_reader_summary_publication_migrator() (
   fi
   [[ -n $catalog_result && $catalog_result != *$'\n'* ]] || return 65
   catalog_delimiters=${catalog_result//[!|]/}
-  ((${#catalog_delimiters} == 18)) || return 65
+  ((${#catalog_delimiters} == 19)) || return 65
 
   IFS='|' read -r database_name current_identity session_identity \
     can_login can_create_role inherits_role is_superuser \
     can_create_database can_replicate can_bypass_rls server_version \
     uses_tls membership_count membership_admin membership_inherit \
     membership_set protected_memberships_valid \
-    unexpected_membership_count outgoing_membership_count extra \
+    unexpected_membership_count outgoing_membership_count \
+    protected_creator_membership_valid extra \
     <<< "$catalog_result"
 
   [[ -z $extra && \
@@ -221,7 +224,8 @@ validate_reader_summary_publication_migrator() (
   [[ $membership_inherit == f && $membership_set == t ]] || return 65
   [[ $protected_memberships_valid == t ]] || return 65
   [[ $unexpected_membership_count == 0 ]] || return 65
-  [[ $outgoing_membership_count == 0 ]] || return 65
+  [[ $outgoing_membership_count == 1 ]] || return 65
+  [[ $protected_creator_membership_valid == t ]] || return 65
 )
 
 reader_summary_publication_admin_secret_metadata() {
@@ -356,13 +360,18 @@ reader_summary_publication_run_postgres_client() (
         operation=$6
         runtime_role=$7
         query=$8
+        provisioner_role=$9
         pgpass_file=
-        cleanup_pgpass() {
+        query_file=
+        cleanup_postgres_client_files() {
           if [ -n "$pgpass_file" ]; then
             rm -f -- "$pgpass_file"
           fi
+          if [ -n "$query_file" ]; then
+            rm -f -- "$query_file"
+          fi
         }
-        trap cleanup_pgpass EXIT
+        trap cleanup_postgres_client_files EXIT
         trap "exit 129" HUP
         trap "exit 130" INT
         trap "exit 143" TERM
@@ -387,10 +396,15 @@ reader_summary_publication_run_postgres_client() (
           catalog)
             PGCONNECT_TIMEOUT=15
             export PGCONNECT_TIMEOUT
+            query_file=$(mktemp /tmp/social-monitor-catalog-query.XXXXXX)
+            printf "%s\n" "$query" > "$query_file"
+            chmod 0600 "$query_file"
+            [ -s "$query_file" ]
             psql -X -A -t -F "|" --no-password -v ON_ERROR_STOP=1 \
               --host="$host" --port="$port" --dbname="$database" \
               --username="$username" --set=runtime_role="$runtime_role" \
-              --command="$query"
+              --set=provisioner_role="$provisioner_role" \
+              --file="$query_file"
             ;;
           availability)
             pg_isready -q -t 15 \
@@ -406,7 +420,8 @@ reader_summary_publication_run_postgres_client() (
       "$READER_SUMMARY_PUBLICATION_DATABASE_PORT" \
       "$READER_SUMMARY_PUBLICATION_DATABASE" \
       "$READER_SUMMARY_PUBLICATION_MIGRATOR_ROLE" \
-      "$application_name" "$operation" "$runtime_role" "$query"
+      "$application_name" "$operation" "$runtime_role" "$query" \
+      "$READER_SUMMARY_PUBLICATION_PROVISIONER_ROLE"
 )
 
 reader_summary_publication_admin_catalog_query() {
@@ -433,7 +448,8 @@ SELECT
   COALESCE(membership.set_option, false),
   COALESCE(membership.protected_memberships_valid, false),
   COALESCE(membership.unexpected_membership_count, 0),
-  COALESCE(outgoing_memberships.membership_count, 0)
+  COALESCE(outgoing_memberships.membership_count, 0),
+  COALESCE(outgoing_memberships.protected_creator_membership_valid, false)
 FROM pg_catalog.pg_roles AS migrator
 LEFT JOIN pg_catalog.pg_stat_ssl AS connection
   ON connection.pid = pg_catalog.pg_backend_pid()
@@ -515,14 +531,8 @@ LEFT JOIN LATERAL (
       )
     ) AND BOOL_AND(
       CASE WHEN granted_role.rolname = :'runtime_role'
-      THEN grantor_role.rolsuper OR (
-        grantor_role.rolcreaterole
-        AND grantor_role.rolname NOT IN (
-          current_user,
-          :'runtime_role',
-          'social_monitor_reader_summary_publication_owner',
-          'social_monitor_reader_summary_publication_runtime'
-        )
+      THEN grantor_role.rolname = :'provisioner_role'
+        AND grantor_role.rolcreaterole
         AND EXISTS (
           SELECT 1
           FROM pg_catalog.pg_auth_members AS provisioner_membership
@@ -531,9 +541,11 @@ LEFT JOIN LATERAL (
           WHERE provisioner_membership.roleid = membership.roleid
             AND provisioner_membership.member = membership.grantor
             AND provisioner_membership.admin_option
+            AND NOT provisioner_membership.inherit_option
+            AND NOT provisioner_membership.set_option
             AND root_grantor.rolsuper
         )
-      ) ELSE true END
+      ELSE true END
     ) AS protected_memberships_valid,
     COUNT(*) FILTER (
       WHERE granted_role.rolname NOT IN (
@@ -552,8 +564,41 @@ LEFT JOIN LATERAL (
     WHERE member_role.rolname = current_user
 ) AS membership ON true
 LEFT JOIN LATERAL (
-  SELECT COUNT(*) AS membership_count
+  SELECT
+    COUNT(*) AS membership_count,
+    BOOL_AND(
+      member_role.rolname = :'provisioner_role'
+      AND grantor_role.rolsuper
+      AND outgoing_membership.admin_option
+      AND NOT outgoing_membership.inherit_option
+      AND NOT outgoing_membership.set_option
+      AND EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_auth_members AS runtime_membership
+        JOIN pg_catalog.pg_roles AS runtime_granted_role
+          ON runtime_granted_role.oid = runtime_membership.roleid
+        JOIN pg_catalog.pg_auth_members AS provisioner_membership
+          ON provisioner_membership.roleid = runtime_membership.roleid
+          AND provisioner_membership.member = runtime_membership.grantor
+        JOIN pg_catalog.pg_roles AS bootstrap_grantor
+          ON bootstrap_grantor.oid = provisioner_membership.grantor
+        WHERE runtime_granted_role.rolname = :'runtime_role'
+          AND runtime_membership.member = migrator.oid
+          AND runtime_membership.grantor = outgoing_membership.member
+          AND runtime_membership.admin_option
+          AND NOT runtime_membership.inherit_option
+          AND runtime_membership.set_option
+          AND provisioner_membership.admin_option
+          AND NOT provisioner_membership.inherit_option
+          AND NOT provisioner_membership.set_option
+          AND bootstrap_grantor.rolsuper
+      )
+    ) AS protected_creator_membership_valid
   FROM pg_catalog.pg_auth_members AS outgoing_membership
+  JOIN pg_catalog.pg_roles AS member_role
+    ON member_role.oid = outgoing_membership.member
+  JOIN pg_catalog.pg_roles AS grantor_role
+    ON grantor_role.oid = outgoing_membership.grantor
   WHERE outgoing_membership.roleid = migrator.oid
 ) AS outgoing_memberships ON true
 WHERE migrator.rolname = current_user;"

--- a/ops/deploy/reader-summary-publication-migrator-validation.test.sh
+++ b/ops/deploy/reader-summary-publication-migrator-validation.test.sh
@@ -16,13 +16,14 @@ EVENT_LOG=$FIXTURE/events.log
 WRITE_LOG=$FIXTURE/writes.log
 TRANSPORT_LOG=$FIXTURE/transport.log
 TRANSPORT_PGPASS_PATH_LOG=$FIXTURE/transport-pgpass-path.log
+TRANSPORT_QUERY_PATH_LOG=$FIXTURE/transport-query-path.log
 FAKE_BIN=$FIXTURE/bin
 PRIVATE_QUERY_PAYLOAD=private-query-output-must-stay-redacted
 PRIVATE_PASSWORD=redacted-test-password
 MIGRATOR_ROLE=social_monitor_publication_migrator
 DATABASE_HOST=dbaas-db-8050451-do-user-39622063-0.e.db.ondigitalocean.com
 VALID_URL="postgresql://${MIGRATOR_ROLE}:${PRIVATE_PASSWORD}@${DATABASE_HOST}:25060/social_monitor?connect_timeout=10&sslmode=verify-full&sslrootcert=%2Frun%2Fsocial-monitor-db%2Fca-certificate.crt"
-VALID_CATALOG="social_monitor|${MIGRATOR_ROLE}|${MIGRATOR_ROLE}|t|t|t|f|f|f|f|180004|t|1|t|f|t|t|0|0"
+VALID_CATALOG="social_monitor|${MIGRATOR_ROLE}|${MIGRATOR_ROLE}|t|t|t|f|f|f|f|180004|t|1|t|f|t|t|0|1|t"
 CATALOG_RESULT=$VALID_CATALOG
 CATALOG_QUERY_STATUS=0
 AVAILABILITY_STATUS=0
@@ -55,6 +56,26 @@ mode=$(stat -c '%a' "$PGPASSFILE")
 [[ $* != *postgresql://* && $* != *redacted-test-password* ]]
 if env | grep -F 'redacted-test-password' >/dev/null; then
   exit 91
+fi
+query_file=
+for argument in "$@"; do
+  case $argument in
+    --command=*) exit 90 ;;
+    --file=/tmp/social-monitor-catalog-query.*) query_file=${argument#--file=} ;;
+  esac
+done
+if [[ -n $query_file ]]; then
+  [[ -f $query_file && ! -L $query_file && -s $query_file ]]
+  query_mode=$(stat -c '%a' "$query_file")
+  [[ $query_mode == 600 ]]
+  query_payload=$(< "$query_file")
+  [[ $query_payload == *"WHERE granted_role.rolname = :'runtime_role'"* ]]
+  [[ $query_payload == *'FROM pg_catalog.pg_auth_members AS membership'* ]]
+  [[ " $* " == *' --set=runtime_role=social_monitor_app '* ]]
+  [[ " $* " == *' --set=provisioner_role=doadmin '* ]]
+  printf '%s\n' "$query_file" > "$TRANSPORT_QUERY_PATH_LOG"
+  printf 'client:psql:catalog-file:mode=%s\n' "$query_mode" \
+    >> "$TRANSPORT_LOG"
 fi
 printf '%s\n' "$PGPASSFILE" > "$TRANSPORT_PGPASS_PATH_LOG"
 printf 'client:psql:mode=%s\n' "$mode" >> "$TRANSPORT_LOG"
@@ -122,15 +143,6 @@ reader_summary_publication_admin_secret_metadata() {
   printf '%s|%s\n' "$CA_OWNER" "$mode"
 }
 
-reader_summary_publication_admin_catalog_query() {
-  printf '%s\n' catalog-query >> "$EVENT_LOG"
-  if ((CATALOG_QUERY_STATUS != 0)); then
-    printf '%s\n' "$PRIVATE_QUERY_PAYLOAD"
-    return "$CATALOG_QUERY_STATUS"
-  fi
-  printf '%s\n' "$CATALOG_RESULT"
-}
-
 reader_summary_publication_admin_availability_query() {
   printf '%s\n' availability >> "$EVENT_LOG"
   return "$AVAILABILITY_STATUS"
@@ -150,7 +162,8 @@ fake_compose() {
 }
 
 docker() {
-  local stdin_payload arguments script status pgpass_path index position
+  local stdin_payload arguments script status pgpass_path query_path
+  local index position
   local -a docker_arguments=("$@") child_arguments
   stdin_payload=$(cat)
   arguments=${docker_arguments[*]}
@@ -181,11 +194,19 @@ docker() {
       TRANSPORT_CLIENT_STATUS="$TRANSPORT_CLIENT_STATUS" \
       TRANSPORT_LOG="$TRANSPORT_LOG" \
       TRANSPORT_PGPASS_PATH_LOG="$TRANSPORT_PGPASS_PATH_LOG" \
+      TRANSPORT_QUERY_PATH_LOG="$TRANSPORT_QUERY_PATH_LOG" \
       sh -c "$script" "${child_arguments[@]}"
   status=${PIPESTATUS[1]}
   set -e
   pgpass_path=$(< "$TRANSPORT_PGPASS_PATH_LOG")
   [[ -n $pgpass_path && ! -e $pgpass_path ]] || return 99
+  query_path=$(< "$TRANSPORT_QUERY_PATH_LOG")
+  if [[ ${child_arguments[6]} == catalog ]]; then
+    [[ -n $query_path && ! -e $query_path ]] || return 89
+    printf 'docker:status=%s:query-removed\n' "$status" >> "$TRANSPORT_LOG"
+  else
+    [[ -z $query_path ]] || return 88
+  fi
   printf 'docker:status=%s:pgpass-removed\n' "$status" >> "$TRANSPORT_LOG"
   return "$status"
 }
@@ -216,6 +237,7 @@ reset_case() {
   : > "$WRITE_LOG"
   : > "$TRANSPORT_LOG"
   : > "$TRANSPORT_PGPASS_PATH_LOG"
+  : > "$TRANSPORT_QUERY_PATH_LOG"
   CATALOG_RESULT=$VALID_CATALOG
   CATALOG_QUERY_STATUS=0
   AVAILABILITY_STATUS=0
@@ -251,9 +273,9 @@ assert_pgpass_transport() {
       actual_status=$?
       ;;
     catalog)
-      reader_summary_publication_run_postgres_client \
-        "$SECRET" "$CA_CERTIFICATE" publication-transport-test \
-        catalog "$READER_SUMMARY_PUBLICATION_RUNTIME_ROLE" 'SELECT 1'
+      reader_summary_publication_admin_catalog_query \
+        "$SECRET" "$CA_CERTIFICATE" \
+        "$READER_SUMMARY_PUBLICATION_RUNTIME_ROLE"
       actual_status=$?
       ;;
     availability)
@@ -266,6 +288,11 @@ assert_pgpass_transport() {
   set -e
   ((actual_status == expected_status))
   grep -Fx "client:${expected_client}:mode=600" "$TRANSPORT_LOG" >/dev/null
+  if [[ $operation == catalog ]]; then
+    grep -Fx 'client:psql:catalog-file:mode=600' "$TRANSPORT_LOG" >/dev/null
+    grep -Fx "docker:status=${expected_status}:query-removed" \
+      "$TRANSPORT_LOG" >/dev/null
+  fi
   grep -Fx "docker:status=${expected_status}:pgpass-removed" \
     "$TRANSPORT_LOG" >/dev/null
   [[ ! -e $ROOT/production.env ]]
@@ -364,17 +391,26 @@ assert_invalid_file() {
   : "$label"
 }
 
+assert_pgpass_transport bootstrap psql
+assert_pgpass_transport catalog psql
+assert_pgpass_transport availability pg_isready
+assert_pgpass_transport catalog psql 37
+
+reader_summary_publication_admin_catalog_query() {
+  printf '%s\n' catalog-query >> "$EVENT_LOG"
+  if ((CATALOG_QUERY_STATUS != 0)); then
+    printf '%s\n' "$PRIVATE_QUERY_PAYLOAD"
+    return "$CATALOG_QUERY_STATUS"
+  fi
+  printf '%s\n' "$CATALOG_RESULT"
+}
+
 reset_case
 valid_output=$(deploy_reader_summary_publication_migrations 2>&1)
 [[ -z $valid_output ]]
 [[ $(< "$EVENT_LOG") == $'availability\ncatalog-query\nwrite:pre\nwrite:prisma\nwrite:post' ]]
 [[ $(< "$WRITE_LOG") == $'psql:pre\nprisma-migrate\npsql:post' ]]
 TEST_COUNT=$((TEST_COUNT + 1))
-
-assert_pgpass_transport bootstrap psql
-assert_pgpass_transport catalog psql
-assert_pgpass_transport availability pg_isready
-assert_pgpass_transport catalog psql 37
 
 for failed_phase in pre prisma post; do
   reset_case
@@ -508,8 +544,12 @@ assert_invalid_catalog inherited-runtime-role "$(catalog_with_field 14 t)"
 assert_invalid_catalog no-runtime-set-option "$(catalog_with_field 15 f)"
 assert_invalid_catalog unsafe-protected-membership "$(catalog_with_field 16 f)"
 assert_invalid_catalog unexpected-role-membership "$(catalog_with_field 17 1)"
-assert_invalid_catalog role-can-impersonate-migrator \
-  "$(catalog_with_field 18 1)"
+assert_invalid_catalog missing-protected-creator-membership \
+  "$(catalog_with_field 18 0)"
+assert_invalid_catalog additional-outgoing-member \
+  "$(catalog_with_field 18 2)"
+assert_invalid_catalog unsafe-protected-creator-membership \
+  "$(catalog_with_field 19 f)"
 
 assert_deploy_backend_preflight_order() {
   local mode=$1
@@ -612,12 +652,18 @@ for catalog_token in \
   'protected_memberships_valid' \
   'unexpected_membership_count' \
   'outgoing_memberships.membership_count' \
+  'protected_creator_membership_valid' \
   'outgoing_membership.roleid = migrator.oid' \
+  "member_role.rolname = :'provisioner_role'" \
+  'grantor_role.rolsuper' \
+  'outgoing_membership.admin_option' \
+  'NOT outgoing_membership.inherit_option' \
+  'NOT outgoing_membership.set_option' \
+  'runtime_membership.grantor = outgoing_membership.member' \
   'membership.admin_option' \
   'membership.inherit_option' \
   'membership.set_option' \
   'membership.grantor' \
-  'grantor_role.rolsuper' \
   'provisioner_membership' \
   'pg_isready' \
   '--no-password'; do

--- a/ops/deploy/social-monitor-production-deploy.test.sh
+++ b/ops/deploy/social-monitor-production-deploy.test.sh
@@ -367,7 +367,15 @@ grep -F 'PGPASSFILE=$pgpass_file' \
   "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" >/dev/null
 grep -F 'chmod 0600 "$pgpass_file"' \
   "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" >/dev/null
-grep -F 'trap cleanup_pgpass EXIT' \
+grep -F 'cleanup_postgres_client_files() {' \
+  "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" >/dev/null
+grep -F 'trap cleanup_postgres_client_files EXIT' \
+  "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" >/dev/null
+grep -F 'rm -f -- "$pgpass_file"' \
+  "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" >/dev/null
+grep -F 'chmod 0600 "$query_file"' \
+  "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" >/dev/null
+grep -F 'rm -f -- "$query_file"' \
   "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" >/dev/null
 grep -F 'social_monitor_app' \
   "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" >/dev/null

--- a/scripts/reader-summary-publication-postgres-privileges.ts
+++ b/scripts/reader-summary-publication-postgres-privileges.ts
@@ -2,6 +2,10 @@ import { readFileSync } from "node:fs";
 
 import { Pool, type PoolClient } from "pg";
 
+import {
+  assertPostgres18CreatorAndPsqlRegression,
+} from "./reader-summary-publication-postgres18-regression";
+
 const protectedOwner = "social_monitor_reader_summary_publication_owner";
 
 export const runReaderSummaryPublicationBootstrapSql = async (
@@ -82,6 +86,12 @@ export const createPublicationFixtureRuntimeRole = async (params: {
        NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS`,
     );
     runtimeCreated = true;
+    await assertPostgres18CreatorAndPsqlRegression({
+      provisionerRole,
+      runtimeRole: params.runtimeRole,
+      serverAdmin,
+      serverAdminDatabaseUrl: params.serverAdminDatabaseUrl,
+    });
     await serverAdmin.query(
       `GRANT CONNECT, CREATE ON DATABASE ${quoteIdentifier(params.databaseName)}
          TO ${quoteIdentifier(params.runtimeRole)}`,

--- a/scripts/reader-summary-publication-postgres18-regression.ts
+++ b/scripts/reader-summary-publication-postgres18-regression.ts
@@ -1,0 +1,151 @@
+import { spawnSync } from "node:child_process";
+
+import type { Pool } from "pg";
+
+const postgresClientImage =
+  "postgres@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15";
+
+export const assertPostgres18CreatorAndPsqlRegression = async (params: {
+  readonly provisionerRole: string;
+  readonly runtimeRole: string;
+  readonly serverAdmin: Pool;
+  readonly serverAdminDatabaseUrl: string;
+}): Promise<void> => {
+  const catalog = await params.serverAdmin.query<{
+    readonly protected_membership_valid: boolean;
+    readonly membership_count: number;
+    readonly server_version_num: string;
+  }>(
+    `SELECT current_setting('server_version_num') AS server_version_num,
+            count(*)::integer AS membership_count,
+            COALESCE(bool_and(
+              member_role.rolname = $2
+              AND member_role.rolcreaterole
+              AND NOT member_role.rolsuper
+              AND grantor_role.rolsuper
+              AND membership.admin_option
+              AND NOT membership.inherit_option
+              AND NOT membership.set_option
+            ), false) AS protected_membership_valid
+       FROM pg_catalog.pg_auth_members AS membership
+       JOIN pg_catalog.pg_roles AS granted_role
+         ON granted_role.oid = membership.roleid
+       JOIN pg_catalog.pg_roles AS member_role
+         ON member_role.oid = membership.member
+       JOIN pg_catalog.pg_roles AS grantor_role
+         ON grantor_role.oid = membership.grantor
+      WHERE granted_role.rolname = $1`,
+    [params.runtimeRole, params.provisionerRole],
+  );
+  const [row] = catalog.rows;
+  if (
+    !row ||
+    !/^18[0-9]{4}$/.test(row.server_version_num) ||
+    row.membership_count !== 1 ||
+    !row.protected_membership_valid
+  ) {
+    throw new Error(
+      "PostgreSQL 18 did not create the exact protected creator membership",
+    );
+  }
+
+  assertPsqlFileInterpolation({
+    databaseUrl: params.serverAdminDatabaseUrl,
+    runtimeRole: params.runtimeRole,
+  });
+};
+
+const assertPsqlFileInterpolation = (params: {
+  readonly databaseUrl: string;
+  readonly runtimeRole: string;
+}): void => {
+  const databaseUrl = new URL(params.databaseUrl);
+  const host = databaseUrl.hostname;
+  const port = databaseUrl.port || "5432";
+  const database = decodeURIComponent(databaseUrl.pathname.slice(1));
+  const username = decodeURIComponent(databaseUrl.username);
+  const password = decodeURIComponent(databaseUrl.password);
+  if (
+    databaseUrl.protocol !== "postgresql:" ||
+    !["127.0.0.1", "localhost"].includes(host) ||
+    !/^[0-9]{1,5}$/.test(port) ||
+    !database ||
+    !username ||
+    !password ||
+    !/^[a-z][a-z0-9_]+$/.test(params.runtimeRole)
+  ) {
+    throw new Error("PostgreSQL 18 psql regression requires a local test URL");
+  }
+  const pgpass = [host, port, database, username, password]
+    .map(pgpassEscape)
+    .join(":");
+  const script = String.raw`
+set -eu
+host=$1
+port=$2
+database=$3
+username=$4
+runtime_role=$5
+pgpass_file=
+query_file=
+cleanup() {
+  if [ -n "$pgpass_file" ]; then rm -f -- "$pgpass_file"; fi
+  if [ -n "$query_file" ]; then rm -f -- "$query_file"; fi
+}
+trap cleanup EXIT
+trap "exit 129" HUP
+trap "exit 130" INT
+trap "exit 143" TERM
+umask 077
+pgpass_file=$(mktemp /tmp/social-monitor-pg18-pgpass.XXXXXX)
+cat > "$pgpass_file"
+chmod 0600 "$pgpass_file"
+[ -s "$pgpass_file" ]
+PGPASSFILE=$pgpass_file
+PGCONNECT_TIMEOUT=15
+export PGPASSFILE PGCONNECT_TIMEOUT
+query="SELECT :'runtime_role'::text;"
+if psql -X -A -t --no-password -v ON_ERROR_STOP=1 \
+  --host="$host" --port="$port" --dbname="$database" \
+  --username="$username" --set=runtime_role="$runtime_role" \
+  --command="$query" >/dev/null 2>&1; then
+  exit 90
+fi
+query_file=$(mktemp /tmp/social-monitor-pg18-query.XXXXXX)
+printf "%s\n" "$query" > "$query_file"
+chmod 0600 "$query_file"
+[ "$(stat -c %a "$query_file")" = 600 ]
+result=$(psql -X -A -t --no-password -v ON_ERROR_STOP=1 \
+  --host="$host" --port="$port" --dbname="$database" \
+  --username="$username" --set=runtime_role="$runtime_role" \
+  --file="$query_file")
+[ "$result" = "$runtime_role" ]
+`;
+  const result = spawnSync(
+    "docker",
+    [
+      "run",
+      "--rm",
+      "-i",
+      "--user=0:0",
+      "--network=host",
+      postgresClientImage,
+      "sh",
+      "-c",
+      script,
+      "_",
+      host,
+      port,
+      database,
+      username,
+      params.runtimeRole,
+    ],
+    { encoding: "utf8", input: `${pgpass}\n` },
+  );
+  if (result.status !== 0) {
+    throw new Error("real psql catalog-variable regression failed");
+  }
+};
+
+const pgpassEscape = (value: string): string =>
+  value.replaceAll("\\", "\\\\").replaceAll(":", "\\:");


### PR DESCRIPTION
Fixes the production migrator preflight for PostgreSQL 18:

- uses a mode-0600 ephemeral SQL file so psql variable interpolation works
- validates the exact protected automatic creator membership created by PostgreSQL 18
- rejects unsafe or additional role memberships fail-closed
- adds real PostgreSQL 18 regression coverage and cleanup contract assertions

Verified through broker-controlled integration:
- 70 migrator fixtures
- production deploy contract
- publication signal and bridge transition tests
- real PostgreSQL 18 privilege/upgrade/replay/concurrency gate
- targeted ESLint, TypeScript build, source-line-cap and secret scan