### PR TITLE
fix(deploy): preserve rollback images safely

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -191,6 +191,8 @@ jobs:
           bridge_release_paths=(
             .github/workflows/production-deploy.yml
             ops/deploy/README.md
+            ops/deploy/backend-image-rescue-lib.sh
+            ops/deploy/backend-image-rescue-lib.test.sh
             ops/deploy/deploy-control-lib.sh
             ops/deploy/deploy-control-lib.test.sh
             ops/deploy/postgres-runtime-deploy-lib.sh
@@ -263,6 +265,8 @@ jobs:
           fi
           deploy_shell_files=(
             ops/deploy/social-monitor-production-deploy.sh
+            ops/deploy/backend-image-rescue-lib.sh
+            ops/deploy/backend-image-rescue-lib.test.sh
             ops/deploy/deploy-control-lib.sh
             ops/deploy/deploy-control-lib.test.sh
             ops/deploy/github-production-deploy-client.sh
@@ -307,6 +311,7 @@ jobs:
             --bootstrap "$POSTGRES_POOL_BOOTSTRAP" \
             --bootstrap-sha "$POSTGRES_POOL_BOOTSTRAP_SHA"
           if [[ $bridge_phase == true ]]; then
+            bash ops/deploy/backend-image-rescue-lib.test.sh
             bash ops/deploy/deploy-control-lib.test.sh
           else
             bash ops/deploy/social-monitor-production-deploy.test.sh

--- a/ops/deploy/README.md
+++ b/ops/deploy/README.md
@@ -47,7 +47,8 @@ cannot silently skip an earlier component change.
   already contains tables created by the following migration;
 - only the 10 newest verified `pre-autodeploy` dumps are retained; manual,
   incident, partial and unknown backup artifacts are never pruned automatically;
-- previous container image IDs are retained and restored on runtime failure;
+- before any backend build, every rollback candidate is pinned to a validated
+  immutable `social-monitor-prod-rollback-rescue:<release>-<service>` tag;
 - frontend releases are immutable directories switched through symlinks;
 - failed frontend health checks restore the previous symlink targets;
 - database migrations are forward-only and are never automatically reversed.
@@ -85,11 +86,11 @@ containers stop and before replacements start, the gate queries live PostgreSQL
 capacity, reserved/role/database limits, and attributed external occupancy. It rejects operator-only
 capacity claims, requires stopped persistent runtime occupancy to be zero,
 enforces absolute and proportional headroom, and stops/removes
-old DB containers before starting replacements. Previous image IDs remain the
-rollback source. The old runtime-control symlink and systemd units are
+old DB containers before starting replacements. Validated project-scoped
+rescue tags remain the rollback source. The old runtime-control symlink and systemd units are
 snapshotted around the complete backend transaction; any backup, build,
 migration, replacement, or health failure restores those files and the prior
-containers from captured image IDs. A 16-connection read-only held-transaction
+containers from rescue tags. A 16-connection read-only held-transaction
 probe proves the maximum declared envelope before start. API readiness executes
 a real query through the bounded Prisma pool, and deployment holds a five-minute
 restart/proxy soak before advancing `backend.sha`. The soak captures per-service
@@ -99,6 +100,63 @@ and requires an ingestion queue tick with `failed=0`. The release-owned daily sc
 refuses to start until its
 release SHA equals the durable backend marker, which fences a host crash during
 the switch.
+
+## Backend image rescue lifecycle
+
+The rescue snapshot is a fail-closed prerequisite to every backend build. Each
+selected persistent service must have exactly one healthy running container.
+Deployment reads that container's recorded `.Image` and pins the image object
+under a full-release-SHA, project-scoped rescue tag. It validates that the tag
+resolves to the recorded image ID and never falls back to the mutable Compose
+`latest` tag for a running service.
+
+One bounded legacy-adoption exception handles Node-service containers whose
+still-running root filesystem exists after BuildKit removed their recorded
+image object. Only when `docker image inspect` of the recorded `.Image` fails,
+deployment requires the container to be running, non-restarting,
+non-OOM-killed, and healthy when a Docker healthcheck exists. The live
+entrypoint, command, working directory, user, and absent image healthcheck must
+exactly match the reviewed legacy Node image contract. Deployment then pauses
+the container, streams `docker container export` into `docker image import`,
+and rebuilds only the reviewed service-specific entrypoint, direct command,
+working directory, and user. It verifies that the reconstructed image has no
+`Config.Env`; production environment values and secrets are never copied into
+rescue image metadata.
+Compose reapplies the reviewed runtime environment and remounts the same
+external volumes during rollback. The mutable current tag is never used for
+this adoption path. The separately built `x-collector` has no reviewed legacy
+reconstruction in this bridge and therefore fails closed if its recorded image
+object is missing.
+
+`migrate` and `daily-runner` are explicit tag-only rollback candidates. They
+normally have no running container, so their current Compose image tag is
+pinned and validated before either tag can be rebuilt. Rollback restores both
+Compose tags but never recreates these one-shot containers: database migrations
+remain forward-only, and the control-owned daily runner starts only through its
+separate singleton/admission path.
+
+The atomically completed rescue manifest and its mode-`0600` phase record
+survive process interruption and are reused unchanged when the same release is
+retried. The phase is `prepared` until immediately before the first service is
+stopped or force-recreated, when it atomically becomes `replacement-started`.
+Preflight, backup, build, and migration failures therefore restore only Compose
+tags and never stop or recreate healthy containers. After replacement starts,
+rollback restores tags, recreates and verifies the captured persistent services
+once, then durably records `rollback-complete`; an outer retry caused by a
+separate runtime-control rollback failure cannot repeat the container rollback,
+and a same-release retry cannot reuse the restored rescue as a fresh snapshot.
+An interrupted or incomplete non-`prepared` rescue blocks a new runtime-control
+snapshot so the original rollback evidence remains available for operator
+recovery.
+
+A partial manifest cannot reach the build phase; HUP, INT, TERM, or the next
+locked deploy removes only that release's deterministic rescue tags. A failed
+release always attempts both backend image/container restoration and PostgreSQL
+runtime-control restoration, reports both failures, and retains rescue tags if
+either rollback is incomplete. Exact rescue tags and their state are removed
+only after the backend marker commits a successful release or after both halves
+of rollback complete. No Docker prune is used, and images or tags owned by
+other projects are never selected for cleanup.
 
 ## GitHub environment
 

--- a/ops/deploy/backend-image-rescue-lib.sh
+++ b/ops/deploy/backend-image-rescue-lib.sh
@@ -1,0 +1,628 @@
+#!/usr/bin/env bash
+
+# Sourced by social-monitor-production-deploy.sh after project paths, Compose,
+# and rollback verification helpers are defined. Rescue tags are deliberately
+# project-scoped and release-scoped; this library never invokes Docker prune.
+
+BACKEND_IMAGE_RESCUE_VERSION=social-monitor-backend-image-rescue-v1
+BACKEND_IMAGE_RESCUE_PHASE_VERSION=social-monitor-backend-image-rescue-phase-v1
+
+backend_image_rescue_state_file() {
+  local sha=$1
+  printf '%s/backend-image-rescue-%s.tsv\n' "$STATE" "$sha"
+}
+
+backend_image_rescue_phase_file() {
+  local state_file=$1
+  printf '%s.phase\n' "$state_file"
+}
+
+backend_image_rescue_tag() {
+  local sha=$1
+  local service=$2
+  printf '%s-rollback-rescue:%s-%s\n' "$PROJECT" "$sha" "$service"
+}
+
+backend_image_rescue_policy() {
+  case $1 in
+    migrate) printf 'tag-only-migrate\n' ;;
+    daily-runner) printf 'tag-only-daily-runner\n' ;;
+    api|agent-runtime|ingestion-worker|intelligence-worker|delivery-service|event-relay|x-collector)
+      printf 'recreate\n'
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+backend_image_rescue_known_services() {
+  printf '%s\n' \
+    migrate api agent-runtime ingestion-worker intelligence-worker \
+    delivery-service event-relay daily-runner x-collector
+}
+
+backend_image_rescue_image_id() {
+  docker image inspect "$1" --format '{{.Id}}' 2>/dev/null
+}
+
+backend_image_rescue_container_config() {
+  docker inspect "$1" --format \
+    '{{json .Config.Entrypoint}}|{{json .Config.Cmd}}|{{json .Config.WorkingDir}}|{{json .Config.User}}|{{json .Config.Healthcheck}}' \
+    2>/dev/null
+}
+
+backend_image_rescue_image_config() {
+  docker image inspect "$1" --format \
+    '{{json .Config.Entrypoint}}|{{json .Config.Cmd}}|{{json .Config.WorkingDir}}|{{json .Config.User}}|{{json .Config.Healthcheck}}' \
+    2>/dev/null
+}
+
+backend_image_rescue_image_env() {
+  docker image inspect "$1" --format '{{json .Config.Env}}' 2>/dev/null
+}
+
+backend_image_rescue_expected_legacy_container_config() {
+  case $1 in
+    api|agent-runtime|ingestion-worker|intelligence-worker|delivery-service|event-relay)
+      printf '%s\n' \
+        '["docker-entrypoint.sh"]|["sh","-c","case \"$SERVICE\" in api) exec node dist/apps/api-gateway/src/main.js ;; agent-runtime) exec node dist/apps/agent-runtime/src/main.js ;; ingestion) exec node dist/apps/ingestion-worker/src/main.js ;; intelligence) exec node dist/apps/intelligence-worker/src/main.js ;; delivery) exec node dist/apps/delivery-service/src/main.js ;; event-relay) exec node dist/apps/event-relay/src/main.js ;; *) echo \"Unknown service: $SERVICE\" >&2; exit 64 ;; esac"]|"/app"|"node"|null'
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+backend_image_rescue_reconstructed_command() {
+  case $1 in
+    api) printf '["/usr/local/bin/node","dist/apps/api-gateway/src/main.js"]\n' ;;
+    agent-runtime) printf '["/usr/local/bin/node","dist/apps/agent-runtime/src/main.js"]\n' ;;
+    ingestion-worker) printf '["/usr/local/bin/node","dist/apps/ingestion-worker/src/main.js"]\n' ;;
+    intelligence-worker) printf '["/usr/local/bin/node","dist/apps/intelligence-worker/src/main.js"]\n' ;;
+    delivery-service) printf '["/usr/local/bin/node","dist/apps/delivery-service/src/main.js"]\n' ;;
+    event-relay) printf '["/usr/local/bin/node","dist/apps/event-relay/src/main.js"]\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+backend_image_rescue_reconstructed_image_config() {
+  local command
+  command=$(backend_image_rescue_reconstructed_command "$1") || return 1
+  printf '["/usr/local/bin/docker-entrypoint.sh"]|%s|"/app"|"node"|null\n' \
+    "$command"
+}
+
+backend_image_rescue_verify_running_container() {
+  local container=$1
+  local state
+  state=$(docker inspect "$container" --format \
+    '{{.State.Status}}|{{.State.Running}}|{{.State.Restarting}}|{{.State.OOMKilled}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+    2>/dev/null) || return 1
+  [[ $state == 'running|true|false|false|none' || \
+     $state == 'running|true|false|false|healthy' ]]
+}
+
+backend_image_rescue_remove_tag() {
+  local rescue_tag=$1
+  if ! backend_image_rescue_image_id "$rescue_tag" >/dev/null; then
+    return 0
+  fi
+  docker image rm "$rescue_tag" >/dev/null || return 1
+  ! backend_image_rescue_image_id "$rescue_tag" >/dev/null
+}
+
+backend_image_rescue_validate_structure() {
+  local state_file=$1
+  [[ -f $state_file && ! -L $state_file && -s $state_file ]] || return 1
+  [[ $(stat -c '%a' "$state_file") == 600 ]] || return 1
+
+  local record target_sha manifest_project expected_tag expected_policy
+  local service policy source_kind source_ref image_id rescue_tag extra
+  local line_number=0 complete_line=0 declared_count=-1 actual_count=0
+  local saw_target=false saw_project=false saw_complete=false
+  local -A seen_services=()
+  while IFS=$'\t' read -r record service policy source_kind source_ref image_id rescue_tag extra; do
+    line_number=$((line_number + 1))
+    case $line_number:$record in
+      1:"$BACKEND_IMAGE_RESCUE_VERSION")
+        [[ -z $service$policy$source_kind$source_ref$image_id$rescue_tag$extra ]] || return 1
+        ;;
+      2:target)
+        [[ $saw_target == false && $service =~ ^[0-9a-f]{40}$ && \
+           -z $policy$source_kind$source_ref$image_id$rescue_tag$extra ]] || return 1
+        target_sha=$service
+        saw_target=true
+        ;;
+      3:project)
+        [[ $saw_project == false && $service =~ ^[a-z0-9][a-z0-9_.-]*$ && \
+           -z $policy$source_kind$source_ref$image_id$rescue_tag$extra ]] || return 1
+        manifest_project=$service
+        saw_project=true
+        ;;
+      *:image)
+        [[ $saw_target == true && $saw_project == true && $saw_complete == false ]] || return 1
+        [[ $service =~ ^[a-z0-9][a-z0-9-]*$ && \
+           $source_kind =~ ^(running-image|container-export-import|compose-tag)$ && \
+           $source_ref != *[$'\t\r\n ']* && \
+           $image_id =~ ^sha256:[0-9a-f]{64}$ && -z $extra ]] || return 1
+        [[ -z ${seen_services[$service]:-} ]] || return 1
+        expected_policy=$(backend_image_rescue_policy "$service")
+        [[ $policy == "$expected_policy" ]] || return 1
+        expected_tag=$(backend_image_rescue_tag "$target_sha" "$service")
+        [[ $rescue_tag == "$expected_tag" ]] || return 1
+        if [[ $policy == recreate ]]; then
+          [[ $source_kind == running-image || \
+             $source_kind == container-export-import ]] || return 1
+        fi
+        seen_services[$service]=1
+        actual_count=$((actual_count + 1))
+        ;;
+      *:complete)
+        [[ $saw_complete == false && $actual_count -gt 0 && \
+           $service =~ ^[0-9]+$ && \
+           -z $policy$source_kind$source_ref$image_id$rescue_tag$extra ]] || return 1
+        declared_count=$service
+        complete_line=$line_number
+        saw_complete=true
+        ;;
+      *) return 1 ;;
+    esac
+  done < "$state_file"
+
+  [[ $line_number -ge 5 && $complete_line -eq $line_number && \
+     $saw_target == true && \
+     $saw_project == true && $saw_complete == true && \
+     $manifest_project == "$PROJECT" && $declared_count -eq $actual_count ]]
+}
+
+backend_image_rescue_manifest_target() {
+  local state_file=$1
+  backend_image_rescue_validate_structure "$state_file" || return 1
+  awk -F '\t' '$1 == "target" {print $2; exit}' "$state_file"
+}
+
+backend_image_rescue_write_phase() (
+  set -uo pipefail
+  local state_file=$1
+  local phase=$2
+  local phase_file next manifest_name
+  [[ $phase == prepared || $phase == replacement-started || \
+     $phase == rollback-complete ]] || return 1
+  backend_image_rescue_validate_structure "$state_file" || return 1
+  phase_file=$(backend_image_rescue_phase_file "$state_file")
+  [[ ! -L $phase_file ]] || return 1
+  next=$phase_file.next.$$
+  manifest_name=${state_file##*/}
+  cleanup_phase_next() {
+    rm -f "$next"
+  }
+  trap cleanup_phase_next EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  umask 077
+  {
+    printf '%s\n' "$BACKEND_IMAGE_RESCUE_PHASE_VERSION"
+    printf 'manifest\t%s\nphase\t%s\n' "$manifest_name" "$phase"
+  } > "$next" || return 1
+  chmod 0600 "$next" || return 1
+  mv -f "$next" "$phase_file" || return 1
+  trap - EXIT HUP INT TERM
+)
+
+backend_image_rescue_read_phase() {
+  local state_file=$1
+  local phase_file manifest_name version_record version_extra
+  local manifest_record manifest_value manifest_extra
+  local phase_record phase_value phase_extra trailing
+  backend_image_rescue_validate_structure "$state_file" || return 1
+  phase_file=$(backend_image_rescue_phase_file "$state_file")
+  [[ -f $phase_file && ! -L $phase_file && -s $phase_file ]] || return 1
+  [[ $(stat -c '%a' "$phase_file") == 600 ]] || return 1
+  manifest_name=${state_file##*/}
+  {
+    IFS=$'\t' read -r version_record version_extra || return 1
+    IFS=$'\t' read -r manifest_record manifest_value manifest_extra || return 1
+    IFS=$'\t' read -r phase_record phase_value phase_extra || return 1
+    ! IFS= read -r trailing || return 1
+  } < "$phase_file"
+  [[ $version_record == "$BACKEND_IMAGE_RESCUE_PHASE_VERSION" && \
+     -z $version_extra && $manifest_record == manifest && \
+     $manifest_value == "$manifest_name" && -z $manifest_extra && \
+     $phase_record == phase && \
+     $phase_value =~ ^(prepared|replacement-started|rollback-complete)$ && \
+     -z $phase_extra ]] || return 1
+  printf '%s\n' "$phase_value"
+}
+
+backend_image_rescue_mark_replacement_started() {
+  local state_file=$1
+  local phase
+  phase=$(backend_image_rescue_read_phase "$state_file") || return 1
+  [[ $phase == replacement-started ]] && return 0
+  [[ $phase == prepared ]] || return 1
+  backend_image_rescue_write_phase "$state_file" replacement-started
+}
+
+backend_image_rescue_validate() {
+  local state_file=$1
+  shift
+  backend_image_rescue_validate_structure "$state_file" || return 1
+
+  local record service policy source_kind source_ref image_id rescue_tag extra
+  local actual_id
+  local -A expected=() captured=()
+  for service in "$@"; do
+    [[ -z ${expected[$service]:-} ]] || return 1
+    expected[$service]=1
+  done
+  while IFS=$'\t' read -r record service policy source_kind source_ref image_id rescue_tag extra; do
+    [[ $record == image ]] || continue
+    actual_id=$(backend_image_rescue_image_id "$rescue_tag") || return 1
+    [[ $actual_id == "$image_id" ]] || return 1
+    captured[$service]=1
+  done < "$state_file"
+  if ((${#expected[@]} > 0)); then
+    ((${#captured[@]} == ${#expected[@]})) || return 1
+    for service in "${!expected[@]}"; do
+      [[ -n ${captured[$service]:-} ]] || return 1
+    done
+  fi
+}
+
+backend_image_rescue_reconstruct_running_container() (
+  set -uo pipefail
+  local service=$1
+  local container=$2
+  local rescue_tag=$3
+  local command expected_container_config actual_container_config
+  local expected_image_config actual_image_config image_env imported_id inspected_id
+  local paused=false unpause_status=0
+
+  command=$(backend_image_rescue_reconstructed_command "$service") || {
+    printf 'deploy-error: missing-image rescue has no reviewed reconstruction for %s\n' \
+      "$service" >&2
+    return 1
+  }
+  expected_container_config=$(
+    backend_image_rescue_expected_legacy_container_config "$service"
+  ) || return 1
+  actual_container_config=$(backend_image_rescue_container_config "$container") || return 1
+  if [[ $actual_container_config != "$expected_container_config" ]]; then
+    printf 'deploy-error: missing-image rescue config is not the reviewed legacy config for %s\n' \
+      "$service" >&2
+    return 1
+  fi
+
+  unpause_container() {
+    [[ $paused == true ]] || return 0
+    docker container unpause "$container" >/dev/null || return 1
+    paused=false
+  }
+  cleanup_paused_container() {
+    unpause_container || true
+  }
+  trap cleanup_paused_container EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  paused=true
+  if ! docker container pause "$container" >/dev/null; then
+    paused=false
+    return 1
+  fi
+  if ! imported_id=$(
+    docker container export "$container" | \
+      docker image import \
+        --change 'ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]' \
+        --change "CMD $command" \
+        --change 'WORKDIR /app' \
+        --change 'USER node' \
+        - "$rescue_tag"
+  ); then
+    unpause_container || unpause_status=$?
+    ((unpause_status == 0)) || \
+      printf 'deploy-error: missing-image rescue import and container unpause both failed for %s\n' \
+        "$service" >&2
+    return 1
+  fi
+  unpause_container || return 1
+  trap - EXIT HUP INT TERM
+
+  [[ $imported_id =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+  inspected_id=$(backend_image_rescue_image_id "$rescue_tag") || return 1
+  [[ $inspected_id == "$imported_id" ]] || return 1
+  expected_image_config=$(
+    backend_image_rescue_reconstructed_image_config "$service"
+  ) || return 1
+  actual_image_config=$(backend_image_rescue_image_config "$rescue_tag") || return 1
+  [[ $actual_image_config == "$expected_image_config" ]] || return 1
+  image_env=$(backend_image_rescue_image_env "$rescue_tag") || return 1
+  [[ $image_env == null || $image_env == '[]' ]] || return 1
+  backend_image_rescue_verify_running_container "$container" || return 1
+  printf 'backend-image-rescue: safely reconstructed missing running image for service %s\n' \
+    "$service" >&2
+)
+
+backend_image_rescue_pin_running_container() {
+  local service=$1
+  local container=$2
+  local rescue_tag=$3
+  local source_kind_name=$4
+  local image_id_name=$5
+  local recorded_id inspected_id reconstructed_id
+
+  backend_image_rescue_verify_running_container "$container" || return 1
+  recorded_id=$(docker inspect "$container" --format '{{.Image}}' 2>/dev/null) || return 1
+  [[ $recorded_id =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+  inspected_id=$(backend_image_rescue_image_id "$recorded_id" || true)
+  if [[ -n $inspected_id ]]; then
+    [[ $inspected_id == "$recorded_id" ]] || return 1
+    docker image tag "$recorded_id" "$rescue_tag" >/dev/null || return 1
+    printf -v "$source_kind_name" '%s' running-image
+    printf -v "$image_id_name" '%s' "$recorded_id"
+    return 0
+  fi
+
+  # The recorded object is gone, so preserve only the paused root filesystem.
+  # Rebuild metadata from a reviewed, service-specific config with no Env.
+  backend_image_rescue_reconstruct_running_container \
+    "$service" "$container" "$rescue_tag" || return 1
+  reconstructed_id=$(backend_image_rescue_image_id "$rescue_tag") || return 1
+  [[ $reconstructed_id =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+  printf -v "$source_kind_name" '%s' container-export-import
+  printf -v "$image_id_name" '%s' "$reconstructed_id"
+}
+
+backend_image_rescue_pin_service() {
+  local sha=$1
+  local service=$2
+  local policy=$3
+  local source_kind_name=$4
+  local source_ref_name=$5
+  local image_id_name=$6
+  local rescue_tag compose_tag pinned_id
+  local source_kind_value source_ref_value image_id_value
+  local -a container_ids=()
+
+  rescue_tag=$(backend_image_rescue_tag "$sha" "$service")
+  mapfile -t container_ids < <(
+    "${COMPOSE[@]}" --profile app --profile daily ps -q "$service"
+  )
+  ((${#container_ids[@]} <= 1)) || return 1
+  if ((${#container_ids[@]} == 1)); then
+    source_ref_value=${container_ids[0]}
+    verify_backend_with_retry "$service" || return 1
+    backend_image_rescue_pin_running_container \
+      "$service" "$source_ref_value" "$rescue_tag" \
+      source_kind_value image_id_value || return 1
+  else
+    [[ $policy != recreate ]] || return 1
+    compose_tag=$(compose_image_name "$service")
+    pinned_id=$(backend_image_rescue_image_id "$compose_tag") || return 1
+    [[ $pinned_id =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+    docker image tag "$compose_tag" "$rescue_tag" >/dev/null || return 1
+    source_kind_value=compose-tag
+    source_ref_value=$compose_tag
+    image_id_value=$pinned_id
+  fi
+  pinned_id=$(backend_image_rescue_image_id "$rescue_tag") || return 1
+  [[ $pinned_id == "$image_id_value" ]] || return 1
+  printf -v "$source_kind_name" '%s' "$source_kind_value"
+  printf -v "$source_ref_name" '%s' "$source_ref_value"
+  printf -v "$image_id_name" '%s' "$image_id_value"
+}
+
+backend_image_rescue_cleanup_abandoned_partials() {
+  local partial sha service rescue_tag phase_file status=0
+  local -a partials=("$STATE"/backend-image-rescue-*.tsv.partial)
+  [[ -e ${partials[0]} || -L ${partials[0]} ]] || return 0
+  for partial in "${partials[@]}"; do
+    if [[ $partial =~ /backend-image-rescue-([0-9a-f]{40})[.]tsv[.]partial$ ]]; then
+      sha=${BASH_REMATCH[1]}
+    else
+      return 1
+    fi
+    while read -r service; do
+      rescue_tag=$(backend_image_rescue_tag "$sha" "$service")
+      backend_image_rescue_remove_tag "$rescue_tag" || status=1
+    done < <(backend_image_rescue_known_services)
+    phase_file=$(backend_image_rescue_phase_file "${partial%.partial}")
+    ((status == 0)) && rm -f "$partial" "$phase_file"
+  done
+  return "$status"
+}
+
+backend_image_rescue_prepare() (
+  set -uo pipefail
+  local sha=$1
+  local state_file=$2
+  shift 2
+  local -a services=("$@")
+  local partial=$state_file.partial
+  local other service policy source_kind source_ref image_id rescue_tag phase
+  local snapshot_complete=false
+
+  [[ $sha =~ ^[0-9a-f]{40}$ && ${#services[@]} -gt 0 ]] || return 1
+  [[ $state_file == "$(backend_image_rescue_state_file "$sha")" ]] || return 1
+  if [[ -e $state_file || -L $state_file ]]; then
+    backend_image_rescue_validate "$state_file" "${services[@]}" || return 1
+    phase=$(backend_image_rescue_read_phase "$state_file") || return 1
+    if [[ $phase != prepared ]]; then
+      printf 'deploy-error: backend image rescue requires rollback before release retry (phase=%s)\n' \
+        "$phase" >&2
+      return 1
+    fi
+    return 0
+  fi
+  backend_image_rescue_cleanup_abandoned_partials || return 1
+  local -a completed=("$STATE"/backend-image-rescue-*.tsv)
+  if [[ -e ${completed[0]} || -L ${completed[0]} ]]; then
+    for other in "${completed[@]}"; do
+      [[ $other == "$state_file" ]] || {
+        printf 'deploy-error: unfinished backend image rescue snapshot blocks a different release: %s\n' \
+          "$other" >&2
+        return 1
+      }
+    done
+  fi
+
+  cleanup_partial_snapshot() {
+    local cleanup_service cleanup_tag phase_file
+    [[ $snapshot_complete == false ]] || return 0
+    for cleanup_service in "${services[@]}"; do
+      cleanup_tag=$(backend_image_rescue_tag "$sha" "$cleanup_service")
+      backend_image_rescue_remove_tag "$cleanup_tag" || true
+    done
+    phase_file=$(backend_image_rescue_phase_file "$state_file")
+    rm -f "$partial" "$state_file" "$phase_file"
+  }
+  trap cleanup_partial_snapshot EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  install -d -m 0755 "$STATE" || return 1
+  umask 077
+  : > "$partial" || return 1
+  chmod 0600 "$partial" || return 1
+  printf '%s\n' "$BACKEND_IMAGE_RESCUE_VERSION" >> "$partial"
+  printf 'target\t%s\nproject\t%s\n' "$sha" "$PROJECT" >> "$partial"
+  for service in "${services[@]}"; do
+    [[ $service =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
+    policy=$(backend_image_rescue_policy "$service")
+    rescue_tag=$(backend_image_rescue_tag "$sha" "$service")
+    backend_image_rescue_remove_tag "$rescue_tag" || return 1
+    backend_image_rescue_pin_service \
+      "$sha" "$service" "$policy" source_kind source_ref image_id || return 1
+    printf 'image\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$service" "$policy" "$source_kind" "$source_ref" "$image_id" \
+      "$rescue_tag" >> "$partial"
+  done
+  printf 'complete\t%d\n' "${#services[@]}" >> "$partial"
+  backend_image_rescue_validate "$partial" "${services[@]}" || return 1
+
+  trap '' HUP INT TERM
+  mv -f "$partial" "$state_file" || return 1
+  backend_image_rescue_write_phase "$state_file" prepared || return 1
+  snapshot_complete=true
+  trap - EXIT HUP INT TERM
+)
+
+backend_image_rescue_restore_tags() {
+  local state_file=$1
+  local record service policy source_kind source_ref image_id rescue_tag extra
+  local restored_id status=0
+  backend_image_rescue_validate "$state_file" || return 1
+  while IFS=$'\t' read -r record service policy source_kind source_ref image_id rescue_tag extra; do
+    [[ $record == image ]] || continue
+    if ! docker image tag "$rescue_tag" "$(compose_image_name "$service")" >/dev/null; then
+      printf 'deploy-error: failed to restore Compose tag for %s from %s\n' \
+        "$service" "$rescue_tag" >&2
+      status=1
+      continue
+    fi
+    restored_id=$(backend_image_rescue_image_id "$(compose_image_name "$service")" || true)
+    if [[ $restored_id != "$image_id" ]]; then
+      printf 'deploy-error: restored Compose tag validation failed for %s\n' \
+        "$service" >&2
+      status=1
+    fi
+  done < "$state_file"
+  return "$status"
+}
+
+rollback_backend_images() {
+  local state_file=$1
+  [[ -e $state_file || -L $state_file ]] || return 0
+  local record service policy source_kind source_ref image_id rescue_tag extra
+  local phase api_rolled_back=false
+  local -a rollback_services=()
+
+  phase=$(backend_image_rescue_read_phase "$state_file") || return 1
+  [[ $phase != rollback-complete ]] || return 0
+  backend_image_rescue_restore_tags "$state_file" || return 1
+  if [[ $phase == prepared ]]; then
+    backend_image_rescue_write_phase "$state_file" rollback-complete
+    return
+  fi
+  [[ $phase == replacement-started ]] || return 1
+  while IFS=$'\t' read -r record service policy source_kind source_ref image_id rescue_tag extra; do
+    [[ $record == image && $policy == recreate ]] || continue
+    rollback_services+=("$service")
+    [[ $service == api ]] && api_rolled_back=true
+  done < "$state_file"
+  if ((${#rollback_services[@]} > 0)); then
+    stop_and_remove_database_services "${rollback_services[@]}" || return 1
+    "${COMPOSE[@]}" --profile app up -d --no-deps --force-recreate \
+      "${rollback_services[@]}" || return 1
+    verify_backend_with_retry "${rollback_services[@]}" || return 1
+    if [[ $api_rolled_back == true ]]; then
+      refresh_frontend_api_proxy || return 1
+    fi
+  fi
+  # This durable terminal phase makes a successful backend rollback idempotent
+  # even when runtime-control restoration later fails and the rescue is kept.
+  # It also prevents a same-release retry from treating a restored rescue as a
+  # fresh pre-replacement snapshot.
+  backend_image_rescue_write_phase "$state_file" rollback-complete
+}
+
+rollback_backend_and_runtime_control() {
+  local backend_required=$1
+  local state_file=$2
+  local runtime_control_backup=$3
+  local backend_status=0 runtime_status=0 cleanup_status=0
+
+  if [[ $backend_required == true ]]; then
+    rollback_backend_images "$state_file" || backend_status=$?
+  fi
+  restore_postgres_runtime_control "$runtime_control_backup" || runtime_status=$?
+
+  if ((backend_status != 0)); then
+    printf 'deploy-error: backend image/container rollback failed (status=%d)\n' \
+      "$backend_status" >&2
+  fi
+  if ((runtime_status != 0)); then
+    printf 'deploy-error: PostgreSQL runtime-control rollback failed (status=%d)\n' \
+      "$runtime_status" >&2
+  fi
+  if ((backend_status == 0 && runtime_status == 0)) && \
+     [[ $backend_required == true ]]; then
+    backend_image_rescue_cleanup "$state_file" || cleanup_status=$?
+    if ((cleanup_status != 0)); then
+      printf 'deploy-error: completed rollback could not remove exact rescue tags (status=%d)\n' \
+        "$cleanup_status" >&2
+    fi
+  fi
+  ((backend_status == 0 && runtime_status == 0 && cleanup_status == 0))
+}
+
+backend_image_rescue_cleanup() {
+  local state_file=$1
+  [[ -e $state_file || -L $state_file ]] || return 0
+  backend_image_rescue_validate_structure "$state_file" || return 1
+  local record service policy source_kind source_ref image_id rescue_tag extra
+  local phase_file
+  local status=0
+  while IFS=$'\t' read -r record service policy source_kind source_ref image_id rescue_tag extra; do
+    [[ $record == image ]] || continue
+    backend_image_rescue_remove_tag "$rescue_tag" || status=1
+  done < "$state_file"
+  if ((status == 0)); then
+    phase_file=$(backend_image_rescue_phase_file "$state_file")
+    rm -f "$state_file" "$state_file.partial" "$phase_file"
+  fi
+  return "$status"
+}
+
+reconcile_completed_backend_image_rescues() {
+  local backend_marker state_file target
+  local -a state_files=("$STATE"/backend-image-rescue-*.tsv)
+  [[ -e ${state_files[0]} || -L ${state_files[0]} ]] || return 0
+  backend_marker=$(marker_value backend)
+  for state_file in "${state_files[@]}"; do
+    target=$(backend_image_rescue_manifest_target "$state_file") || return 1
+    if [[ -n $backend_marker && $target == "$backend_marker" ]]; then
+      backend_image_rescue_cleanup "$state_file" || return 1
+    fi
+  done
+}

--- a/ops/deploy/backend-image-rescue-lib.test.sh
+++ b/ops/deploy/backend-image-rescue-lib.test.sh
@@ -1,0 +1,603 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LIBRARY=$SCRIPT_DIR/backend-image-rescue-lib.sh
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/backend-image-rescue-test.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+
+PROJECT=fixture-project
+FAKE_DOCKER_REFS=$FIXTURE/docker-refs.tsv
+FAKE_DOCKER_CONTAINERS=$FIXTURE/docker-containers.tsv
+FAKE_COMPOSE_CONTAINERS=$FIXTURE/compose-containers.tsv
+EVENT_LOG=$FIXTURE/events.log
+export FAKE_DOCKER_REFS FAKE_DOCKER_CONTAINERS EVENT_LOG
+
+ID_A=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+ID_B=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ID_C=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ID_D=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+ID_E=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+LEGACY_CONFIG='["docker-entrypoint.sh"]|["sh","-c","case \"$SERVICE\" in api) exec node dist/apps/api-gateway/src/main.js ;; agent-runtime) exec node dist/apps/agent-runtime/src/main.js ;; ingestion) exec node dist/apps/ingestion-worker/src/main.js ;; intelligence) exec node dist/apps/intelligence-worker/src/main.js ;; delivery) exec node dist/apps/delivery-service/src/main.js ;; event-relay) exec node dist/apps/event-relay/src/main.js ;; *) echo \"Unknown service: $SERVICE\" >&2; exit 64 ;; esac"]|"/app"|"node"|null'
+CONFIG='["/entry"]|["node","dist/main.js"]|"/app"|"node"|null'
+SAFE_API_CONFIG='["/usr/local/bin/docker-entrypoint.sh"]|["/usr/local/bin/node","dist/apps/api-gateway/src/main.js"]|"/app"|"node"|null'
+SENTINEL_ENV='["RESCUE_SENTINEL_DO_NOT_PERSIST=fixture-only-value"]'
+export SAFE_API_CONFIG
+SHA=1111111111111111111111111111111111111111
+
+FAKE_BIN=$FIXTURE/bin
+install -d "$FAKE_BIN"
+cat > "$FAKE_BIN/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+lookup_ref() {
+  awk -F '\t' -v ref="$1" '$1 == ref {print $2; exit}' "$FAKE_DOCKER_REFS"
+}
+
+lookup_ref_config() {
+  awk -F '\t' -v ref="$1" '$1 == ref {print $3; exit}' "$FAKE_DOCKER_REFS"
+}
+
+lookup_ref_env() {
+  awk -F '\t' -v ref="$1" '$1 == ref {print $4; exit}' "$FAKE_DOCKER_REFS"
+}
+
+set_ref() {
+  local ref=$1 image_id=$2 config=$3 env=${4:-null}
+  local next=$FAKE_DOCKER_REFS.next.$$
+  awk -F '\t' -v ref="$ref" '$1 != ref' "$FAKE_DOCKER_REFS" > "$next"
+  printf '%s\t%s\t%s\t%s\n' "$ref" "$image_id" "$config" "$env" >> "$next"
+  mv -f "$next" "$FAKE_DOCKER_REFS"
+}
+
+remove_ref() {
+  local ref=$1 next=$FAKE_DOCKER_REFS.next.$$
+  awk -F '\t' -v ref="$ref" '$1 != ref' "$FAKE_DOCKER_REFS" > "$next"
+  mv -f "$next" "$FAKE_DOCKER_REFS"
+}
+
+append_docker_event() {
+  local row=docker argument
+  for argument in "$@"; do
+    printf -v row '%s\t%s' "$row" "$argument"
+  done
+  {
+    flock 9
+    printf '%s\n' "$row" >&9
+  } 9>> "$EVENT_LOG"
+}
+
+append_docker_event "$@"
+
+case ${1:-}:${2:-} in
+  image:inspect)
+    image_id=$(lookup_ref "$3")
+    [[ -n $image_id ]] || exit 1
+    if [[ ${*: -1} == *'.Id'* ]]; then
+      printf '%s\n' "$image_id"
+    elif [[ ${*: -1} == *'.Config.Env'* ]]; then
+      lookup_ref_env "$3"
+    else
+      lookup_ref_config "$3"
+    fi
+    ;;
+  image:tag)
+    image_id=$(lookup_ref "$3")
+    [[ -n $image_id ]] || exit 1
+    config=$(lookup_ref_config "$3")
+    env=$(lookup_ref_env "$3")
+    set_ref "$4" "$image_id" "$config" "$env"
+    if [[ ${FAKE_DOCKER_SIGNAL_TAG:-} == "$4" ]]; then
+      kill -TERM "$PPID"
+    fi
+    ;;
+  image:rm)
+    [[ -n $(lookup_ref "$3") ]] || exit 1
+    remove_ref "$3"
+    ;;
+  inspect:*)
+    container=$2
+    row=$(awk -F '\t' -v container="$container" \
+      '$1 == container {print; exit}' "$FAKE_DOCKER_CONTAINERS")
+    [[ -n $row ]] || exit 1
+    IFS=$'\t' read -r _ image_id state config env <<< "$row"
+    case ${*: -1} in
+      *'.Image'*) printf '%s\n' "$image_id" ;;
+      *'.State.Status'*) printf '%s\n' "$state" ;;
+      *) printf '%s\n' "$config" ;;
+    esac
+    ;;
+  container:pause|container:unpause)
+    [[ -n ${3:-} ]]
+    ;;
+  container:export)
+    [[ -n ${3:-} ]]
+    printf 'fixture-root-filesystem:%s\n' "$3"
+    ;;
+  image:import)
+    cat >/dev/null
+    [[ ${FAKE_IMPORT_STATUS:-0} == 0 ]] || exit "$FAKE_IMPORT_STATUS"
+    rescue_tag=${*: -1}
+    set_ref "$rescue_tag" "$FAKE_DOCKER_IMPORT_ID" \
+      "$SAFE_API_CONFIG" '[]'
+    printf '%s\n' "$FAKE_DOCKER_IMPORT_ID"
+    ;;
+  *) exit 90 ;;
+esac
+SH
+chmod 0755 "$FAKE_BIN/docker"
+PATH=$FAKE_BIN:$PATH
+
+compose_image_name() {
+  printf '%s-%s:latest\n' "$PROJECT" "$1"
+}
+
+append_compose_event() {
+  local row=compose argument
+  for argument in "$@"; do
+    printf -v row '%s\t%s' "$row" "$argument"
+  done
+  {
+    flock 9
+    printf '%s\n' "$row" >&9
+  } 9>> "$EVENT_LOG"
+}
+
+fake_compose() {
+  append_compose_event "$@"
+  if [[ $* == *' ps -q '* ]]; then
+    local service=${*: -1}
+    awk -F '\t' -v service="$service" '$1 == service {print $2}' \
+      "$FAKE_COMPOSE_CONTAINERS"
+    return 0
+  fi
+  [[ $* == *' up -d --no-deps --force-recreate '* ]] || return 91
+  [[ ${FAKE_COMPOSE_UP_STATUS:-0} == 0 ]]
+}
+
+COMPOSE=(fake_compose)
+
+stop_and_remove_database_services() {
+  printf 'stop-database\t%s\n' "$*" >> "$EVENT_LOG"
+  [[ ${FAKE_STOP_STATUS:-0} == 0 ]]
+}
+
+verify_backend_with_retry() {
+  printf 'verify-backend\t%s\n' "$*" >> "$EVENT_LOG"
+  [[ ${FAKE_VERIFY_STATUS:-0} == 0 ]]
+}
+
+refresh_frontend_api_proxy() {
+  printf 'refresh-proxy\n' >> "$EVENT_LOG"
+  [[ ${FAKE_PROXY_STATUS:-0} == 0 ]]
+}
+
+marker_value() {
+  [[ -s $STATE/backend.sha ]] && tr -d '\n' < "$STATE/backend.sha"
+}
+
+# shellcheck source=ops/deploy/backend-image-rescue-lib.sh
+source "$LIBRARY"
+
+reset_case() {
+  local name=$1
+  STATE=$FIXTURE/$name/state
+  install -d "$STATE"
+  : > "$FAKE_DOCKER_REFS"
+  : > "$FAKE_DOCKER_CONTAINERS"
+  : > "$FAKE_COMPOSE_CONTAINERS"
+  : > "$EVENT_LOG"
+  FAKE_DOCKER_IMPORT_ID=$ID_E
+  export FAKE_DOCKER_IMPORT_ID
+  unset FAKE_DOCKER_SIGNAL_TAG FAKE_COMPOSE_UP_STATUS FAKE_STOP_STATUS \
+    FAKE_VERIFY_STATUS FAKE_PROXY_STATUS FAKE_IMPORT_STATUS
+}
+
+add_ref() {
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "${3:-$CONFIG}" "${4:-null}" \
+    >> "$FAKE_DOCKER_REFS"
+}
+
+add_container() {
+  printf '%s\t%s\t%s\t%s\t%s\n' "$2" "$3" \
+    "${4:-running|true|false|false|none}" "${5:-$CONFIG}" "${6:-[]}" \
+    >> "$FAKE_DOCKER_CONTAINERS"
+  printf '%s\t%s\n' "$1" "$2" >> "$FAKE_COMPOSE_CONTAINERS"
+}
+
+set_ref_direct() {
+  local ref=$1 image_id=$2 config=${3:-$CONFIG} env=${4:-null}
+  local next=$FAKE_DOCKER_REFS.next
+  awk -F '\t' -v ref="$ref" '$1 != ref' "$FAKE_DOCKER_REFS" > "$next"
+  printf '%s\t%s\t%s\t%s\n' "$ref" "$image_id" "$config" "$env" >> "$next"
+  mv -f "$next" "$FAKE_DOCKER_REFS"
+}
+
+ref_id() {
+  awk -F '\t' -v ref="$1" '$1 == ref {print $2; exit}' "$FAKE_DOCKER_REFS"
+}
+
+assert_no_rescue_refs() {
+  if awk -F '\t' -v prefix="$PROJECT-rollback-rescue:" \
+    'index($1, prefix) == 1 {found=1} END {exit !found}' "$FAKE_DOCKER_REFS"; then
+    echo 'unexpected rescue tag remained' >&2
+    exit 1
+  fi
+}
+
+# Running services are pinned from their recorded image IDs. The migrate and
+# daily-runner one-shot policies pin their existing Compose tags, but rollback
+# never attempts to recreate those containers.
+reset_case normal
+add_ref "$ID_A" "$ID_A"
+add_ref "$(compose_image_name migrate)" "$ID_B"
+add_ref "$(compose_image_name daily-runner)" "$ID_C"
+add_ref other-project-rollback-rescue:keep "$ID_D"
+add_container api api-container "$ID_A"
+normal_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$normal_state" api migrate daily-runner
+backend_image_rescue_validate "$normal_state" api migrate daily-runner
+[[ $(stat -c '%a' "$normal_state") == 600 ]]
+[[ $(backend_image_rescue_read_phase "$normal_state") == prepared ]]
+[[ $(stat -c '%a' "$(backend_image_rescue_phase_file "$normal_state")") == 600 ]]
+grep -F $'image\tapi\trecreate\trunning-image\tapi-container' "$normal_state" >/dev/null
+grep -F $'image\tmigrate\ttag-only-migrate\tcompose-tag' "$normal_state" >/dev/null
+grep -F $'image\tdaily-runner\ttag-only-daily-runner\tcompose-tag' "$normal_state" >/dev/null
+if grep -F $'docker\tcommit' "$EVENT_LOG" >/dev/null; then
+  echo 'ordinary image pin unexpectedly used docker commit' >&2
+  exit 1
+fi
+backend_image_rescue_cleanup "$normal_state"
+[[ ! -e $normal_state ]]
+[[ $(ref_id other-project-rollback-rescue:keep) == "$ID_D" ]]
+assert_no_rescue_refs
+
+# If and only if the running container's recorded image object is missing, a
+# reviewed Node-service config can reconstruct a paused filesystem export. The
+# production container Env, including a sentinel secret, is never copied.
+reset_case adoption
+add_container api adopted-api "$ID_A" 'running|true|false|false|healthy' \
+  "$LEGACY_CONFIG" "$SENTINEL_ENV"
+adoption_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$adoption_state" api
+grep -F $'image\tapi\trecreate\tcontainer-export-import\tadopted-api' \
+  "$adoption_state" >/dev/null
+grep -F $'docker\tcontainer\tpause\tadopted-api' "$EVENT_LOG" >/dev/null
+grep -F $'docker\tcontainer\texport\tadopted-api' "$EVENT_LOG" >/dev/null
+grep -F $'docker\timage\timport' "$EVENT_LOG" >/dev/null
+grep -F $'docker\tcontainer\tunpause\tadopted-api' "$EVENT_LOG" >/dev/null
+[[ $(ref_id "$(backend_image_rescue_tag "$SHA" api)") == "$ID_E" ]]
+adopted_config=$(
+  backend_image_rescue_image_config "$(backend_image_rescue_tag "$SHA" api)"
+)
+adopted_env=$(
+  backend_image_rescue_image_env "$(backend_image_rescue_tag "$SHA" api)"
+)
+[[ $adopted_config == "$SAFE_API_CONFIG" ]]
+[[ $adopted_config != *RESCUE_SENTINEL_DO_NOT_PERSIST* ]]
+[[ $adopted_env == '[]' ]]
+[[ $adopted_env != *RESCUE_SENTINEL_DO_NOT_PERSIST* ]]
+if grep -F $'docker\tcommit' "$EVENT_LOG" >/dev/null; then
+  echo 'safe missing-image reconstruction unexpectedly used docker commit' >&2
+  exit 1
+fi
+
+# A completed snapshot is immutable across an interrupted deploy retry. It is
+# validated and reused instead of being overwritten from current/latest tags.
+tag_count_before=$(grep -c $'docker\timage\ttag' "$EVENT_LOG" || true)
+import_count_before=$(grep -c $'docker\timage\timport' "$EVENT_LOG" || true)
+set_ref_direct "$(compose_image_name api)" "$ID_B"
+backend_image_rescue_prepare "$SHA" "$adoption_state" api
+tag_count_after=$(grep -c $'docker\timage\ttag' "$EVENT_LOG" || true)
+import_count_after=$(grep -c $'docker\timage\timport' "$EVENT_LOG" || true)
+((tag_count_before == tag_count_after && import_count_before == import_count_after))
+backend_image_rescue_cleanup "$adoption_state"
+
+# Missing or unhealthy required persistent containers fail closed and leave no
+# tag or state that could let a build begin with a partial snapshot.
+reset_case missing-running
+missing_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$missing_state" api
+missing_status=$?
+set -e
+((missing_status != 0))
+[[ ! -e $missing_state && ! -e $missing_state.partial ]]
+assert_no_rescue_refs
+
+reset_case unhealthy-running
+add_ref "$ID_A" "$ID_A"
+add_container api unhealthy-api "$ID_A" 'running|true|false|false|unhealthy'
+unhealthy_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$unhealthy_state" api
+unhealthy_status=$?
+set -e
+((unhealthy_status != 0))
+[[ ! -e $unhealthy_state && ! -e $unhealthy_state.partial ]]
+assert_no_rescue_refs
+
+reset_case config-mismatch
+add_container api mismatch-api "$ID_A" 'running|true|false|false|healthy' \
+  '[]|[]|"/wrong"|"root"' "$SENTINEL_ENV"
+mismatch_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$mismatch_state" api
+mismatch_status=$?
+set -e
+((mismatch_status != 0))
+[[ ! -e $mismatch_state && ! -e $mismatch_state.partial ]]
+assert_no_rescue_refs
+
+# The separate x-collector image has no reviewed reconstruction in this bridge.
+# Its explicit missing-image edge fails closed without pausing or exporting it.
+reset_case unsupported-missing-image
+add_container x-collector missing-x "$ID_A" 'running|true|false|false|healthy' \
+  '[]|[]|"/srv"|"collector"' "$SENTINEL_ENV"
+unsupported_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$unsupported_state" x-collector
+unsupported_status=$?
+set -e
+((unsupported_status != 0))
+[[ ! -e $unsupported_state && ! -e $unsupported_state.partial ]]
+if grep -E $'docker\tcontainer\t(pause|export)\tmissing-x' "$EVENT_LOG" >/dev/null; then
+  echo 'unsupported missing image was touched before fail-closed validation' >&2
+  exit 1
+fi
+assert_no_rescue_refs
+
+# A failed import always unpauses the healthy container and removes the exact
+# partial rescue tag/state; it never falls back to copying container metadata.
+reset_case import-failure
+add_container api import-failure-api "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+export FAKE_IMPORT_STATUS=73
+import_failure_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$import_failure_state" api
+import_failure_status=$?
+set -e
+((import_failure_status != 0))
+grep -F $'docker\tcontainer\tunpause\timport-failure-api' "$EVENT_LOG" >/dev/null
+[[ ! -e $import_failure_state && ! -e $import_failure_state.partial ]]
+assert_no_rescue_refs
+unset FAKE_IMPORT_STATUS
+
+# HUP/INT/TERM use the same partial-snapshot cleanup path. A simulated TERM
+# after the first tag proves the exact tag and partial ledger are removed.
+reset_case signal-cleanup
+add_ref "$ID_A" "$ID_A"
+add_container api signal-api "$ID_A"
+signal_state=$(backend_image_rescue_state_file "$SHA")
+export FAKE_DOCKER_SIGNAL_TAG
+FAKE_DOCKER_SIGNAL_TAG=$(backend_image_rescue_tag "$SHA" api)
+set +e
+backend_image_rescue_prepare "$SHA" "$signal_state" api
+signal_status=$?
+set -e
+((signal_status != 0))
+[[ ! -e $signal_state && ! -e $signal_state.partial ]]
+assert_no_rescue_refs
+unset FAKE_DOCKER_SIGNAL_TAG
+
+# A SIGKILL-style abandoned partial cannot have reached build. The following
+# deploy removes only deterministic project rescue names and preserves another
+# project's similarly named tag.
+reset_case abandoned-partial
+abandoned_sha=2222222222222222222222222222222222222222
+abandoned_partial=$STATE/backend-image-rescue-$abandoned_sha.tsv.partial
+: > "$abandoned_partial"
+add_ref "$(backend_image_rescue_tag "$abandoned_sha" api)" "$ID_A"
+add_ref other-project-rollback-rescue:keep "$ID_D"
+add_ref "$ID_B" "$ID_B"
+add_container api next-api "$ID_B"
+next_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$next_state" api
+[[ ! -e $abandoned_partial ]]
+[[ -z $(ref_id "$(backend_image_rescue_tag "$abandoned_sha" api)") ]]
+[[ $(ref_id other-project-rollback-rescue:keep) == "$ID_D" ]]
+backend_image_rescue_cleanup "$next_state"
+
+# Before replacement, rollback restores every Compose tag but leaves all
+# healthy containers untouched. This covers failures in preflight, backup,
+# build, and migration, which all occur while the durable phase is prepared.
+reset_case rollback-before-replacement
+add_ref "$ID_A" "$ID_A"
+add_ref "$(compose_image_name migrate)" "$ID_B"
+add_ref "$(compose_image_name daily-runner)" "$ID_C"
+add_ref other-project-rollback-rescue:keep "$ID_D"
+add_container api rollback-api "$ID_A"
+rollback_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$rollback_state" api migrate daily-runner
+set_ref_direct "$(compose_image_name api)" "$ID_E"
+set_ref_direct "$(compose_image_name migrate)" "$ID_E"
+set_ref_direct "$(compose_image_name daily-runner)" "$ID_E"
+: > "$EVENT_LOG"
+rollback_backend_images "$rollback_state"
+[[ $(ref_id "$(compose_image_name api)") == "$ID_A" ]]
+[[ $(ref_id "$(compose_image_name migrate)") == "$ID_B" ]]
+[[ $(ref_id "$(compose_image_name daily-runner)") == "$ID_C" ]]
+[[ $(backend_image_rescue_read_phase "$rollback_state") == rollback-complete ]]
+if grep -E $'^(stop-database|compose\t.*force-recreate|verify-backend)' \
+  "$EVENT_LOG" >/dev/null; then
+  echo 'pre-replacement rollback touched healthy containers' >&2
+  exit 1
+fi
+
+# A rescue that has entered rollback cannot be reused as a fresh snapshot by a
+# same-release process retry. The outer rollback remains the only recovery path.
+set +e
+backend_image_rescue_prepare "$SHA" "$rollback_state" api migrate daily-runner
+completed_retry_status=$?
+set -e
+((completed_retry_status != 0))
+[[ $(backend_image_rescue_read_phase "$rollback_state") == rollback-complete ]]
+backend_image_rescue_cleanup "$rollback_state"
+assert_no_rescue_refs
+
+# Once replacement is durably marked, rollback restores the same tags and
+# recreates/verifies persistent services exactly once. One-shot services stay
+# tag-only, and success records a terminal phase so an outer retry cannot
+# double-run it or reuse the rescue as a fresh deployment snapshot.
+reset_case rollback-after-replacement
+add_ref "$ID_A" "$ID_A"
+add_ref "$(compose_image_name migrate)" "$ID_B"
+add_ref "$(compose_image_name daily-runner)" "$ID_C"
+add_ref other-project-rollback-rescue:keep "$ID_D"
+add_container api rollback-api "$ID_A"
+rollback_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$rollback_state" api migrate daily-runner
+set_ref_direct "$(compose_image_name api)" "$ID_E"
+set_ref_direct "$(compose_image_name migrate)" "$ID_E"
+set_ref_direct "$(compose_image_name daily-runner)" "$ID_E"
+backend_image_rescue_mark_replacement_started "$rollback_state"
+set +e
+backend_image_rescue_prepare "$SHA" "$rollback_state" api migrate daily-runner
+started_retry_status=$?
+set -e
+((started_retry_status != 0))
+[[ $(backend_image_rescue_read_phase "$rollback_state") == replacement-started ]]
+: > "$EVENT_LOG"
+rollback_backend_images "$rollback_state"
+[[ $(backend_image_rescue_read_phase "$rollback_state") == rollback-complete ]]
+grep -F $'compose\t--profile\tapp\tup\t-d\t--no-deps\t--force-recreate\tapi' \
+  "$EVENT_LOG" >/dev/null
+if grep -E $'force-recreate.*(migrate|daily-runner)' "$EVENT_LOG" >/dev/null; then
+  echo 'tag-only service was recreated during rollback' >&2
+  exit 1
+fi
+grep -F 'refresh-proxy' "$EVENT_LOG" >/dev/null
+[[ $(grep -c '^stop-database' "$EVENT_LOG") == 1 ]]
+[[ $(grep -c $'^compose\t.*force-recreate' "$EVENT_LOG") == 1 ]]
+[[ $(grep -c '^verify-backend' "$EVENT_LOG") == 1 ]]
+[[ $(grep -c '^refresh-proxy' "$EVENT_LOG") == 1 ]]
+
+restore_postgres_runtime_control() {
+  printf 'restore-runtime\t%s\n' "$1" >> "$EVENT_LOG"
+}
+: > "$EVENT_LOG"
+rollback_backend_and_runtime_control true "$rollback_state" runtime-backup
+[[ ! -e $rollback_state ]]
+assert_no_rescue_refs
+[[ $(ref_id other-project-rollback-rescue:keep) == "$ID_D" ]]
+if grep -E $'^(stop-database|compose\t.*force-recreate|verify-backend)' \
+  "$EVENT_LOG" >/dev/null; then
+  echo 'outer rollback repeated a completed backend recreation' >&2
+  exit 1
+fi
+
+# Backend and runtime rollback statuses aggregate. If backend rollback succeeds
+# but runtime restoration fails, the terminal phase prevents a second outer
+# attempt from recreating healthy containers again.
+reset_case aggregation-retry
+add_ref "$ID_A" "$ID_A"
+add_container api aggregation-api "$ID_A"
+aggregation_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$aggregation_state" api
+backend_image_rescue_mark_replacement_started "$aggregation_state"
+restore_postgres_runtime_control() {
+  printf 'restore-runtime\t%s\n' "$1" >> "$EVENT_LOG"
+  [[ ${FAKE_RUNTIME_STATUS:-0} == 0 ]]
+}
+: > "$EVENT_LOG"
+export FAKE_RUNTIME_STATUS=42
+set +e
+rollback_backend_and_runtime_control true "$aggregation_state" runtime-backup
+first_aggregation_status=$?
+set -e
+((first_aggregation_status != 0))
+[[ -e $aggregation_state ]]
+[[ $(backend_image_rescue_read_phase "$aggregation_state") == rollback-complete ]]
+[[ $(grep -c $'^compose\t.*force-recreate' "$EVENT_LOG") == 1 ]]
+export FAKE_RUNTIME_STATUS=0
+rollback_backend_and_runtime_control true "$aggregation_state" runtime-backup
+[[ $(grep -c $'^compose\t.*force-recreate' "$EVENT_LOG") == 1 ]]
+[[ ! -e $aggregation_state ]]
+assert_no_rescue_refs
+unset FAKE_RUNTIME_STATUS
+
+# The same aggregation rule applies before replacement: a runtime-control
+# restore failure retains a terminal tag-only rollback without ever touching
+# the healthy container, and the later retry performs only runtime restoration.
+reset_case prepared-aggregation-retry
+add_ref "$ID_A" "$ID_A"
+add_container api prepared-aggregation-api "$ID_A"
+prepared_aggregation_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$prepared_aggregation_state" api
+set_ref_direct "$(compose_image_name api)" "$ID_E"
+restore_postgres_runtime_control() {
+  printf 'restore-runtime\t%s\n' "$1" >> "$EVENT_LOG"
+  [[ ${FAKE_RUNTIME_STATUS:-0} == 0 ]]
+}
+: > "$EVENT_LOG"
+export FAKE_RUNTIME_STATUS=42
+set +e
+rollback_backend_and_runtime_control \
+  true "$prepared_aggregation_state" runtime-backup
+prepared_aggregation_status=$?
+set -e
+((prepared_aggregation_status != 0))
+[[ $(ref_id "$(compose_image_name api)") == "$ID_A" ]]
+[[ $(backend_image_rescue_read_phase "$prepared_aggregation_state") == \
+   rollback-complete ]]
+if grep -E $'^(stop-database|compose\t.*force-recreate|verify-backend)' \
+  "$EVENT_LOG" >/dev/null; then
+  echo 'pre-replacement aggregation touched a healthy container' >&2
+  exit 1
+fi
+export FAKE_RUNTIME_STATUS=0
+rollback_backend_and_runtime_control \
+  true "$prepared_aggregation_state" runtime-backup
+[[ ! -e $prepared_aggregation_state ]]
+assert_no_rescue_refs
+unset FAKE_RUNTIME_STATUS
+
+# Backend rollback failure never short-circuits runtime-control restoration;
+# both failures are reported and rescue cleanup is deliberately skipped.
+set +e
+aggregation_output=$(
+  rollback_backend_images() {
+    printf 'forced-backend-rollback\n' >> "$EVENT_LOG"
+    return 41
+  }
+  restore_postgres_runtime_control() {
+    printf 'forced-runtime-rollback\n' >> "$EVENT_LOG"
+    return 42
+  }
+  rollback_backend_and_runtime_control true unavailable-state runtime-backup 2>&1
+)
+aggregation_status=$?
+set -e
+((aggregation_status != 0))
+grep -F 'backend image/container rollback failed (status=41)' \
+  <<< "$aggregation_output" >/dev/null
+grep -F 'PostgreSQL runtime-control rollback failed (status=42)' \
+  <<< "$aggregation_output" >/dev/null
+grep -F 'forced-backend-rollback' "$EVENT_LOG" >/dev/null
+grep -F 'forced-runtime-rollback' "$EVENT_LOG" >/dev/null
+
+# If a process died after committing backend.sha but before exact cleanup, the
+# next deploy under the singleton lock reconciles that completed release.
+reset_case reconcile-success
+add_ref "$ID_A" "$ID_A"
+add_container api reconciled-api "$ID_A"
+reconciled_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$reconciled_state" api
+printf '%s\n' "$SHA" > "$STATE/backend.sha"
+reconcile_completed_backend_image_rescues
+[[ ! -e $reconciled_state ]]
+assert_no_rescue_refs
+
+if grep -E $'docker\t(image\t)?(system\t)?prune' "$EVENT_LOG" >/dev/null; then
+  echo 'backend rescue contract invoked a broad Docker prune' >&2
+  exit 1
+fi
+if grep -E 'docker([[:space:]]+container)?[[:space:]]+commit' \
+  "$LIBRARY" >/dev/null; then
+  echo 'backend rescue library retained unsafe docker commit adoption' >&2
+  exit 1
+fi
+
+echo 'Backend image rescue contract tests passed'

--- a/ops/deploy/deploy-control-lib.sh
+++ b/ops/deploy/deploy-control-lib.sh
@@ -70,8 +70,10 @@ initialize_deploy_control_bridge() {
   local entrypoint=$REPO/ops/deploy/social-monitor-production-deploy.sh
   local deploy_library=$REPO/ops/deploy/deploy-control-lib.sh
   local postgres_library=$REPO/ops/deploy/postgres-runtime-deploy-lib.sh
+  local image_rescue_library=$REPO/ops/deploy/backend-image-rescue-lib.sh
 
-  [[ -f $entrypoint && -f $deploy_library && -f $postgres_library ]] || \
+  [[ -f $entrypoint && -f $deploy_library && -f $postgres_library && \
+     -f $image_rescue_library ]] || \
     fail 'current integration is missing deploy control bridge sources'
   DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST=$(
     deploy_control_file_digest "$entrypoint"
@@ -82,25 +84,33 @@ initialize_deploy_control_bridge() {
   DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST=$(
     deploy_control_file_digest "$postgres_library"
   )
+  DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST=$(
+    deploy_control_file_digest "$image_rescue_library"
+  )
 }
 
 verify_deploy_control_bridge_compatibility() {
   local entrypoint=$REPO/ops/deploy/social-monitor-production-deploy.sh
   local deploy_library=$REPO/ops/deploy/deploy-control-lib.sh
   local postgres_library=$REPO/ops/deploy/postgres-runtime-deploy-lib.sh
+  local image_rescue_library=$REPO/ops/deploy/backend-image-rescue-lib.sh
 
   [[ -n ${DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST:-} && \
      -n ${DEPLOY_CONTROL_BRIDGE_LIBRARY_DIGEST:-} && \
-     -n ${DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST:-} ]] || \
+     -n ${DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST:-} && \
+     -n ${DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST:-} ]] || \
     fail 'deploy control bridge was not initialized before integration advance'
-  [[ -f $entrypoint && -f $deploy_library && -f $postgres_library ]] || \
+  [[ -f $entrypoint && -f $deploy_library && -f $postgres_library && \
+     -f $image_rescue_library ]] || \
     fail 'target integration is missing deploy control bridge sources'
   [[ $(deploy_control_file_digest "$entrypoint") == \
      "$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST" && \
      $(deploy_control_file_digest "$deploy_library") == \
      "$DEPLOY_CONTROL_BRIDGE_LIBRARY_DIGEST" && \
      $(deploy_control_file_digest "$postgres_library") == \
-     "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST" ]] || \
+       "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST" && \
+     $(deploy_control_file_digest "$image_rescue_library") == \
+       "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST" ]] || \
     fail 'deploy control changed with runtime assets; deploy the bridge release first'
 }
 
@@ -109,11 +119,14 @@ verify_deploy_control_bridge_target_compatibility() {
   local entrypoint_path=ops/deploy/social-monitor-production-deploy.sh
   local deploy_library_path=ops/deploy/deploy-control-lib.sh
   local postgres_library_path=ops/deploy/postgres-runtime-deploy-lib.sh
+  local image_rescue_library_path=ops/deploy/backend-image-rescue-lib.sh
   local entrypoint_digest deploy_library_digest postgres_library_digest
+  local image_rescue_library_digest
 
   [[ -n ${DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST:-} && \
      -n ${DEPLOY_CONTROL_BRIDGE_LIBRARY_DIGEST:-} && \
-     -n ${DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST:-} ]] || \
+     -n ${DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST:-} && \
+     -n ${DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST:-} ]] || \
     fail 'deploy control bridge was not initialized before target verification'
   entrypoint_digest=$(
     deploy_control_git_blob_digest "$sha" "$entrypoint_path"
@@ -124,10 +137,15 @@ verify_deploy_control_bridge_target_compatibility() {
   postgres_library_digest=$(
     deploy_control_git_blob_digest "$sha" "$postgres_library_path"
   ) || fail 'target integration is missing the PostgreSQL control bridge library'
+  image_rescue_library_digest=$(
+    deploy_control_git_blob_digest "$sha" "$image_rescue_library_path"
+  ) || fail 'target integration is missing the backend image rescue bridge library'
   [[ $entrypoint_digest == "$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST" && \
      $deploy_library_digest == "$DEPLOY_CONTROL_BRIDGE_LIBRARY_DIGEST" && \
      $postgres_library_digest == \
-       "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST" ]] || \
+       "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST" && \
+     $image_rescue_library_digest == \
+       "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST" ]] || \
     fail 'deploy control changed with runtime assets; deploy the bridge release first'
 }
 
@@ -249,6 +267,10 @@ deploy_release() {
   fetch_main
   validate_main_commit "$sha"
   install -d -m 0755 "$STATE" "$STAGING" "$RELEASES"
+  if declare -F reconcile_completed_backend_image_rescues >/dev/null; then
+    reconcile_completed_backend_image_rescues || \
+      fail 'completed backend image rescue cleanup could not be reconciled'
+  fi
 
   local current
   current=$(git -C "$REPO" rev-parse HEAD)

--- a/ops/deploy/deploy-control-lib.test.sh
+++ b/ops/deploy/deploy-control-lib.test.sh
@@ -17,6 +17,7 @@ install -d "$REPO/ops/deploy" "$CONTROL" "$STATE"
 cp "$SCRIPT_DIR/social-monitor-production-deploy.sh" \
   "$SCRIPT_DIR/deploy-control-lib.sh" \
   "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" \
+  "$SCRIPT_DIR/backend-image-rescue-lib.sh" \
   "$REPO/ops/deploy/"
 
 fail() {
@@ -107,6 +108,20 @@ set -e
 grep -F 'deploy the bridge release first' <<< "$bridge_error" >/dev/null
 cp "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" \
   "$REPO/ops/deploy/postgres-runtime-deploy-lib.sh"
+verify_deploy_control_bridge_compatibility
+
+# The image-rescue controller is part of the same control-only bridge digest;
+# a publication/runtime target cannot replace it under the running controller.
+printf '# target rescue mutation\n' >> \
+  "$REPO/ops/deploy/backend-image-rescue-lib.sh"
+set +e
+rescue_bridge_error=$(verify_deploy_control_bridge_compatibility 2>&1)
+rescue_bridge_status=$?
+set -e
+((rescue_bridge_status != 0))
+grep -F 'deploy the bridge release first' <<< "$rescue_bridge_error" >/dev/null
+cp "$SCRIPT_DIR/backend-image-rescue-lib.sh" \
+  "$REPO/ops/deploy/backend-image-rescue-lib.sh"
 verify_deploy_control_bridge_compatibility
 
 echo 'Deploy control library tests passed'

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -7,6 +7,7 @@ BASE=$(
   python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["adoptionBaseCommit"])' \
     "$SCRIPT_DIR/postgres-pool-release-contract.json"
 )
+RELEASE_A_COMMIT=83f6932eaaa87a49c64b9f8b07ada5052d47a7b4
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/postgres-pool-bootstrap-transition.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
 
@@ -151,8 +152,11 @@ readlink "$POSTGRES_RUNTIME_CURRENT" \
 printf '#!/usr/bin/env bash\nexit 98\n' > "$FIXTURE/bin/docker"
 chmod 0755 "$FIXTURE/bin/docker"
 
-cp "$PROJECT_ROOT/ops/deploy/social-monitor-production-deploy.sh" \
-  "$REPO/ops/deploy/social-monitor-production-deploy.sh"
+# This is a historical Release A transition. Later control bridges must not be
+# spliced into its exact 18-path producer fixture.
+git -C "$PROJECT_ROOT" show \
+  "$RELEASE_A_COMMIT:ops/deploy/social-monitor-production-deploy.sh" \
+  > "$REPO/ops/deploy/social-monitor-production-deploy.sh"
 cp "$PROJECT_ROOT/ops/deploy/postgres-runtime-deploy-lib.sh" "$REPO/ops/deploy/"
 cp "$PROJECT_ROOT/ops/deploy/reader-summary-publication-deploy-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/reader-summary-publication-pre-migration.sql" \

--- a/ops/deploy/reader-summary-publication-bridge-transition.test.sh
+++ b/ops/deploy/reader-summary-publication-bridge-transition.test.sh
@@ -20,13 +20,6 @@ SYNTHESIS_REPO=$FIXTURE/synthesis
 INSTALLED_ENTRYPOINT=$FIXTURE/installed-c59-entrypoint.sh
 
 git -C "$PROJECT_ROOT" cat-file -e "$INSTALLED_CONTROLLER^{commit}"
-for bridge_path in "${BRIDGE_PATHS[@]}"; do
-  cmp -s "$PROJECT_ROOT/$bridge_path" \
-    <(git -C "$PROJECT_ROOT" show "$INSTALLED_CONTROLLER:$bridge_path") || {
-    echo "current bridge differs from c59: $bridge_path" >&2
-    exit 1
-  }
-done
 git -C "$PROJECT_ROOT" show \
   "$INSTALLED_CONTROLLER:ops/deploy/social-monitor-production-deploy.sh" \
   > "$INSTALLED_ENTRYPOINT"
@@ -390,8 +383,8 @@ run_target_case "$FINAL_SHA" helper-preloaded \
   'PostgreSQL backup entrypoint was loaded before target validation' failure
 run_target_case "$FINAL_SHA" correct '' success
 
-# The literal c59 sequence is the authenticated seam: advance, source target,
-# then sync and enter the runtime transaction.
+# The current controller preserves the authenticated c59 seam ordering:
+# advance, source target, then sync and enter the runtime transaction.
 # shellcheck disable=SC2016
 advance_line=$(grep -nF 'advance_integration "$sha"' \
   "$PROJECT_ROOT/ops/deploy/deploy-control-lib.sh" | tail -1 | cut -d: -f1)

--- a/ops/deploy/reader-summary-publication-migrator-validation.test.sh
+++ b/ops/deploy/reader-summary-publication-migrator-validation.test.sh
@@ -38,6 +38,7 @@ mkdir -p "$ROOT/secrets/db" "$REPO/ops/deploy" "$FAKE_BIN"
 printf '%s\n' 'test-only-ca-certificate' > "$CA_CERTIFICATE"
 cp "$SCRIPT_DIR/deploy-control-lib.sh" "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" "$REPO/ops/deploy/"
+cp "$SCRIPT_DIR/backend-image-rescue-lib.sh" "$REPO/ops/deploy/"
 cp "$DEPLOY_ENTRYPOINT" "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/postgres-backup-deploy-lib.sh" "$REPO/ops/deploy/"
 git init -q -b main "$REPO"
@@ -591,7 +592,7 @@ assert_deploy_backend_preflight_order() {
         grep -F "create_pre_migration_database_backup \"\$@\"" >/dev/null
       backend_services() { printf "%s\n" migrate; }
       marker_value() { printf "%s\n" 0123456789abcdef0123456789abcdef01234567; }
-      capture_previous_images() { printf "%s\n" capture >> "$ORCHESTRATION_LOG"; }
+      backend_image_rescue_prepare() { printf "%s\n" capture >> "$ORCHESTRATION_LOG"; }
       verify_migration_compatibility() { printf "%s\n" compatibility >> "$ORCHESTRATION_LOG"; }
       backup_database() { printf "%s\n" backup >> "$ORCHESTRATION_LOG"; }
       reader_summary_publication_migrator_preflight() {
@@ -630,9 +631,9 @@ assert_deploy_backend_preflight_order() {
   TEST_COUNT=$((TEST_COUNT + 1))
 }
 
-assert_deploy_backend_preflight_order first-failure 'preflight:1'
+assert_deploy_backend_preflight_order first-failure $'capture\npreflight:1'
 assert_deploy_backend_preflight_order second-failure \
-  $'preflight:1\ncapture\ncompatibility\nbackup\nbuild\npreflight:2'
+  $'capture\npreflight:1\ncompatibility\nbackup\nbuild\npreflight:2'
 
 for catalog_token in \
   'current_database()' \

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -206,6 +206,8 @@ else
 fi
 # shellcheck source=ops/deploy/postgres-runtime-deploy-lib.sh
 source "$REPO/ops/deploy/postgres-runtime-deploy-lib.sh"
+# shellcheck source=ops/deploy/backend-image-rescue-lib.sh
+source "$REPO/ops/deploy/backend-image-rescue-lib.sh"
 initialize_deploy_control_bridge
 
 verify_compose_scope() (
@@ -575,54 +577,6 @@ stop_and_remove_database_services() {
   done
 }
 
-capture_previous_images() {
-  local state_file=$1
-  shift
-  : > "$state_file"
-  local service image_id
-  local -a container_ids
-  for service in "$@"; do
-    mapfile -t container_ids < <("${COMPOSE[@]}" --profile app --profile daily ps -q "$service")
-    image_id=''
-    if ((${#container_ids[@]} > 0)); then
-      image_id=$(docker inspect "${container_ids[0]}" --format '{{.Image}}' 2>/dev/null || true)
-    fi
-    if [[ -z $image_id ]]; then
-      image_id=$(docker image inspect "$(compose_image_name "$service")" --format '{{.Id}}' 2>/dev/null || true)
-    fi
-    [[ -n $image_id ]] && printf '%s %s\n' "$service" "$image_id" >> "$state_file"
-  done
-}
-
-restore_previous_image_tags() {
-  local state_file=$1
-  [[ -s $state_file ]] || return 0
-  local service image_id
-  while read -r service image_id; do
-    docker image tag "$image_id" "$(compose_image_name "$service")" || return 1
-  done < "$state_file"
-}
-
-rollback_backend_images() {
-  local state_file=$1
-  [[ -s $state_file ]] || return 0
-  local api_rolled_back=false
-  local -a rollback_services
-  restore_previous_image_tags "$state_file" || return 1
-  mapfile -t rollback_services < <(awk '$1 != "migrate" && $1 != "daily-runner" {print $1}' "$state_file")
-  if ((${#rollback_services[@]} > 0)); then
-    if printf '%s\n' "${rollback_services[@]}" | grep -qx api; then
-      api_rolled_back=true
-    fi
-    stop_and_remove_database_services "${rollback_services[@]}" || return 1
-    "${COMPOSE[@]}" --profile app up -d --no-deps --force-recreate "${rollback_services[@]}" || return 1
-    verify_backend_with_retry "${rollback_services[@]}" || return 1
-    if [[ $api_rolled_back == true ]]; then
-      refresh_frontend_api_proxy || return 1
-    fi
-  fi
-}
-
 verify_migration_compatibility() {
   local from=$1
   local to=$2
@@ -766,7 +720,6 @@ deploy_backend() (
   from=$(marker_value backend)
   mapfile -t services < <(backend_services "$from" "$sha")
   if ((${#services[@]} == 0)); then
-    printf '%s\n' "$sha" > "$STATE/backend.sha"
     return 0
   fi
 
@@ -793,6 +746,10 @@ deploy_backend() (
   mapfile -t captured_services < <(
     printf '%s\n' "${services[@]}" "${persistent[@]}" | awk 'NF && !seen[$0]++'
   )
+  local previous
+  previous=$(backend_image_rescue_state_file "$sha")
+  backend_image_rescue_prepare "$sha" "$previous" "${captured_services[@]}" || \
+    fail 'required rollback images could not be pinned before build'
   local needs_migrate=false
   for service in "${services[@]}"; do
     [[ $service == x-collector || $service == daily-runner ]] || \
@@ -803,8 +760,6 @@ deploy_backend() (
       fail 'reader summary publication migrator preflight failed'
   fi
 
-  local previous=$STATE/previous-images-${sha:0:12}.txt
-  capture_previous_images "$previous" "${captured_services[@]}"
   verify_migration_compatibility "$from" "$sha"
   backup_database "$sha"
 
@@ -825,32 +780,31 @@ deploy_backend() (
     if [[ $database_replacement == true ]]; then
       umask 077
       capture_effective_postgres_environment "$postgres_env"
+      backend_image_rescue_mark_replacement_started "$previous" || \
+        fail 'backend replacement phase could not be persisted'
       if ! stop_and_remove_database_services "${persistent[@]}"; then
-        rollback_backend_images "$previous" || fail 'database service removal and backend rollback both failed'
-        fail 'database service removal failed; previous images restored'
+        fail 'database service removal failed'
       fi
       verify_live_postgres_admission "$postgres_env"
       probe_postgres_maximum_envelope "$postgres_env"
+    else
+      backend_image_rescue_mark_replacement_started "$previous" || \
+        fail 'backend replacement phase could not be persisted'
     fi
     if ! "${COMPOSE[@]}" --profile app up -d --no-deps --force-recreate "${persistent[@]}"; then
-      rollback_backend_images "$previous" || fail 'backend recreate and rollback both failed'
-      fail 'backend recreate failed; previous images restored'
+      fail 'backend recreate failed'
     fi
     if ! verify_backend_with_retry "${persistent[@]}"; then
-      rollback_backend_images "$previous" || fail 'backend health and rollback verification both failed'
-      fail 'backend health failed; previous images restored'
+      fail 'backend health failed'
     fi
     if printf '%s\n' "${persistent[@]}" | grep -qx api && ! refresh_frontend_api_proxy; then
-      rollback_backend_images "$previous" || fail 'frontend API proxy refresh and backend rollback both failed'
-      fail 'frontend API proxy refresh failed; previous backend images restored'
+      fail 'frontend API proxy refresh failed'
     fi
     if [[ $database_replacement == true ]] && \
       ! soak_backend_release "${persistent[@]}" frontend caddy; then
-      rollback_backend_images "$previous" || fail 'backend soak and rollback verification both failed'
-      fail 'backend restart/readiness/502 soak failed; previous images restored'
+      fail 'backend restart/readiness/502 soak failed'
     fi
   fi
-  printf '%s\n' "$sha" > "$STATE/backend.sha"
 )
 
 switch_link() {
@@ -869,7 +823,8 @@ deploy_release_runtime_transaction() {
   local backend=$2
   local runtime_control=$3
   local compatible_backend_sha=$sha
-  local runtime_control_backup previous_images activation_status
+  local runtime_control_backup previous_images previous_phase activation_status
+  local transaction_signal= rollback_status=0
 
   [[ $backend =~ ^(true|false)$ && $runtime_control =~ ^(true|false)$ ]] || \
     fail 'runtime-control deployment classification is invalid'
@@ -890,12 +845,18 @@ deploy_release_runtime_transaction() {
       fail 'control-only runtime activation requires a committed backend marker'
   fi
 
-  runtime_control_backup=$(snapshot_postgres_runtime_control "$sha")
-  previous_images=$STATE/previous-images-${sha:0:12}.txt
-  if [[ $backend == true ]]; then
-    rm -f "$previous_images"
+  previous_images=$(backend_image_rescue_state_file "$sha")
+  if [[ $backend == true && ( -e $previous_images || -L $previous_images ) ]]; then
+    previous_phase=$(backend_image_rescue_read_phase "$previous_images") || \
+      fail 'existing backend image rescue phase is invalid'
+    [[ $previous_phase == prepared ]] || \
+      fail 'unfinished backend rollback requires operator recovery before retry'
   fi
+  runtime_control_backup=$(snapshot_postgres_runtime_control "$sha")
 
+  trap 'transaction_signal=HUP' HUP
+  trap 'transaction_signal=INT' INT
+  trap 'transaction_signal=TERM' TERM
   set +e
   (
     set -euo pipefail
@@ -907,17 +868,28 @@ deploy_release_runtime_transaction() {
   )
   activation_status=$?
   set -e
+  if [[ -n $transaction_signal && $activation_status -eq 0 ]]; then
+    activation_status=1
+  fi
+  trap - HUP INT TERM
   if ((activation_status != 0)); then
-    if [[ $backend == true ]]; then
-      rollback_backend_images "$previous_images" || \
-        fail 'backend release failed and previous containers could not be restored'
+    rollback_backend_and_runtime_control \
+      "$backend" "$previous_images" "$runtime_control_backup" || rollback_status=$?
+    if ((rollback_status != 0)); then
+      fail 'release failed; rollback is incomplete and rescue tags were preserved'
     fi
-    restore_postgres_runtime_control "$runtime_control_backup" || \
-      fail 'release failed and PostgreSQL runtime-control rollback also failed'
-    fail 'release failed; previous PostgreSQL runtime control was restored'
+    fail 'release failed; backend images and PostgreSQL runtime control were restored'
   fi
 
+  if [[ $backend == true ]]; then
+    printf '%s\n' "$sha" > "$STATE/backend.sha.next"
+    mv -f "$STATE/backend.sha.next" "$STATE/backend.sha"
+  fi
   rm -rf "$runtime_control_backup"
+  if [[ $backend == true ]]; then
+    backend_image_rescue_cleanup "$previous_images" || \
+      fail 'release succeeded but exact backend rescue-tag cleanup failed'
+  fi
   if [[ ${COMPOSE[-1]} != \
         "$POSTGRES_RUNTIME_CURRENT/compose.postgres-runtime.yml" ]]; then
     COMPOSE+=(

--- a/ops/deploy/social-monitor-production-deploy.test.sh
+++ b/ops/deploy/social-monitor-production-deploy.test.sh
@@ -25,6 +25,7 @@ install -d "$REPO/apps/frontend" "$REPO/apps/api-gateway" \
   "$STATE" "$STAGING"
 cp "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/deploy-control-lib.sh" "$REPO/ops/deploy/"
+cp "$SCRIPT_DIR/backend-image-rescue-lib.sh" "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/reader-summary-publication-deploy-lib.sh" \
   "$SCRIPT_DIR/reader-summary-publication-pre-migration.sql" \
   "$SCRIPT_DIR/reader-summary-publication-post-migration.sql" \
@@ -126,9 +127,10 @@ git -C "$REPO" checkout -q main
 
 grep -F "if printf '%s\\n' \"\${persistent[@]}\" | grep -qx api && ! refresh_frontend_api_proxy; then" \
   "$ENTRYPOINT" >/dev/null
-grep -F "if [[ \$api_rolled_back == true ]]; then" "$ENTRYPOINT" >/dev/null
+grep -F "if [[ \$api_rolled_back == true ]]; then" \
+  "$SCRIPT_DIR/backend-image-rescue-lib.sh" >/dev/null
 grep -F 'refresh_frontend_api_proxy || return 1' \
-  "$ENTRYPOINT" >/dev/null
+  "$SCRIPT_DIR/backend-image-rescue-lib.sh" >/dev/null
 grep -F 'http://127.0.0.1:13080/auth/session' \
   "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" >/dev/null
 # shellcheck disable=SC2016
@@ -378,9 +380,304 @@ grep -F 'activate_postgres_runtime_control "$sha" "$compatible_backend_sha"' \
 grep -F 'snapshot_postgres_runtime_control "$sha"' \
   "$ENTRYPOINT" >/dev/null
 grep -F 'restore_postgres_runtime_control "$runtime_control_backup"' \
+  "$SCRIPT_DIR/backend-image-rescue-lib.sh" >/dev/null
+grep -F 'rollback_backend_and_runtime_control' "$ENTRYPOINT" >/dev/null
+grep -F 'rollback_backend_images "$state_file" || backend_status=$?' \
+  "$SCRIPT_DIR/backend-image-rescue-lib.sh" >/dev/null
+grep -F 'restore_postgres_runtime_control "$runtime_control_backup" || runtime_status=$?' \
+  "$SCRIPT_DIR/backend-image-rescue-lib.sh" >/dev/null
+grep -F 'backend_image_rescue_prepare "$sha" "$previous"' \
   "$ENTRYPOINT" >/dev/null
-grep -F 'rollback_backend_images "$previous_images"' \
-  "$ENTRYPOINT" >/dev/null
+rescue_prepare_line=$(grep -nF \
+  'backend_image_rescue_prepare "$sha" "$previous"' "$ENTRYPOINT" | cut -d: -f1)
+backend_build_line=$(grep -nF \
+  '"${COMPOSE[@]}" --profile app --profile daily build' \
+  "$ENTRYPOINT" | cut -d: -f1)
+((rescue_prepare_line < backend_build_line))
+
+# A rescue-pin failure exits deploy_backend before preflight, backup, or build.
+BUILD_GUARD_LOG=$FIXTURE/backend-build-guard.log
+set +e
+build_guard_error=$(
+  ENTRYPOINT="$ENTRYPOINT" BUILD_GUARD_LOG="$BUILD_GUARD_LOG" \
+  SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 \
+  SOCIAL_MONITOR_DEPLOY_ROOT="$ROOT" \
+  SOCIAL_MONITOR_DEPLOY_REPO="$REPO" \
+  SOCIAL_MONITOR_DEPLOY_CONTROL="$CONTROL" \
+  SOCIAL_MONITOR_DEPLOY_STATE="$STATE" \
+  SOCIAL_MONITOR_DEPLOY_STAGING="$STAGING" \
+    bash -c '
+      source "$ENTRYPOINT"
+      backend_services() { printf "%s\n" api; }
+      marker_value() { printf "%s\n" 0123456789abcdef0123456789abcdef01234567; }
+      backend_image_rescue_prepare() { return 77; }
+      reader_summary_publication_migrator_preflight() {
+        printf "preflight\n" >> "$BUILD_GUARD_LOG"
+      }
+      backup_database() { printf "backup\n" >> "$BUILD_GUARD_LOG"; }
+      fake_compose() { printf "compose:%s\n" "$*" >> "$BUILD_GUARD_LOG"; }
+      COMPOSE=(fake_compose)
+      deploy_backend fedcba9876543210fedcba9876543210fedcba98
+    ' 2>&1
+)
+build_guard_status=$?
+set -e
+((build_guard_status != 0))
+grep -F 'required rollback images could not be pinned before build' \
+  <<< "$build_guard_error" >/dev/null
+[[ ! -s $BUILD_GUARD_LOG ]]
+
+# The replacement phase is a durable inner/outer transaction seam. Failures in
+# preflight, backup, build, and migration all reach outer rollback as prepared;
+# no healthy service is stopped or recreated in any of those paths.
+assert_pre_replacement_failure() {
+  local stage=$1
+  local expected=$2
+  local log=$FIXTURE/pre-replacement-$stage.log
+  local output status actual
+  : > "$log"
+  set +e
+  output=$(
+    ENTRYPOINT="$ENTRYPOINT" FAILURE_STAGE="$stage" FAILURE_LOG="$log" \
+    SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 \
+    SOCIAL_MONITOR_DEPLOY_ROOT="$ROOT" \
+    SOCIAL_MONITOR_DEPLOY_REPO="$REPO" \
+    SOCIAL_MONITOR_DEPLOY_CONTROL="$CONTROL" \
+    SOCIAL_MONITOR_DEPLOY_STATE="$STATE" \
+    SOCIAL_MONITOR_DEPLOY_STAGING="$STAGING" \
+      bash -c '
+        set -euo pipefail
+        source "$ENTRYPOINT"
+        backend_services() { printf "%s\n" api; }
+        marker_value() {
+          printf "%s\n" 0123456789abcdef0123456789abcdef01234567
+        }
+        backend_image_rescue_prepare() {
+          printf "prepared\n" > "$(backend_image_rescue_phase_file "$2")"
+          printf "prepare\n" >> "$FAILURE_LOG"
+        }
+        backend_image_rescue_mark_replacement_started() {
+          printf "replacement-started\n" > \
+            "$(backend_image_rescue_phase_file "$1")"
+          printf "mark-replacement\n" >> "$FAILURE_LOG"
+        }
+        reader_summary_publication_migrator_preflight() {
+          printf "preflight\n" >> "$FAILURE_LOG"
+          [[ $FAILURE_STAGE != preflight ]]
+        }
+        verify_migration_compatibility() {
+          printf "compatibility\n" >> "$FAILURE_LOG"
+        }
+        backup_database() {
+          printf "backup\n" >> "$FAILURE_LOG"
+          [[ $FAILURE_STAGE != backup ]]
+        }
+        deploy_reader_summary_publication_migrations() {
+          printf "migration\n" >> "$FAILURE_LOG"
+          [[ $FAILURE_STAGE != migration ]]
+        }
+        fake_compose() {
+          if [[ " $* " == *" build "* ]]; then
+            printf "build\n" >> "$FAILURE_LOG"
+            [[ $FAILURE_STAGE != build ]]
+          else
+            printf "compose-up\n" >> "$FAILURE_LOG"
+            return 90
+          fi
+        }
+        COMPOSE=(fake_compose)
+        stop_and_remove_database_services() {
+          printf "stop\n" >> "$FAILURE_LOG"
+          return 91
+        }
+        snapshot_postgres_runtime_control() {
+          printf "%s/runtime-backup\n" "$STATE"
+        }
+        activate_postgres_runtime_control() { :; }
+        verify_compose_scope() { :; }
+        rollback_backend_and_runtime_control() {
+          local phase_file
+          phase_file=$(backend_image_rescue_phase_file "$2")
+          printf "rollback:%s\n" "$(< "$phase_file")" >> "$FAILURE_LOG"
+        }
+        deploy_release_runtime_transaction \
+          fedcba9876543210fedcba9876543210fedcba98 true false
+      ' 2>&1
+  )
+  status=$?
+  set -e
+  ((status != 0))
+  actual=$(< "$log")
+  if [[ $actual != "$expected" ]]; then
+    printf 'pre-replacement-failure-mismatch:%s:actual=%q:output=%q\n' \
+      "$stage" "$actual" "$output" >&2
+    return 1
+  fi
+}
+
+assert_pre_replacement_failure preflight \
+  $'prepare\npreflight\nrollback:prepared'
+assert_pre_replacement_failure backup \
+  $'prepare\npreflight\ncompatibility\nbackup\nrollback:prepared'
+assert_pre_replacement_failure build \
+  $'prepare\npreflight\ncompatibility\nbackup\nbuild\nrollback:prepared'
+assert_pre_replacement_failure migration \
+  $'prepare\npreflight\ncompatibility\nbackup\nbuild\nmigration\nrollback:prepared'
+
+# Every failure after the durable replacement transition is aggregated by the
+# outer transaction. Legacy inner rollback calls would add `inner-rollback`
+# here and cause a second backend rollback from the outer transaction.
+assert_post_replacement_failure() {
+  local stage=$1
+  local log=$FIXTURE/post-replacement-$stage.log
+  local output status
+  : > "$log"
+  set +e
+  output=$(
+    ENTRYPOINT="$ENTRYPOINT" FAILURE_STAGE="$stage" FAILURE_LOG="$log" \
+    SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 \
+    SOCIAL_MONITOR_DEPLOY_ROOT="$ROOT" \
+    SOCIAL_MONITOR_DEPLOY_REPO="$REPO" \
+    SOCIAL_MONITOR_DEPLOY_CONTROL="$CONTROL" \
+    SOCIAL_MONITOR_DEPLOY_STATE="$STATE" \
+    SOCIAL_MONITOR_DEPLOY_STAGING="$STAGING" \
+      bash -c '
+        set -euo pipefail
+        source "$ENTRYPOINT"
+        backend_services() { printf "%s\n" api; }
+        marker_value() {
+          printf "%s\n" 0123456789abcdef0123456789abcdef01234567
+        }
+        backend_image_rescue_prepare() {
+          printf "prepared\n" > "$(backend_image_rescue_phase_file "$2")"
+        }
+        backend_image_rescue_mark_replacement_started() {
+          printf "replacement-started\n" > \
+            "$(backend_image_rescue_phase_file "$1")"
+          printf "mark-replacement\n" >> "$FAILURE_LOG"
+        }
+        reader_summary_publication_migrator_preflight() { :; }
+        verify_migration_compatibility() { :; }
+        backup_database() { :; }
+        deploy_reader_summary_publication_migrations() { :; }
+        capture_effective_postgres_environment() { : > "$1"; }
+        verify_live_postgres_admission() { :; }
+        probe_postgres_maximum_envelope() { :; }
+        fake_compose() {
+          if [[ " $* " == *" build "* ]]; then
+            return 0
+          fi
+          printf "recreate\n" >> "$FAILURE_LOG"
+          [[ $FAILURE_STAGE != recreate ]] || {
+            printf "fail-stage:recreate\n" >> "$FAILURE_LOG"
+            return 72
+          }
+        }
+        COMPOSE=(fake_compose)
+        stop_and_remove_database_services() {
+          printf "stop\n" >> "$FAILURE_LOG"
+          [[ $FAILURE_STAGE != stop ]] || {
+            printf "fail-stage:stop\n" >> "$FAILURE_LOG"
+            return 71
+          }
+        }
+        verify_backend_with_retry() {
+          printf "verify\n" >> "$FAILURE_LOG"
+          [[ $FAILURE_STAGE != health ]] || {
+            printf "fail-stage:health\n" >> "$FAILURE_LOG"
+            return 73
+          }
+        }
+        refresh_frontend_api_proxy() {
+          printf "proxy\n" >> "$FAILURE_LOG"
+          [[ $FAILURE_STAGE != proxy ]] || {
+            printf "fail-stage:proxy\n" >> "$FAILURE_LOG"
+            return 74
+          }
+        }
+        soak_backend_release() {
+          printf "soak\n" >> "$FAILURE_LOG"
+          [[ $FAILURE_STAGE != soak ]] || {
+            printf "fail-stage:soak\n" >> "$FAILURE_LOG"
+            return 75
+          }
+        }
+        snapshot_postgres_runtime_control() {
+          printf "%s/runtime-backup\n" "$STATE"
+        }
+        activate_postgres_runtime_control() { :; }
+        verify_compose_scope() { :; }
+        rollback_backend_images() {
+          printf "inner-rollback\n" >> "$FAILURE_LOG"
+        }
+        rollback_backend_and_runtime_control() {
+          local phase_file
+          phase_file=$(backend_image_rescue_phase_file "$2")
+          printf "outer-rollback:%s\n" "$(< "$phase_file")" \
+            >> "$FAILURE_LOG"
+        }
+        deploy_release_runtime_transaction \
+          fedcba9876543210fedcba9876543210fedcba98 true false
+      ' 2>&1
+  )
+  status=$?
+  set -e
+  ((status != 0))
+  grep -Fx "fail-stage:$stage" "$log" >/dev/null
+  [[ $(grep -c '^mark-replacement$' "$log") == 1 ]]
+  [[ $(grep -c '^outer-rollback:replacement-started$' "$log") == 1 ]]
+  if grep -F 'inner-rollback' "$log" >/dev/null; then
+    printf 'post-replacement failure ran inner and outer rollback: %s: %q\n' \
+      "$stage" "$output" >&2
+    return 1
+  fi
+}
+
+assert_post_replacement_failure stop
+assert_post_replacement_failure recreate
+assert_post_replacement_failure health
+assert_post_replacement_failure proxy
+assert_post_replacement_failure soak
+
+# A process retry cannot snapshot over the runtime-control evidence associated
+# with an interrupted replacement. It fails closed before activation or a new
+# rollback transaction begins.
+INTERRUPTED_RETRY_LOG=$FIXTURE/interrupted-retry.log
+: > "$INTERRUPTED_RETRY_LOG"
+set +e
+interrupted_retry_output=$(
+  ENTRYPOINT="$ENTRYPOINT" FAILURE_LOG="$INTERRUPTED_RETRY_LOG" \
+  SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 \
+  SOCIAL_MONITOR_DEPLOY_ROOT="$ROOT" \
+  SOCIAL_MONITOR_DEPLOY_REPO="$REPO" \
+  SOCIAL_MONITOR_DEPLOY_CONTROL="$CONTROL" \
+  SOCIAL_MONITOR_DEPLOY_STATE="$STATE" \
+  SOCIAL_MONITOR_DEPLOY_STAGING="$STAGING" \
+    bash -c '
+      set -euo pipefail
+      source "$ENTRYPOINT"
+      target=fedcba9876543210fedcba9876543210fedcba98
+      : > "$(backend_image_rescue_state_file "$target")"
+      backend_image_rescue_read_phase() { printf "replacement-started\n"; }
+      snapshot_postgres_runtime_control() {
+        printf "snapshot\n" >> "$FAILURE_LOG"
+      }
+      activate_postgres_runtime_control() {
+        printf "activate\n" >> "$FAILURE_LOG"
+      }
+      rollback_backend_and_runtime_control() {
+        printf "rollback\n" >> "$FAILURE_LOG"
+      }
+      deploy_release_runtime_transaction "$target" true false
+    ' 2>&1
+)
+interrupted_retry_status=$?
+set -e
+((interrupted_retry_status != 0))
+grep -F 'unfinished backend rollback requires operator recovery before retry' \
+  <<< "$interrupted_retry_output" >/dev/null
+[[ ! -s $INTERRUPTED_RETRY_LOG ]]
+rm -f "$STATE/backend-image-rescue-fedcba9876543210fedcba9876543210fedcba98.tsv"
 grep -F 'verify_live_postgres_admission "$postgres_env"' "$ENTRYPOINT" >/dev/null
 grep -F 'probe_postgres_maximum_envelope "$postgres_env"' "$ENTRYPOINT" >/dev/null
 grep -F 'deploy_reader_summary_publication_migrations' "$ENTRYPOINT" >/dev/null
@@ -609,6 +906,7 @@ if run_entrypoint upload "$TARGET_SHA" < "$FIXTURE/bad-frontend.tgz" >/dev/null 
 fi
 
 echo 'Production deploy contract tests passed'
+bash "$SCRIPT_DIR/backend-image-rescue-lib.test.sh"
 bash "$SCRIPT_DIR/postgres-runtime-deploy-lib.test.sh"
 bash "$SCRIPT_DIR/verify-postgres-runtime-topology.test.sh"
 bash "$SCRIPT_DIR/reader-summary-publication-migrator-validation.test.sh"


### PR DESCRIPTION
## Summary
- pin exact project/release-scoped rollback images before backend replacement
- reconstruct only reviewed legacy service configs without environment secrets
- persist rollback phases for idempotent recovery
- add fail-closed and 50-run concurrency coverage

## Verification
- backend image rescue stress: 50/50
- production deploy contract
- deploy-control contract
- PostgreSQL runtime topology
- source line cap
- secret scan


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resilient backend image recovery and rollback support for deployments.
  * Backend services can now be restored using validated rescue images when original images are unavailable.
  * Added safer handling for interrupted, partial, or failed deployment transactions.

* **Documentation**
  * Expanded rollback and backend image rescue lifecycle guidance.

* **Tests**
  * Added comprehensive coverage for rescue image creation, validation, cleanup, reconciliation, and rollback scenarios.
  * Extended deployment checks to validate the new recovery workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->