### PR TITLE
fix(deploy): restore runtime control bridge

### DIFF
--- a/ops/deploy/runtime-control-refresh-bridge-transition.test.sh
+++ b/ops/deploy/runtime-control-refresh-bridge-transition.test.sh
@@ -346,6 +346,7 @@ run_transition_test() {
   git -C "$object_repository" show \
     "$FINAL_SOURCE_SHA:ops/deploy/social-monitor-production-deploy.sh" > "$entrypoint"
   python3 - "$entrypoint" <<'PY'
+import os
 import pathlib
 import sys
 
@@ -360,6 +361,17 @@ source = source.replace(
     1,
 )
 source = source.replace(" -o root -g root", "")
+ownership_check = (
+    "[[ $(stat -c '%U:%G:%a' \"$auth_refresh_destination\") == root:root:700 ]]"
+)
+if source.count(ownership_check) != 1:
+    raise SystemExit("fixture could not find the auth refresh ownership check")
+source = source.replace(
+    ownership_check,
+    "[[ $(stat -c '%u:%g:%a' \"$auth_refresh_destination\") == "
+    f"{os.getuid()}:{os.getgid()}:700 ]]",
+    1,
+)
 path.write_text(source, encoding="utf-8")
 PY
   chmod 0755 "$entrypoint"

--- a/ops/deploy/runtime-control-refresh-bridge.manifest
+++ b/ops/deploy/runtime-control-refresh-bridge.manifest
@@ -129,7 +129,7 @@
 000000 - ops/deploy/reader-summary-publication-migrator-validation.test.sh
 000000 - ops/deploy/reader-summary-publication-post-migration.sql
 000000 - ops/deploy/reader-summary-publication-pre-migration.sql
-100644 92915567d82e3eb62783090da9857aedafc926a7 ops/deploy/runtime-control-refresh-bridge-transition.test.sh
+100644 d6fc585ef240dd23c84314d64c59b3d9d1fde338 ops/deploy/runtime-control-refresh-bridge-transition.test.sh
 100644 SELF ops/deploy/runtime-control-refresh-bridge.manifest
 100644 bb17fdc645e7b20ec853c257abd9df6a1fd9dc7f package.json
 000000 - prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql


### PR DESCRIPTION
Restores the independently reviewed runtime-control bridge from exact parent c8.

Verified:
- transition test
- bash syntax
- source line cap
- diff check
- secret scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment transition testing to validate bridge ownership using the current runtime user and group while preserving strict permissions.
  * Added validation to ensure the expected ownership check is updated exactly once.

* **Chores**
  * Updated the deployment manifest checksum to reflect the latest test fixture changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the runtime-control bridge transition test and its manifest to the state established at parent commit `c8`. The only substantive code change is a new Python fixture patch that adapts the production deploy script's `stat -c '%U:%G:%a' … root:root:700` ownership assertion into a numeric `stat -c '%u:%g:%a' … UID:GID:700` form using the test runner's actual process identity, letting the transition test pass without root privileges.

- The `import os` addition and the new `source.replace` block are logically consistent: the stat format switches from symbolic names (`%U:%G`) to numeric IDs (`%u:%g`), and the right-hand side of the comparison is built from `os.getuid()`/`os.getgid()` (both return integers, so there is no injection surface). A count guard (`source.count(ownership_check) != 1`) ensures the patch fails loudly if the needle drifts.
- The manifest blob hash is updated from `92915567…` to `d6fc585e…` to stay consistent with the modified test file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted test-fixture patch with no effect on production code paths.

The production deploy script is untouched; only the in-test Python mutation of that script gains a third patch. The patch is narrowly scoped, guards against needle-not-found with an explicit count check, and uses os.getuid()/os.getgid() (pure integers) to build the replacement string, leaving no room for format mismatch or injection. The manifest hash update is mechanically consistent with the file change.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ops/deploy/runtime-control-refresh-bridge-transition.test.sh | Adds `import os` and a Python fixture patch that replaces the root-only `stat '%U:%G:%a'` ownership assertion with a numeric `stat '%u:%g:%a'` check keyed to the current process's UID/GID, allowing the transition test to run as a non-root user. |
| ops/deploy/runtime-control-refresh-bridge.manifest | Bumps the recorded blob hash of the test script from `92915567…` to `d6fc585e…`, keeping the manifest consistent with the updated file. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run_transition_test] --> B[git show deploy script into bridge-entrypoint.sh]
    B --> C[python3 heredoc patches entrypoint]
    C --> D1[Patch 1: inject DEPLOY_TEST_MODE bypass into verify_compose_scope]
    C --> D2[Patch 2: strip -o root -g root from install commands]
    C --> D3["NEW Patch 3: replace stat '%U:%G:%a' root:root check with stat '%u:%g:%a' os.getuid():os.getgid()"]
    D1 --> E[Write patched script back to disk]
    D2 --> E
    D3 --> E
    E --> F[chmod 0755 entrypoint]
    F --> G[Execute patched entrypoint for plan / deploy assertions]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[run_transition_test] --> B[git show deploy script into bridge-entrypoint.sh]
    B --> C[python3 heredoc patches entrypoint]
    C --> D1[Patch 1: inject DEPLOY_TEST_MODE bypass into verify_compose_scope]
    C --> D2[Patch 2: strip -o root -g root from install commands]
    C --> D3["NEW Patch 3: replace stat '%U:%G:%a' root:root check with stat '%u:%g:%a' os.getuid():os.getgid()"]
    D1 --> E[Write patched script back to disk]
    D2 --> E
    D3 --> E
    E --> F[chmod 0755 entrypoint]
    F --> G[Execute patched entrypoint for plan / deploy assertions]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): make bridge fixture non-root po..."](https://github.com/777genius/social-monitor/commit/ff01eb7c91d43be398444665b7d114640fea28c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45578707)</sub>

<!-- /greptile_comment -->