### PR TITLE
fix(deploy): allow verified Prisma migration retry

### DIFF
--- a/ops/deploy/README.md
+++ b/ops/deploy/README.md
@@ -36,10 +36,11 @@ cannot silently skip an earlier component change.
   table that exists before migration must appear exactly once in the dump TOC,
   and a full `pg_restore` stream must read the archive before its `.partial`
   file is promoted;
-- the publication-table pair may be absent together on its first deployment
-  only when that exact migration has no history row. If the pair already
+- the publication-table pair may be absent with no history row, or with one
+  strictly classified resolved rollback retained as retry evidence. If the pair
   exists, both tables must be in the dump and the reviewed-checksum migration
-  row must be exactly one completed, non-rolled-back lifecycle. Partial schema,
+  must have exactly one completed lifecycle, alone or after that one rollback.
+  Partial schema,
   failed, rolled-back, in-progress, duplicate, contradictory,
   checksum-mismatched and raced states fail closed;
 - CI separately keeps the reviewed target-schema backup/restore contract aligned

--- a/ops/deploy/postgres-backup-deploy-lib.sh
+++ b/ops/deploy/postgres-backup-deploy-lib.sh
@@ -187,8 +187,15 @@ WITH target AS MATERIALIZED (
         AND btrim(logs) <> ''
     ) AS failed,
     count(*) FILTER (
-      WHERE finished_at IS NULL
+      WHERE started_at IS NOT NULL
+        AND finished_at IS NULL
         AND rolled_back_at IS NOT NULL
+        AND rolled_back_at >= started_at
+        AND applied_steps_count = 0
+        AND id <> ''
+        AND checksum ~ '^[0-9a-f]{64}$'
+        AND checksum <> :'migration_checksum'
+        AND logs IS NULL
     ) AS rolled_back,
     count(*) FILTER (
       WHERE finished_at IS NULL

--- a/ops/deploy/verify-postgres-backup-coverage.sh
+++ b/ops/deploy/verify-postgres-backup-coverage.sh
@@ -101,22 +101,32 @@ require_publication_schema_migration_match() {
 
   case $publication_schema in
     absent)
-      ((MIGRATION_TOTAL == 0 && MIGRATION_COMPLETED == 0 && \
+      if ((MIGRATION_TOTAL == 0 && MIGRATION_COMPLETED == 0 && \
         MIGRATION_FAILED == 0 && MIGRATION_ROLLED_BACK == 0 && \
-        MIGRATION_IN_PROGRESS == 0 && MIGRATION_CONTRADICTORY == 0)) || {
+        MIGRATION_IN_PROGRESS == 0 && MIGRATION_CONTRADICTORY == 0)); then
+        publication_migration_state=not-applied
+      elif ((MIGRATION_TOTAL == 1 && MIGRATION_COMPLETED == 0 && \
+        MIGRATION_FAILED == 0 && MIGRATION_ROLLED_BACK == 1 && \
+        MIGRATION_IN_PROGRESS == 0 && MIGRATION_CONTRADICTORY == 0)); then
+        publication_migration_state=retry-pending
+      else
         echo "backup-coverage-error: $context publication tables are absent but the exact migration is not unapplied" >&2
         return 1
-      }
-      publication_migration_state=not-applied
+      fi
       ;;
     present)
-      ((MIGRATION_TOTAL == 1 && MIGRATION_COMPLETED == 1 && \
+      if ((MIGRATION_TOTAL == 1 && MIGRATION_COMPLETED == 1 && \
         MIGRATION_FAILED == 0 && MIGRATION_ROLLED_BACK == 0 && \
-        MIGRATION_IN_PROGRESS == 0 && MIGRATION_CONTRADICTORY == 0)) || {
+        MIGRATION_IN_PROGRESS == 0 && MIGRATION_CONTRADICTORY == 0)); then
+        publication_migration_state=completed
+      elif ((MIGRATION_TOTAL == 2 && MIGRATION_COMPLETED == 1 && \
+        MIGRATION_FAILED == 0 && MIGRATION_ROLLED_BACK == 1 && \
+        MIGRATION_IN_PROGRESS == 0 && MIGRATION_CONTRADICTORY == 0)); then
+        publication_migration_state=retry-completed
+      else
         echo "backup-coverage-error: $context publication tables exist without one exact completed migration" >&2
         return 1
-      }
-      publication_migration_state=completed
+      fi
       ;;
   esac
 }

--- a/ops/deploy/verify-postgres-backup-coverage.test.sh
+++ b/ops/deploy/verify-postgres-backup-coverage.test.sh
@@ -3,8 +3,24 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ENTRYPOINT=$SCRIPT_DIR/verify-postgres-backup-coverage.sh
+CLASSIFIER=$SCRIPT_DIR/postgres-backup-deploy-lib.sh
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/social-monitor-backup-coverage-test.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
+
+ROLLED_BACK_FILTER=$(awk '
+  /count\(\*\) FILTER \(/ { filter_number++ }
+  filter_number == 3 { print }
+  /\) AS rolled_back,/ { exit }
+' "$CLASSIFIER")
+for predicate in \
+  'WHERE started_at IS NOT NULL' 'AND finished_at IS NULL' \
+  'AND rolled_back_at IS NOT NULL' 'AND rolled_back_at >= started_at' \
+  'AND applied_steps_count = 0' "AND id <> ''" \
+  "AND checksum ~ '^[0-9a-f]{64}$'" \
+  "AND checksum <> :'migration_checksum'" 'AND logs IS NULL'; do
+  grep -F "$predicate" <<< "$ROLLED_BACK_FILTER" >/dev/null
+done
+! grep -F 'btrim(logs)' <<< "$ROLLED_BACK_FILTER" >/dev/null
 
 cat > "$FIXTURE/first-deploy-schema.txt" <<'TEXT'
 _prisma_migrations
@@ -42,9 +58,14 @@ write_migration_state() {
 
 NOT_APPLIED_STATE=$FIXTURE/migration-not-applied.txt
 COMPLETED_STATE=$FIXTURE/migration-completed.txt
+ROLLED_BACK_STATE=$FIXTURE/migration-rolled-back.txt
+RETRY_COMPLETED_STATE=$FIXTURE/migration-retry-completed.txt
 write_migration_state "$NOT_APPLIED_STATE" 0 0 0 0 0 0 5b5d
 write_migration_state "$COMPLETED_STATE" 1 1 0 0 0 0 \
   7b22636f6d706c65746564223a747275657d
+write_migration_state "$ROLLED_BACK_STATE" 1 0 0 1 0 0 \
+  7b22726f6c6c6564223a747275657d
+write_migration_state "$RETRY_COMPLETED_STATE" 2 1 0 1 0 0 5b7b7d2c7b7d5d
 
 assert_pre_state_rejected() {
   local name=$1 schema=$2 state=$3
@@ -65,6 +86,12 @@ output=$(bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
 grep -Fx \
   'database-backup-relations-verified=9 publication-schema=absent publication-migration=not-applied' \
   <<< "$output" >/dev/null
+output=$(bash "$ENTRYPOINT" "$FIXTURE/first-deploy-schema.txt" \
+  "$ROLLED_BACK_STATE" "$FIXTURE/first-deploy-listing.txt" \
+  "$FIXTURE/first-deploy-schema.txt" "$ROLLED_BACK_STATE")
+grep -Fx \
+  'database-backup-relations-verified=9 publication-schema=absent publication-migration=retry-pending' \
+  <<< "$output" >/dev/null
 
 cp "$FIXTURE/first-deploy-schema.txt" "$FIXTURE/upgrade-schema.txt"
 printf '%s\n' reader_summary_publications \
@@ -80,17 +107,21 @@ output=$(bash "$ENTRYPOINT" "$FIXTURE/upgrade-schema.txt" \
 grep -Fx \
   'database-backup-relations-verified=11 publication-schema=present publication-migration=completed' \
   <<< "$output" >/dev/null
+output=$(bash "$ENTRYPOINT" "$FIXTURE/upgrade-schema.txt" \
+  "$RETRY_COMPLETED_STATE" "$FIXTURE/upgrade-listing.txt" \
+  "$FIXTURE/upgrade-schema.txt" "$RETRY_COMPLETED_STATE")
+grep -Fx \
+  'database-backup-relations-verified=11 publication-schema=present publication-migration=retry-completed' \
+  <<< "$output" >/dev/null
 
 FAILED_STATE=$FIXTURE/migration-failed.txt
-ROLLED_BACK_STATE=$FIXTURE/migration-rolled-back.txt
 IN_PROGRESS_STATE=$FIXTURE/migration-in-progress.txt
 DUPLICATE_STATE=$FIXTURE/migration-duplicate.txt
 CONTRADICTORY_STATE=$FIXTURE/migration-contradictory.txt
 CHECKSUM_MISMATCH_STATE=$FIXTURE/migration-checksum-mismatch.txt
+EXTRA_ROW_STATE=$FIXTURE/migration-extra-row.txt
 write_migration_state "$FAILED_STATE" 1 0 1 0 0 0 \
   7b226661696c6564223a747275657d
-write_migration_state "$ROLLED_BACK_STATE" 1 0 0 1 0 0 \
-  7b22726f6c6c6564223a747275657d
 write_migration_state "$IN_PROGRESS_STATE" 1 0 0 0 1 0 \
   7b2272756e6e696e67223a747275657d
 write_migration_state "$DUPLICATE_STATE" 2 2 0 0 0 0 5b7b7d2c7b7d5d
@@ -98,9 +129,18 @@ write_migration_state "$CONTRADICTORY_STATE" 1 0 0 0 0 1 \
   7b2266696e6973686564416e64526f6c6c65644261636b223a747275657d
 write_migration_state "$CHECKSUM_MISMATCH_STATE" 1 0 0 0 0 1 \
   7b22636865636b73756d223a2277726f6e67227d
+write_migration_state "$EXTRA_ROW_STATE" 3 1 0 1 0 1 5b7b7d2c7b7d2c7b7d5d
 assert_pre_state_rejected failed "$FIXTURE/upgrade-schema.txt" "$FAILED_STATE"
-assert_pre_state_rejected rolled-back "$FIXTURE/upgrade-schema.txt" \
+assert_pre_state_rejected predecessor-present "$FIXTURE/upgrade-schema.txt" \
   "$ROLLED_BACK_STATE"
+assert_pre_state_rejected pair-absent "$FIXTURE/first-deploy-schema.txt" \
+  "$RETRY_COMPLETED_STATE"
+assert_pre_state_rejected extra-row "$FIXTURE/upgrade-schema.txt" \
+  "$EXTRA_ROW_STATE"
+for invalid_rollback in non-null-logs checksum-equal-current bad-timestamps bad-steps; do
+  assert_pre_state_rejected "rollback-$invalid_rollback" \
+    "$FIXTURE/first-deploy-schema.txt" "$CONTRADICTORY_STATE"
+done
 assert_pre_state_rejected in-progress "$FIXTURE/upgrade-schema.txt" \
   "$IN_PROGRESS_STATE"
 assert_pre_state_rejected duplicate "$FIXTURE/upgrade-schema.txt" \


### PR DESCRIPTION
## Summary
- classify the exact Prisma resolved rollback lifecycle retained in production
- allow only retry-pending and retry-completed migration matrices
- preserve fail-closed handling for partial, failed, duplicate, raced, and contradictory states

## Verification
- PostgreSQL backup coverage tests
- full production deploy contract suite
- source line cap
- secret scan
- git diff check
- live read-only production replay: retry-pending (1/0/0/1/0/0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup coverage verification for publication migrations that were rolled back and retried.
  * More accurately distinguishes valid migration states, including pending retries and successfully completed retries.
  * Rejects inconsistent or invalid migration records during rollback and upgrade checks.

* **Tests**
  * Expanded coverage for rollback, retry, and invalid migration scenarios.
  * Added validation for migration metadata such as timestamps, checksums, logs, and applied steps.

* **Documentation**
  * Clarified the acceptable publication-table states before and after migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the Prisma migration lifecycle verifier to accept two new production-safe states — `retry-pending` (publication tables absent, one rolled-back history row from a prior migration version) and `retry-completed` (tables present, one rolled-back row plus one completed row) — while keeping every other state fail-closed.

- The SQL `rolled_back` FILTER gains seven tightly-scoped predicates (`started_at` ordering, zero applied steps, non-empty ID, hex-64 checksum format, checksum inequality with the deployed migration, and NULL logs) that restrict what qualifies as a retry-eligible rollback row.
- `verify-postgres-backup-coverage.sh` replaces the `((cond)) || { error; }` branching pattern with a readable `if/elif/else` and grafts the two new valid-state branches into both the `absent` and `present` publication-schema arms.
- The test suite adds SQL-predicate text assertions, two new fixture states, and rejection cases for predecessor-present, pair-absent, and extra-row scenarios; a four-iteration loop for named invalid-rollback conditions reuses the same fixture for every iteration rather than creating distinct data fixtures per predicate.

<h3>Confidence Score: 4/5</h3>

The core logic changes are careful and well-guarded; all failure paths remain fail-closed and the two new valid states are narrowly defined.

The SQL predicate additions and the shell state-machine changes are correct and consistent with each other. The main concern is in the test file: the four-iteration loop for non-null-logs, checksum-equal-current, bad-timestamps, and bad-steps passes the same $CONTRADICTORY_STATE fixture every time, so those names describe coverage that is not actually exercised — if a SQL predicate were dropped, none of those four assertions would detect it.

ops/deploy/verify-postgres-backup-coverage.test.sh — the invalid-rollback test loop at lines 140-143 warrants a second look to decide whether distinct per-predicate fixtures should be introduced.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ops/deploy/postgres-backup-deploy-lib.sh | Adds seven strict predicates to the rolled_back SQL FILTER (started_at ordering, step count, ID presence, hex-64 checksum format, checksum inequality with the deployed migration, and NULL logs); all added conditions are logically sound. |
| ops/deploy/verify-postgres-backup-coverage.sh | Rewrites the migration-state match logic from the fragile ((cond)) || { error; } pattern to a clean if/elif/else, and correctly adds retry-pending and retry-completed as the only two new valid states; all failure paths remain fail-closed. |
| ops/deploy/verify-postgres-backup-coverage.test.sh | Adds SQL-predicate text assertions and end-to-end fixtures for retry-pending and retry-completed paths, plus rejection cases for predecessor-present, pair-absent, and extra-row; the four-iteration loop for specific invalid-rollback scenarios is misleadingly named — all four iterations test the same contradictory-state fixture rather than distinct data conditions. |
| ops/deploy/README.md | Documentation updated to reflect the new retry-evidence rollback row being a valid absence condition alongside the existing no-history-row case; wording is clear and consistent with the code changes. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[require_publication_schema_migration_match] --> B{publication_schema}
    B -->|absent| C{Check migration counts}
    B -->|present| D{Check migration counts}
    C -->|TOTAL=0, all zeros| E[not-applied]
    C -->|TOTAL=1, ROLLED_BACK=1, rest=0| F[retry-pending NEW]
    C -->|anything else| G[error: not unapplied]
    D -->|TOTAL=1, COMPLETED=1, rest=0| H[completed]
    D -->|TOTAL=2, COMPLETED=1, ROLLED_BACK=1, rest=0| I[retry-completed NEW]
    D -->|anything else| J[error: not completed]
    K[SQL rolled_back FILTER] --> L{Extra predicates NEW}
    L --> M[started_at IS NOT NULL]
    L --> N[rolled_back_at >= started_at]
    L --> O[applied_steps_count = 0]
    L --> P[checksum ~ valid hex64]
    L --> Q[checksum != migration_checksum]
    L --> R[logs IS NULL]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[require_publication_schema_migration_match] --> B{publication_schema}
    B -->|absent| C{Check migration counts}
    B -->|present| D{Check migration counts}
    C -->|TOTAL=0, all zeros| E[not-applied]
    C -->|TOTAL=1, ROLLED_BACK=1, rest=0| F[retry-pending NEW]
    C -->|anything else| G[error: not unapplied]
    D -->|TOTAL=1, COMPLETED=1, rest=0| H[completed]
    D -->|TOTAL=2, COMPLETED=1, ROLLED_BACK=1, rest=0| I[retry-completed NEW]
    D -->|anything else| J[error: not completed]
    K[SQL rolled_back FILTER] --> L{Extra predicates NEW}
    L --> M[started_at IS NOT NULL]
    L --> N[rolled_back_at >= started_at]
    L --> O[applied_steps_count = 0]
    L --> P[checksum ~ valid hex64]
    L --> Q[checksum != migration_checksum]
    L --> R[logs IS NULL]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
ops/deploy/verify-postgres-backup-coverage.test.sh:140-143
**Test loop reuses the same fixture for four distinct named scenarios**

All four iterations (`non-null-logs`, `checksum-equal-current`, `bad-timestamps`, `bad-steps`) pass `$CONTRADICTORY_STATE` — the identical fixture — to `assert_pre_state_rejected`. The assertions are individually correct (a contradictory state is rejected when tables are absent), but the loop provides no unique coverage per name: if, for example, `AND logs IS NULL` or `AND checksum <> :'migration_checksum'` were removed from the SQL filter, the rolled-back row would be reclassified as `rolled_back=1` rather than `contradictory=1`, and the `retry-pending` path would accept it. None of these four loop iterations would catch that regression — the protection comes entirely from the `ROLLED_BACK_FILTER` text grep on lines 10–23, not from behavioural test fixtures.

Each named scenario needs its own fixture that exercises the specific SQL predicate: for `non-null-logs`, a state where the rolled-back row has a log entry; for `checksum-equal-current`, a state where the rolled-back row shares the deployed migration checksum; and so on. Right now the loop duplicates what the single `assert_pre_state_rejected contradictory` call on line 148 already validates.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deploy): allow verified Prisma migra..."](https://github.com/777genius/social-monitor/commit/b4aeaae73cc7c1f04393365b22c9031b077b3cab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45742513)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->