### PR TITLE
feat(frontend): reveal more top posts on scroll

### DIFF
--- a/apps/frontend/app/test/architecture/top_posts_shared_surface_test.dart
+++ b/apps/frontend/app/test/architecture/top_posts_shared_surface_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('guest and admin pages compose the same projected top posts sliver', () {
+    final publishedPage = _readSummariesSource(
+      'lib/src/presentation/pages/published_summary_page.dart',
+    );
+    final adminPage = _readSummariesSource(
+      'lib/src/presentation/pages/summaries_feature_page.dart',
+    );
+    final sharedSection = _readSummariesSource(
+      'lib/src/presentation/components/'
+      'reader_summary_top_posts_section_sliver.dart',
+    );
+
+    for (final page in [publishedPage, adminPage]) {
+      expect(page, contains('ReaderSummaryTopPostsSectionSliver('));
+      expect(page, isNot(contains('ReaderSummaryTopPostsSliver(')));
+    }
+    expect(
+      sharedSection,
+      contains('readerSummaryTopPostsProjection(widget.summary)'),
+    );
+    expect(sharedSection, contains('ReaderSummaryTopPostsSliver('));
+  });
+}
+
+String _readSummariesSource(String packagePath) {
+  final candidates = [
+    packagePath,
+    'features/summaries/$packagePath',
+    '../features/summaries/$packagePath',
+    'apps/frontend/features/summaries/$packagePath',
+  ];
+  for (final path in candidates) {
+    final file = File(path);
+    if (file.existsSync()) {
+      return file.readAsStringSync();
+    }
+  }
+  throw StateError('Cannot locate summaries source: $packagePath');
+}

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_brief_surface.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_brief_surface.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_graph_view/flutter_graph_view.dart'
     as flutter_graph_view;
@@ -19,6 +20,8 @@ import '../formatters/reader_summary_claim_anchor_resolver.dart';
 import '../formatters/summary_period_formats.dart';
 import '../formatters/top_post_metrics.dart';
 import '../formatters/top_post_source_label.dart';
+import '../view_models/reader_summary_top_posts_projection.dart';
+import '../view_models/top_posts_continuation_window.dart';
 import 'reader_summary_citation_text.dart';
 import 'reader_summary_confirmation.dart';
 import 'reader_summary_next_actions.dart';
@@ -67,6 +70,7 @@ part 'reader_summary_top_post_rating_reason_dialog.dart';
 part 'reader_summary_top_post_rating_slot.dart';
 part 'reader_summary_top_post_row.dart';
 part 'reader_summary_top_posts.dart';
+part 'reader_summary_top_posts_reveal_trigger.dart';
 part 'reader_summary_top_posts_sliver.dart';
 part 'reader_summary_top_posts_controls.dart';
 part 'reader_summary_top_posts_tabs.dart';

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts.dart
@@ -1,6 +1,6 @@
 part of 'reader_summary_brief_surface.dart';
 
-const _githubTrendingProviderKey = 'github-trending-page';
+const _githubTrendingProviderKey = readerSummaryGitHubTrendingProviderKey;
 
 enum _TopPostSort { editorial, engagement }
 
@@ -11,8 +11,7 @@ enum _TopPostBoard { posts, githubTrending }
 class ReaderSummaryTopPosts extends StatefulWidget {
   const ReaderSummaryTopPosts({
     super.key,
-    required this.items,
-    required this.curatedTopPostCount,
+    required this.projection,
     required this.selectedPostCount,
     required this.period,
     required this.citationsById,
@@ -21,8 +20,7 @@ class ReaderSummaryTopPosts extends StatefulWidget {
     required this.onOpenUrl,
   });
 
-  final List<TopRead> items;
-  final int curatedTopPostCount;
+  final ReaderSummaryTopPostsProjection projection;
   final int selectedPostCount;
   final SummaryPeriod period;
   final Map<String, SummaryCitation> citationsById;
@@ -49,14 +47,17 @@ class _ReaderSummaryTopPostsState extends State<ReaderSummaryTopPosts> {
   @override
   void initState() {
     super.initState();
-    _board = _availableTopPostBoard(widget.items);
+    _board = _availableTopPostBoard(widget.projection.items);
   }
 
   @override
   void didUpdateWidget(covariant ReaderSummaryTopPosts oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.items != oldWidget.items) {
-      _board = _availableTopPostBoard(widget.items, preferred: _board);
+    if (!widget.projection.hasSameDatasetAs(oldWidget.projection)) {
+      _board = _availableTopPostBoard(
+        widget.projection.items,
+        preferred: _board,
+      );
     }
   }
 
@@ -69,12 +70,8 @@ class _ReaderSummaryTopPostsState extends State<ReaderSummaryTopPosts> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final postItems = widget.items
-        .where((item) => !_isGithubTrendingTopRead(item))
-        .toList(growable: false);
-    final githubTrendingItems = orderGitHubTrendingPosts(
-      widget.items.where(_isGithubTrendingTopRead),
-    );
+    final postItems = widget.projection.posts;
+    final githubTrendingItems = widget.projection.githubTrendingPosts;
     final activeBoard = _board;
     final boardItems = switch (activeBoard) {
       _TopPostBoard.posts => postItems,
@@ -99,7 +96,7 @@ class _ReaderSummaryTopPostsState extends State<ReaderSummaryTopPosts> {
           sort: _sort,
           postCount: postItems.length,
           githubTrendingCount: githubTrendingItems.length,
-          curatedTopPostCount: widget.curatedTopPostCount,
+          curatedTopPostCount: widget.projection.curatedPosts.length,
           selectedPostCount: widget.selectedPostCount,
           providerKeys: {
             for (final item in boardItems) item.providerKey,
@@ -143,7 +140,8 @@ class _ReaderSummaryTopPostsState extends State<ReaderSummaryTopPosts> {
                   final item = filtered[index];
                   return _TopPostRow(
                     key: ValueKey(
-                      'reader-summary-top-post-${_topPostStableId(item)}',
+                      'reader-summary-top-post-'
+                      '${readerSummaryTopPostIdentity(item)}-$index',
                     ),
                     index: index,
                     item: item,
@@ -203,14 +201,6 @@ double _topPostsListViewportHeight(BuildContext context) {
     return 620;
   }
   return (windowHeight * 0.68).clamp(360.0, 760.0).toDouble();
-}
-
-String _topPostStableId(TopRead item) {
-  final canonicalUrl = item.canonicalUrl?.trim();
-  if (canonicalUrl != null && canonicalUrl.isNotEmpty) {
-    return canonicalUrl;
-  }
-  return '${item.providerKey.trim()}:${item.title.trim()}';
 }
 
 class _TopPostsHeader extends StatelessWidget {
@@ -328,9 +318,6 @@ class _TopPostsHeader extends StatelessWidget {
   }
 }
 
-bool _isGithubTrendingTopRead(TopRead item) =>
-    item.providerKey.trim().toLowerCase() == _githubTrendingProviderKey;
-
 _TopPostBoard _availableTopPostBoard(
   Iterable<TopRead> items, {
   _TopPostBoard? preferred,
@@ -338,7 +325,7 @@ _TopPostBoard _availableTopPostBoard(
   var hasPosts = false;
   var hasGitHubTrending = false;
   for (final item in items) {
-    if (_isGithubTrendingTopRead(item)) {
+    if (isGitHubTrendingTopPost(item)) {
       hasGitHubTrending = true;
     } else {
       hasPosts = true;

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_reveal_trigger.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_reveal_trigger.dart
@@ -1,0 +1,128 @@
+part of 'reader_summary_brief_surface.dart';
+
+class _TopPostsRevealTrigger extends StatefulWidget {
+  const _TopPostsRevealTrigger({
+    required this.generation,
+    required this.remainingCount,
+    required this.onReveal,
+  });
+
+  final int generation;
+  final int remainingCount;
+  final bool Function(int generation) onReveal;
+
+  @override
+  State<_TopPostsRevealTrigger> createState() => _TopPostsRevealTriggerState();
+}
+
+class _TopPostsRevealTriggerState extends State<_TopPostsRevealTrigger> {
+  ScrollableState? _scrollable;
+  ScrollPosition? _scrollPosition;
+  bool _callbackScheduled = false;
+  int? _revealedRemainingCount;
+  int? _revealedGeneration;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final scrollable = Scrollable.maybeOf(context);
+    final scrollPosition = scrollable?.position;
+    if (!identical(scrollPosition, _scrollPosition)) {
+      _detachScrollableListeners();
+      _scrollable = scrollable;
+      _scrollPosition = scrollPosition;
+      _scrollPosition?.addListener(_handleScrollPositionChanged);
+    } else {
+      _scrollable = scrollable;
+    }
+    _scheduleRevealCheck();
+  }
+
+  @override
+  void didUpdateWidget(covariant _TopPostsRevealTrigger oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _scheduleRevealCheck();
+  }
+
+  @override
+  void dispose() {
+    _detachScrollableListeners();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+      child: Center(
+        child: Text(
+          'More top posts available',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+            letterSpacing: 0,
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _handleScrollPositionChanged() {
+    _scheduleRevealCheck();
+  }
+
+  void _detachScrollableListeners() {
+    _scrollPosition?.removeListener(_handleScrollPositionChanged);
+  }
+
+  void _scheduleRevealCheck() {
+    if (widget.remainingCount <= 0 ||
+        _callbackScheduled ||
+        (_revealedGeneration == widget.generation &&
+            _revealedRemainingCount == widget.remainingCount)) {
+      return;
+    }
+    _callbackScheduled = true;
+    final scheduledGeneration = widget.generation;
+    final scheduledRemainingCount = widget.remainingCount;
+    final onReveal = widget.onReveal;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _callbackScheduled = false;
+      if (!mounted ||
+          widget.generation != scheduledGeneration ||
+          widget.remainingCount != scheduledRemainingCount ||
+          !_isVisibleInScrollableViewport()) {
+        return;
+      }
+      if (onReveal(scheduledGeneration)) {
+        _revealedGeneration = scheduledGeneration;
+        _revealedRemainingCount = scheduledRemainingCount;
+      }
+    });
+  }
+
+  bool _isVisibleInScrollableViewport() {
+    final scrollable = _scrollable;
+    if (scrollable == null) {
+      return false;
+    }
+    final position = _scrollPosition;
+    if (position == null || !position.hasPixels) {
+      return false;
+    }
+    final triggerBox = context.findRenderObject();
+    final viewportBox = scrollable.context.findRenderObject();
+    if (triggerBox is! RenderBox ||
+        viewportBox is! RenderBox ||
+        !triggerBox.attached ||
+        !viewportBox.attached ||
+        !triggerBox.hasSize ||
+        !viewportBox.hasSize) {
+      return false;
+    }
+    final triggerRect = triggerBox.localToGlobal(Offset.zero) & triggerBox.size;
+    final viewportRect =
+        viewportBox.localToGlobal(Offset.zero) & viewportBox.size;
+    return triggerRect.overlaps(viewportRect);
+  }
+}

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_section_sliver.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_section_sliver.dart
@@ -3,10 +3,10 @@ import 'package:social_monitor_design_system/social_monitor_design_system.dart';
 
 import '../../domain/aggregates/reader_summary.dart';
 import '../../domain/entities/post_rating.dart';
-import '../formatters/top_post_metrics.dart';
+import '../view_models/reader_summary_top_posts_projection.dart';
 import 'reader_summary_brief_surface.dart';
 
-class ReaderSummaryTopPostsSectionSliver extends StatelessWidget {
+class ReaderSummaryTopPostsSectionSliver extends StatefulWidget {
   const ReaderSummaryTopPostsSectionSliver({
     super.key,
     required this.summary,
@@ -28,29 +28,49 @@ class ReaderSummaryTopPostsSectionSliver extends StatelessWidget {
   onRated;
 
   @override
+  State<ReaderSummaryTopPostsSectionSliver> createState() =>
+      _ReaderSummaryTopPostsSectionSliverState();
+}
+
+class _ReaderSummaryTopPostsSectionSliverState
+    extends State<ReaderSummaryTopPostsSectionSliver> {
+  late ReaderSummaryTopPostsProjection _projection;
+
+  @override
+  void initState() {
+    super.initState();
+    _projection = readerSummaryTopPostsProjection(widget.summary);
+  }
+
+  @override
+  void didUpdateWidget(covariant ReaderSummaryTopPostsSectionSliver oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(widget.summary, oldWidget.summary)) {
+      _projection = readerSummaryTopPostsProjection(widget.summary);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final items = readerSummaryTopPostItems(summary);
-    final editorialTopPostCount = readerSummaryEditorialTopPostCount(summary);
-    if (items.isEmpty) {
+    if (_projection.isEmpty) {
       return const SliverToBoxAdapter(child: SizedBox.shrink());
     }
     return SliverMainAxisGroup(
       slivers: [
         const SliverToBoxAdapter(child: SizedBox(height: AppSpacing.md + 2)),
         SliverPadding(
-          padding: contentPadding,
+          padding: widget.contentPadding,
           sliver: ReaderSummaryTopPostsSliver(
-            items: items,
-            curatedTopPostCount: editorialTopPostCount,
-            selectedPostCount:
-                summary.coverage?.selectedFeedItemCount ?? items.length,
-            period: summary.period,
+            projection: _projection,
+            selectedPostCount: _selectedPostCount(widget.summary),
+            period: widget.summary.period,
             citationsById: {
-              for (final citation in summary.citations) citation.id: citation,
+              for (final citation in widget.summary.citations)
+                citation.id: citation,
             },
-            ratingFor: ratingFor,
-            onRated: onRated,
-            onOpenUrl: onOpenUrl,
+            ratingFor: widget.ratingFor,
+            onRated: widget.onRated,
+            onOpenUrl: widget.onOpenUrl,
           ),
         ),
       ],
@@ -58,30 +78,13 @@ class ReaderSummaryTopPostsSectionSliver extends StatelessWidget {
   }
 }
 
-const _githubTrendingTopPostProviderKey = 'github-trending-page';
-
-List<TopRead> readerSummaryTopPostItems(ReaderSummary summary) {
-  final githubSource = summary.content.selectedPosts.isNotEmpty
-      ? summary.content.selectedPosts
-      : summary.content.topReads;
-  final editorialPosts = summary.content.topReads
-      .where((item) => !_isGitHubTrendingPost(item))
-      .toList(growable: false);
-  final githubTrendingPosts = githubSource
-      .where(_isGitHubTrendingPost)
-      .toList(growable: false);
-
-  return [
-    ...editorialPosts,
-    ...orderGitHubTrendingPosts(githubTrendingPosts),
-  ];
+int _selectedPostCount(ReaderSummary summary) {
+  final coverageCount = summary.coverage?.selectedFeedItemCount;
+  if (coverageCount != null) {
+    return coverageCount;
+  }
+  final selectedPosts = summary.content.selectedPosts;
+  return selectedPosts.isNotEmpty
+      ? selectedPosts.length
+      : summary.content.topReads.length;
 }
-
-int readerSummaryEditorialTopPostCount(ReaderSummary summary) {
-  return summary.content.topReads
-      .where((item) => !_isGitHubTrendingPost(item))
-      .length;
-}
-
-bool _isGitHubTrendingPost(TopRead item) =>
-    item.providerKey.trim().toLowerCase() == _githubTrendingTopPostProviderKey;

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_sliver.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_sliver.dart
@@ -1,13 +1,9 @@
 part of 'reader_summary_brief_surface.dart';
 
-const _topPostsInitialVisibleCount = 24;
-const _topPostsRevealBatchSize = 24;
-
 class ReaderSummaryTopPostsSliver extends StatefulWidget {
   const ReaderSummaryTopPostsSliver({
     super.key,
-    required this.items,
-    required this.curatedTopPostCount,
+    required this.projection,
     required this.selectedPostCount,
     required this.period,
     required this.citationsById,
@@ -16,8 +12,7 @@ class ReaderSummaryTopPostsSliver extends StatefulWidget {
     required this.onOpenUrl,
   });
 
-  final List<TopRead> items;
-  final int curatedTopPostCount;
+  final ReaderSummaryTopPostsProjection projection;
   final int selectedPostCount;
   final SummaryPeriod period;
   final Map<String, SummaryCitation> citationsById;
@@ -39,53 +34,80 @@ class _ReaderSummaryTopPostsSliverState
     extends State<ReaderSummaryTopPostsSliver> {
   _TopPostSort _sort = _TopPostSort.editorial;
   late _TopPostBoard _board;
+  late final TopPostsContinuationWindow _continuation;
+  late List<TopRead> _boardItems;
+  late List<TopRead> _filteredItems;
+  late List<String> _providerKeys;
+  late bool _reservePreviewSpace;
   final Set<String> _hiddenProviders = {};
-  int _visibleItemLimit = _topPostsInitialVisibleCount;
+  ScrollPosition? _scrollPosition;
+  double? _lastObservedScrollPixels;
+  int _userScrollSerial = 0;
+  int _lastRevealUserScrollSerial = 0;
   bool _denseView = false;
 
   @override
   void initState() {
     super.initState();
-    _board = _availableTopPostBoard(widget.items);
+    _board = _availableTopPostBoard(widget.projection.items);
+    _continuation = TopPostsContinuationWindow(
+      initialVisibleCount: readerSummaryCuratedTopPostLimit,
+    );
+    _refreshBoardItems();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final scrollPosition = Scrollable.maybeOf(context)?.position;
+    if (identical(scrollPosition, _scrollPosition)) {
+      return;
+    }
+    _scrollPosition?.removeListener(_handleScrollPositionChanged);
+    _scrollPosition = scrollPosition;
+    _lastObservedScrollPixels = scrollPosition?.hasPixels == true
+        ? scrollPosition!.pixels
+        : null;
+    _scrollPosition?.addListener(_handleScrollPositionChanged);
   }
 
   @override
   void didUpdateWidget(covariant ReaderSummaryTopPostsSliver oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.items != oldWidget.items) {
-      _visibleItemLimit = _topPostsInitialVisibleCount;
-      _board = _availableTopPostBoard(widget.items, preferred: _board);
+    final datasetChanged = !widget.projection.hasSameDatasetAs(
+      oldWidget.projection,
+    );
+    final periodChanged = widget.period != oldWidget.period;
+    if (datasetChanged || periodChanged) {
+      _continuation.reset(
+        initialVisibleCount: readerSummaryCuratedTopPostLimit,
+      );
+      _requireFreshUserScroll();
     }
+    _board = _availableTopPostBoard(widget.projection.items, preferred: _board);
+    _refreshBoardItems();
+  }
+
+  @override
+  void dispose() {
+    _scrollPosition?.removeListener(_handleScrollPositionChanged);
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final postItems = widget.items
-        .where((item) => !_isGithubTrendingTopRead(item))
-        .toList(growable: false);
-    final githubTrendingItems = orderGitHubTrendingPosts(
-      widget.items.where(_isGithubTrendingTopRead),
-    );
     final activeBoard = _board;
-    final boardItems = switch (activeBoard) {
-      _TopPostBoard.posts => postItems,
-      _TopPostBoard.githubTrending => githubTrendingItems,
-    };
-    final filtered = orderTopPosts(
-      boardItems.where((item) => !_hiddenProviders.contains(item.providerKey)),
-      byEngagement:
-          activeBoard == _TopPostBoard.posts &&
-          _sort == _TopPostSort.engagement,
-    );
-    final reservePreviewSpace = filtered.any(
-      (item) => item.previewMedia != null,
-    );
-    final visibleItemCount = math.min(filtered.length, _visibleItemLimit);
-    final hasMoreItems = visibleItemCount < filtered.length;
+    final filtered = _filteredItems;
+    final visibleItemCount = activeBoard == _TopPostBoard.posts
+        ? _continuation.visibleItemCount(filtered.length)
+        : filtered.length;
+    final hasMoreItems =
+        activeBoard == _TopPostBoard.posts &&
+        visibleItemCount < filtered.length;
     final sliverItemCount = hasMoreItems
-        ? visibleItemCount * 2
-        : visibleItemCount * 2 - 1;
+        ? math.max(1, visibleItemCount * 2)
+        : math.max(0, visibleItemCount * 2 - 1);
 
     return SliverMainAxisGroup(
       slivers: [
@@ -93,13 +115,11 @@ class _ReaderSummaryTopPostsSliverState
           child: _TopPostsHeader(
             board: activeBoard,
             sort: _sort,
-            postCount: postItems.length,
-            githubTrendingCount: githubTrendingItems.length,
-            curatedTopPostCount: widget.curatedTopPostCount,
+            postCount: widget.projection.posts.length,
+            githubTrendingCount: widget.projection.githubTrendingPosts.length,
+            curatedTopPostCount: widget.projection.curatedPosts.length,
             selectedPostCount: widget.selectedPostCount,
-            providerKeys: {
-              for (final item in boardItems) item.providerKey,
-            }.toList(growable: false),
+            providerKeys: _providerKeys,
             hiddenProviders: _hiddenProviders,
             denseView: _denseView,
             onBoardChanged: _setBoard,
@@ -130,6 +150,7 @@ class _ReaderSummaryTopPostsSliverState
             itemBuilder: (context, index) {
               if (hasMoreItems && index == sliverItemCount - 1) {
                 return _TopPostsRevealTrigger(
+                  generation: _continuation.generation,
                   remainingCount: filtered.length - visibleItemCount,
                   onReveal: _revealMoreItems,
                 );
@@ -143,14 +164,15 @@ class _ReaderSummaryTopPostsSliverState
               final item = filtered[itemIndex];
               return _TopPostRow(
                 key: ValueKey(
-                  'reader-summary-top-post-${_topPostStableId(item)}',
+                  'reader-summary-top-post-'
+                  '${readerSummaryTopPostIdentity(item)}-$itemIndex',
                 ),
                 index: itemIndex,
                 item: item,
                 dateLabel: _topPostDateLabel(item, widget.period),
                 citationsById: widget.citationsById,
                 dense: _denseView,
-                reservePreviewSpace: reservePreviewSpace,
+                reservePreviewSpace: _reservePreviewSpace,
                 rating: widget.ratingFor?.call(item),
                 onRated: widget.onRated,
                 onOpenUrl: widget.onOpenUrl,
@@ -167,7 +189,8 @@ class _ReaderSummaryTopPostsSliverState
     }
     setState(() {
       _board = board;
-      _visibleItemLimit = _topPostsInitialVisibleCount;
+      _resetContinuation();
+      _refreshBoardItems();
     });
   }
 
@@ -177,7 +200,8 @@ class _ReaderSummaryTopPostsSliverState
     }
     setState(() {
       _sort = sort;
-      _visibleItemLimit = _topPostsInitialVisibleCount;
+      _resetContinuation();
+      _refreshBoardItems();
     });
   }
 
@@ -186,7 +210,8 @@ class _ReaderSummaryTopPostsSliverState
       if (!_hiddenProviders.remove(providerKey)) {
         _hiddenProviders.add(providerKey);
       }
-      _visibleItemLimit = _topPostsInitialVisibleCount;
+      _resetContinuation();
+      _refreshBoardItems();
     });
   }
 
@@ -196,90 +221,68 @@ class _ReaderSummaryTopPostsSliverState
     }
     setState(() {
       _denseView = dense;
-      _visibleItemLimit = _topPostsInitialVisibleCount;
     });
   }
 
-  void _revealMoreItems() {
-    if (!mounted) {
-      return;
+  bool _revealMoreItems(int generation) {
+    if (!mounted ||
+        _board != _TopPostBoard.posts ||
+        generation != _continuation.generation ||
+        _userScrollSerial <= _lastRevealUserScrollSerial ||
+        _continuation.visibleItemCount(_filteredItems.length) >=
+            _filteredItems.length) {
+      return false;
     }
+    var didReveal = false;
     setState(() {
-      _visibleItemLimit += _topPostsRevealBatchSize;
+      didReveal = _continuation.revealNext(
+        generation: generation,
+        totalItemCount: _filteredItems.length,
+      );
+      if (didReveal) {
+        _lastRevealUserScrollSerial = _userScrollSerial;
+      }
     });
-  }
-}
-
-class _TopPostsRevealTrigger extends StatefulWidget {
-  const _TopPostsRevealTrigger({
-    required this.remainingCount,
-    required this.onReveal,
-  });
-
-  final int remainingCount;
-  final VoidCallback onReveal;
-
-  @override
-  State<_TopPostsRevealTrigger> createState() => _TopPostsRevealTriggerState();
-}
-
-class _TopPostsRevealTriggerState extends State<_TopPostsRevealTrigger> {
-  int? _scheduledRemainingCount;
-
-  @override
-  void initState() {
-    super.initState();
-    _scheduleReveal();
+    return didReveal;
   }
 
-  @override
-  void didUpdateWidget(covariant _TopPostsRevealTrigger oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    _scheduleReveal();
+  void _resetContinuation() {
+    _continuation.reset(initialVisibleCount: readerSummaryCuratedTopPostLimit);
+    _requireFreshUserScroll();
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
-      child: Center(
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SizedBox(
-              width: 16,
-              height: 16,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: colorScheme.primary,
-              ),
-            ),
-            const SizedBox(width: AppSpacing.sm),
-            Text(
-              'Loading more top posts',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: colorScheme.onSurfaceVariant,
-                letterSpacing: 0,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _scheduleReveal() {
-    if (widget.remainingCount <= 0 ||
-        _scheduledRemainingCount == widget.remainingCount) {
+  void _handleScrollPositionChanged() {
+    final position = _scrollPosition;
+    if (position == null || !position.hasPixels) {
       return;
     }
-    _scheduledRemainingCount = widget.remainingCount;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) {
-        return;
-      }
-      widget.onReveal();
-    });
+    final pixels = position.pixels;
+    final pixelsChanged = _lastObservedScrollPixels != pixels;
+    _lastObservedScrollPixels = pixels;
+    if (pixelsChanged && position.userScrollDirection != ScrollDirection.idle) {
+      _userScrollSerial += 1;
+    }
+  }
+
+  void _requireFreshUserScroll() {
+    _lastRevealUserScrollSerial = _userScrollSerial;
+  }
+
+  void _refreshBoardItems() {
+    _boardItems = switch (_board) {
+      _TopPostBoard.posts => widget.projection.posts,
+      _TopPostBoard.githubTrending => widget.projection.githubTrendingPosts,
+    };
+    _providerKeys = {
+      for (final item in _boardItems) item.providerKey,
+    }.toList(growable: false);
+    _filteredItems = orderTopPosts(
+      _boardItems.where((item) => !_hiddenProviders.contains(item.providerKey)),
+      byEngagement:
+          _board == _TopPostBoard.posts && _sort == _TopPostSort.engagement,
+    );
+    _reservePreviewSpace = _filteredItems.any(
+      (item) => item.previewMedia != null,
+    );
   }
 }

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_view.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_view.dart
@@ -7,9 +7,9 @@ import '../../domain/entities/post_rating.dart';
 import '../../domain/entities/reader_summary_topic_recommendation.dart';
 import '../../domain/entities/summary_citation.dart';
 import '../../domain/value_objects/reader_action_target.dart';
+import '../view_models/reader_summary_top_posts_projection.dart';
 import 'reader_summary_brief_surface.dart';
 import 'reader_summary_next_actions.dart';
-import 'reader_summary_top_posts_section_sliver.dart';
 import 'reader_summary_topic_recommendations_panel.dart';
 import 'reader_summary_trust_panel.dart';
 
@@ -86,10 +86,14 @@ class ReaderSummaryView extends StatelessWidget {
     final citationsById = {
       for (final citation in summary.citations) citation.id: citation,
     };
-    final topPostItems = readerSummaryTopPostItems(summary);
-    final editorialTopPostCount = readerSummaryEditorialTopPostCount(summary);
+    final topPostsProjection = includeTopPosts
+        ? readerSummaryTopPostsProjection(summary)
+        : null;
     final selectedPostCount =
-        summary.coverage?.selectedFeedItemCount ?? topPostItems.length;
+        summary.coverage?.selectedFeedItemCount ??
+        (summary.content.selectedPosts.isNotEmpty
+            ? summary.content.selectedPosts.length
+            : summary.content.topReads.length);
 
     return SelectionArea(
       child: Column(
@@ -119,11 +123,10 @@ class ReaderSummaryView extends StatelessWidget {
               onOpenUrl: onOpenUrl,
             ),
           ],
-          if (includeTopPosts && topPostItems.isNotEmpty) ...[
+          if (topPostsProjection != null && !topPostsProjection.isEmpty) ...[
             const SizedBox(height: AppSpacing.md + 2),
             ReaderSummaryTopPosts(
-              items: topPostItems,
-              curatedTopPostCount: editorialTopPostCount,
+              projection: topPostsProjection,
               selectedPostCount: selectedPostCount,
               period: summary.period,
               citationsById: citationsById,

--- a/apps/frontend/features/summaries/lib/src/presentation/formatters/top_post_metrics.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/formatters/top_post_metrics.dart
@@ -1,5 +1,8 @@
 import '../../domain/aggregates/reader_summary.dart';
 
+const _githubTrendingProviderKey = 'github-trending-page';
+const _githubTrendingMetricLabel = 'github trending today';
+
 /// One display metric slot in a top post row, e.g. `2.0K Likes`.
 final class TopPostMetric {
   const TopPostMetric({
@@ -20,7 +23,7 @@ const _metricSlotsByProvider = <String, List<String>>{
   'twitter': ['Likes', 'Reposts', 'Replies', 'Views'],
   'reddit': ['Upvotes', 'Comments', 'Shares', 'Views'],
   'hacker-news': ['Points', 'Comments', 'Shares', 'Views'],
-  'github-trending-page': ['Stars', 'Stars today', 'Rank', 'Forks'],
+  _githubTrendingProviderKey: ['Stars', 'Stars today', 'Rank', 'Forks'],
   'github-issues': ['Comments', 'Reactions', 'Stars', 'Views'],
 };
 
@@ -82,16 +85,14 @@ List<TopPostMetric> topPostMetricsFor(TopRead read) {
 /// GitHub Trending repositories only become breakout signals above 1,000
 /// stars gained today. Exactly 1,000 remains a regular trend.
 bool isGitHubTrendingBreakout(TopRead read) =>
-    read.providerKey.trim().toLowerCase() == 'github-trending-page' &&
+    read.providerKey.trim().toLowerCase() == _githubTrendingProviderKey &&
     (_githubTrendingStarsToday(read) ?? 0) > 1000;
 
 /// Accepts only the canonical backend GitHub board in exact rank order.
 ///
 /// A partial, reordered, duplicated or identity-less projection is rejected as
 /// a whole so presentation cannot make invalid selectedPosts look publishable.
-List<TopRead> orderGitHubTrendingPosts(
-  Iterable<TopRead> items,
-) {
+List<TopRead> orderGitHubTrendingPosts(Iterable<TopRead> items) {
   final canonical = items.toList(growable: false);
   if (canonical.length != 10) {
     return const [];
@@ -104,7 +105,8 @@ List<TopRead> orderGitHubTrendingPosts(
     final citationId = item.citationIds.length == 1
         ? item.citationIds[0].trim()
         : null;
-    if (_githubTrendingRank(item) != index + 1 ||
+    if (item.providerKey.trim().toLowerCase() != _githubTrendingProviderKey ||
+        _githubTrendingRank(item) != index + 1 ||
         repositoryIdentity == null ||
         !repositoryIdentities.add(repositoryIdentity) ||
         item.citationIds.length != 1 ||
@@ -138,7 +140,7 @@ String? _githubRepositoryIdentity(String? value) {
 
 int? _githubTrendingRank(TopRead read) {
   for (final metric in read.providerMetrics) {
-    if (!metric.label.toLowerCase().contains('trending today')) {
+    if (!_isGitHubTrendingMetric(metric)) {
       continue;
     }
     final rawRank = RegExp(r'#([\d,]+)').firstMatch(metric.value)?.group(1);
@@ -152,7 +154,7 @@ int? _githubTrendingRank(TopRead read) {
 
 num? _githubTrendingStarsToday(TopRead read) {
   for (final metric in read.providerMetrics) {
-    if (!metric.label.toLowerCase().contains('trending today')) {
+    if (!_isGitHubTrendingMetric(metric)) {
       continue;
     }
     final rawStars = RegExp(
@@ -177,7 +179,7 @@ Map<String, String> _parsedMetrics(TopRead read) {
 }
 
 void _collectTrendingToday(ProviderMetric metric, Map<String, String> found) {
-  if (!metric.label.toLowerCase().contains('trending today')) {
+  if (!_isGitHubTrendingMetric(metric)) {
     return;
   }
   final rank = RegExp(r'#\d+').firstMatch(metric.value)?.group(0);
@@ -195,6 +197,9 @@ void _collectTrendingToday(ProviderMetric metric, Map<String, String> found) {
     );
   }
 }
+
+bool _isGitHubTrendingMetric(ProviderMetric metric) =>
+    metric.label.trim().toLowerCase() == _githubTrendingMetricLabel;
 
 final _numberWordPattern = RegExp(
   r'([\d][\d,.]*[kKmM]?)\s*(?:x\s+)?([a-zA-Z][a-zA-Z ]*)',
@@ -267,13 +272,20 @@ List<TopRead> orderTopPosts(
   required bool byEngagement,
 }) {
   final ordered = items.toList(growable: false);
-  if (byEngagement) {
-    ordered.sort(
-      (a, b) => topPostEngagementScore(b).compareTo(topPostEngagementScore(a)),
-    );
+  if (!byEngagement) {
+    return ordered;
   }
 
-  return ordered;
+  final indexed = ordered.indexed.toList(growable: false)
+    ..sort((left, right) {
+      final engagementOrder = topPostEngagementScore(
+        right.$2,
+      ).compareTo(topPostEngagementScore(left.$2));
+      return engagementOrder != 0
+          ? engagementOrder
+          : left.$1.compareTo(right.$1);
+    });
+  return indexed.map((entry) => entry.$2).toList(growable: false);
 }
 
 num _rawMetricNumber(String raw) {

--- a/apps/frontend/features/summaries/lib/src/presentation/view_models/reader_summary_top_posts_projection.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/view_models/reader_summary_top_posts_projection.dart
@@ -1,0 +1,245 @@
+import '../../domain/aggregates/reader_summary.dart';
+import '../formatters/top_post_metrics.dart';
+
+const readerSummaryCuratedTopPostLimit = 8;
+const readerSummaryGitHubTrendingProviderKey = 'github-trending-page';
+
+final class ReaderSummaryTopPostsProjection {
+  ReaderSummaryTopPostsProjection._({
+    required this.curatedPosts,
+    required this.continuationPosts,
+    required this.posts,
+    required this.githubTrendingPosts,
+    required this.items,
+    required List<String> datasetOrder,
+  }) : _datasetOrder = datasetOrder;
+
+  final List<TopRead> curatedPosts;
+  final List<TopRead> continuationPosts;
+  final List<TopRead> posts;
+  final List<TopRead> githubTrendingPosts;
+  final List<TopRead> items;
+  final List<String> _datasetOrder;
+
+  bool get isEmpty => items.isEmpty;
+
+  bool hasSameDatasetAs(ReaderSummaryTopPostsProjection other) {
+    if (_datasetOrder.length != other._datasetOrder.length) {
+      return false;
+    }
+    for (var index = 0; index < _datasetOrder.length; index += 1) {
+      if (_datasetOrder[index] != other._datasetOrder[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+ReaderSummaryTopPostsProjection readerSummaryTopPostsProjection(
+  ReaderSummary summary,
+) {
+  final editorialTopReads = _stableUniquePosts(
+    summary.content.topReads.where((item) => !isGitHubTrendingTopPost(item)),
+  );
+  final curatedPosts = editorialTopReads
+      .take(readerSummaryCuratedTopPostLimit)
+      .toList(growable: false);
+  // Preserve backend order while keeping the first identity across the
+  // complete non-GitHub continuation.
+  final continuationPosts = List<TopRead>.unmodifiable(
+    _stableUniquePosts(
+      [
+        ...editorialTopReads.skip(readerSummaryCuratedTopPostLimit),
+        ...summary.content.selectedPosts.where(
+          (item) => !isGitHubTrendingTopPost(item),
+        ),
+      ],
+      seenIdentities: {
+        for (final item in curatedPosts) readerSummaryTopPostIdentity(item),
+      },
+    ),
+  );
+  final posts = List<TopRead>.unmodifiable([
+    ...curatedPosts,
+    ...continuationPosts,
+  ]);
+  final githubTrendingPosts = List<TopRead>.unmodifiable(
+    orderGitHubTrendingPosts(
+      summary.content.selectedPosts.where(isGitHubTrendingTopPost),
+    ),
+  );
+  final items = List<TopRead>.unmodifiable([...posts, ...githubTrendingPosts]);
+
+  return ReaderSummaryTopPostsProjection._(
+    curatedPosts: List<TopRead>.unmodifiable(curatedPosts),
+    continuationPosts: continuationPosts,
+    posts: posts,
+    githubTrendingPosts: githubTrendingPosts,
+    items: items,
+    datasetOrder: List<String>.unmodifiable([
+      'curated:${curatedPosts.length}',
+      for (final item in posts) 'post:${readerSummaryTopPostIdentity(item)}',
+      for (final item in githubTrendingPosts)
+        'github:${readerSummaryTopPostIdentity(item)}',
+    ]),
+  );
+}
+
+bool isGitHubTrendingTopPost(TopRead item) =>
+    item.providerKey.trim().toLowerCase() ==
+    readerSummaryGitHubTrendingProviderKey;
+
+String readerSummaryTopPostIdentity(TopRead item) {
+  final canonicalUrl = item.canonicalUrl;
+  if (canonicalUrl != null && canonicalUrl.trim().isNotEmpty) {
+    return 'url:${_normalizedCanonicalUrl(canonicalUrl)}';
+  }
+  return 'fallback:${_normalizedText(item.providerKey)}:'
+      '${_normalizedText(item.title)}';
+}
+
+String readerSummaryGitHubRepositoryIdentity(TopRead item) {
+  final canonicalUrl = item.canonicalUrl;
+  if (canonicalUrl != null) {
+    final repository = _repositoryFromGitHubUrl(canonicalUrl);
+    if (repository != null) {
+      return repository;
+    }
+  }
+
+  final titleMatch = RegExp(
+    r'([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+)',
+  ).firstMatch(item.title);
+  if (titleMatch != null) {
+    final owner = _normalizedRepositorySegment(titleMatch.group(1)!);
+    final repository = _normalizedRepositorySegment(titleMatch.group(2)!);
+    if (owner.isNotEmpty && repository.isNotEmpty) {
+      return '$owner/$repository';
+    }
+  }
+
+  return readerSummaryTopPostIdentity(item);
+}
+
+List<TopRead> _stableUniquePosts(
+  Iterable<TopRead> items, {
+  Set<String>? seenIdentities,
+}) {
+  final seen = {...?seenIdentities};
+  final unique = <TopRead>[];
+  for (final item in items) {
+    if (seen.add(readerSummaryTopPostIdentity(item))) {
+      unique.add(item);
+    }
+  }
+  return unique;
+}
+
+String? _repositoryFromGitHubUrl(String rawUrl) {
+  final uri = Uri.tryParse(rawUrl.trim());
+  if (uri == null) {
+    return null;
+  }
+  final host = uri.host.toLowerCase();
+  if (host != 'github.com' && host != 'www.github.com') {
+    return null;
+  }
+  final segments = uri.pathSegments
+      .where((segment) => segment.trim().isNotEmpty)
+      .toList(growable: false);
+  if (segments.length < 2) {
+    return null;
+  }
+  final owner = _normalizedRepositorySegment(segments[0]);
+  final repository = _normalizedRepositorySegment(segments[1]);
+  return owner.isEmpty || repository.isEmpty ? null : '$owner/$repository';
+}
+
+String _normalizedRepositorySegment(String value) {
+  return value
+      .trim()
+      .replaceFirst(RegExp(r'\.git$', caseSensitive: false), '')
+      .replaceFirst(RegExp(r'[.,:;]+$'), '')
+      .toLowerCase();
+}
+
+String _normalizedCanonicalUrl(String rawUrl) {
+  final trimmed = rawUrl.trim();
+  final uri = Uri.tryParse(trimmed);
+  if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+    return _normalizedText(trimmed);
+  }
+
+  var path = uri.path;
+  while (path.length > 1 && path.endsWith('/')) {
+    path = path.substring(0, path.length - 1);
+  }
+  if (path == '/') {
+    path = '';
+  }
+  final scheme = uri.scheme.toLowerCase();
+  final isDefaultPort =
+      (scheme == 'http' && uri.port == 80) ||
+      (scheme == 'https' && uri.port == 443);
+  final query = _normalizedCanonicalQuery(uri);
+
+  return Uri(
+    scheme: scheme,
+    userInfo: uri.userInfo,
+    host: uri.host.toLowerCase(),
+    port: uri.hasPort && !isDefaultPort ? uri.port : null,
+    path: path,
+    query: query.isEmpty ? null : query,
+  ).toString();
+}
+
+String _normalizedCanonicalQuery(Uri uri) {
+  if (!uri.hasQuery) {
+    return '';
+  }
+  final host = uri.host.toLowerCase();
+  final entries = <MapEntry<String, String>>[];
+  for (final parameter in uri.queryParametersAll.entries) {
+    final normalizedKey = parameter.key.trim().toLowerCase();
+    if (normalizedKey.startsWith('utm_') ||
+        _discardedTrackingParameters.contains(normalizedKey) ||
+        (_isGitHubHost(host) && normalizedKey == 'ref')) {
+      continue;
+    }
+    for (final value in parameter.value) {
+      entries.add(MapEntry(parameter.key, value));
+    }
+  }
+  entries.sort((left, right) {
+    final keyOrder = left.key.toLowerCase().compareTo(right.key.toLowerCase());
+    if (keyOrder != 0) {
+      return keyOrder;
+    }
+    final exactKeyOrder = left.key.compareTo(right.key);
+    return exactKeyOrder != 0
+        ? exactKeyOrder
+        : left.value.compareTo(right.value);
+  });
+  return entries
+      .map(
+        (entry) =>
+            '${Uri.encodeQueryComponent(entry.key)}='
+            '${Uri.encodeQueryComponent(entry.value)}',
+      )
+      .join('&');
+}
+
+const _discardedTrackingParameters = <String>{
+  'fbclid',
+  'gclid',
+  'igshid',
+  'mc_cid',
+  'mc_eid',
+};
+
+bool _isGitHubHost(String host) =>
+    host == 'github.com' || host == 'www.github.com';
+
+String _normalizedText(String value) =>
+    value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');

--- a/apps/frontend/features/summaries/lib/src/presentation/view_models/top_posts_continuation_window.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/view_models/top_posts_continuation_window.dart
@@ -1,0 +1,37 @@
+const topPostsContinuationBatchSize = 24;
+
+final class TopPostsContinuationWindow {
+  TopPostsContinuationWindow({required int initialVisibleCount})
+    : _visibleItemLimit = _nonNegative(initialVisibleCount);
+
+  int _visibleItemLimit;
+  int _generation = 0;
+
+  int get generation => _generation;
+
+  int visibleItemCount(int totalItemCount) {
+    final total = _nonNegative(totalItemCount);
+    return _visibleItemLimit < total ? _visibleItemLimit : total;
+  }
+
+  void reset({required int initialVisibleCount}) {
+    _generation += 1;
+    _visibleItemLimit = _nonNegative(initialVisibleCount);
+  }
+
+  bool revealNext({required int generation, required int totalItemCount}) {
+    if (generation != _generation) {
+      return false;
+    }
+    final total = _nonNegative(totalItemCount);
+    final nextLimit = _visibleItemLimit + topPostsContinuationBatchSize;
+    final boundedLimit = nextLimit < total ? nextLimit : total;
+    if (boundedLimit <= _visibleItemLimit) {
+      return false;
+    }
+    _visibleItemLimit = boundedLimit;
+    return true;
+  }
+}
+
+int _nonNegative(int value) => value < 0 ? 0 : value;

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_continuation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_continuation_test.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_monitor_design_system/social_monitor_design_system.dart';
+import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.dart';
+import 'package:social_monitor_summaries/src/presentation/components/reader_summary_top_posts_section_sliver.dart';
+
+import '../../support/top_posts_test_fixtures.dart';
+
+void main() {
+  testWidgets('starts at eight and reveals two automatic batches on scroll', (
+    tester,
+  ) async {
+    _configureView(tester);
+    final summary = _continuationSummary();
+
+    await tester.pumpWidget(_TopPostsTestApp(summary: summary));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Curated 0'), findsOneWidget);
+    expect(find.text('Continuation 0'), findsNothing);
+    expect(find.textContaining('Load more'), findsNothing);
+    expect(_topPostSliverChildCount(tester), 16);
+
+    await tester.scrollUntilVisible(
+      find.text('Continuation 2'),
+      420,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 100,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Continuation 2'), findsOneWidget);
+    expect(_topPostSliverChildCount(tester), 64);
+
+    await tester.scrollUntilVisible(
+      find.text('Continuation 28'),
+      420,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 100,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Continuation 28'), findsOneWidget);
+    expect(_topPostSliverChildCount(tester), 112);
+  });
+
+  testWidgets('does not reveal a visible sentinel before user scroll', (
+    tester,
+  ) async {
+    _configureView(tester, height: 6000);
+
+    await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
+    await tester.pumpAndSettle();
+
+    expect(_topPostSliverChildCount(tester), 16);
+    expect(find.text('Continuation 0'), findsNothing);
+  });
+
+  testWidgets('keeps selected continuation reachable with zero top reads', (
+    tester,
+  ) async {
+    _configureView(tester);
+    final summary = topPostsSummaryFixture(
+      topReads: const [],
+      selectedPosts: [
+        for (var index = 0; index < 12; index += 1)
+          topPostFixture(title: 'Selected $index'),
+      ],
+    );
+
+    await tester.pumpWidget(_TopPostsTestApp(summary: summary));
+    await tester.pumpAndSettle();
+
+    expect(_topPostSliverChildCount(tester), 16);
+    expect(find.text('Selected 8'), findsNothing);
+
+    await tester.scrollUntilVisible(
+      find.text('Selected 8'),
+      420,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 100,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Selected 8'), findsOneWidget);
+    expect(_topPostSliverChildCount(tester), 23);
+  });
+
+  testWidgets('dedupes top reads while filling eight unique initial posts', (
+    tester,
+  ) async {
+    _configureView(tester);
+    final summary = topPostsSummaryFixture(
+      topReads: [
+        topPostFixture(
+          title: 'Curated 0',
+          canonicalUrl: 'https://news.example/curated/0',
+        ),
+        topPostFixture(
+          title: 'Duplicate inside top reads',
+          canonicalUrl: 'https://news.example/curated/0/',
+        ),
+        for (var index = 1; index < 3; index += 1)
+          topPostFixture(
+            title: 'Curated $index',
+            canonicalUrl: 'https://news.example/curated/$index',
+          ),
+      ],
+      selectedPosts: [
+        topPostFixture(
+          title: 'Duplicate curated',
+          canonicalUrl: 'https://news.example/curated/0/',
+        ),
+        for (var index = 0; index < 9; index += 1)
+          topPostFixture(title: 'Selected $index'),
+      ],
+    );
+
+    await tester.pumpWidget(_TopPostsTestApp(summary: summary));
+    await tester.pumpAndSettle();
+
+    expect(_topPostSliverChildCount(tester), 16);
+    expect(find.text('Duplicate inside top reads'), findsNothing);
+    expect(find.text('Selected 5'), findsNothing);
+
+    await tester.scrollUntilVisible(
+      find.text('Selected 8'),
+      420,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 100,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Selected 8'), findsOneWidget);
+    expect(_topPostSliverChildCount(tester), 23);
+  });
+
+  testWidgets('keeps continuation on an equivalent dataset rebuild', (
+    tester,
+  ) async {
+    _configureView(tester);
+
+    await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('Continuation 2'),
+      420,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 100,
+    );
+    await tester.pumpAndSettle();
+    expect(_topPostSliverChildCount(tester), 64);
+
+    await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Continuation 2'), findsOneWidget);
+    expect(_topPostSliverChildCount(tester), 64);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('resets continuation when the summary period changes', (
+    tester,
+  ) async {
+    _configureView(tester);
+
+    await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('Continuation 2'),
+      420,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 100,
+    );
+    await tester.pumpAndSettle();
+    expect(_topPostSliverChildCount(tester), 64);
+
+    await tester.scrollUntilVisible(
+      find.text('Curated 0'),
+      -420,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 100,
+    );
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(
+      _TopPostsTestApp(
+        summary: _continuationSummary(
+          period: SummaryPeriod(
+            cadence: SummaryPeriodCadence.daily,
+            startedAt: DateTime.utc(2026, 6, 27),
+            endedAt: DateTime.utc(2026, 6, 28),
+            timezone: 'UTC',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(_topPostSliverChildCount(tester), 16);
+  });
+}
+
+int _topPostSliverChildCount(WidgetTester tester) {
+  final sliver = tester.widget<SliverList>(find.byType(SliverList));
+  return sliver.delegate.estimatedChildCount!;
+}
+
+ReaderSummary _continuationSummary({SummaryPeriod? period}) {
+  return topPostsSummaryFixture(
+    topReads: [
+      for (var index = 0; index < 8; index += 1)
+        topPostFixture(
+          title: 'Curated $index',
+          canonicalUrl: 'https://news.example/curated/$index',
+        ),
+    ],
+    selectedPosts: [
+      for (var index = 0; index < 60; index += 1)
+        topPostFixture(
+          title: 'Continuation $index',
+          canonicalUrl: 'https://news.example/continuation/$index',
+        ),
+    ],
+    period: period,
+  );
+}
+
+void _configureView(WidgetTester tester, {double height = 700}) {
+  tester.view.physicalSize = Size(1100, height);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+}
+
+class _TopPostsTestApp extends StatelessWidget {
+  const _TopPostsTestApp({required this.summary});
+
+  final ReaderSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppTheme.light();
+    return AppHeadlessScope(
+      theme: theme,
+      appBuilder: (overlayBuilder) => MaterialApp(
+        theme: theme,
+        builder: overlayBuilder,
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: [
+              ReaderSummaryTopPostsSectionSliver(
+                summary: summary,
+                contentPadding: const EdgeInsets.all(AppSpacing.md),
+                onOpenUrl: (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_sliver_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_sliver_test.dart
@@ -5,7 +5,7 @@ import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.da
 import 'package:social_monitor_summaries/src/infrastructure/api/summary_api_dto.dart';
 import 'package:social_monitor_summaries/src/infrastructure/mappers/summary_mapper.dart';
 import 'package:social_monitor_summaries/src/presentation/components/reader_summary_brief_surface.dart';
-import 'package:social_monitor_summaries/src/presentation/components/reader_summary_top_posts_section_sliver.dart';
+import 'package:social_monitor_summaries/src/presentation/view_models/reader_summary_top_posts_projection.dart';
 
 import '../../support/summaries_test_fixtures.dart';
 
@@ -130,7 +130,7 @@ void main() {
   );
 
   testWidgets(
-    'shows only editorial reads as top posts and keeps selected GitHub trends',
+    'continues selected posts after editorial reads and keeps GitHub separate',
     (tester) async {
       tester.view.physicalSize = const Size(1100, 900);
       tester.view.devicePixelRatio = 1;
@@ -162,12 +162,25 @@ void main() {
       await tester.pumpWidget(_TestApp(summary: summary));
       await tester.pumpAndSettle();
 
-      expect(find.bySemanticsLabel('Top posts, 2 items'), findsOneWidget);
+      expect(find.bySemanticsLabel('Top posts, 3 items'), findsOneWidget);
       expect(find.text('2 editorial picks from 3 selected'), findsOneWidget);
       expect(find.text('Backend editorial winner'), findsOneWidget);
       expect(find.text('Higher engagement runner-up'), findsOneWidget);
-      expect(find.text('Long-tail selected evidence'), findsNothing);
 
+      await tester.scrollUntilVisible(
+        find.text('Long-tail selected evidence'),
+        320,
+        scrollable: find.byType(Scrollable).first,
+        maxScrolls: 20,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Long-tail selected evidence'), findsOneWidget);
+
+      await tester.ensureVisible(
+        find.byKey(const ValueKey('reader-summary-top-posts-board-github')),
+      );
+      await tester.pumpAndSettle();
       await tester.tap(
         find.byKey(const ValueKey('reader-summary-top-posts-board-github')),
       );
@@ -179,7 +192,7 @@ void main() {
     },
   );
 
-  test('rejects a partial GitHub board as a whole', () {
+  test('keeps selected continuation but rejects a partial GitHub board', () {
     final selectedPosts = [_longTailSelectedPost(), _githubTopReads().first];
     final summary = const SummaryMapper().readerSummaryToDomain(
       readerSummaryApiDto(
@@ -190,10 +203,11 @@ void main() {
       ),
     );
 
-    final items = readerSummaryTopPostItems(summary);
+    final projection = readerSummaryTopPostsProjection(summary);
 
-    expect(readerSummaryEditorialTopPostCount(summary), 0);
-    expect(items, isEmpty);
+    expect(projection.curatedPosts, isEmpty);
+    expect(projection.posts.single.title, 'Long-tail selected evidence');
+    expect(projection.githubTrendingPosts, isEmpty);
   });
 
   testWidgets('falls back when a new day changes the available board', (
@@ -249,9 +263,9 @@ void main() {
 
     final summary = const SummaryMapper().readerSummaryToDomain(
       readerSummaryApiDto(
-        content: readerSummaryContentApiDto(
-          topReads: _githubTopReads(),
-          sourceProviderKey: 'github-trending-page',
+        content: _contentWithSelectedPosts(
+          readerSummaryContentApiDto(topReads: const []),
+          _githubTopReads(),
         ),
         citations: _githubCitations(),
       ),
@@ -428,7 +442,7 @@ class _TestApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = AppTheme.light();
-    final items = readerSummaryTopPostItems(summary);
+    final projection = readerSummaryTopPostsProjection(summary);
     return AppHeadlessScope(
       theme: theme,
       appBuilder: (overlayBuilder) => MaterialApp(
@@ -440,12 +454,12 @@ class _TestApp extends StatelessWidget {
               SliverPadding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 sliver: ReaderSummaryTopPostsSliver(
-                  items: items,
-                  curatedTopPostCount: readerSummaryEditorialTopPostCount(
-                    summary,
-                  ),
+                  projection: projection,
                   selectedPostCount:
-                      summary.coverage?.selectedFeedItemCount ?? items.length,
+                      summary.coverage?.selectedFeedItemCount ??
+                      (summary.content.selectedPosts.isNotEmpty
+                          ? summary.content.selectedPosts.length
+                          : summary.content.topReads.length),
                   period: summary.period,
                   citationsById: {
                     for (final citation in summary.citations)

--- a/apps/frontend/features/summaries/test/presentation/formatters/top_post_metrics_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/formatters/top_post_metrics_test.dart
@@ -19,10 +19,7 @@ void main() {
       isEmpty,
     );
     expect(orderGitHubTrendingPosts(posts.take(9)), isEmpty);
-    expect(
-      orderGitHubTrendingPosts([...posts, _githubTrend(11)]),
-      isEmpty,
-    );
+    expect(orderGitHubTrendingPosts([...posts, _githubTrend(11)]), isEmpty);
   });
 
   test('rejects duplicate and invalid repository identities', () {
@@ -40,6 +37,25 @@ void main() {
     expect(orderGitHubTrendingPosts(invalid), isEmpty);
   });
 
+  test('rejects non-GitHub providers and non-canonical rank metrics', () {
+    final posts = List.generate(10, (index) => _githubTrend(index + 1));
+
+    expect(
+      orderGitHubTrendingPosts([
+        ...posts.take(9),
+        _githubTrend(10, providerKey: 'github-issues'),
+      ]),
+      isEmpty,
+    );
+    expect(
+      orderGitHubTrendingPosts([
+        ...posts.take(9),
+        _githubTrend(10, trendingMetricLabel: 'Not GitHub Trending today'),
+      ]),
+      isEmpty,
+    );
+  });
+
   test('rejects duplicate citation identity for the whole board', () {
     final posts = List.generate(10, (index) => _githubTrend(index + 1));
     final duplicateCitation = [
@@ -50,31 +66,34 @@ void main() {
     expect(orderGitHubTrendingPosts(duplicateCitation), isEmpty);
   });
 
-  test('rejects missing or ambiguous citation identity for the whole board', () {
-    final posts = List.generate(10, (index) => _githubTrend(index + 1));
+  test(
+    'rejects missing or ambiguous citation identity for the whole board',
+    () {
+      final posts = List.generate(10, (index) => _githubTrend(index + 1));
 
-    expect(
-      orderGitHubTrendingPosts([
-        ...posts.take(9),
-        _githubTrend(10, citationIds: const []),
-      ]),
-      isEmpty,
-    );
-    expect(
-      orderGitHubTrendingPosts([
-        ...posts.take(9),
-        _githubTrend(10, citationIds: const ['github-c-10', 'github-c-11']),
-      ]),
-      isEmpty,
-    );
-    expect(
-      orderGitHubTrendingPosts([
-        ...posts.take(9),
-        _githubTrend(10, citationId: '  '),
-      ]),
-      isEmpty,
-    );
-  });
+      expect(
+        orderGitHubTrendingPosts([
+          ...posts.take(9),
+          _githubTrend(10, citationIds: const []),
+        ]),
+        isEmpty,
+      );
+      expect(
+        orderGitHubTrendingPosts([
+          ...posts.take(9),
+          _githubTrend(10, citationIds: const ['github-c-10', 'github-c-11']),
+        ]),
+        isEmpty,
+      );
+      expect(
+        orderGitHubTrendingPosts([
+          ...posts.take(9),
+          _githubTrend(10, citationId: '  '),
+        ]),
+        isEmpty,
+      );
+    },
+  );
 
   for (final invalidUrl in const [
     'https://user@github.com/owner/repo-10',
@@ -114,7 +133,40 @@ void main() {
       isFalse,
     );
   });
+
+  test('changes order only for engagement and keeps source order on ties', () {
+    final first = _postWithLikes('Editorial first', 100);
+    final second = _postWithLikes('Editorial second', 100);
+    final high = _postWithLikes('Engagement winner', 500);
+    final posts = [first, second, high];
+
+    expect(orderTopPosts(posts, byEngagement: false), posts);
+    expect(orderTopPosts(posts, byEngagement: true).map((post) => post.title), [
+      'Engagement winner',
+      'Editorial first',
+      'Editorial second',
+    ]);
+  });
 }
+
+TopRead _postWithLikes(String title, int likes) => TopRead(
+  title: title,
+  providerKey: 'x-twitter',
+  reason: 'Editorial evidence.',
+  matchedInterestIds: const ['ai-developer-tools'],
+  matchedRules: const [],
+  signalScore: SignalScore.normalized(1),
+  confidence: const TopReadConfidence(
+    level: 'medium',
+    score: 0.6,
+    rationale: 'Provider evidence.',
+  ),
+  confirmedProviderKeys: const ['x-twitter'],
+  providerMetrics: [ProviderMetric(label: 'Likes', value: '$likes Likes')],
+  whyImportant: const [],
+  whyNow: 'Current window.',
+  citationIds: const [],
+);
 
 TopRead _githubTrend(
   int rank, {
@@ -122,9 +174,11 @@ TopRead _githubTrend(
   String? canonicalUrl,
   String? citationId,
   List<String>? citationIds,
+  String providerKey = 'github-trending-page',
+  String trendingMetricLabel = 'GitHub Trending today',
 }) => TopRead(
   title: 'owner/repo-$rank',
-  providerKey: 'github-trending-page',
+  providerKey: providerKey,
   reason: 'Repository ranked by GitHub Trending.',
   matchedInterestIds: const ['ai-developer-tools'],
   matchedRules: const [],
@@ -138,7 +192,7 @@ TopRead _githubTrend(
   providerMetrics: [
     const ProviderMetric(label: 'Stars', value: '12,000'),
     ProviderMetric(
-      label: 'GitHub Trending today',
+      label: trendingMetricLabel,
       value: '#$rank, +$starsToday stars today',
     ),
   ],

--- a/apps/frontend/features/summaries/test/presentation/view_models/reader_summary_top_posts_projection_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/view_models/reader_summary_top_posts_projection_test.dart
@@ -1,0 +1,246 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.dart';
+import 'package:social_monitor_summaries/src/presentation/view_models/reader_summary_top_posts_projection.dart';
+
+import '../../support/top_posts_test_fixtures.dart';
+
+void main() {
+  test('dedupes the full editorial sequence before taking eight', () {
+    final curated = [
+      for (var index = 0; index < 8; index += 1)
+        topPostFixture(
+          title: 'Editorial $index',
+          canonicalUrl: index < 2
+              ? 'https://news.example/shared-editorial'
+              : 'https://news.example/editorial/$index',
+        ),
+    ];
+    final summary = topPostsSummaryFixture(
+      topReads: [
+        ...curated,
+        topPostFixture(
+          title: 'Legacy duplicate of curated',
+          canonicalUrl: 'https://news.example/shared-editorial/',
+        ),
+        topPostFixture(
+          title: 'Legacy position 10',
+          canonicalUrl: 'https://news.example/legacy/10',
+        ),
+      ],
+      selectedPosts: [
+        topPostFixture(
+          title: 'Selected duplicate of curated',
+          canonicalUrl:
+              'https://NEWS.example/shared-editorial?utm_source=selected',
+        ),
+        topPostFixture(
+          title: 'Selected duplicate of legacy',
+          canonicalUrl: 'https://news.example/legacy/10/',
+        ),
+        topPostFixture(title: 'Selected A'),
+        topPostFixture(title: '  selected   a  ', providerKey: ' REDDIT '),
+        topPostFixture(title: 'Selected B'),
+      ],
+    );
+
+    final projection = readerSummaryTopPostsProjection(summary);
+
+    expect(projection.curatedPosts.map((item) => item.title), [
+      'Editorial 0',
+      for (var index = 2; index < 8; index += 1) 'Editorial $index',
+      'Legacy position 10',
+    ]);
+    expect(projection.continuationPosts.map((item) => item.title), [
+      'Selected A',
+      'Selected B',
+    ]);
+    expect(projection.curatedPosts, hasLength(8));
+    expect(projection.posts, hasLength(10));
+    expect(
+      projection.posts.map(readerSummaryTopPostIdentity).toSet(),
+      hasLength(projection.posts.length),
+    );
+    expect(projection.githubTrendingPosts, isEmpty);
+  });
+
+  test('fills eight unique initial posts from selected continuation', () {
+    final summary = topPostsSummaryFixture(
+      topReads: [
+        topPostFixture(
+          title: 'Curated 0',
+          canonicalUrl: 'https://news.example/curated/0',
+        ),
+        topPostFixture(
+          title: 'Duplicate curated 0',
+          canonicalUrl: 'https://news.example/curated/0/',
+        ),
+        for (var index = 1; index < 3; index += 1)
+          topPostFixture(
+            title: 'Curated $index',
+            canonicalUrl: 'https://news.example/curated/$index',
+          ),
+      ],
+      selectedPosts: [
+        topPostFixture(
+          title: 'Selected duplicate of curated',
+          canonicalUrl: 'https://news.example/curated/0?utm_source=selected',
+        ),
+        for (var index = 0; index < 9; index += 1)
+          topPostFixture(
+            title: 'Selected $index',
+            canonicalUrl: 'https://news.example/selected/$index',
+          ),
+      ],
+    );
+
+    final projection = readerSummaryTopPostsProjection(summary);
+
+    expect(projection.curatedPosts.map((item) => item.title), [
+      'Curated 0',
+      'Curated 1',
+      'Curated 2',
+    ]);
+    expect(projection.posts.take(8).map((item) => item.title), [
+      'Curated 0',
+      'Curated 1',
+      'Curated 2',
+      for (var index = 0; index < 5; index += 1) 'Selected $index',
+    ]);
+    expect(projection.posts, hasLength(12));
+  });
+
+  test(
+    'normalizes canonical tracking, invalid URLs, and fallback identity',
+    () {
+      final canonical = topPostFixture(
+        title: 'Canonical original',
+        canonicalUrl:
+            'HTTPS://News.Example/story/?story=7&utm_source=feed&'
+            'UTM_CAMPAIGN=launch&fbclid=a&gclid=b&igshid=c&mc_cid=d&mc_eid=e',
+      );
+      final canonicalDuplicate = topPostFixture(
+        title: 'Canonical duplicate',
+        canonicalUrl: 'https://news.example/story?story=7#reader',
+      );
+      final invalid = topPostFixture(
+        title: 'Invalid URL original',
+        canonicalUrl: '  NOT   A VALID URL  ',
+      );
+      final invalidDuplicate = topPostFixture(
+        title: 'Invalid URL duplicate',
+        canonicalUrl: 'not a valid url',
+      );
+      final fallback = topPostFixture(title: '  Same   Headline  ');
+      final fallbackDuplicate = topPostFixture(
+        title: 'same headline',
+        providerKey: ' REDDIT ',
+      );
+
+      expect(
+        readerSummaryTopPostIdentity(canonical),
+        readerSummaryTopPostIdentity(canonicalDuplicate),
+      );
+      expect(
+        readerSummaryTopPostIdentity(invalid),
+        readerSummaryTopPostIdentity(invalidDuplicate),
+      );
+      expect(
+        readerSummaryTopPostIdentity(fallback),
+        readerSummaryTopPostIdentity(fallbackDuplicate),
+      );
+    },
+  );
+
+  test('uses selectedPosts as the exclusive fail-closed GitHub source', () {
+    final topReadBoard = _githubBoard(prefix: 'top-read');
+    final selectedBoard = _githubBoard(prefix: 'selected');
+    final projection = readerSummaryTopPostsProjection(
+      topPostsSummaryFixture(
+        topReads: topReadBoard,
+        selectedPosts: selectedBoard,
+      ),
+    );
+
+    expect(projection.posts, isEmpty);
+    expect(projection.githubTrendingPosts.map((item) => item.title), [
+      for (var rank = 1; rank <= 10; rank += 1) 'selected/repo-$rank',
+    ]);
+
+    final partialSelected = readerSummaryTopPostsProjection(
+      topPostsSummaryFixture(
+        topReads: topReadBoard,
+        selectedPosts: selectedBoard.take(9).toList(growable: false),
+      ),
+    );
+    expect(partialSelected.githubTrendingPosts, isEmpty);
+  });
+
+  test('does not repair a missing selectedPosts board from topReads', () {
+    final projection = readerSummaryTopPostsProjection(
+      topPostsSummaryFixture(topReads: _githubBoard(prefix: 'fallback')),
+    );
+
+    expect(projection.posts, isEmpty);
+    expect(projection.githubTrendingPosts, isEmpty);
+  });
+
+  test('recognizes an incidental equal-dataset rebuild', () {
+    ReaderSummaryTopPostsProjection project({bool append = false}) {
+      return readerSummaryTopPostsProjection(
+        topPostsSummaryFixture(
+          topReads: [
+            for (var index = 0; index < 9; index += 1)
+              topPostFixture(
+                title: 'Editorial $index',
+                canonicalUrl: 'https://news.example/$index',
+              ),
+          ],
+          selectedPosts: [
+            topPostFixture(title: 'Selected A'),
+            if (append) topPostFixture(title: 'Selected B'),
+          ],
+        ),
+      );
+    }
+
+    expect(project().hasSameDatasetAs(project()), isTrue);
+    expect(project().hasSameDatasetAs(project(append: true)), isFalse);
+  });
+
+  test('treats a source-order change as a new dataset', () {
+    ReaderSummaryTopPostsProjection project(List<String> titles) {
+      return readerSummaryTopPostsProjection(
+        topPostsSummaryFixture(
+          topReads: [
+            for (final title in titles)
+              topPostFixture(
+                title: title,
+                canonicalUrl: 'https://news.example/$title',
+              ),
+          ],
+        ),
+      );
+    }
+
+    expect(
+      project(const [
+        'first',
+        'second',
+      ]).hasSameDatasetAs(project(const ['second', 'first'])),
+      isFalse,
+    );
+  });
+}
+
+List<TopRead> _githubBoard({required String prefix}) {
+  return [
+    for (var rank = 1; rank <= 10; rank += 1)
+      topPostFixture(
+        title: '$prefix/repo-$rank',
+        providerKey: readerSummaryGitHubTrendingProviderKey,
+        canonicalUrl: 'https://github.com/$prefix/repo-$rank',
+        githubRank: rank,
+        citationIds: ['$prefix-citation-$rank'],
+      ),
+  ];
+}

--- a/apps/frontend/features/summaries/test/presentation/view_models/top_posts_continuation_window_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/view_models/top_posts_continuation_window_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_monitor_summaries/src/presentation/view_models/top_posts_continuation_window.dart';
+
+void main() {
+  test('reveals bounded batches and rejects a stale reset generation', () {
+    final window = TopPostsContinuationWindow(initialVisibleCount: 8);
+    final staleGeneration = window.generation;
+
+    expect(window.visibleItemCount(80), 8);
+    expect(
+      window.revealNext(generation: staleGeneration, totalItemCount: 80),
+      isTrue,
+    );
+    expect(window.visibleItemCount(80), 32);
+
+    window.reset(initialVisibleCount: 8);
+
+    expect(
+      window.revealNext(generation: staleGeneration, totalItemCount: 80),
+      isFalse,
+    );
+    expect(window.visibleItemCount(80), 8);
+    expect(
+      window.revealNext(generation: window.generation, totalItemCount: 80),
+      isTrue,
+    );
+    expect(window.visibleItemCount(80), 32);
+    expect(
+      window.revealNext(generation: window.generation, totalItemCount: 80),
+      isTrue,
+    );
+    expect(window.visibleItemCount(80), 56);
+  });
+}

--- a/apps/frontend/features/summaries/test/support/top_posts_test_fixtures.dart
+++ b/apps/frontend/features/summaries/test/support/top_posts_test_fixtures.dart
@@ -1,0 +1,85 @@
+import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.dart';
+import 'package:social_monitor_summaries/src/infrastructure/mappers/summary_mapper.dart';
+
+import 'summaries_test_fixtures.dart';
+
+TopRead topPostFixture({
+  required String title,
+  String providerKey = 'reddit',
+  String? canonicalUrl,
+  int? githubRank,
+  List<ProviderMetric>? providerMetrics,
+  List<String> citationIds = const [],
+}) {
+  return TopRead(
+    title: title,
+    providerKey: providerKey,
+    reason: '$title is relevant evidence.',
+    matchedInterestIds: const ['ai-developer-tools'],
+    matchedRules: const [],
+    signalScore: SignalScore.normalized(1),
+    confidence: const TopReadConfidence(
+      level: 'medium',
+      score: 0.6,
+      rationale: 'Test evidence.',
+    ),
+    confirmedProviderKeys: [providerKey],
+    providerMetrics:
+        providerMetrics ??
+        [
+          if (githubRank != null)
+            ProviderMetric(
+              label: 'GitHub Trending today',
+              value: '#$githubRank, +100 stars today',
+            ),
+        ],
+    whyImportant: const [],
+    whyNow: 'Current test window.',
+    citationIds: citationIds,
+    canonicalUrl: canonicalUrl,
+  );
+}
+
+ReaderSummary topPostsSummaryFixture({
+  required List<TopRead> topReads,
+  List<TopRead> selectedPosts = const [],
+  SummaryPeriod? period,
+}) {
+  final base = const SummaryMapper().readerSummaryToDomain(
+    readerSummaryApiDto(),
+  );
+  final content = base.content;
+  return ReaderSummary(
+    id: base.id,
+    title: base.title,
+    executiveSummary: base.executiveSummary,
+    userId: base.userId,
+    content: ReaderSummaryContent(
+      headline: content.headline,
+      oneLineTakeaway: content.oneLineTakeaway,
+      bullets: content.bullets,
+      narrativeSections: content.narrativeSections,
+      mainTopics: content.mainTopics,
+      topicMap: content.topicMap,
+      qualityState: content.qualityState,
+      interestSections: content.interestSections,
+      sourceMix: content.sourceMix,
+      topReads: topReads,
+      selectedPosts: selectedPosts,
+      claimBoard: content.claimBoard,
+      reliabilityReport: content.reliabilityReport,
+      trendDelta: content.trendDelta,
+      openQuestions: content.openQuestions,
+      risks: content.risks,
+      nextActions: content.nextActions,
+    ),
+    topStories: base.topStories,
+    repeatedSignals: base.repeatedSignals,
+    citations: base.citations,
+    period: period ?? base.period,
+    summaryWindow: base.summaryWindow,
+    freshnessLabel: base.freshnessLabel,
+    isDegraded: base.isDegraded,
+    coverage: base.coverage,
+  );
+}


### PR DESCRIPTION
## Summary
- show 8 initial unique editorial posts
- reveal stable 24-item continuation batches on user scroll
- keep GitHub Trending isolated as ranked Top 10

## Verification
- 35 focused Flutter tests
- 22 frontend architecture tests
- flutter analyze
- format, source line cap and diff checks

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a scroll-driven "reveal more" pattern for editorial top posts: the UI shows 8 unique curated posts initially, then appends stable 24-item batches each time the user scrolls to the reveal sentinel, while GitHub Trending remains a separate validated Top-10 board that is never paginated.

- **New `ReaderSummaryTopPostsProjection` view model** deduplicates editorial posts with URL normalization (strips UTM/tracking params, trailing slashes, fragments), caps curated posts at 8, and appends continuation posts from `selectedPosts` — all computed once and cached in `ReaderSummaryTopPostsSectionSliver` state.
- **`TopPostsContinuationWindow`** manages a generation-stamped visible limit, rejecting stale-generation reveals and expanding by 24 per confirmed user-scroll event via a `_userScrollSerial` guard in the sliver.
- **`_TopPostsRevealTrigger`** listens to the ambient `ScrollPosition`, fires a post-frame callback when visible in the scrollable viewport, and calls `onReveal` — but the sliver only acts when a fresh user scroll has been recorded since the last reveal, preventing automatic pre-loading.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the generation stamp, scroll-serial gate, and viewport check form a solid triple guard against premature reveals, and the 57 focused tests cover the projection and continuation logic well.

The _isGitHubTrendingMetric switch from contains to exact equality is the more consequential finding: if the backend ever emits a label that differs from the exact string after normalisation, GitHub Trending rank and stars parsers silently return no result and the whole board fails validation. The ReaderSummaryView.build concern is a consistency gap with the caching pattern introduced elsewhere in the same PR, not a correctness problem.

top_post_metrics.dart for the label-matching change, and reader_summary_view.dart for the uncached projection call.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/frontend/features/summaries/lib/src/presentation/view_models/reader_summary_top_posts_projection.dart | New view model: deduplicates editorial posts (stable unique, URL-normalized), caps curated at 8, appends continuation posts from selectedPosts, and isolates GitHub Trending as a validated Top-10 board. |
| apps/frontend/features/summaries/lib/src/presentation/view_models/top_posts_continuation_window.dart | Minimal, well-guarded continuation window: tracks generation + visibleItemLimit, increments by 24 per batch, and rejects stale-generation reveals. |
| apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_reveal_trigger.dart | New scroll-triggered reveal sentinel: attaches to ScrollPosition, fires a post-frame callback when visible, and delegates the scroll-serial guard to the parent sliver. |
| apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_sliver.dart | Major refactor: replaces raw item list + simple int limit with TopPostsContinuationWindow + scroll-serial guard. Requires a fresh user scroll before each 24-item reveal batch. |
| apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_section_sliver.dart | Promoted to StatefulWidget to cache the projection behind an identical() guard; _selectedPostCount fallback logic is correct but duplicated in ReaderSummaryView. |
| apps/frontend/features/summaries/lib/src/presentation/formatters/top_post_metrics.dart | Extracts _isGitHubTrendingMetric helper and tightens matching from contains to exact equality; adds per-item providerKey validation inside orderGitHubTrendingPosts. |
| apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_view.dart | Computes readerSummaryTopPostsProjection eagerly in build() of this StatelessWidget, running full dedup and URL normalization on every parent rebuild. |
| apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts.dart | Receives ReaderSummaryTopPostsProjection instead of raw items; uses hasSameDatasetAs for board reset guard. Clean refactor. |
| apps/frontend/app/test/architecture/top_posts_shared_surface_test.dart | Architecture test asserting both pages compose via ReaderSummaryTopPostsSectionSliver with multi-path file resolution. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Parent as Parent widget
    participant Section as SectionSliver
    participant Sliver as TopPostsSliver
    participant Window as ContinuationWindow
    participant Trigger as RevealTrigger
    participant Scroll as ScrollPosition

    Parent->>Section: summary
    Section->>Section: readerSummaryTopPostsProjection cached in state
    Section->>Sliver: "projection (curatedPosts=8, continuationPosts=N)"
    Sliver->>Window: "new TopPostsContinuationWindow(initialVisibleCount=8)"
    Sliver->>Sliver: _refreshBoardItems, filteredItems built
    Scroll-->>Sliver: addListener(_handleScrollPositionChanged)
    Note over Sliver: build: visible=min(8,total), RevealTrigger at last slot
    Sliver->>Trigger: generation, remainingCount, onReveal
    Scroll-->>Trigger: addListener(_scheduleRevealCheck)
    User->>Scroll: scroll event
    Scroll-->>Sliver: _userScrollSerial incremented
    Scroll-->>Trigger: _scheduleRevealCheck scheduled
    Trigger->>Trigger: post-frame callback fires
    Trigger->>Trigger: _isVisibleInScrollableViewport check
    Trigger->>Sliver: onReveal(generation)
    Sliver->>Sliver: check userScrollSerial greater than lastRevealSerial
    Sliver->>Window: revealNext(generation, totalItemCount)
    Window-->>Sliver: true, visibleItemLimit grows by 24
    Sliver->>Sliver: setState rebuild with 32 visible items
    Note over Sliver: Next reveal requires another user scroll
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Parent as Parent widget
    participant Section as SectionSliver
    participant Sliver as TopPostsSliver
    participant Window as ContinuationWindow
    participant Trigger as RevealTrigger
    participant Scroll as ScrollPosition

    Parent->>Section: summary
    Section->>Section: readerSummaryTopPostsProjection cached in state
    Section->>Sliver: "projection (curatedPosts=8, continuationPosts=N)"
    Sliver->>Window: "new TopPostsContinuationWindow(initialVisibleCount=8)"
    Sliver->>Sliver: _refreshBoardItems, filteredItems built
    Scroll-->>Sliver: addListener(_handleScrollPositionChanged)
    Note over Sliver: build: visible=min(8,total), RevealTrigger at last slot
    Sliver->>Trigger: generation, remainingCount, onReveal
    Scroll-->>Trigger: addListener(_scheduleRevealCheck)
    User->>Scroll: scroll event
    Scroll-->>Sliver: _userScrollSerial incremented
    Scroll-->>Trigger: _scheduleRevealCheck scheduled
    Trigger->>Trigger: post-frame callback fires
    Trigger->>Trigger: _isVisibleInScrollableViewport check
    Trigger->>Sliver: onReveal(generation)
    Sliver->>Sliver: check userScrollSerial greater than lastRevealSerial
    Sliver->>Window: revealNext(generation, totalItemCount)
    Window-->>Sliver: true, visibleItemLimit grows by 24
    Sliver->>Sliver: setState rebuild with 32 visible items
    Note over Sliver: Next reveal requires another user scroll
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/frontend/features/summaries/lib/src/presentation/formatters/top_post_metrics.dart:201-202
The new helper switches from `contains('trending today')` to exact equality against `'github trending today'`. This is intentionally stricter, but it also means any backend label that previously matched — e.g. `'GitHub Trending today (rank #3)'` (extra text) — would silently stop being recognised as a trending metric. `_githubTrendingRank` and `_githubTrendingStarsToday` both depend on this, so GitHub Trending posts with a non-exact label would fail the `orderGitHubTrendingPosts` rank check and be silently dropped from the board. Consider keeping `contains` for the rank/stars parsers, or add a test fixture documenting the exact accepted label contract.

```suggestion
bool _isGitHubTrendingMetric(ProviderMetric metric) =>
    metric.label.trim().toLowerCase().contains(_githubTrendingMetricLabel);
```

### Issue 2 of 2
apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_view.dart:89-91
`readerSummaryTopPostsProjection` in a `StatelessWidget` `build` method — `ReaderSummaryTopPostsSectionSliver` (now StatefulWidget) deliberately caches the same call in state and only recomputes when `!identical(widget.summary, oldWidget.summary)`. Here the full dedup + URL-normalisation pipeline runs on every parent rebuild of `ReaderSummaryView`. Consider lifting the projection into a local cache or converting this widget to StatefulWidget the same way the section sliver was, or memoising behind an `identical` guard.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(frontend): reveal more top posts on..."](https://github.com/777genius/social-monitor/commit/a1d7b899f5a82eecdf4982f1ea672a548c885613) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45603199)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->