### PR TITLE
fix(deploy): execute migration snapshots from sql files

### DIFF
--- a/ops/deploy/postgres-backup-deploy-lib.sh
+++ b/ops/deploy/postgres-backup-deploy-lib.sh
@@ -130,12 +130,24 @@ capture_pre_migration_schema_tables() {
     "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE' ORDER BY table_name"
 }
 
-capture_reader_summary_publication_migration_state() {
+capture_reader_summary_publication_migration_state() (
   local env_file=$1
   local backup_image=$2
   local migration_checksum=$3
   local migration_id=$READER_SUMMARY_PUBLICATION_MIGRATION_ID
   local sql
+  sql_file=
+
+  cleanup_migration_state_sql() {
+    if [[ -n $sql_file ]]; then
+      rm -f -- "$sql_file"
+    fi
+  }
+  trap cleanup_migration_state_sql EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  umask 077
 
   # The summary classifies every Prisma lifecycle. The second record is a
   # canonical hex encoding of every target row, including logs and timestamps,
@@ -220,11 +232,21 @@ SELECT 'exact-hex=' || exact_hex
 FROM exact_state;
 SQL
 
+  sql_file=$(mktemp "$STATE/database-backup.XXXXXX.migration-state.sql") || \
+    fail 'database backup migration query file cannot be created'
+  printf '%s\n' "$sql" > "$sql_file" || \
+    fail 'database backup migration query file cannot be written'
+  chmod 0600 "$sql_file" || \
+    fail 'database backup migration query file cannot be secured'
+  [[ -f $sql_file && ! -L $sql_file && -s $sql_file ]] || \
+    fail 'database backup migration query file is invalid'
+
   # shellcheck disable=SC2016 # Expansion occurs in the child shell.
   docker run --rm \
     --env-file "$env_file" \
     -v "$ROOT/secrets/db/ca-certificate.crt:/run/social-monitor-db/ca-certificate.crt:ro" \
+    -v "$sql_file:/run/social-monitor-db/migration-state.sql:ro" \
     "$backup_image" \
-    sh -c 'exec psql "$DATABASE_URL" -X -A -t -v ON_ERROR_STOP=1 -v "migration_id=$1" -v "migration_checksum=$2" -c "$3"' \
-      _ "$migration_id" "$migration_checksum" "$sql"
-}
+    sh -c 'exec psql "$DATABASE_URL" -X -A -t -v ON_ERROR_STOP=1 -v "migration_id=$1" -v "migration_checksum=$2" --file=/run/social-monitor-db/migration-state.sql' \
+      _ "$migration_id" "$migration_checksum"
+)

--- a/ops/deploy/social-monitor-production-deploy.test.sh
+++ b/ops/deploy/social-monitor-production-deploy.test.sh
@@ -232,7 +232,15 @@ run_backup_fixture() {
       printf "%s\n" "$BACKUP_TIMESTAMP"
     }
     docker() {
+      local argument migration_sql_file=
       printf "%s\n" "$*" >> "$BACKUP_DOCKER_LOG"
+      for argument in "$@"; do
+        case $argument in
+          *:/run/social-monitor-db/migration-state.sql:ro)
+            migration_sql_file=${argument%:/run/social-monitor-db/migration-state.sql:ro}
+            ;;
+        esac
+      done
       if [[ $1 == inspect ]]; then
         printf "%s\n" \
           "DATABASE_URL=postgresql://fixture@db.invalid/social_monitor"
@@ -244,7 +252,27 @@ run_backup_fixture() {
         fi
       elif [[ $* == *"information_schema.tables"* ]]; then
         command cat "$BACKUP_SCHEMA"
-      elif [[ $* == *"reader-summary-publication-migration-state-v1"* ]]; then
+      elif [[ -n $migration_sql_file ]]; then
+        [[ -f $migration_sql_file && ! -L $migration_sql_file && \
+          -s $migration_sql_file ]]
+        [[ $(command stat -c "%a" "$migration_sql_file") == 600 ]]
+        grep -F "WHERE migration_name = :" \
+          "$migration_sql_file" >/dev/null
+        grep -F "checksum = :" \
+          "$migration_sql_file" >/dev/null
+        [[ $* == *"--file=/run/social-monitor-db/migration-state.sql"* ]]
+        [[ $* == *"-v \"migration_id=\$1\""* ]]
+        [[ $* == *"-v \"migration_checksum=\$2\""* ]]
+        [[ $* != *"-c \"\$3\""* && $* != *"--command"* ]]
+        [[ ${*: -2:1} == \
+          20260716170000_reader_summary_fail_closed_publication ]]
+        [[ ${*: -1} =~ ^[0-9a-f]{64}$ ]]
+        printf "migration-state-sql-file:mode=600:variables-via-file\n" \
+          >> "$BACKUP_DOCKER_LOG"
+        if [[ $BACKUP_DUMP_MODE == signal-* ]]; then
+          kill -s "${BACKUP_DUMP_MODE#signal-}" "$BASHPID"
+          return 93
+        fi
         command cat "$BACKUP_MIGRATION_STATE"
       elif [[ $* == *"pg_dump --format=custom"* ]]; then
         [[ $BACKUP_DUMP_MODE != dump-failure ]] || return 72
@@ -272,9 +300,16 @@ grep -F 'pg_restore --file=/dev/null --no-owner --no-privileges' \
   "$BACKUP_DOCKER_LOG" >/dev/null
 grep -F '20260716170000_reader_summary_fail_closed_publication' \
   "$BACKUP_DOCKER_LOG" >/dev/null
-grep -F "checksum = :'migration_checksum'" "$BACKUP_DOCKER_LOG" >/dev/null
+[[ $(grep -cFx \
+  'migration-state-sql-file:mode=600:variables-via-file' \
+  "$BACKUP_DOCKER_LOG") == 2 ]]
+if grep -F -- '-c "$3"' "$BACKUP_DOCKER_LOG" >/dev/null || \
+  grep -F -- '--command' "$BACKUP_DOCKER_LOG" >/dev/null; then
+  echo 'migration ledger SQL used a psql command argument' >&2
+  exit 1
+fi
 mapfile -t migration_snapshot_lines < <(
-  grep -nF 'reader-summary-publication-migration-state-v1' \
+  grep -nF 'migration-state-sql-file:mode=600:variables-via-file' \
     "$BACKUP_DOCKER_LOG" | cut -d: -f1
 )
 ((${#migration_snapshot_lines[@]} == 2))
@@ -304,6 +339,9 @@ assert_backup_failure_clean corrupt 20260719T120001Z
 assert_backup_failure_clean empty 20260719T120002Z
 assert_backup_failure_clean dump-failure 20260719T120003Z
 assert_backup_failure_clean wrong-database 20260719T120004Z
+assert_backup_failure_clean signal-HUP 20260719T120005Z
+assert_backup_failure_clean signal-INT 20260719T120006Z
+assert_backup_failure_clean signal-TERM 20260719T120007Z
 grep -F 'ops/deploy/host/refresh-codex-auth.sh' "$ENTRYPOINT" >/dev/null
 # shellcheck disable=SC2016
 grep -F 'install -m 0700 -o root -g root "$auth_refresh_source" "$auth_refresh_destination.next"' \


### PR DESCRIPTION
## Summary
- execute migration-state SQL through a protected temporary file so psql variables are expanded
- clean the query file on success, failure, and signals
- add deploy-contract regressions for file mode, arguments, cleanup, and signals

## Verification
- production deploy contract passed
- migrator validation 70/70 passed
- bash syntax and ShellCheck passed
- secret scan and source-line-cap passed
- reviewed patch applies cleanly to current main

Fixes the fail-closed deployment error in Actions run 29676987946.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and security of PostgreSQL backup migration-state processing.
  * Temporary migration files are securely created, cleaned up automatically, and removed during interruptions or termination.
  * Updated database command handling to avoid exposing migration SQL through command arguments.

* **Tests**
  * Expanded backup validation for temporary file permissions, contents, and cleanup.
  * Added coverage for multiple interruption and termination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->