### PR TITLE
fix(deploy): satisfy backup coverage shellcheck

### DIFF
--- a/ops/deploy/verify-postgres-backup-coverage.test.sh
+++ b/ops/deploy/verify-postgres-backup-coverage.test.sh
@@ -20,7 +20,10 @@ for predicate in \
   "AND checksum <> :'migration_checksum'" 'AND logs IS NULL'; do
   grep -F "$predicate" <<< "$ROLLED_BACK_FILTER" >/dev/null
 done
-! grep -F 'btrim(logs)' <<< "$ROLLED_BACK_FILTER" >/dev/null
+if grep -F 'btrim(logs)' <<< "$ROLLED_BACK_FILTER" >/dev/null; then
+  echo 'rolled-back migration classifier must require literal NULL logs' >&2
+  exit 1
+fi
 
 cat > "$FIXTURE/first-deploy-schema.txt" <<'TEXT'
 _prisma_migrations


### PR DESCRIPTION
## Summary
- replace the SC2251-prone negated grep with an explicit fail-closed conditional
- preserve the assertion that the rollback classifier must not normalize logs

## Verification
- shellcheck passes for the changed test
- cached diff check passes
- the underlying backup/deploy suites passed unchanged before this syntax-only correction

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a one-line shellcheck fix in the Postgres backup coverage test script. The `! grep -F 'btrim(logs)'` pattern triggered the SC2251 lint warning because using `!` to negate a simple command's exit status in a `set -e` script is non-obvious and can mislead static analysis tools.

- The negated-grep assertion is replaced with an explicit `if grep …; then echo … >&2; exit 1; fi` block, which is functionally identical but also emits a human-readable error message on failure.
- No logic, control flow, or test coverage is altered; only the syntactic form of one assertion changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a syntactic rewrite of a single assertion with no behavioral differences.

The old `! grep` form and the new `if grep … exit 1` form produce identical outcomes for every possible grep exit code (0 = found → fail, 1 = not found → pass, 2 = error → pass, same in both paths). The new form additionally surfaces a clear diagnostic message on failure. No logic, data paths, or coverage rules change.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ops/deploy/verify-postgres-backup-coverage.test.sh | Replaces `! grep` negation (SC2251) with an explicit `if`/`exit 1` block; behavior is equivalent and now includes a descriptive error message. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Extract ROLLED_BACK_FILTER via awk] --> B{For each required predicate}
    B -->|grep -F predicate| C[grep exits 0 → predicate present ✓]
    B -->|grep exits 1 → predicate missing| D[set -e kills script ✗]
    C --> E{grep -F 'btrim logs'}
    E -->|exit 0 — btrim found| F["echo error >&2\nexit 1 ✗"]
    E -->|exit 1 — btrim absent| G[Test continues ✓]
    G --> H[Fixture setup & scenario tests]
    H --> I["echo 'tests passed'"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Extract ROLLED_BACK_FILTER via awk] --> B{For each required predicate}
    B -->|grep -F predicate| C[grep exits 0 → predicate present ✓]
    B -->|grep exits 1 → predicate missing| D[set -e kills script ✗]
    C --> E{grep -F 'btrim logs'}
    E -->|exit 0 — btrim found| F["echo error >&2\nexit 1 ✗"]
    E -->|exit 1 — btrim absent| G[Test continues ✓]
    G --> H[Fixture setup & scenario tests]
    H --> I["echo 'tests passed'"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(deploy): satisfy backup coverage she..."](https://github.com/777genius/social-monitor/commit/98736c91a1696f2b3df5a6878c3e3a23e3f770e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45745204)</sub>

<!-- /greptile_comment -->