### PR TITLE
fix(db): use built-in sha256 for publication migration

### DIFF
--- a/ops/deploy/backend-image-rescue-lib.sh
+++ b/ops/deploy/backend-image-rescue-lib.sh
@@ -74,6 +74,10 @@ backend_image_rescue_expected_legacy_container_config() {
       printf '%s\n' \
         '["docker-entrypoint.sh"]|["sh","-c","case \"$SERVICE\" in api) exec node dist/apps/api-gateway/src/main.js ;; agent-runtime) exec node dist/apps/agent-runtime/src/main.js ;; ingestion) exec node dist/apps/ingestion-worker/src/main.js ;; intelligence) exec node dist/apps/intelligence-worker/src/main.js ;; delivery) exec node dist/apps/delivery-service/src/main.js ;; event-relay) exec node dist/apps/event-relay/src/main.js ;; *) echo \"Unknown service: $SERVICE\" >&2; exit 64 ;; esac"]|"/app"|"node"|null'
       ;;
+    x-collector)
+      printf '%s\n' \
+        "null|[\"python\",\"-m\",\"x_collector\"]|\"/app/apps/x-collector\"|\"1000:1000\"|{\"Test\":[\"CMD\",\"python\",\"-c\",\"import socket; s=socket.create_connection(('127.0.0.1',50051),2); s.close()\"],\"Interval\":15000000000,\"Timeout\":5000000000,\"StartPeriod\":30000000000,\"Retries\":20}"
+      ;;
     *) return 1 ;;
   esac
 }
@@ -86,15 +90,20 @@ backend_image_rescue_reconstructed_command() {
     intelligence-worker) printf '["/usr/local/bin/node","dist/apps/intelligence-worker/src/main.js"]\n' ;;
     delivery-service) printf '["/usr/local/bin/node","dist/apps/delivery-service/src/main.js"]\n' ;;
     event-relay) printf '["/usr/local/bin/node","dist/apps/event-relay/src/main.js"]\n' ;;
+    x-collector) printf '["python","-m","x_collector"]\n' ;;
     *) return 1 ;;
   esac
 }
 
 backend_image_rescue_reconstructed_image_config() {
-  local command
-  command=$(backend_image_rescue_reconstructed_command "$1") || return 1
-  printf '["/usr/local/bin/docker-entrypoint.sh"]|%s|"/app"|"node"|null\n' \
-    "$command"
+  local service=$1 command
+  command=$(backend_image_rescue_reconstructed_command "$service") || return 1
+  if [[ $service == x-collector ]]; then
+    printf 'null|%s|"/app/apps/x-collector"|"1000:1000"|null\n' "$command"
+  else
+    printf '["/usr/local/bin/docker-entrypoint.sh"]|%s|"/app"|"node"|null\n' \
+      "$command"
+  fi
 }
 
 backend_image_rescue_verify_running_container() {
@@ -424,6 +433,7 @@ backend_image_rescue_reconstruct_running_container() (
   local recorded_image=$4
   local original_container baseline_image baseline_restart_count
   local paused=false unpause_status=0
+  local -a import_changes
 
   command=$(backend_image_rescue_reconstructed_command "$service") || {
     printf 'deploy-error: missing-image rescue has no reviewed reconstruction for %s\n' \
@@ -438,6 +448,20 @@ backend_image_rescue_reconstruct_running_container() (
     printf 'deploy-error: missing-image rescue config is not the reviewed legacy config for %s\n' \
       "$service" >&2
     return 1
+  fi
+  if [[ $service == x-collector ]]; then
+    import_changes=(
+      --change "CMD $command"
+      --change 'WORKDIR /app/apps/x-collector'
+      --change 'USER 1000:1000'
+    )
+  else
+    import_changes=(
+      --change 'ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]'
+      --change "CMD $command"
+      --change 'WORKDIR /app'
+      --change 'USER node'
+    )
   fi
 
   unpause_container() {
@@ -466,10 +490,7 @@ backend_image_rescue_reconstruct_running_container() (
   if ! imported_id=$(
     docker container export "$original_container" | \
       docker image import \
-        --change 'ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]' \
-        --change "CMD $command" \
-        --change 'WORKDIR /app' \
-        --change 'USER node' \
+        "${import_changes[@]}" \
         - "$rescue_tag"
   ); then
     unpause_container || unpause_status=$?

--- a/ops/deploy/backend-image-rescue-lib.test.sh
+++ b/ops/deploy/backend-image-rescue-lib.test.sh
@@ -31,6 +31,12 @@ CONFIG='["/entry"]|["node","dist/main.js"]|"/app"|"node"|null'
 # The literal quotes are opaque reconstructed-image fixture JSON.
 # shellcheck disable=SC2089
 export SAFE_API_CONFIG='["/usr/local/bin/docker-entrypoint.sh"]|["/usr/local/bin/node","dist/apps/api-gateway/src/main.js"]|"/app"|"node"|null'
+X_COMMAND='["python","-m","x_collector"]'
+X_WORKDIR='"/app/apps/x-collector"'
+X_USER='"1000:1000"'
+X_HEALTHCHECK="{\"Test\":[\"CMD\",\"python\",\"-c\",\"import socket; s=socket.create_connection(('127.0.0.1',50051),2); s.close()\"],\"Interval\":15000000000,\"Timeout\":5000000000,\"StartPeriod\":30000000000,\"Retries\":20}"
+SAFE_X_CONFIG="null|$X_COMMAND|$X_WORKDIR|$X_USER|null"
+LEGACY_X_CONFIG="null|$X_COMMAND|$X_WORKDIR|$X_USER|$X_HEALTHCHECK"
 # The literal quotes are opaque Docker image Env fixture JSON.
 # shellcheck disable=SC2089
 SENTINEL_ENV='["RESCUE_SENTINEL_DO_NOT_PERSIST=fixture-only-value"]'
@@ -414,24 +420,26 @@ import_count_after=$(grep -c $'docker\timage\timport' "$EVENT_LOG" || true)
 ((tag_count_before == tag_count_after && import_count_before == import_count_after))
 backend_image_rescue_cleanup "$adoption_state"
 
-# Imported rescue identity, reviewed config, and empty Env are each validated
+# Imported rescue identity, reviewed config, and non-empty Env are each validated
 # after unpause and before runtime stability polling.
-for validation_case in id config env; do
+for validation_case in id config env x-sentinel-env; do
   reset_case "strict-rescue-$validation_case"
+  validation_service=api validation_container_config=$LEGACY_CONFIG
   case $validation_case in
     id) FAKE_DOCKER_IMPORT_STORED_ID=$ID_D ;;
     config) FAKE_DOCKER_IMPORT_CONFIG=$CONFIG ;;
     env) FAKE_DOCKER_IMPORT_ENV=$SENTINEL_ENV ;;
+    x-sentinel-env) validation_service=x-collector; validation_container_config=$LEGACY_X_CONFIG; set_import_service_config x-collector; FAKE_DOCKER_IMPORT_ENV=$SENTINEL_ENV ;;
   esac
   # Export preserves the selected opaque JSON fixtures for fake docker.
   # shellcheck disable=SC2090
   export FAKE_DOCKER_IMPORT_STORED_ID FAKE_DOCKER_IMPORT_CONFIG \
     FAKE_DOCKER_IMPORT_ENV
-  add_container api "strict-rescue-$validation_case-api" "$ID_A" \
-    'running|true|false|false|healthy' "$LEGACY_CONFIG" "$SENTINEL_ENV"
+  add_container "$validation_service" "strict-rescue-$validation_case-api" "$ID_A" \
+    'running|true|false|false|healthy' "$validation_container_config" "$SENTINEL_ENV"
   strict_state=$(backend_image_rescue_state_file "$SHA")
   set +e
-  backend_image_rescue_prepare "$SHA" "$strict_state" api
+  backend_image_rescue_prepare "$SHA" "$strict_state" "$validation_service"
   strict_status=$?
   set -e
   ((strict_status != 0))
@@ -682,23 +690,77 @@ set -e
 [[ ! -e $mismatch_state && ! -e $mismatch_state.partial ]]
 assert_no_rescue_refs
 
-# The separate x-collector image has no reviewed reconstruction in this bridge.
-# Its explicit missing-image edge fails closed without pausing or exporting it.
-reset_case unsupported-missing-image
-add_container x-collector missing-x "$ID_A" 'running|true|false|false|healthy' \
-  '[]|[]|"/srv"|"collector"' "$SENTINEL_ENV"
-unsupported_state=$(backend_image_rescue_state_file "$SHA")
-set +e
-backend_image_rescue_prepare "$SHA" "$unsupported_state" x-collector
-unsupported_status=$?
-set -e
-((unsupported_status != 0))
-[[ ! -e $unsupported_state && ! -e $unsupported_state.partial ]]
-if grep -E $'docker\tcontainer\t(pause|export)\tmissing-x' "$EVENT_LOG" >/dev/null; then
-  echo 'unsupported missing image was touched before fail-closed validation' >&2
-  exit 1
-fi
-assert_no_rescue_refs
+# The legacy x-collector is reconstructed without copying container metadata.
+for x_env_case in array null; do
+  case $x_env_case in
+    array) x_empty_env='[]' ;;
+    null) x_empty_env=null ;;
+  esac
+  reset_case "x-collector-adoption-$x_env_case"
+  set_import_service_config x-collector
+  FAKE_DOCKER_IMPORT_ENV=$x_empty_env
+  export FAKE_DOCKER_IMPORT_ENV
+  add_container x-collector rescued-x "$ID_A" \
+    'running|true|false|false|healthy' "$LEGACY_X_CONFIG" "$SENTINEL_ENV"
+  x_state=$(backend_image_rescue_state_file "$SHA")
+  backend_image_rescue_prepare "$SHA" "$x_state" x-collector
+  grep -F \
+    $'image\tx-collector\trecreate\tcontainer-export-import\trescued-x' \
+    "$x_state" >/dev/null
+  x_tag=$(backend_image_rescue_tag "$SHA" x-collector)
+  [[ $(backend_image_rescue_image_config "$x_tag") == "$SAFE_X_CONFIG" ]]
+  [[ $(backend_image_rescue_image_env "$x_tag") == "$x_empty_env" ]]
+  printf -v expected_x_import '%s%s%s%s%s' \
+    $'docker\timage\timport\t--change\t' \
+    'CMD ["python","-m","x_collector"]' \
+    $'\t--change\tWORKDIR /app/apps/x-collector' \
+    $'\t--change\tUSER 1000:1000\t-\t' \
+    "$x_tag"
+  grep -Fx "$expected_x_import" "$EVENT_LOG" >/dev/null
+  grep -F $'docker\tcontainer\tpause\trescued-x' \
+    "$EVENT_LOG" >/dev/null
+  grep -F $'docker\tcontainer\texport\trescued-x' \
+    "$EVENT_LOG" >/dev/null
+  grep -F $'docker\tcontainer\tunpause\trescued-x' \
+    "$EVENT_LOG" >/dev/null
+  backend_image_rescue_mark_replacement_started "$x_state"
+  set_ref_direct "$(compose_image_name x-collector)" "$ID_D"
+  : > "$EVENT_LOG"
+  rollback_backend_images "$x_state"
+  grep -F \
+    $'compose\t--profile\tapp\tup\t-d\t--no-deps\t--force-recreate\tx-collector' \
+    "$EVENT_LOG" >/dev/null
+  [[ $(ref_id "$(compose_image_name x-collector)") == "$ID_E" ]]
+  backend_image_rescue_cleanup "$x_state"
+done
+
+# Every reviewed x-collector metadata field is validated before pause/export.
+for x_drift in entrypoint command workdir user healthcheck; do
+  reset_case "x-drift-$x_drift"
+  drift_entrypoint=null drift_command=$X_COMMAND drift_workdir=$X_WORKDIR
+  drift_user=$X_USER drift_healthcheck=$X_HEALTHCHECK
+  case $x_drift in
+    entrypoint) drift_entrypoint='["drift"]' ;;
+    command) drift_command='["drift"]' ;;
+    workdir) drift_workdir='"/drift"' ;;
+    user) drift_user='"0:0"' ;;
+    healthcheck) drift_healthcheck=null ;;
+  esac
+  drift_config="$drift_entrypoint|$drift_command|$drift_workdir|$drift_user|$drift_healthcheck"
+  add_container x-collector "drift-$x_drift" "$ID_A" \
+    'running|true|false|false|healthy' "$drift_config" "$SENTINEL_ENV"
+  drift_state=$(backend_image_rescue_state_file "$SHA")
+  set +e
+  backend_image_rescue_prepare "$SHA" "$drift_state" x-collector
+  drift_status=$?
+  set -e
+  ((drift_status != 0))
+  if grep -E $'docker\tcontainer\t(pause|export)\t' "$EVENT_LOG" >/dev/null; then
+    echo "x-collector $x_drift drift was touched before validation" >&2
+    exit 1
+  fi
+  assert_failed_rescue_cleaned "$drift_state"
+done
 
 # A failed import always unpauses the healthy container and removes the exact
 # partial rescue tag/state; it never falls back to copying container metadata.

--- a/prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql
+++ b/prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql
@@ -5,8 +5,6 @@
 
 BEGIN;
 
-CREATE EXTENSION IF NOT EXISTS "pgcrypto";
-
 -- The pre-migration bootstrap grants this NOLOGIN role only the object and
 -- schema capabilities required below. Create the protected graph as its final
 -- owner so foreign-key checks never depend on broad migrator ACLs.
@@ -237,7 +235,7 @@ BEGIN
     RAISE EXCEPTION 'reader summary canonical report is invalid JSON';
   END;
   v_report_sha256 := encode(
-    digest(convert_to(v_report_canonical, 'UTF8'), 'sha256'),
+    sha256(convert_to(v_report_canonical, 'UTF8')),
     'hex'
   );
   IF payload->>'reportSha256' IS DISTINCT FROM v_report_sha256 THEN
@@ -345,7 +343,7 @@ BEGIN
     RAISE EXCEPTION 'reader summary exact publication proof mismatch';
   END IF;
   v_proof_sha256 := encode(
-    digest(convert_to(v_proof_canonical, 'UTF8'), 'sha256'),
+    sha256(convert_to(v_proof_canonical, 'UTF8')),
     'hex'
   );
   IF payload->>'proofSha256' IS DISTINCT FROM v_proof_sha256 THEN
@@ -653,7 +651,7 @@ WITH "legacy_candidates" AS (
   SELECT
     report.*,
     encode(
-      digest(convert_to(report."legacy_report"::TEXT, 'UTF8'), 'sha256'),
+      sha256(convert_to(report."legacy_report"::TEXT, 'UTF8')),
       'hex'
     ) AS "legacy_report_sha256",
     jsonb_build_object(
@@ -690,7 +688,7 @@ WITH "legacy_candidates" AS (
       'semanticStatus', report."status"::TEXT,
       'modelVersion', report."model_version",
       'reportSha256', encode(
-        digest(convert_to(report."legacy_report"::TEXT, 'UTF8'), 'sha256'),
+        sha256(convert_to(report."legacy_report"::TEXT, 'UTF8')),
         'hex'
       )
     ) AS "legacy_proof"
@@ -714,7 +712,7 @@ SELECT
   proof."created_at", proof."model_version",
   "reader_summary_model_authority_rank"(proof."model_version"),
   proof."legacy_report_sha256",
-  encode(digest(convert_to(proof."legacy_proof"::TEXT, 'UTF8'), 'sha256'), 'hex'),
+  encode(sha256(convert_to(proof."legacy_proof"::TEXT, 'UTF8')), 'hex'),
   proof."legacy_proof", NULL, proof."updated_at"
 FROM "legacy_proofs" AS proof;
 


### PR DESCRIPTION
Removes the pgcrypto CREATE EXTENSION requirement from the fail-closed reader-summary publication migration and uses PostgreSQL 18 built-in sha256(bytea) for all five hashes.

Validated with:
- 70-case publication migrator deploy test
- PostgreSQL 18 production dry-run ending in ROLLBACK
- no residual schema objects or pgcrypto
- source line cap, secret scan, and diff check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of missing `x-collector` container images, including service-specific runtime settings and validation.
  * Added fail-closed checks for unsupported or changed `x-collector` metadata.
  * Updated reader summary and publication proof hashing to use PostgreSQL’s native SHA-256 support.
  * Removed the need for the `pgcrypto` extension when generating these hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two independent changes: it replaces five `pgcrypto.digest(…,'sha256')` calls in the reader-summary publication migration with the built-in `sha256(bytea)` function (removing the `CREATE EXTENSION IF NOT EXISTS "pgcrypto"` requirement), and it extends the backend image-rescue library to support reconstructing the `x-collector` Python service container alongside the existing Node.js services.

- **Migration (`20260716170000_reader_summary_fail_closed_publication`)**: Drops the pgcrypto extension dependency by substituting all `digest(…,'sha256')` calls with the built-in `sha256(bytea)`, which has been available since PostgreSQL 11 (the PR description says PG 18, but compatibility is broader). All five hash sites are updated consistently and the `encode/hex` wrapper is preserved.
- **`backend-image-rescue-lib.sh`**: Adds an `x-collector` branch to the expected-legacy-config, reconstructed-command, and reconstructed-image-config functions, and builds service-specific `import_changes` arrays (no ENTRYPOINT for x-collector, distinct WORKDIR and USER, healthcheck intentionally omitted from the reconstructed image).
- **`backend-image-rescue-lib.test.sh`**: Replaces the old \"unsupported missing-image\" test with full adoption tests (env=array and env=null variants), five drift-field rejection tests (entrypoint, command, workdir, user, healthcheck), and a sentinel-env rejection test for x-collector.

<h3>Confidence Score: 4/5</h3>

Safe to merge once confirmed that no environment has the migration's prior checksum recorded in _prisma_migrations.

The SQL substitution is mechanically correct and the shell-script changes are well-tested with thorough coverage of adoption, drift-rejection, and sentinel-env cases. The one concern is that this migration file has been modified in-place across multiple commits; if any connected database already has the old checksum recorded, future migration runs on that database will fail. Everything else — the built-in sha256 substitution, the x-collector image-reconstruction logic, and the test harness — looks solid.

prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql — verify no environment has a stale checksum for this migration before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql | Removes pgcrypto extension and replaces all five digest() calls with built-in sha256(bytea); semantically identical — carries a Prisma checksum-mismatch risk if the prior version was applied to any environment. |
| ops/deploy/backend-image-rescue-lib.sh | Adds x-collector support with correct service-specific entrypoint/workdir/user/healthcheck handling and an array-based import_changes pattern that avoids word-splitting issues. |
| ops/deploy/backend-image-rescue-lib.test.sh | Comprehensive x-collector test coverage added: adoption (null/array env), all five metadata drift rejections, and sentinel-env rejection; old unsupported-service test correctly replaced. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[prisma migrate deploy] --> B{migration already applied?}
    B -- No --> C[Apply migration SQL
sha256 built-in, no pgcrypto]
    B -- Yes, old checksum --> D[Prisma checksum mismatch error
migrations blocked]
    C --> E[encode + sha256 bytea
for all 5 hash sites]
    E --> F[COMMIT]

    G[backend_image_rescue_prepare] --> H{service?}
    H -- Node.js services --> I[import_changes:
ENTRYPOINT + CMD + WORKDIR /app + USER node]
    H -- x-collector --> J[import_changes:
CMD + WORKDIR /app/apps/x-collector + USER 1000:1000]
    I --> K[docker image import]
    J --> K
    K --> L[Validate: config + env + stability]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[prisma migrate deploy] --> B{migration already applied?}
    B -- No --> C[Apply migration SQL
sha256 built-in, no pgcrypto]
    B -- Yes, old checksum --> D[Prisma checksum mismatch error
migrations blocked]
    C --> E[encode + sha256 bytea
for all 5 hash sites]
    E --> F[COMMIT]

    G[backend_image_rescue_prepare] --> H{service?}
    H -- Node.js services --> I[import_changes:
ENTRYPOINT + CMD + WORKDIR /app + USER node]
    H -- x-collector --> J[import_changes:
CMD + WORKDIR /app/apps/x-collector + USER 1000:1000]
    I --> K[docker image import]
    J --> K
    K --> L[Validate: config + env + stability]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql`, line 1-6 ([link](https://github.com/777genius/social-monitor/blob/f622a3fd0bfd9950ab5dca7c39900bf8f3f37548/prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql#L1-L6)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Prisma checksum mismatch risk on pre-applied environments**

   The git history shows this migration file has been modified in-place across several commits (`94ca6eab`, `3a1c09d3`, `eb9b9899`, and now this PR). If any environment (staging, CI, a developer's local DB) ran `prisma migrate deploy` against a prior version of this file, the checksum recorded in `_prisma_migrations` will no longer match the updated SQL — Prisma will refuse to apply future migrations on that database with a "migration was modified after it was applied" error. Please confirm that no connected environment has this migration recorded as already applied before merging; if they do, the affected `_prisma_migrations` rows will need a manual checksum update.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql
   Line: 1-6

   Comment:
   **Prisma checksum mismatch risk on pre-applied environments**

   The git history shows this migration file has been modified in-place across several commits (`94ca6eab`, `3a1c09d3`, `eb9b9899`, and now this PR). If any environment (staging, CI, a developer's local DB) ran `prisma migrate deploy` against a prior version of this file, the checksum recorded in `_prisma_migrations` will no longer match the updated SQL — Prisma will refuse to apply future migrations on that database with a "migration was modified after it was applied" error. Please confirm that no connected environment has this migration recorded as already applied before merging; if they do, the affected `_prisma_migrations` rows will need a manual checksum update.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql:1-6
**Prisma checksum mismatch risk on pre-applied environments**

The git history shows this migration file has been modified in-place across several commits (`94ca6eab`, `3a1c09d3`, `eb9b9899`, and now this PR). If any environment (staging, CI, a developer's local DB) ran `prisma migrate deploy` against a prior version of this file, the checksum recorded in `_prisma_migrations` will no longer match the updated SQL — Prisma will refuse to apply future migrations on that database with a "migration was modified after it was applied" error. Please confirm that no connected environment has this migration recorded as already applied before merging; if they do, the affected `_prisma_migrations` rows will need a manual checksum update.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(db): use built-in sha256 for publica..."](https://github.com/777genius/social-monitor/commit/f622a3fd0bfd9950ab5dca7c39900bf8f3f37548) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45708251)</sub>

<!-- /greptile_comment -->