### PR TITLE
fix(deploy): restore x collector rollback image

### DIFF
--- a/ops/deploy/backend-image-rescue-lib.sh
+++ b/ops/deploy/backend-image-rescue-lib.sh
@@ -74,6 +74,10 @@ backend_image_rescue_expected_legacy_container_config() {
       printf '%s\n' \
         '["docker-entrypoint.sh"]|["sh","-c","case \"$SERVICE\" in api) exec node dist/apps/api-gateway/src/main.js ;; agent-runtime) exec node dist/apps/agent-runtime/src/main.js ;; ingestion) exec node dist/apps/ingestion-worker/src/main.js ;; intelligence) exec node dist/apps/intelligence-worker/src/main.js ;; delivery) exec node dist/apps/delivery-service/src/main.js ;; event-relay) exec node dist/apps/event-relay/src/main.js ;; *) echo \"Unknown service: $SERVICE\" >&2; exit 64 ;; esac"]|"/app"|"node"|null'
       ;;
+    x-collector)
+      printf '%s\n' \
+        "null|[\"python\",\"-m\",\"x_collector\"]|\"/app/apps/x-collector\"|\"1000:1000\"|{\"Test\":[\"CMD\",\"python\",\"-c\",\"import socket; s=socket.create_connection(('127.0.0.1',50051),2); s.close()\"],\"Interval\":15000000000,\"Timeout\":5000000000,\"StartPeriod\":30000000000,\"Retries\":20}"
+      ;;
     *) return 1 ;;
   esac
 }
@@ -86,15 +90,20 @@ backend_image_rescue_reconstructed_command() {
     intelligence-worker) printf '["/usr/local/bin/node","dist/apps/intelligence-worker/src/main.js"]\n' ;;
     delivery-service) printf '["/usr/local/bin/node","dist/apps/delivery-service/src/main.js"]\n' ;;
     event-relay) printf '["/usr/local/bin/node","dist/apps/event-relay/src/main.js"]\n' ;;
+    x-collector) printf '["python","-m","x_collector"]\n' ;;
     *) return 1 ;;
   esac
 }
 
 backend_image_rescue_reconstructed_image_config() {
-  local command
-  command=$(backend_image_rescue_reconstructed_command "$1") || return 1
-  printf '["/usr/local/bin/docker-entrypoint.sh"]|%s|"/app"|"node"|null\n' \
-    "$command"
+  local service=$1 command
+  command=$(backend_image_rescue_reconstructed_command "$service") || return 1
+  if [[ $service == x-collector ]]; then
+    printf 'null|%s|"/app/apps/x-collector"|"1000:1000"|null\n' "$command"
+  else
+    printf '["/usr/local/bin/docker-entrypoint.sh"]|%s|"/app"|"node"|null\n' \
+      "$command"
+  fi
 }
 
 backend_image_rescue_verify_running_container() {
@@ -424,6 +433,7 @@ backend_image_rescue_reconstruct_running_container() (
   local recorded_image=$4
   local original_container baseline_image baseline_restart_count
   local paused=false unpause_status=0
+  local -a import_changes
 
   command=$(backend_image_rescue_reconstructed_command "$service") || {
     printf 'deploy-error: missing-image rescue has no reviewed reconstruction for %s\n' \
@@ -438,6 +448,20 @@ backend_image_rescue_reconstruct_running_container() (
     printf 'deploy-error: missing-image rescue config is not the reviewed legacy config for %s\n' \
       "$service" >&2
     return 1
+  fi
+  if [[ $service == x-collector ]]; then
+    import_changes=(
+      --change "CMD $command"
+      --change 'WORKDIR /app/apps/x-collector'
+      --change 'USER 1000:1000'
+    )
+  else
+    import_changes=(
+      --change 'ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]'
+      --change "CMD $command"
+      --change 'WORKDIR /app'
+      --change 'USER node'
+    )
   fi
 
   unpause_container() {
@@ -466,10 +490,7 @@ backend_image_rescue_reconstruct_running_container() (
   if ! imported_id=$(
     docker container export "$original_container" | \
       docker image import \
-        --change 'ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]' \
-        --change "CMD $command" \
-        --change 'WORKDIR /app' \
-        --change 'USER node' \
+        "${import_changes[@]}" \
         - "$rescue_tag"
   ); then
     unpause_container || unpause_status=$?

--- a/ops/deploy/backend-image-rescue-lib.test.sh
+++ b/ops/deploy/backend-image-rescue-lib.test.sh
@@ -31,6 +31,12 @@ CONFIG='["/entry"]|["node","dist/main.js"]|"/app"|"node"|null'
 # The literal quotes are opaque reconstructed-image fixture JSON.
 # shellcheck disable=SC2089
 export SAFE_API_CONFIG='["/usr/local/bin/docker-entrypoint.sh"]|["/usr/local/bin/node","dist/apps/api-gateway/src/main.js"]|"/app"|"node"|null'
+X_COMMAND='["python","-m","x_collector"]'
+X_WORKDIR='"/app/apps/x-collector"'
+X_USER='"1000:1000"'
+X_HEALTHCHECK="{\"Test\":[\"CMD\",\"python\",\"-c\",\"import socket; s=socket.create_connection(('127.0.0.1',50051),2); s.close()\"],\"Interval\":15000000000,\"Timeout\":5000000000,\"StartPeriod\":30000000000,\"Retries\":20}"
+SAFE_X_CONFIG="null|$X_COMMAND|$X_WORKDIR|$X_USER|null"
+LEGACY_X_CONFIG="null|$X_COMMAND|$X_WORKDIR|$X_USER|$X_HEALTHCHECK"
 # The literal quotes are opaque Docker image Env fixture JSON.
 # shellcheck disable=SC2089
 SENTINEL_ENV='["RESCUE_SENTINEL_DO_NOT_PERSIST=fixture-only-value"]'
@@ -414,24 +420,26 @@ import_count_after=$(grep -c $'docker\timage\timport' "$EVENT_LOG" || true)
 ((tag_count_before == tag_count_after && import_count_before == import_count_after))
 backend_image_rescue_cleanup "$adoption_state"
 
-# Imported rescue identity, reviewed config, and empty Env are each validated
+# Imported rescue identity, reviewed config, and non-empty Env are each validated
 # after unpause and before runtime stability polling.
-for validation_case in id config env; do
+for validation_case in id config env x-sentinel-env; do
   reset_case "strict-rescue-$validation_case"
+  validation_service=api validation_container_config=$LEGACY_CONFIG
   case $validation_case in
     id) FAKE_DOCKER_IMPORT_STORED_ID=$ID_D ;;
     config) FAKE_DOCKER_IMPORT_CONFIG=$CONFIG ;;
     env) FAKE_DOCKER_IMPORT_ENV=$SENTINEL_ENV ;;
+    x-sentinel-env) validation_service=x-collector; validation_container_config=$LEGACY_X_CONFIG; set_import_service_config x-collector; FAKE_DOCKER_IMPORT_ENV=$SENTINEL_ENV ;;
   esac
   # Export preserves the selected opaque JSON fixtures for fake docker.
   # shellcheck disable=SC2090
   export FAKE_DOCKER_IMPORT_STORED_ID FAKE_DOCKER_IMPORT_CONFIG \
     FAKE_DOCKER_IMPORT_ENV
-  add_container api "strict-rescue-$validation_case-api" "$ID_A" \
-    'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+  add_container "$validation_service" "strict-rescue-$validation_case-api" "$ID_A" \
+    'running|true|false|false|healthy' "$validation_container_config" "$SENTINEL_ENV"
   strict_state=$(backend_image_rescue_state_file "$SHA")
   set +e
-  backend_image_rescue_prepare "$SHA" "$strict_state" api
+  backend_image_rescue_prepare "$SHA" "$strict_state" "$validation_service"
   strict_status=$?
   set -e
   ((strict_status != 0))
@@ -682,23 +690,77 @@ set -e
 [[ ! -e $mismatch_state && ! -e $mismatch_state.partial ]]
 assert_no_rescue_refs
 
-# The separate x-collector image has no reviewed reconstruction in this bridge.
-# Its explicit missing-image edge fails closed without pausing or exporting it.
-reset_case unsupported-missing-image
-add_container x-collector missing-x "$ID_A" 'running|true|false|false|healthy' \
-  '[]|[]|"/srv"|"collector"' "$SENTINEL_ENV"
-unsupported_state=$(backend_image_rescue_state_file "$SHA")
-set +e
-backend_image_rescue_prepare "$SHA" "$unsupported_state" x-collector
-unsupported_status=$?
-set -e
-((unsupported_status != 0))
-[[ ! -e $unsupported_state && ! -e $unsupported_state.partial ]]
-if grep -E $'docker\tcontainer\t(pause|export)\tmissing-x' "$EVENT_LOG" >/dev/null; then
-  echo 'unsupported missing image was touched before fail-closed validation' >&2
-  exit 1
-fi
-assert_no_rescue_refs
+# The legacy x-collector is reconstructed without copying container metadata.
+for x_env_case in array null; do
+  case $x_env_case in
+    array) x_empty_env='[]' ;;
+    null) x_empty_env=null ;;
+  esac
+  reset_case "x-collector-adoption-$x_env_case"
+  set_import_service_config x-collector
+  FAKE_DOCKER_IMPORT_ENV=$x_empty_env
+  export FAKE_DOCKER_IMPORT_ENV
+  add_container x-collector rescued-x "$ID_A" \
+    'running|true|false|false|healthy' "$LEGACY_X_CONFIG" "$SENTINEL_ENV"
+  x_state=$(backend_image_rescue_state_file "$SHA")
+  backend_image_rescue_prepare "$SHA" "$x_state" x-collector
+  grep -F \
+    $'image\tx-collector\trecreate\tcontainer-export-import\trescued-x' \
+    "$x_state" >/dev/null
+  x_tag=$(backend_image_rescue_tag "$SHA" x-collector)
+  [[ $(backend_image_rescue_image_config "$x_tag") == "$SAFE_X_CONFIG" ]]
+  [[ $(backend_image_rescue_image_env "$x_tag") == "$x_empty_env" ]]
+  printf -v expected_x_import '%s%s%s%s%s' \
+    $'docker\timage\timport\t--change\t' \
+    'CMD ["python","-m","x_collector"]' \
+    $'\t--change\tWORKDIR /app/apps/x-collector' \
+    $'\t--change\tUSER 1000:1000\t-\t' \
+    "$x_tag"
+  grep -Fx "$expected_x_import" "$EVENT_LOG" >/dev/null
+  grep -F $'docker\tcontainer\tpause\trescued-x' \
+    "$EVENT_LOG" >/dev/null
+  grep -F $'docker\tcontainer\texport\trescued-x' \
+    "$EVENT_LOG" >/dev/null
+  grep -F $'docker\tcontainer\tunpause\trescued-x' \
+    "$EVENT_LOG" >/dev/null
+  backend_image_rescue_mark_replacement_started "$x_state"
+  set_ref_direct "$(compose_image_name x-collector)" "$ID_D"
+  : > "$EVENT_LOG"
+  rollback_backend_images "$x_state"
+  grep -F \
+    $'compose\t--profile\tapp\tup\t-d\t--no-deps\t--force-recreate\tx-collector' \
+    "$EVENT_LOG" >/dev/null
+  [[ $(ref_id "$(compose_image_name x-collector)") == "$ID_E" ]]
+  backend_image_rescue_cleanup "$x_state"
+done
+
+# Every reviewed x-collector metadata field is validated before pause/export.
+for x_drift in entrypoint command workdir user healthcheck; do
+  reset_case "x-drift-$x_drift"
+  drift_entrypoint=null drift_command=$X_COMMAND drift_workdir=$X_WORKDIR
+  drift_user=$X_USER drift_healthcheck=$X_HEALTHCHECK
+  case $x_drift in
+    entrypoint) drift_entrypoint='["drift"]' ;;
+    command) drift_command='["drift"]' ;;
+    workdir) drift_workdir='"/drift"' ;;
+    user) drift_user='"0:0"' ;;
+    healthcheck) drift_healthcheck=null ;;
+  esac
+  drift_config="$drift_entrypoint|$drift_command|$drift_workdir|$drift_user|$drift_healthcheck"
+  add_container x-collector "drift-$x_drift" "$ID_A" \
+    'running|true|false|false|healthy' "$drift_config" "$SENTINEL_ENV"
+  drift_state=$(backend_image_rescue_state_file "$SHA")
+  set +e
+  backend_image_rescue_prepare "$SHA" "$drift_state" x-collector
+  drift_status=$?
+  set -e
+  ((drift_status != 0))
+  if grep -E $'docker\tcontainer\t(pause|export)\t' "$EVENT_LOG" >/dev/null; then
+    echo "x-collector $x_drift drift was touched before validation" >&2
+    exit 1
+  fi
+  assert_failed_rescue_cleaned "$drift_state"
+done
 
 # A failed import always unpauses the healthy container and removes the exact
 # partial rescue tag/state; it never falls back to copying container metadata.


### PR DESCRIPTION
## Summary
- add exact reviewed rollback reconstruction for x-collector
- preserve Node rescue behavior and avoid copying container environment
- cover both empty Env encodings, config drift, pause/export/import/unpause and rollback

## Verification
- backend image rescue contract tests
- deploy control tests
- ShellCheck v0.10.0
- source line cap
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery and reconstruction of the x-collector service when restoring running containers.
  - Preserved essential service settings, including startup command, working directory, user, environment values, and health checks.
  - Improved compatibility with legacy x-collector image configurations.
  - Added validation to prevent recovery from proceeding when required service metadata is incomplete or invalid.
  - Expanded automated coverage for successful and failure recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes x-collector from an unsupported service (previously failing closed with no rescue path) to a fully reconstructed rollback target, matching its Python-based container metadata rather than the Node entrypoint used by all other services.

- **Library changes** (`backend-image-rescue-lib.sh`): Adds x-collector to the expected-legacy-config, reconstructed-command, and reconstructed-image-config lookups; introduces a `local -a import_changes` array so the x-collector import path omits `ENTRYPOINT` (correctly reproducing a `null` entrypoint) while using `WORKDIR /app/apps/x-collector` and `USER 1000:1000` in place of the Node-service defaults.
- **Test changes** (`backend-image-rescue-lib.test.sh`): Removes the old \"unsupported-missing-image\" failure test for x-collector and replaces it with adoption tests for both empty-env encodings (`[]` and `null`), a full rollback flow, an env-isolation sentinel check, and five per-field drift-detection cases that verify the container is never paused or exported when its config deviates from the reviewed value.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the library change is well-isolated and the test suite covers adoption, env isolation, per-field drift detection, and rollback for x-collector.

The implementation is correct and the test coverage is thorough. The only issue found is a comment wording change in the test file that now reads as if non-empty env is accepted by the validation loop, when the opposite is true — the loop tests that a non-empty env causes failure. This is a documentation clarity concern only and does not affect runtime behavior.

ops/deploy/backend-image-rescue-lib.test.sh line 423: the updated comment may mislead future contributors about the direction of the env validation check.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ops/deploy/backend-image-rescue-lib.sh | Adds x-collector support via a dedicated import_changes array that omits ENTRYPOINT (correctly matching null in both expected legacy and reconstructed configs) and uses Python-specific WORKDIR/USER; the config-drift guard runs before any pause/export as intended |
| ops/deploy/backend-image-rescue-lib.test.sh | Replaces the old unsupported x-collector failure test with comprehensive adoption, rollback, env-isolation, and per-field drift-detection tests; the test comment at line 423 was changed to non-empty Env which reads as if non-empty env is accepted, inverting the actual intent |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant P as backend_image_rescue_prepare
    participant R as reconstruct_running_container
    participant D as Docker

    P->>R: "service=x-collector, container, rescue_tag, recorded_image"
    R->>D: inspect container config
    D-->>R: "null|[python,-m,x_collector]|/app/apps/x-collector|1000:1000|{healthcheck}"
    R->>R: compare vs expected_legacy_container_config(x-collector)
    Note over R: Fails fast if any field drifts (entrypoint,cmd,workdir,user,healthcheck)
    R->>R: build import_changes (CMD, WORKDIR, USER — no ENTRYPOINT)
    R->>D: docker container pause original_container
    R->>D: "docker container export | docker image import --change CMD ... --change WORKDIR ... --change USER ... - rescue_tag"
    D-->>R: sha256:imported_id
    R->>D: docker container unpause original_container
    R->>D: docker image inspect rescue_tag (id, config, env)
    R->>R: "assert imported_id == inspected_id"
    R->>R: "assert image_config == null|[python,-m,x_collector]|/app/apps/x-collector|1000:1000|null"
    R->>R: "assert image_env == null or []"
    R-->>P: success — rescue tag ready
    P->>P: "write state file + phase=prepared"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant P as backend_image_rescue_prepare
    participant R as reconstruct_running_container
    participant D as Docker

    P->>R: "service=x-collector, container, rescue_tag, recorded_image"
    R->>D: inspect container config
    D-->>R: "null|[python,-m,x_collector]|/app/apps/x-collector|1000:1000|{healthcheck}"
    R->>R: compare vs expected_legacy_container_config(x-collector)
    Note over R: Fails fast if any field drifts (entrypoint,cmd,workdir,user,healthcheck)
    R->>R: build import_changes (CMD, WORKDIR, USER — no ENTRYPOINT)
    R->>D: docker container pause original_container
    R->>D: "docker container export | docker image import --change CMD ... --change WORKDIR ... --change USER ... - rescue_tag"
    D-->>R: sha256:imported_id
    R->>D: docker container unpause original_container
    R->>D: docker image inspect rescue_tag (id, config, env)
    R->>R: "assert imported_id == inspected_id"
    R->>R: "assert image_config == null|[python,-m,x_collector]|/app/apps/x-collector|1000:1000|null"
    R->>R: "assert image_env == null or []"
    R-->>P: success — rescue tag ready
    P->>P: "write state file + phase=prepared"
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
ops/deploy/backend-image-rescue-lib.test.sh:423-424
**Misleading comment after wording change**

The comment was changed from "empty Env encodings" to "non-empty Env", which now reads as if the test validates that non-empty `Env` is acceptable. The actual intent is the opposite: the loop verifies that a non-empty `FAKE_DOCKER_IMPORT_ENV` (a sentinel value) causes rescue to fail. "empty Env" (the old wording) described the constraint being enforced — the imported image's env must be empty. The new phrasing inverts that meaning for a reader skimming the test.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deploy): restore x collector rollbac..."](https://github.com/777genius/social-monitor/commit/3b6c1b11e18e7dab3a8f2a9a977570e6e7170ab9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45650484)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->