### PR TITLE
fix(deploy): satisfy rescue shellcheck

### DIFF
--- a/ops/deploy/backend-image-rescue-lib.sh
+++ b/ops/deploy/backend-image-rescue-lib.sh
@@ -120,7 +120,7 @@ backend_image_rescue_compose_container_id() {
 
 backend_image_rescue_decimal_increment() {
   local value=$1
-  local result= digit next carry=1 index
+  local result='' digit next carry=1 index
 
   [[ $value =~ ^(0|[1-9][0-9]*)$ ]] || return 1
   for ((index = ${#value} - 1; index >= 0; index--)); do

--- a/ops/deploy/backend-image-rescue-lib.test.sh
+++ b/ops/deploy/backend-image-rescue-lib.test.sh
@@ -25,8 +25,14 @@ ID_E=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 # The dollar expressions are fixture data for the inspected legacy command.
 # shellcheck disable=SC2016
 LEGACY_CONFIG='["docker-entrypoint.sh"]|["sh","-c","case \"$SERVICE\" in api) exec node dist/apps/api-gateway/src/main.js ;; agent-runtime) exec node dist/apps/agent-runtime/src/main.js ;; ingestion) exec node dist/apps/ingestion-worker/src/main.js ;; intelligence) exec node dist/apps/intelligence-worker/src/main.js ;; delivery) exec node dist/apps/delivery-service/src/main.js ;; event-relay) exec node dist/apps/event-relay/src/main.js ;; *) echo \"Unknown service: $SERVICE\" >&2; exit 64 ;; esac"]|"/app"|"node"|null'
+# The literal quotes are opaque Docker inspect fixture JSON, not shell syntax.
+# shellcheck disable=SC2089
 CONFIG='["/entry"]|["node","dist/main.js"]|"/app"|"node"|null'
+# The literal quotes are opaque reconstructed-image fixture JSON.
+# shellcheck disable=SC2089
 export SAFE_API_CONFIG='["/usr/local/bin/docker-entrypoint.sh"]|["/usr/local/bin/node","dist/apps/api-gateway/src/main.js"]|"/app"|"node"|null'
+# The literal quotes are opaque Docker image Env fixture JSON.
+# shellcheck disable=SC2089
 SENTINEL_ENV='["RESCUE_SENTINEL_DO_NOT_PERSIST=fixture-only-value"]'
 SHA=1111111111111111111111111111111111111111
 
@@ -251,8 +257,12 @@ reset_case() {
   : > "$EVENT_LOG"
   FAKE_DOCKER_IMPORT_ID=$ID_E
   FAKE_DOCKER_IMPORT_STORED_ID=$ID_E
+  # The literal quotes are opaque Docker inspect fixture JSON, not shell syntax.
+  # shellcheck disable=SC2089
   FAKE_DOCKER_IMPORT_CONFIG=$SAFE_API_CONFIG
   FAKE_DOCKER_IMPORT_ENV='[]'
+  # Export preserves that opaque JSON for the fake docker child process.
+  # shellcheck disable=SC2090
   export FAKE_DOCKER_IMPORT_ID FAKE_DOCKER_IMPORT_STORED_ID \
     FAKE_DOCKER_IMPORT_CONFIG FAKE_DOCKER_IMPORT_ENV
   unset FAKE_DOCKER_SIGNAL_TAG FAKE_COMPOSE_UP_STATUS FAKE_STOP_STATUS \
@@ -413,6 +423,8 @@ for validation_case in id config env; do
     config) FAKE_DOCKER_IMPORT_CONFIG=$CONFIG ;;
     env) FAKE_DOCKER_IMPORT_ENV=$SENTINEL_ENV ;;
   esac
+  # Export preserves the selected opaque JSON fixtures for fake docker.
+  # shellcheck disable=SC2090
   export FAKE_DOCKER_IMPORT_STORED_ID FAKE_DOCKER_IMPORT_CONFIG \
     FAKE_DOCKER_IMPORT_ENV
   add_container api "strict-rescue-$validation_case-api" "$ID_A" \


### PR DESCRIPTION
## Summary
- keep backend image rescue behavior unchanged
- narrow ShellCheck suppressions to opaque fixture assignments and exports
- preserve decimal increment initialization fix

## Verification
- pinned ShellCheck stable: warning level clean
- rescue unit suite
- full production deploy contract suite
- bash syntax, source line cap and diff check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when incrementing backend image rescue values by ensuring the result is initialized consistently.

* **Chores**
  * Added clarifying comments and static-analysis guidance to deployment test fixtures without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two ShellCheck-only changes: it makes the empty-string initializer in `backend_image_rescue_decimal_increment` explicit (`result=''` instead of `result=`), and it adds narrowly-targeted `SC2089`/`SC2090` suppressions to the test file for fixture variables that hold opaque Docker-inspect JSON strings containing embedded literal quotes.

- **`backend-image-rescue-lib.sh` (line 123):** `local result=` → `local result=''`. Both forms initialize `result` to the empty string in bash; the change silences a ShellCheck warning with no behavioral difference.
- **`backend-image-rescue-lib.test.sh`:** Five new `# shellcheck disable` directives, each placed immediately before the specific assignment or `export` that triggers SC2089/SC2090, with a one-line comment explaining the fixture-data rationale. No test logic is altered.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are cosmetic ShellCheck fixes with no effect on runtime behavior.

The library change (`result=''`) is semantically identical to the original in bash; the test-file changes add explanatory comments and tightly-scoped suppression directives without touching any assertion or fixture logic. No control flow, data path, or contract is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ops/deploy/backend-image-rescue-lib.sh | Single-character fix: `local result=` changed to `local result=''` in `backend_image_rescue_decimal_increment` — semantically identical in bash, resolves ShellCheck uninitialized-variable warning. No behavioral change. |
| ops/deploy/backend-image-rescue-lib.test.sh | Adds narrowly-scoped `SC2089`/`SC2090` suppressions for fixture JSON variables that contain embedded literal quotes, plus matching explanatory comments. All suppressions are placed immediately before the specific assignment or export they cover; no existing test logic is changed. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["backend_image_rescue_decimal_increment(value)"] --> B["local result='' digit next carry=1 index"]
    B --> C{"value matches\n^(0|[1-9][0-9]*)$?"}
    C -- no --> D["return 1"]
    C -- yes --> E["Loop digits right-to-left"]
    E --> F{"carry == 1?"}
    F -- yes, digit==9 --> G["next=0, carry stays 1"]
    F -- yes, digit!=9 --> H["next=digit+1, carry=0"]
    F -- no --> I["next=digit"]
    G --> J["result = next + result"]
    H --> J
    I --> J
    J --> E
    E -- done --> K{"carry == 0?"}
    K -- no --> L["result = '1' + result"]
    K -- yes --> M["printf result"]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["backend_image_rescue_decimal_increment(value)"] --> B["local result='' digit next carry=1 index"]
    B --> C{"value matches\n^(0|[1-9][0-9]*)$?"}
    C -- no --> D["return 1"]
    C -- yes --> E["Loop digits right-to-left"]
    E --> F{"carry == 1?"}
    F -- yes, digit==9 --> G["next=0, carry stays 1"]
    F -- yes, digit!=9 --> H["next=digit+1, carry=0"]
    F -- no --> I["next=digit"]
    G --> J["result = next + result"]
    H --> J
    I --> J
    J --> E
    E -- done --> K{"carry == 0?"}
    K -- no --> L["result = '1' + result"]
    K -- yes --> M["printf result"]
    L --> M
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(deploy): satisfy rescue shellcheck"](https://github.com/777genius/social-monitor/commit/acc25c9bdd407c4b2dc3828191e11ab89223c660) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45606577)</sub>

<!-- /greptile_comment -->