### PR TITLE
fix(deploy): document trap cleanup for shellcheck

### DIFF
--- a/ops/deploy/postgres-backup-deploy-lib.sh
+++ b/ops/deploy/postgres-backup-deploy-lib.sh
@@ -138,6 +138,8 @@ capture_reader_summary_publication_migration_state() (
   local sql
   sql_file=
 
+  # Invoked through the EXIT trap below.
+  # shellcheck disable=SC2317
   cleanup_migration_state_sql() {
     if [[ -n $sql_file ]]; then
       rm -f -- "$sql_file"


### PR DESCRIPTION
## Summary
- document the EXIT-trap invocation for the migration SQL cleanup function
- suppress only ShellCheck SC2317 at the function that is reached through the trap

## Verification
- bash syntax
- production deploy contract tests
- PostgreSQL migrator validation (70/70)
- secret scan
- source line cap
- git diff --check
