### PR TITLE
test(postgres): register PG18 regression dependency

### DIFF
--- a/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
@@ -449,6 +449,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       'scripts/reader-summary-publication-postgres-legacy.ts',
       'scripts/reader-summary-publication-postgres-privileges.ts',
       'scripts/reader-summary-publication-postgres-runtime-guard.ts',
+      'scripts/reader-summary-publication-postgres18-regression.ts',
       'scripts/run-reader-summary-clean-real-day-collection.ts',
       'scripts/run-reader-summary-production-day.ts',
     ]);


### PR DESCRIPTION
Register the reviewed PostgreSQL 18 regression script in the exact raw database-client dependency inventory.

- one test-only insertion
- preserves fail-closed exact inventory semantics
- exact inventory gate: 32/32 passed
- targeted ESLint, secret scan, source-line-cap and diff check passed