### PR TITLE
fix(deploy): stabilize backend image rescue

### DIFF
--- a/ops/deploy/backend-image-rescue-lib.sh
+++ b/ops/deploy/backend-image-rescue-lib.sh
@@ -6,6 +6,10 @@
 
 BACKEND_IMAGE_RESCUE_VERSION=social-monitor-backend-image-rescue-v1
 BACKEND_IMAGE_RESCUE_PHASE_VERSION=social-monitor-backend-image-rescue-phase-v1
+# These reviewed bounds overwrite inherited environment values. Focused tests
+# shorten them only after sourcing this library.
+BACKEND_IMAGE_RESCUE_POST_UNPAUSE_TIMEOUT_SECONDS=60
+BACKEND_IMAGE_RESCUE_POST_UNPAUSE_POLL_SECONDS=3
 
 backend_image_rescue_state_file() {
   local sha=$1
@@ -101,6 +105,143 @@ backend_image_rescue_verify_running_container() {
     2>/dev/null) || return 1
   [[ $state == 'running|true|false|false|none' || \
      $state == 'running|true|false|false|healthy' ]]
+}
+
+backend_image_rescue_compose_container_id() {
+  local service=$1
+  local container
+
+  container=$(
+    "${COMPOSE[@]}" --profile app --profile daily ps -q "$service"
+  ) || return 1
+  [[ -n $container && $container != *[$'\t\r\n ']* ]] || return 1
+  printf '%s\n' "$container"
+}
+
+backend_image_rescue_decimal_increment() {
+  local value=$1
+  local result= digit next carry=1 index
+
+  [[ $value =~ ^(0|[1-9][0-9]*)$ ]] || return 1
+  for ((index = ${#value} - 1; index >= 0; index--)); do
+    digit=${value:index:1}
+    if ((carry == 1)); then
+      if [[ $digit == 9 ]]; then
+        next=0
+      else
+        next=$((digit + 1))
+        carry=0
+      fi
+    else
+      next=$digit
+    fi
+    result=$next$result
+  done
+  ((carry == 0)) || result=1$result
+  printf '%s\n' "$result"
+}
+
+backend_image_rescue_capture_container_baseline() {
+  local service=$1
+  local expected_container=$2
+  local expected_image=$3
+  local container_name=$4
+  local image_name=$5
+  local restart_count_name=$6
+  local container image restart_count
+
+  container=$(backend_image_rescue_compose_container_id "$service") || return 1
+  [[ $container == "$expected_container" ]] || return 1
+  image=$(docker inspect "$container" --format '{{.Image}}' \
+    2>/dev/null) || return 1
+  restart_count=$(docker inspect "$container" --format '{{.RestartCount}}' \
+    2>/dev/null) || return 1
+  [[ $image == "$expected_image" && \
+     $image =~ ^sha256:[0-9a-f]{64}$ && \
+     $restart_count =~ ^(0|[1-9][0-9]*)$ ]] || return 1
+
+  printf -v "$container_name" '%s' "$container"
+  printf -v "$image_name" '%s' "$image"
+  printf -v "$restart_count_name" '%s' "$restart_count"
+}
+
+backend_image_rescue_wait_running_container() {
+  local service=$1
+  local container=$2
+  local expected_image=$3
+  local baseline_restart_count=$4
+  local timeout_seconds=$BACKEND_IMAGE_RESCUE_POST_UNPAUSE_TIMEOUT_SECONDS
+  local poll_seconds=$BACKEND_IMAGE_RESCUE_POST_UNPAUSE_POLL_SECONDS
+  local elapsed_seconds=0 stable_samples=0 stable_restart_count=
+  local last_restart_count=$baseline_restart_count
+  local allowed_restart_count compose_container sample
+  local status running restarting oom_killed health image restart_count
+  local sleep_seconds
+
+  [[ $timeout_seconds =~ ^([1-9]|[1-5][0-9]|60)$ && \
+     $poll_seconds =~ ^[1-9][0-9]*$ && \
+     $baseline_restart_count =~ ^(0|[1-9][0-9]*)$ ]] || return 1
+  ((poll_seconds <= timeout_seconds)) || return 1
+  allowed_restart_count=$(
+    backend_image_rescue_decimal_increment "$baseline_restart_count"
+  ) || return 1
+
+  while true; do
+    compose_container=$(
+      backend_image_rescue_compose_container_id "$service"
+    ) || return 1
+    [[ $compose_container == "$container" ]] || return 1
+    sample=$(docker inspect "$container" --format \
+      '{{.State.Status}}|{{.State.Running}}|{{.State.Restarting}}|{{.State.OOMKilled}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}|{{.Image}}|{{.RestartCount}}' \
+      2>/dev/null) || return 1
+    IFS='|' read -r status running restarting oom_killed health image \
+      restart_count <<< "$sample"
+    [[ $running == true || $running == false ]] || return 1
+    [[ $restarting == true || $restarting == false ]] || return 1
+    [[ $oom_killed == false ]] || return 1
+    [[ $health == none || $health == healthy || $health == starting ]] || return 1
+    [[ $image == "$expected_image" ]] || return 1
+    [[ $restart_count =~ ^(0|[1-9][0-9]*)$ ]] || return 1
+    [[ $restart_count == "$baseline_restart_count" || \
+       $restart_count == "$allowed_restart_count" ]] || return 1
+    if [[ $last_restart_count == "$allowed_restart_count" && \
+          $restart_count == "$baseline_restart_count" ]]; then
+      return 1
+    fi
+    last_restart_count=$restart_count
+
+    if [[ $status == running && $running == true && \
+          $restarting == false && $health != starting ]]; then
+      if [[ $stable_restart_count == "$restart_count" ]]; then
+        stable_samples=$((stable_samples + 1))
+      else
+        stable_samples=1
+        stable_restart_count=$restart_count
+      fi
+      if ((stable_samples == 3)); then
+        compose_container=$(
+          backend_image_rescue_compose_container_id "$service"
+        ) || return 1
+        [[ $compose_container == "$container" ]] || return 1
+        return 0
+      fi
+    elif [[ $status == restarting || $status == exited || \
+            $status == starting || $restarting == true || \
+            $health == starting ]]; then
+      stable_samples=0
+      stable_restart_count=
+    else
+      return 1
+    fi
+
+    ((elapsed_seconds < timeout_seconds)) || return 1
+    sleep_seconds=$poll_seconds
+    if ((elapsed_seconds + sleep_seconds > timeout_seconds)); then
+      sleep_seconds=$((timeout_seconds - elapsed_seconds))
+    fi
+    sleep "$sleep_seconds" || return 1
+    elapsed_seconds=$((elapsed_seconds + sleep_seconds))
+  done
 }
 
 backend_image_rescue_remove_tag() {
@@ -280,6 +421,8 @@ backend_image_rescue_reconstruct_running_container() (
   local rescue_tag=$3
   local command expected_container_config actual_container_config
   local expected_image_config actual_image_config image_env imported_id inspected_id
+  local recorded_image=$4
+  local original_container baseline_image baseline_restart_count
   local paused=false unpause_status=0
 
   command=$(backend_image_rescue_reconstructed_command "$service") || {
@@ -312,13 +455,16 @@ backend_image_rescue_reconstruct_running_container() (
   trap 'exit 130' INT
   trap 'exit 143' TERM
 
+  backend_image_rescue_capture_container_baseline \
+    "$service" "$container" "$recorded_image" \
+    original_container baseline_image baseline_restart_count || return 1
   paused=true
-  if ! docker container pause "$container" >/dev/null; then
+  if ! docker container pause "$original_container" >/dev/null; then
     paused=false
     return 1
   fi
   if ! imported_id=$(
-    docker container export "$container" | \
+    docker container export "$original_container" | \
       docker image import \
         --change 'ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]' \
         --change "CMD $command" \
@@ -345,7 +491,9 @@ backend_image_rescue_reconstruct_running_container() (
   [[ $actual_image_config == "$expected_image_config" ]] || return 1
   image_env=$(backend_image_rescue_image_env "$rescue_tag") || return 1
   [[ $image_env == null || $image_env == '[]' ]] || return 1
-  backend_image_rescue_verify_running_container "$container" || return 1
+  backend_image_rescue_wait_running_container \
+    "$service" "$original_container" "$baseline_image" \
+    "$baseline_restart_count" || return 1
   printf 'backend-image-rescue: safely reconstructed missing running image for service %s\n' \
     "$service" >&2
 )
@@ -373,7 +521,7 @@ backend_image_rescue_pin_running_container() {
   # The recorded object is gone, so preserve only the paused root filesystem.
   # Rebuild metadata from a reviewed, service-specific config with no Env.
   backend_image_rescue_reconstruct_running_container \
-    "$service" "$container" "$rescue_tag" || return 1
+    "$service" "$container" "$rescue_tag" "$recorded_id" || return 1
   reconstructed_id=$(backend_image_rescue_image_id "$rescue_tag") || return 1
   [[ $reconstructed_id =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
   printf -v "$source_kind_name" '%s' container-export-import

--- a/ops/deploy/backend-image-rescue-lib.test.sh
+++ b/ops/deploy/backend-image-rescue-lib.test.sh
@@ -9,9 +9,13 @@ trap 'rm -rf "$FIXTURE"' EXIT
 PROJECT=fixture-project
 FAKE_DOCKER_REFS=$FIXTURE/docker-refs.tsv
 FAKE_DOCKER_CONTAINERS=$FIXTURE/docker-containers.tsv
+FAKE_DOCKER_CONTAINER_STATES=$FIXTURE/docker-container-states.tsv
 FAKE_COMPOSE_CONTAINERS=$FIXTURE/compose-containers.tsv
+FAKE_COMPOSE_CONTAINER_STATES=$FIXTURE/compose-container-states.tsv
 EVENT_LOG=$FIXTURE/events.log
-export FAKE_DOCKER_REFS FAKE_DOCKER_CONTAINERS EVENT_LOG
+export FAKE_DOCKER_REFS FAKE_DOCKER_CONTAINERS \
+  FAKE_DOCKER_CONTAINER_STATES FAKE_COMPOSE_CONTAINERS \
+  FAKE_COMPOSE_CONTAINER_STATES EVENT_LOG
 
 ID_A=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ID_B=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
@@ -69,6 +73,18 @@ append_docker_event() {
   } 9>> "$EVENT_LOG"
 }
 
+take_container_state() {
+  local container=$1 row next=$FAKE_DOCKER_CONTAINER_STATES.next.$$
+  row=$(awk -F '\t' -v container="$container" \
+    '$1 == container {print; exit}' "$FAKE_DOCKER_CONTAINER_STATES")
+  [[ -n $row ]] || return 1
+  awk -F '\t' -v container="$container" \
+    '$1 == container && !removed {removed=1; next} {print}' \
+    "$FAKE_DOCKER_CONTAINER_STATES" > "$next"
+  mv -f "$next" "$FAKE_DOCKER_CONTAINER_STATES"
+  printf '%s\n' "${row#*$'\t'}"
+}
+
 append_docker_event "$@"
 
 case ${1:-}:${2:-} in
@@ -102,10 +118,30 @@ case ${1:-}:${2:-} in
     row=$(awk -F '\t' -v container="$container" \
       '$1 == container {print; exit}' "$FAKE_DOCKER_CONTAINERS")
     [[ -n $row ]] || exit 1
-    IFS=$'\t' read -r _ image_id state config env <<< "$row"
+    IFS=$'\t' read -r _ image_id state config env restart_count <<< "$row"
+    restart_count=${restart_count:-0}
     case ${*: -1} in
+      *'.State.Status'*)
+        state=$(take_container_state "$container" || printf '%s\n' "$state")
+        [[ $state != missing ]] || exit 1
+        IFS='|' read -r status running restarting oom_killed health \
+          sampled_image sampled_restart_count <<< "$state"
+        sampled_image=${sampled_image:-$image_id}
+        sampled_restart_count=${sampled_restart_count:-$restart_count}
+        if [[ ${*: -1} == *'.RestartCount'* ]]; then
+          printf '%s|%s|%s|%s|%s|%s|%s\n' \
+            "$status" "$running" "$restarting" "$oom_killed" "$health" \
+            "$sampled_image" "$sampled_restart_count"
+        else
+          printf '%s|%s|%s|%s|%s\n' \
+            "$status" "$running" "$restarting" "$oom_killed" "$health"
+        fi
+        ;;
+      *'.Image'*'.RestartCount'*)
+        printf '%s|%s\n' "$image_id" "$restart_count"
+        ;;
       *'.Image'*) printf '%s\n' "$image_id" ;;
-      *'.State.Status'*) printf '%s\n' "$state" ;;
+      *'.RestartCount'*) printf '%s\n' "$restart_count" ;;
       *) printf '%s\n' "$config" ;;
     esac
     ;;
@@ -120,18 +156,36 @@ case ${1:-}:${2:-} in
     cat >/dev/null
     [[ ${FAKE_IMPORT_STATUS:-0} == 0 ]] || exit "$FAKE_IMPORT_STATUS"
     rescue_tag=${*: -1}
-    set_ref "$rescue_tag" "$FAKE_DOCKER_IMPORT_ID" \
-      "$SAFE_API_CONFIG" '[]'
+    set_ref "$rescue_tag" "$FAKE_DOCKER_IMPORT_STORED_ID" \
+      "$FAKE_DOCKER_IMPORT_CONFIG" "$FAKE_DOCKER_IMPORT_ENV"
     printf '%s\n' "$FAKE_DOCKER_IMPORT_ID"
     ;;
   *) exit 90 ;;
 esac
 SH
 chmod 0755 "$FAKE_BIN/docker"
+cat > "$FAKE_BIN/sleep" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'sleep\t%s\n' "$1" >> "$EVENT_LOG"
+SH
+chmod 0755 "$FAKE_BIN/sleep"
 PATH=$FAKE_BIN:$PATH
 
 compose_image_name() {
   printf '%s-%s:latest\n' "$PROJECT" "$1"
+}
+
+take_compose_container() {
+  local service=$1 row next=$FAKE_COMPOSE_CONTAINER_STATES.next.$$
+  row=$(awk -F '\t' -v service="$service" \
+    '$1 == service {print; exit}' "$FAKE_COMPOSE_CONTAINER_STATES")
+  [[ -n $row ]] || return 1
+  awk -F '\t' -v service="$service" \
+    '$1 == service && !removed {removed=1; next} {print}' \
+    "$FAKE_COMPOSE_CONTAINER_STATES" > "$next"
+  mv -f "$next" "$FAKE_COMPOSE_CONTAINER_STATES"
+  printf '%s\n' "${row#*$'\t'}"
 }
 
 append_compose_event() {
@@ -148,7 +202,11 @@ append_compose_event() {
 fake_compose() {
   append_compose_event "$@"
   if [[ $* == *' ps -q '* ]]; then
-    local service=${*: -1}
+    local service=${*: -1} queued_container
+    if queued_container=$(take_compose_container "$service"); then
+      [[ $queued_container == missing ]] || printf '%s\n' "$queued_container"
+      return 0
+    fi
     awk -F '\t' -v service="$service" '$1 == service {print $2}' \
       "$FAKE_COMPOSE_CONTAINERS"
     return 0
@@ -187,10 +245,16 @@ reset_case() {
   install -d "$STATE"
   : > "$FAKE_DOCKER_REFS"
   : > "$FAKE_DOCKER_CONTAINERS"
+  : > "$FAKE_DOCKER_CONTAINER_STATES"
   : > "$FAKE_COMPOSE_CONTAINERS"
+  : > "$FAKE_COMPOSE_CONTAINER_STATES"
   : > "$EVENT_LOG"
   FAKE_DOCKER_IMPORT_ID=$ID_E
-  export FAKE_DOCKER_IMPORT_ID
+  FAKE_DOCKER_IMPORT_STORED_ID=$ID_E
+  FAKE_DOCKER_IMPORT_CONFIG=$SAFE_API_CONFIG
+  FAKE_DOCKER_IMPORT_ENV='[]'
+  export FAKE_DOCKER_IMPORT_ID FAKE_DOCKER_IMPORT_STORED_ID \
+    FAKE_DOCKER_IMPORT_CONFIG FAKE_DOCKER_IMPORT_ENV
   unset FAKE_DOCKER_SIGNAL_TAG FAKE_COMPOSE_UP_STATUS FAKE_STOP_STATUS \
     FAKE_VERIFY_STATUS FAKE_PROXY_STATUS FAKE_IMPORT_STATUS
 }
@@ -201,10 +265,36 @@ add_ref() {
 }
 
 add_container() {
-  printf '%s\t%s\t%s\t%s\t%s\n' "$2" "$3" \
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$2" "$3" \
     "${4:-running|true|false|false|none}" "${5:-$CONFIG}" "${6:-[]}" \
+    "${7:-0}" \
     >> "$FAKE_DOCKER_CONTAINERS"
   printf '%s\t%s\n' "$1" "$2" >> "$FAKE_COMPOSE_CONTAINERS"
+}
+
+queue_compose_containers() {
+  local service=$1 container
+  shift
+  for container in "$@"; do
+    printf '%s\t%s\n' "$service" "$container" \
+      >> "$FAKE_COMPOSE_CONTAINER_STATES"
+  done
+}
+
+queue_container_states() {
+  local container=$1 state
+  shift
+  for state in "$@"; do
+    printf '%s\t%s\n' "$container" "$state" \
+      >> "$FAKE_DOCKER_CONTAINER_STATES"
+  done
+}
+
+set_import_service_config() {
+  FAKE_DOCKER_IMPORT_CONFIG=$(
+    backend_image_rescue_reconstructed_image_config "$1"
+  )
+  export FAKE_DOCKER_IMPORT_CONFIG
 }
 
 set_ref_direct() {
@@ -226,6 +316,17 @@ assert_no_rescue_refs() {
     exit 1
   fi
 }
+
+assert_failed_rescue_cleaned() {
+  local state_file=$1
+  [[ ! -e $state_file && ! -e $state_file.partial ]]
+  assert_no_rescue_refs
+}
+
+((BACKEND_IMAGE_RESCUE_POST_UNPAUSE_TIMEOUT_SECONDS == 60))
+((BACKEND_IMAGE_RESCUE_POST_UNPAUSE_POLL_SECONDS == 3))
+BACKEND_IMAGE_RESCUE_POST_UNPAUSE_TIMEOUT_SECONDS=2
+BACKEND_IMAGE_RESCUE_POST_UNPAUSE_POLL_SECONDS=1
 
 # Running services are pinned from their recorded image IDs. The migrate and
 # daily-runner one-shot policies pin their existing Compose tags, but rollback
@@ -279,6 +380,14 @@ adopted_env=$(
 [[ $adopted_config != *RESCUE_SENTINEL_DO_NOT_PERSIST* ]]
 [[ $adopted_env == '[]' ]]
 [[ $adopted_env != *RESCUE_SENTINEL_DO_NOT_PERSIST* ]]
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG") == 2 ]]
+baseline_line=$(grep -nF \
+  $'docker\tinspect\tadopted-api\t--format\t{{.RestartCount}}' \
+  "$EVENT_LOG" | cut -d: -f1)
+pause_line=$(grep -nF $'docker\tcontainer\tpause\tadopted-api' \
+  "$EVENT_LOG" | cut -d: -f1)
+[[ -n $baseline_line && -n $pause_line ]]
+((baseline_line < pause_line))
 if grep -F $'docker\tcommit' "$EVENT_LOG" >/dev/null; then
   echo 'safe missing-image reconstruction unexpectedly used docker commit' >&2
   exit 1
@@ -294,6 +403,236 @@ tag_count_after=$(grep -c $'docker\timage\ttag' "$EVENT_LOG" || true)
 import_count_after=$(grep -c $'docker\timage\timport' "$EVENT_LOG" || true)
 ((tag_count_before == tag_count_after && import_count_before == import_count_after))
 backend_image_rescue_cleanup "$adoption_state"
+
+# Imported rescue identity, reviewed config, and empty Env are each validated
+# after unpause and before runtime stability polling.
+for validation_case in id config env; do
+  reset_case "strict-rescue-$validation_case"
+  case $validation_case in
+    id) FAKE_DOCKER_IMPORT_STORED_ID=$ID_D ;;
+    config) FAKE_DOCKER_IMPORT_CONFIG=$CONFIG ;;
+    env) FAKE_DOCKER_IMPORT_ENV=$SENTINEL_ENV ;;
+  esac
+  export FAKE_DOCKER_IMPORT_STORED_ID FAKE_DOCKER_IMPORT_CONFIG \
+    FAKE_DOCKER_IMPORT_ENV
+  add_container api "strict-rescue-$validation_case-api" "$ID_A" \
+    'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+  strict_state=$(backend_image_rescue_state_file "$SHA")
+  set +e
+  backend_image_rescue_prepare "$SHA" "$strict_state" api
+  strict_status=$?
+  set -e
+  ((strict_status != 0))
+  grep -F $'docker\tcontainer\tunpause' "$EVENT_LOG" >/dev/null
+  [[ $(grep -c $'^sleep\t1$' "$EVENT_LOG" || true) == 0 ]]
+  assert_failed_rescue_cleaned "$strict_state"
+done
+
+# One bounded restart is accepted only after transient restarting, exited, and
+# health-starting samples are followed by three stable samples at baseline+1.
+reset_case one-post-unpause-restart
+BACKEND_IMAGE_RESCUE_POST_UNPAUSE_TIMEOUT_SECONDS=5
+set_import_service_config intelligence-worker
+add_container intelligence-worker restarting-intelligence "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+queue_container_states restarting-intelligence \
+  "running|true|false|false|healthy|$ID_A|0" \
+  "restarting|false|true|false|none|$ID_A|1" \
+  "exited|false|false|false|none|$ID_A|1" \
+  "running|true|false|false|starting|$ID_A|1" \
+  "running|true|false|false|healthy|$ID_A|1" \
+  "running|true|false|false|healthy|$ID_A|1" \
+  "running|true|false|false|healthy|$ID_A|1"
+transient_state=$(backend_image_rescue_state_file "$SHA")
+backend_image_rescue_prepare "$SHA" "$transient_state" intelligence-worker
+grep -F $'image\tintelligence-worker\trecreate\tcontainer-export-import\trestarting-intelligence' \
+  "$transient_state" >/dev/null
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG") == 5 ]]
+[[ $(ref_id "$(backend_image_rescue_tag "$SHA" intelligence-worker)") == \
+   "$ID_E" ]]
+backend_image_rescue_cleanup "$transient_state"
+assert_no_rescue_refs
+BACKEND_IMAGE_RESCUE_POST_UNPAUSE_TIMEOUT_SECONDS=2
+
+# Losing the original container during the wait is an immediate failure; the
+# rescue never follows a replacement container with the same Compose service.
+reset_case missing-post-unpause
+add_container intelligence-worker missing-intelligence "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+set_import_service_config intelligence-worker
+queue_container_states missing-intelligence \
+  'running|true|false|false|healthy' missing
+missing_post_unpause_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare \
+  "$SHA" "$missing_post_unpause_state" intelligence-worker
+missing_post_unpause_status=$?
+set -e
+((missing_post_unpause_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG" || true) == 0 ]]
+assert_failed_rescue_cleaned "$missing_post_unpause_state"
+
+# A malformed baseline is rejected before pause. A malformed or decreased
+# post-unpause count also fails on its first sample.
+reset_case malformed-restart-baseline
+set_import_service_config api
+add_container api malformed-baseline-api "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV" bad
+malformed_baseline_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$malformed_baseline_state" api
+malformed_baseline_status=$?
+set -e
+((malformed_baseline_status != 0))
+if grep -F $'docker\tcontainer\tpause\tmalformed-baseline-api' \
+  "$EVENT_LOG" >/dev/null; then
+  echo 'container was paused before a valid restart baseline was captured' >&2
+  exit 1
+fi
+assert_failed_rescue_cleaned "$malformed_baseline_state"
+
+reset_case malformed-post-unpause-restart
+set_import_service_config api
+add_container api malformed-restart-api "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+queue_container_states malformed-restart-api \
+  "running|true|false|false|healthy|$ID_A|0" \
+  "running|true|false|false|healthy|$ID_A|bad"
+malformed_restart_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$malformed_restart_state" api
+malformed_restart_status=$?
+set -e
+((malformed_restart_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG" || true) == 0 ]]
+assert_failed_rescue_cleaned "$malformed_restart_state"
+
+reset_case decreased-post-unpause-restart
+set_import_service_config api
+add_container api decreased-restart-api "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV" 2
+queue_container_states decreased-restart-api \
+  "running|true|false|false|healthy|$ID_A|2" \
+  "restarting|false|true|false|none|$ID_A|3" \
+  "running|true|false|false|healthy|$ID_A|2"
+decreased_restart_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$decreased_restart_state" api
+decreased_restart_status=$?
+set -e
+((decreased_restart_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG") == 1 ]]
+assert_failed_rescue_cleaned "$decreased_restart_state"
+
+# Baseline+2 is never accepted, including if the container looks healthy.
+reset_case excessive-post-unpause-restart
+set_import_service_config api
+add_container api excessive-restart-api "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV" 3
+queue_container_states excessive-restart-api \
+  "running|true|false|false|healthy|$ID_A|3" \
+  "running|true|false|false|healthy|$ID_A|5"
+excessive_restart_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$excessive_restart_state" api
+excessive_restart_status=$?
+set -e
+((excessive_restart_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG" || true) == 0 ]]
+assert_failed_rescue_cleaned "$excessive_restart_state"
+
+# A container that never returns to the strict running state times out. The
+# imported tag and partial manifest are removed, so no build can consume them.
+reset_case permanent-post-unpause-stop
+set_import_service_config ingestion-worker
+add_container ingestion-worker stopped-ingestion "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+queue_container_states stopped-ingestion \
+  'running|true|false|false|healthy' \
+  'exited|false|false|false|none' \
+  'exited|false|false|false|none' \
+  'exited|false|false|false|none'
+stopped_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$stopped_state" ingestion-worker
+stopped_status=$?
+set -e
+((stopped_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG") == 2 ]]
+assert_failed_rescue_cleaned "$stopped_state"
+
+# OOM and unhealthy states remain fail-closed even if Docker still reports the
+# same container as running for every bounded poll.
+reset_case permanent-post-unpause-oom
+set_import_service_config ingestion-worker
+add_container ingestion-worker oom-ingestion "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+queue_container_states oom-ingestion \
+  "running|true|false|false|healthy|$ID_A|0" \
+  "running|true|false|true|none|$ID_A|0"
+oom_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$oom_state" ingestion-worker
+oom_status=$?
+set -e
+((oom_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG" || true) == 0 ]]
+assert_failed_rescue_cleaned "$oom_state"
+
+reset_case permanent-post-unpause-unhealthy
+set_import_service_config intelligence-worker
+add_container intelligence-worker unhealthy-intelligence "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+queue_container_states unhealthy-intelligence \
+  "running|true|false|false|healthy|$ID_A|0" \
+  "running|true|false|false|unhealthy|$ID_A|0"
+post_unpause_unhealthy_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare \
+  "$SHA" "$post_unpause_unhealthy_state" intelligence-worker
+post_unpause_unhealthy_status=$?
+set -e
+((post_unpause_unhealthy_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG" || true) == 0 ]]
+assert_failed_rescue_cleaned "$post_unpause_unhealthy_state"
+
+# A changed container image fails before any stability wait can continue.
+reset_case post-unpause-image-mismatch
+set_import_service_config api
+add_container api image-mismatch-api "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+queue_container_states image-mismatch-api \
+  "running|true|false|false|healthy|$ID_A|0" \
+  "running|true|false|false|healthy|$ID_B|0"
+image_mismatch_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$image_mismatch_state" api
+image_mismatch_status=$?
+set -e
+((image_mismatch_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG" || true) == 0 ]]
+assert_failed_rescue_cleaned "$image_mismatch_state"
+
+# Even after three good samples, the final Compose mapping must still name the
+# exact container captured before pause.
+reset_case post-unpause-compose-replacement
+set_import_service_config api
+add_container api original-api "$ID_A" \
+  'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+queue_compose_containers api \
+  original-api original-api original-api original-api original-api replacement-api
+replacement_state=$(backend_image_rescue_state_file "$SHA")
+set +e
+backend_image_rescue_prepare "$SHA" "$replacement_state" api
+replacement_status=$?
+set -e
+((replacement_status != 0))
+[[ $(grep -c $'^sleep\t1$' "$EVENT_LOG") == 2 ]]
+if grep -F $'docker\tinspect\treplacement-api' "$EVENT_LOG" >/dev/null; then
+  echo 'rescue followed the replacement instead of the original container' >&2
+  exit 1
+fi
+assert_failed_rescue_cleaned "$replacement_state"
 
 # Missing or unhealthy required persistent containers fail closed and leave no
 # tag or state that could let a build begin with a partial snapshot.


### PR DESCRIPTION
Fixes the rollback-image rescue race by pinning container identity and image, allowing at most one bounded restart, requiring three stable samples, and failing closed on replacement, OOM, unhealthy state, or restart loops.\n\nValidated with rescue unit tests, the full production deploy contract, Bash syntax, source line cap, diff check, and secret scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend image recovery when containers are recreated or replaced during the rescue process.
  * Added post-recovery stabilization checks for container health, image identity, and restart activity.
  * Recovery now fails safely for missing, unhealthy, mismatched, or unstable containers.
  * Added bounded waiting and polling to prevent recovery from hanging indefinitely.

* **Tests**
  * Expanded coverage for recovery failures, container replacement, restart limits, timeouts, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the backend image rescue race by pinning container identity and image digest before the pause/export/import cycle, enforcing at most one bounded restart post-unpause, and requiring three consecutive stable health samples before declaring success. Failures on OOM, unhealthy state, image mismatch, compose reassignment, or loop timeout are all fail-closed.

- Adds `backend_image_rescue_capture_container_baseline` (captures container ID, image SHA, and restart count before pause), `backend_image_rescue_decimal_increment` (pure-bash carry arithmetic for the restart-count ceiling), and `backend_image_rescue_wait_running_container` (bounded polling loop with a 60-second / 3-second default).
- Replaces the single-shot `verify_running_container` call after unpause with the new polling loop, and threads the recorded image digest down from `pin_running_container` into `reconstruct_running_container` as a fourth parameter.
- Adds twelve new test scenarios covering transient restarts, timeouts, OOM, unhealthy state, image mismatch, compose replacement, and malformed baseline/restart-count values.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core rescue path is well-defended and the test suite covers all the new failure modes exhaustively.

The two findings are both minor: one is a small race window between two sequential Docker inspects that could allow one extra restart in an already-unlikely scenario, and the other is a naming inconsistency in a cleanup closure that is protected by an invariant enforced immediately before the closure could fire. Neither affects the correctness of the happy path or the fail-closed contract on the critical paths (OOM, replacement, timeout, image mismatch).

ops/deploy/backend-image-rescue-lib.sh lines 155–161 (two-call inspect in capture_container_baseline) and lines 443–447 (unpause_container closure variable).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ops/deploy/backend-image-rescue-lib.sh | Adds container identity pinning before pause (baseline capture), a pure-bash decimal increment helper, and a bounded post-unpause polling loop requiring three stable samples at the original image digest with at most one restart; replaces the single-shot verify_running_container call. |
| ops/deploy/backend-image-rescue-lib.test.sh | Extends the fake Docker/Compose harness to support queued per-container state sequences and adds twelve new test scenarios covering the bounded restart, OOM, unhealthy, timeout, image-mismatch, compose-replacement, and malformed-baseline paths. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PR as pin_running_container
    participant RR as reconstruct_running_container
    participant CB as capture_container_baseline
    participant DC as Docker daemon
    participant WR as wait_running_container

    PR->>DC: inspect container (Image)
    PR->>RR: reconstruct(service, container, tag, recorded_image)
    RR->>CB: capture_baseline(service, container, recorded_image)
    CB->>DC: compose ps -q service (verify identity)
    CB->>DC: "inspect container --format {{.Image}}"
    CB->>DC: "inspect container --format {{.RestartCount}}"
    CB-->>RR: original_container, baseline_image, baseline_restart_count
    RR->>DC: container pause original_container
    RR->>DC: "container export | image import (rescue_tag)"
    RR->>DC: container unpause original_container
    RR->>WR: wait(service, original_container, baseline_image, baseline_restart_count)
    loop Poll (max 60s, every 3s)
        WR->>DC: compose ps -q service (identity check)
        WR->>DC: "inspect container (Status|Running|Restarting|OOMKilled|Health|Image|RestartCount)"
        alt stable running for 3 consecutive samples
            WR->>DC: compose ps -q service (final identity check)
            WR-->>RR: success
        else OOM / unhealthy / image mismatch / excessive restart / replacement
            WR-->>RR: fail (return 1)
        else timeout
            WR-->>RR: fail (return 1)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PR as pin_running_container
    participant RR as reconstruct_running_container
    participant CB as capture_container_baseline
    participant DC as Docker daemon
    participant WR as wait_running_container

    PR->>DC: inspect container (Image)
    PR->>RR: reconstruct(service, container, tag, recorded_image)
    RR->>CB: capture_baseline(service, container, recorded_image)
    CB->>DC: compose ps -q service (verify identity)
    CB->>DC: "inspect container --format {{.Image}}"
    CB->>DC: "inspect container --format {{.RestartCount}}"
    CB-->>RR: original_container, baseline_image, baseline_restart_count
    RR->>DC: container pause original_container
    RR->>DC: "container export | image import (rescue_tag)"
    RR->>DC: container unpause original_container
    RR->>WR: wait(service, original_container, baseline_image, baseline_restart_count)
    loop Poll (max 60s, every 3s)
        WR->>DC: compose ps -q service (identity check)
        WR->>DC: "inspect container (Status|Running|Restarting|OOMKilled|Health|Image|RestartCount)"
        alt stable running for 3 consecutive samples
            WR->>DC: compose ps -q service (final identity check)
            WR-->>RR: success
        else OOM / unhealthy / image mismatch / excessive restart / replacement
            WR-->>RR: fail (return 1)
        else timeout
            WR-->>RR: fail (return 1)
        end
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ops/deploy/backend-image-rescue-lib.sh`, line 443-447 ([link](https://github.com/777genius/social-monitor/blob/16f4207b6e2693ad7ce058fbef74e5517e07c77c/ops/deploy/backend-image-rescue-lib.sh#L443-L447)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`unpause_container` references `$container`, not `$original_container`**

   The cleanup closure still unpauses `$container` (the raw parameter), while the pause and export operations below now use `$original_container`. This is functionally equivalent because `capture_container_baseline` enforces `$original_container == $container` before `paused` is ever set to `true`, so the wrong variable can never name a different container at cleanup time. However, a future refactor that changes when or how `original_container` is validated could silently break the symmetry. Updating the closure to use `$original_container` directly would make the invariant explicit.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ops/deploy/backend-image-rescue-lib.sh
   Line: 443-447

   Comment:
   **`unpause_container` references `$container`, not `$original_container`**

   The cleanup closure still unpauses `$container` (the raw parameter), while the pause and export operations below now use `$original_container`. This is functionally equivalent because `capture_container_baseline` enforces `$original_container == $container` before `paused` is ever set to `true`, so the wrong variable can never name a different container at cleanup time. However, a future refactor that changes when or how `original_container` is validated could silently break the symmetry. Updating the closure to use `$original_container` directly would make the invariant explicit.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
ops/deploy/backend-image-rescue-lib.sh:155-161
**Two separate inspects leave a restart-count race**

`capture_container_baseline` issues one `docker inspect` for `.Image` and a second for `.RestartCount`. If the container restarts between the two calls, `baseline_restart_count` reflects the post-restart value (N+1) while `baseline_image` reflects the pre-restart snapshot. `allowed_restart_count` then becomes N+2, silently raising the one-restart ceiling by one for that rescue attempt. Using a single combined inspect (`{{.Image}}|{{.RestartCount}}`) — the same format used by `wait_running_container` — would eliminate this window atomically. The existing fake-docker handler already supports this path (`*'.Image'*'.RestartCount'*`).

### Issue 2 of 2
ops/deploy/backend-image-rescue-lib.sh:443-447
**`unpause_container` references `$container`, not `$original_container`**

The cleanup closure still unpauses `$container` (the raw parameter), while the pause and export operations below now use `$original_container`. This is functionally equivalent because `capture_container_baseline` enforces `$original_container == $container` before `paused` is ever set to `true`, so the wrong variable can never name a different container at cleanup time. However, a future refactor that changes when or how `original_container` is validated could silently break the symmetry. Updating the closure to use `$original_container` directly would make the invariant explicit.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deploy): stabilize backend image res..."](https://github.com/777genius/social-monitor/commit/16f4207b6e2693ad7ce058fbef74e5517e07c77c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45597328)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->