### PR TITLE
fix(db): isolate public schema ownership

### DIFF
--- a/ops/deploy/reader-summary-publication-deploy-lib.sh
+++ b/ops/deploy/reader-summary-publication-deploy-lib.sh
@@ -645,6 +645,27 @@ LEFT JOIN LATERAL (
         SELECT 1 FROM pg_catalog.pg_roles
         WHERE rolname = 'social_monitor_public_schema_owner'
       )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.aclexplode(
+          COALESCE(
+            namespace.nspacl,
+            pg_catalog.acldefault('n', namespace.nspowner)
+          )
+        ) schema_privilege
+        LEFT JOIN pg_catalog.pg_roles schema_grantee
+          ON schema_grantee.oid = schema_privilege.grantee
+        WHERE schema_privilege.privilege_type = 'CREATE'
+          AND (
+            schema_privilege.grantee = 0
+            OR schema_grantee.rolname NOT IN (
+              'pg_database_owner',
+              current_user,
+              :'runtime_role',
+              'social_monitor_reader_summary_publication_owner'
+            )
+          )
+      )
     ) OR (
       schema_owner.rolname = 'social_monitor_public_schema_owner'
       AND EXISTS (
@@ -675,6 +696,26 @@ LEFT JOIN LATERAL (
         WHERE schema_granted.rolname =
             'social_monitor_public_schema_owner'
           AND schema_member.rolname <> current_user
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.aclexplode(
+          COALESCE(
+            namespace.nspacl,
+            pg_catalog.acldefault('n', namespace.nspowner)
+          )
+        ) schema_privilege
+        LEFT JOIN pg_catalog.pg_roles schema_grantee
+          ON schema_grantee.oid = schema_privilege.grantee
+        WHERE schema_privilege.privilege_type = 'CREATE'
+          AND (
+            schema_privilege.grantee = 0
+            OR schema_grantee.rolname NOT IN (
+              'social_monitor_public_schema_owner',
+              current_user,
+              'social_monitor_reader_summary_publication_owner'
+            )
+          )
       )
     )
   ) AS boundary_valid

--- a/ops/deploy/reader-summary-publication-deploy-lib.sh
+++ b/ops/deploy/reader-summary-publication-deploy-lib.sh
@@ -159,7 +159,7 @@ validate_reader_summary_publication_migrator() (
   local server_version uses_tls membership_count membership_admin
   local membership_inherit membership_set protected_memberships_valid
   local unexpected_membership_count outgoing_membership_count
-  local protected_creator_membership_valid extra
+  local protected_creator_membership_valid public_schema_boundary_valid extra
   local query_status availability_status
 
   [[ -f $secret && ! -L $secret && -s $secret ]] || return 64
@@ -198,7 +198,7 @@ validate_reader_summary_publication_migrator() (
   fi
   [[ -n $catalog_result && $catalog_result != *$'\n'* ]] || return 65
   catalog_delimiters=${catalog_result//[!|]/}
-  ((${#catalog_delimiters} == 19)) || return 65
+  ((${#catalog_delimiters} == 20)) || return 65
 
   IFS='|' read -r database_name current_identity session_identity \
     can_login can_create_role inherits_role is_superuser \
@@ -206,7 +206,7 @@ validate_reader_summary_publication_migrator() (
     uses_tls membership_count membership_admin membership_inherit \
     membership_set protected_memberships_valid \
     unexpected_membership_count outgoing_membership_count \
-    protected_creator_membership_valid extra \
+    protected_creator_membership_valid public_schema_boundary_valid extra \
     <<< "$catalog_result"
 
   [[ -z $extra && \
@@ -226,6 +226,7 @@ validate_reader_summary_publication_migrator() (
   [[ $unexpected_membership_count == 0 ]] || return 65
   [[ $outgoing_membership_count == 1 ]] || return 65
   [[ $protected_creator_membership_valid == t ]] || return 65
+  [[ $public_schema_boundary_valid == t ]] || return 65
 )
 
 reader_summary_publication_admin_secret_metadata() {
@@ -449,7 +450,8 @@ SELECT
   COALESCE(membership.protected_memberships_valid, false),
   COALESCE(membership.unexpected_membership_count, 0),
   COALESCE(outgoing_memberships.membership_count, 0),
-  COALESCE(outgoing_memberships.protected_creator_membership_valid, false)
+  COALESCE(outgoing_memberships.protected_creator_membership_valid, false),
+  COALESCE(public_schema_ownership.boundary_valid, false)
 FROM pg_catalog.pg_roles AS migrator
 LEFT JOIN pg_catalog.pg_stat_ssl AS connection
   ON connection.pid = pg_catalog.pg_backend_pid()
@@ -468,6 +470,38 @@ LEFT JOIN LATERAL (
       WHERE granted_role.rolname = :'runtime_role'
     ) AS set_option,
     (
+      (
+        NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_roles
+          WHERE rolname = 'social_monitor_public_schema_owner'
+        ) AND COUNT(*) FILTER (
+          WHERE granted_role.rolname =
+            'social_monitor_public_schema_owner'
+        ) = 0
+      ) OR (
+        EXISTS (
+          SELECT 1 FROM pg_catalog.pg_roles
+          WHERE rolname = 'social_monitor_public_schema_owner'
+        ) AND COUNT(*) FILTER (
+          WHERE granted_role.rolname =
+            'social_monitor_public_schema_owner'
+        ) = 2 AND COUNT(*) FILTER (
+          WHERE granted_role.rolname =
+            'social_monitor_public_schema_owner'
+            AND membership.admin_option
+            AND NOT membership.inherit_option
+            AND NOT membership.set_option
+            AND grantor_role.rolsuper
+        ) = 1 AND COUNT(*) FILTER (
+          WHERE granted_role.rolname =
+            'social_monitor_public_schema_owner'
+            AND NOT membership.admin_option
+            AND NOT membership.inherit_option
+            AND membership.set_option
+            AND grantor_role.rolname = current_user
+        ) = 1
+      )
+    ) AND (
       (
         NOT EXISTS (
           SELECT 1 FROM pg_catalog.pg_roles
@@ -550,6 +584,7 @@ LEFT JOIN LATERAL (
     COUNT(*) FILTER (
       WHERE granted_role.rolname NOT IN (
         :'runtime_role',
+        'social_monitor_public_schema_owner',
         'social_monitor_reader_summary_publication_owner',
         'social_monitor_reader_summary_publication_runtime'
       )
@@ -601,6 +636,57 @@ LEFT JOIN LATERAL (
     ON grantor_role.oid = outgoing_membership.grantor
   WHERE outgoing_membership.roleid = migrator.oid
 ) AS outgoing_memberships ON true
+LEFT JOIN LATERAL (
+  SELECT (
+    (
+      schema_owner.rolname = 'pg_database_owner'
+      AND database_owner.rolname = :'runtime_role'
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_roles
+        WHERE rolname = 'social_monitor_public_schema_owner'
+      )
+    ) OR (
+      schema_owner.rolname = 'social_monitor_public_schema_owner'
+      AND EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_roles protected_schema_owner
+        WHERE protected_schema_owner.rolname =
+            'social_monitor_public_schema_owner'
+          AND NOT protected_schema_owner.rolcanlogin
+          AND NOT protected_schema_owner.rolsuper
+          AND NOT protected_schema_owner.rolcreatedb
+          AND NOT protected_schema_owner.rolcreaterole
+          AND NOT protected_schema_owner.rolinherit
+          AND NOT protected_schema_owner.rolreplication
+          AND NOT protected_schema_owner.rolbypassrls
+      )
+      AND NOT pg_has_role(
+        :'runtime_role',
+        'social_monitor_public_schema_owner',
+        'MEMBER'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_auth_members schema_membership
+        JOIN pg_catalog.pg_roles schema_granted
+          ON schema_granted.oid = schema_membership.roleid
+        JOIN pg_catalog.pg_roles schema_member
+          ON schema_member.oid = schema_membership.member
+        WHERE schema_granted.rolname =
+            'social_monitor_public_schema_owner'
+          AND schema_member.rolname <> current_user
+      )
+    )
+  ) AS boundary_valid
+  FROM pg_catalog.pg_namespace namespace
+  JOIN pg_catalog.pg_roles schema_owner
+    ON schema_owner.oid = namespace.nspowner
+  JOIN pg_catalog.pg_database database
+    ON database.datname = current_database()
+  JOIN pg_catalog.pg_roles database_owner
+    ON database_owner.oid = database.datdba
+  WHERE namespace.nspname = 'public'
+) AS public_schema_ownership ON true
 WHERE migrator.rolname = current_user;"
 
   reader_summary_publication_run_postgres_client \

--- a/ops/deploy/reader-summary-publication-migrator-validation.test.sh
+++ b/ops/deploy/reader-summary-publication-migrator-validation.test.sh
@@ -75,6 +75,10 @@ if [[ -n $query_file ]]; then
   [[ $query_payload == *'social_monitor_public_schema_owner'* ]]
   [[ $query_payload == *'pg_catalog.pg_namespace namespace'* ]]
   [[ $query_payload == *'public_schema_ownership.boundary_valid'* ]]
+  [[ $query_payload == *'schema_grantee.rolname NOT IN ('* ]]
+  [[ $query_payload == *"'social_monitor_public_schema_owner',"* ]]
+  [[ $query_payload == *"current_user,"* ]]
+  [[ $query_payload == *"'social_monitor_reader_summary_publication_owner'"* ]]
   [[ " $* " == *' --set=runtime_role=social_monitor_app '* ]]
   [[ " $* " == *' --set=provisioner_role=doadmin '* ]]
   printf '%s\n' "$query_file" > "$TRANSPORT_QUERY_PATH_LOG"
@@ -662,6 +666,9 @@ for catalog_token in \
   'public_schema_ownership.boundary_valid' \
   'social_monitor_public_schema_owner' \
   'pg_catalog.pg_namespace namespace' \
+  'pg_catalog.aclexplode' \
+  'namespace.nspacl' \
+  "schema_privilege.privilege_type = 'CREATE'" \
   "schema_owner.rolname = 'pg_database_owner'" \
   "database_owner.rolname = :'runtime_role'" \
   "pg_has_role(" \

--- a/ops/deploy/reader-summary-publication-migrator-validation.test.sh
+++ b/ops/deploy/reader-summary-publication-migrator-validation.test.sh
@@ -23,7 +23,7 @@ PRIVATE_PASSWORD=redacted-test-password
 MIGRATOR_ROLE=social_monitor_publication_migrator
 DATABASE_HOST=dbaas-db-8050451-do-user-39622063-0.e.db.ondigitalocean.com
 VALID_URL="postgresql://${MIGRATOR_ROLE}:${PRIVATE_PASSWORD}@${DATABASE_HOST}:25060/social_monitor?connect_timeout=10&sslmode=verify-full&sslrootcert=%2Frun%2Fsocial-monitor-db%2Fca-certificate.crt"
-VALID_CATALOG="social_monitor|${MIGRATOR_ROLE}|${MIGRATOR_ROLE}|t|t|t|f|f|f|f|180004|t|1|t|f|t|t|0|1|t"
+VALID_CATALOG="social_monitor|${MIGRATOR_ROLE}|${MIGRATOR_ROLE}|t|t|t|f|f|f|f|180004|t|1|t|f|t|t|0|1|t|t"
 CATALOG_RESULT=$VALID_CATALOG
 CATALOG_QUERY_STATUS=0
 AVAILABILITY_STATUS=0
@@ -72,6 +72,9 @@ if [[ -n $query_file ]]; then
   query_payload=$(< "$query_file")
   [[ $query_payload == *"WHERE granted_role.rolname = :'runtime_role'"* ]]
   [[ $query_payload == *'FROM pg_catalog.pg_auth_members AS membership'* ]]
+  [[ $query_payload == *'social_monitor_public_schema_owner'* ]]
+  [[ $query_payload == *'pg_catalog.pg_namespace namespace'* ]]
+  [[ $query_payload == *'public_schema_ownership.boundary_valid'* ]]
   [[ " $* " == *' --set=runtime_role=social_monitor_app '* ]]
   [[ " $* " == *' --set=provisioner_role=doadmin '* ]]
   printf '%s\n' "$query_file" > "$TRANSPORT_QUERY_PATH_LOG"
@@ -551,6 +554,8 @@ assert_invalid_catalog additional-outgoing-member \
   "$(catalog_with_field 18 2)"
 assert_invalid_catalog unsafe-protected-creator-membership \
   "$(catalog_with_field 19 f)"
+assert_invalid_catalog unsafe-public-schema-owner-boundary \
+  "$(catalog_with_field 20 f)"
 
 assert_deploy_backend_preflight_order() {
   local mode=$1
@@ -654,6 +659,12 @@ for catalog_token in \
   'unexpected_membership_count' \
   'outgoing_memberships.membership_count' \
   'protected_creator_membership_valid' \
+  'public_schema_ownership.boundary_valid' \
+  'social_monitor_public_schema_owner' \
+  'pg_catalog.pg_namespace namespace' \
+  "schema_owner.rolname = 'pg_database_owner'" \
+  "database_owner.rolname = :'runtime_role'" \
+  "pg_has_role(" \
   'outgoing_membership.roleid = migrator.oid' \
   "member_role.rolname = :'provisioner_role'" \
   'grantor_role.rolsuper' \

--- a/ops/deploy/reader-summary-publication-post-migration.sql
+++ b/ops/deploy/reader-summary-publication-post-migration.sql
@@ -5,6 +5,32 @@ SELECT set_config(
   :'runtime_role',
   false
 );
+SELECT set_config(
+  'social_monitor.bootstrap_migrator_role',
+  current_user,
+  false
+);
+
+-- The migrator receives CREATE WITH GRANT OPTION only inside the committed pre
+-- phase so Prisma can apply the ordered migration. Remove it as the dedicated
+-- schema owner before auditing the runtime boundary.
+SET ROLE social_monitor_public_schema_owner;
+REVOKE CREATE ON SCHEMA public
+FROM pg_database_owner,
+  PUBLIC,
+  social_monitor_reader_summary_publication_owner,
+  social_monitor_reader_summary_publication_runtime,
+  :"runtime_role"
+CASCADE;
+DO $revoke_migrator_schema_create$
+BEGIN
+  EXECUTE format(
+    'REVOKE CREATE ON SCHEMA public FROM %I CASCADE',
+    current_setting('social_monitor.bootstrap_migrator_role')::NAME
+  );
+END
+$revoke_migrator_schema_create$;
+RESET ROLE;
 
 -- Protected object ACLs can only be repaired as their NOLOGIN owner. The
 -- migrator has SET but deliberately does not inherit this role.
@@ -32,14 +58,10 @@ DECLARE
   v_owner_count INTEGER;
   v_trigger_count INTEGER;
   v_function RECORD;
+  v_role RECORD;
 BEGIN
   -- Remove any direct authority retained from an older runtime-owned schema.
   -- The application receives only the audited capability-role grants.
-  EXECUTE format('REVOKE CREATE ON SCHEMA public FROM %I', v_runtime_role);
-  REVOKE CREATE ON SCHEMA public
-  FROM PUBLIC,
-    social_monitor_reader_summary_publication_owner,
-    social_monitor_reader_summary_publication_runtime;
   EXECUTE format(
     'GRANT social_monitor_reader_summary_publication_runtime TO %I '
       'WITH ADMIN FALSE GRANTED BY CURRENT_USER',
@@ -55,6 +77,21 @@ BEGIN
       'WITH SET FALSE GRANTED BY CURRENT_USER',
     v_runtime_role
   );
+
+  SELECT * INTO v_role FROM pg_roles
+  WHERE rolname = 'social_monitor_public_schema_owner';
+  IF NOT FOUND OR v_role.rolcanlogin OR v_role.rolsuper
+    OR v_role.rolcreatedb OR v_role.rolcreaterole OR v_role.rolinherit
+    OR v_role.rolreplication OR v_role.rolbypassrls THEN
+    RAISE EXCEPTION 'public schema owner role is unsafe';
+  END IF;
+  IF (
+    SELECT pg_get_userbyid(namespace.nspowner)
+    FROM pg_namespace namespace
+    WHERE namespace.nspname = 'public'
+  ) <> 'social_monitor_public_schema_owner' THEN
+    RAISE EXCEPTION 'public schema has an unsafe owner';
+  END IF;
 
   SELECT count(*) INTO v_owner_count
   FROM pg_class relation
@@ -137,6 +174,10 @@ BEGIN
     v_runtime_role,
     'social_monitor_reader_summary_publication_owner',
     'MEMBER'
+  ) OR pg_has_role(
+    v_runtime_role,
+    'social_monitor_public_schema_owner',
+    'MEMBER'
   ) OR NOT pg_has_role(
     v_runtime_role,
     'social_monitor_reader_summary_publication_runtime',
@@ -158,8 +199,41 @@ BEGIN
       'social_monitor_reader_summary_publication_owner',
       'public',
       'CREATE'
-    ) THEN
+  ) THEN
     RAISE EXCEPTION 'runtime role can bypass publication ownership';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM pg_auth_members membership
+    JOIN pg_roles granted ON granted.oid = membership.roleid
+    JOIN pg_roles member ON member.oid = membership.member
+    WHERE granted.rolname = 'social_monitor_public_schema_owner'
+      AND member.rolname <> current_user
+  ) THEN
+    RAISE EXCEPTION 'public schema owner has an unreviewed member';
+  END IF;
+  IF (
+    SELECT count(*) <> 2
+      OR count(*) FILTER (
+        WHERE membership.admin_option
+          AND NOT membership.inherit_option
+          AND NOT membership.set_option
+          AND grantor.rolsuper
+      ) <> 1
+      OR count(*) FILTER (
+        WHERE NOT membership.admin_option
+          AND NOT membership.inherit_option
+          AND membership.set_option
+          AND grantor.rolname = current_user
+      ) <> 1
+    FROM pg_auth_members membership
+    JOIN pg_roles granted ON granted.oid = membership.roleid
+    JOIN pg_roles member ON member.oid = membership.member
+    JOIN pg_roles grantor ON grantor.oid = membership.grantor
+    WHERE granted.rolname = 'social_monitor_public_schema_owner'
+      AND member.rolname = current_user
+  ) THEN
+    RAISE EXCEPTION 'public schema owner membership is unsafe';
   END IF;
   IF (
     SELECT count(*) <> 2
@@ -230,6 +304,7 @@ BEGIN
           AND grantor.rolname NOT IN (
             current_user,
             v_runtime_role,
+            'social_monitor_public_schema_owner',
             'social_monitor_reader_summary_publication_owner',
             'social_monitor_reader_summary_publication_runtime'
           )

--- a/ops/deploy/reader-summary-publication-post-migration.sql
+++ b/ops/deploy/reader-summary-publication-post-migration.sql
@@ -92,6 +92,25 @@ BEGIN
   ) <> 'social_monitor_public_schema_owner' THEN
     RAISE EXCEPTION 'public schema has an unsafe owner';
   END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM pg_namespace namespace
+    CROSS JOIN LATERAL aclexplode(
+      COALESCE(
+        namespace.nspacl,
+        acldefault('n', namespace.nspowner)
+      )
+    ) privilege
+    LEFT JOIN pg_roles grantee ON grantee.oid = privilege.grantee
+    WHERE namespace.nspname = 'public'
+      AND privilege.privilege_type = 'CREATE'
+      AND (
+        privilege.grantee = 0
+        OR grantee.rolname <> 'social_monitor_public_schema_owner'
+      )
+  ) THEN
+    RAISE EXCEPTION 'public schema retains an unreviewed CREATE grant';
+  END IF;
 
   SELECT count(*) INTO v_owner_count
   FROM pg_class relation

--- a/ops/deploy/reader-summary-publication-pre-migration.sql
+++ b/ops/deploy/reader-summary-publication-pre-migration.sql
@@ -21,6 +21,7 @@ BEGIN
   END IF;
   IF v_runtime_role IN (
     current_user,
+    'social_monitor_public_schema_owner',
     'social_monitor_reader_summary_publication_owner',
     'social_monitor_reader_summary_publication_runtime'
   ) THEN
@@ -45,6 +46,24 @@ BEGIN
   IF NOT v_role.rolcanlogin OR v_role.rolsuper OR v_role.rolcreatedb OR v_role.rolcreaterole
     OR v_role.rolreplication OR v_role.rolbypassrls THEN
     RAISE EXCEPTION 'reader summary runtime role has unsafe privileges';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_roles
+    WHERE rolname = 'social_monitor_public_schema_owner'
+  ) THEN
+    PERFORM pg_catalog.set_config('createrole_self_grant', 'set', true);
+    EXECUTE 'CREATE ROLE social_monitor_public_schema_owner '
+      'NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT '
+      'NOREPLICATION NOBYPASSRLS';
+  END IF;
+  PERFORM pg_catalog.set_config('createrole_self_grant', '', true);
+  SELECT * INTO v_role FROM pg_roles
+  WHERE rolname = 'social_monitor_public_schema_owner';
+  IF v_role.rolcanlogin OR v_role.rolsuper OR v_role.rolcreatedb
+    OR v_role.rolcreaterole OR v_role.rolinherit OR v_role.rolreplication
+    OR v_role.rolbypassrls THEN
+    RAISE EXCEPTION 'public schema owner role is unsafe';
   END IF;
 
   IF NOT EXISTS (
@@ -85,6 +104,23 @@ BEGIN
     'GRANT USAGE, CREATE ON SCHEMA public TO %I',
     current_user
   );
+  IF EXISTS (
+    SELECT 1
+    FROM pg_auth_members membership
+    JOIN pg_roles granted ON granted.oid = membership.roleid
+    JOIN pg_roles member ON member.oid = membership.member
+    WHERE granted.rolname = 'social_monitor_public_schema_owner'
+      AND member.rolname <> current_user
+  ) THEN
+    RAISE EXCEPTION 'public schema owner has an unreviewed member';
+  END IF;
+  IF pg_has_role(
+    v_runtime_role,
+    'social_monitor_public_schema_owner',
+    'MEMBER'
+  ) THEN
+    RAISE EXCEPTION 'runtime role can assume public schema ownership';
+  END IF;
   IF EXISTS (
     SELECT 1
     FROM pg_auth_members membership
@@ -155,6 +191,29 @@ BEGIN
     JOIN pg_roles granted ON granted.oid = membership.roleid
     JOIN pg_roles member ON member.oid = membership.member
     JOIN pg_roles grantor ON grantor.oid = membership.grantor
+    WHERE granted.rolname = 'social_monitor_public_schema_owner'
+      AND member.rolname = current_user
+  ) THEN
+    RAISE EXCEPTION 'public schema owner membership is unsafe';
+  END IF;
+  IF (
+    SELECT count(*) <> 2
+      OR count(*) FILTER (
+        WHERE membership.admin_option
+          AND NOT membership.inherit_option
+          AND NOT membership.set_option
+          AND grantor.rolsuper
+      ) <> 1
+      OR count(*) FILTER (
+        WHERE NOT membership.admin_option
+          AND NOT membership.inherit_option
+          AND membership.set_option
+          AND grantor.rolname = current_user
+      ) <> 1
+    FROM pg_auth_members membership
+    JOIN pg_roles granted ON granted.oid = membership.roleid
+    JOIN pg_roles member ON member.oid = membership.member
+    JOIN pg_roles grantor ON grantor.oid = membership.grantor
     WHERE granted.rolname =
       'social_monitor_reader_summary_publication_owner'
       AND member.rolname = current_user
@@ -206,6 +265,7 @@ BEGIN
           AND grantor.rolname NOT IN (
             current_user,
             v_runtime_role,
+            'social_monitor_public_schema_owner',
             'social_monitor_reader_summary_publication_owner',
             'social_monitor_reader_summary_publication_runtime'
           )
@@ -240,6 +300,103 @@ $bootstrap$;
 REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 GRANT USAGE, CREATE ON SCHEMA public
 TO social_monitor_reader_summary_publication_owner;
+
+-- Managed PostgreSQL initially makes the application login the database owner,
+-- while public is owned by the dynamic pg_database_owner role. Direct REVOKE
+-- cannot remove an owner's implicit CREATE authority. Move public to a
+-- dedicated NOLOGIN role inside this transaction, remove the temporary upward
+-- membership before commit, and grant the migrator only the authority needed
+-- for the ordered Prisma migration.
+DO $schema_ownership_transfer$
+DECLARE
+  v_admin_role NAME := current_user;
+  v_database_owner NAME;
+  v_runtime_role NAME := current_setting(
+    'social_monitor.bootstrap_runtime_role'
+  )::NAME;
+  v_schema_owner NAME;
+BEGIN
+  SELECT owner.rolname INTO v_database_owner
+  FROM pg_database database
+  JOIN pg_roles owner ON owner.oid = database.datdba
+  WHERE database.datname = current_database();
+
+  SELECT pg_get_userbyid(namespace.nspowner) INTO v_schema_owner
+  FROM pg_namespace namespace
+  WHERE namespace.nspname = 'public';
+
+  IF v_schema_owner = 'pg_database_owner' THEN
+    IF v_database_owner <> v_runtime_role THEN
+      RAISE EXCEPTION
+        'public schema requires an explicitly reviewed ownership transfer';
+    END IF;
+    EXECUTE format(
+      'GRANT social_monitor_public_schema_owner TO %I '
+        'WITH ADMIN FALSE, INHERIT FALSE, SET TRUE GRANTED BY CURRENT_USER',
+      v_runtime_role
+    );
+    EXECUTE format('SET LOCAL ROLE %I', v_runtime_role);
+    ALTER SCHEMA public OWNER TO social_monitor_public_schema_owner;
+    EXECUTE 'RESET ROLE';
+    EXECUTE format(
+      'REVOKE social_monitor_public_schema_owner FROM %I '
+        'GRANTED BY CURRENT_USER',
+      v_runtime_role
+    );
+  ELSIF v_schema_owner <>
+    'social_monitor_public_schema_owner' THEN
+    RAISE EXCEPTION 'public schema has an unexpected owner';
+  END IF;
+
+  EXECUTE format(
+    'REVOKE CREATE ON SCHEMA public FROM %I '
+      'GRANTED BY CURRENT_USER CASCADE',
+    v_runtime_role
+  );
+  EXECUTE 'SET LOCAL ROLE social_monitor_public_schema_owner';
+  EXECUTE format(
+    'GRANT USAGE, CREATE ON SCHEMA public TO %I WITH GRANT OPTION',
+    v_admin_role
+  );
+  REVOKE CREATE ON SCHEMA public
+  FROM pg_database_owner,
+    PUBLIC,
+    social_monitor_reader_summary_publication_owner,
+    social_monitor_reader_summary_publication_runtime
+  CASCADE;
+  EXECUTE format(
+    'REVOKE CREATE ON SCHEMA public FROM %I',
+    v_runtime_role
+  );
+  EXECUTE 'RESET ROLE';
+
+  IF pg_get_userbyid((
+    SELECT namespace.nspowner
+    FROM pg_namespace namespace
+    WHERE namespace.nspname = 'public'
+  )) <> 'social_monitor_public_schema_owner'
+    OR pg_has_role(
+      v_runtime_role,
+      'social_monitor_public_schema_owner',
+      'MEMBER'
+    )
+    OR has_schema_privilege(v_runtime_role, 'public', 'CREATE') THEN
+    RAISE EXCEPTION
+      'public schema ownership transfer is unsafe (owner=%, member=%, create=%)',
+      (
+        SELECT pg_get_userbyid(namespace.nspowner)
+        FROM pg_namespace namespace
+        WHERE namespace.nspname = 'public'
+      ),
+      pg_has_role(
+        v_runtime_role,
+        'social_monitor_public_schema_owner',
+        'MEMBER'
+      ),
+      has_schema_privilege(v_runtime_role, 'public', 'CREATE');
+  END IF;
+END
+$schema_ownership_transfer$;
 
 -- Existing installations were migrated by the application login before the
 -- protected publication owner existed. Transfer the artifact table while all

--- a/ops/deploy/reader-summary-publication-pre-migration.sql
+++ b/ops/deploy/reader-summary-publication-pre-migration.sql
@@ -325,6 +325,32 @@ BEGIN
   FROM pg_namespace namespace
   WHERE namespace.nspname = 'public';
 
+  IF EXISTS (
+    SELECT 1
+    FROM pg_namespace namespace
+    CROSS JOIN LATERAL aclexplode(
+      COALESCE(
+        namespace.nspacl,
+        acldefault('n', namespace.nspowner)
+      )
+    ) privilege
+    LEFT JOIN pg_roles grantee ON grantee.oid = privilege.grantee
+    WHERE namespace.nspname = 'public'
+      AND privilege.privilege_type = 'CREATE'
+      AND (
+        privilege.grantee = 0
+        OR grantee.rolname NOT IN (
+          'pg_database_owner',
+          v_admin_role,
+          v_runtime_role,
+          'social_monitor_public_schema_owner',
+          'social_monitor_reader_summary_publication_owner'
+        )
+      )
+  ) THEN
+    RAISE EXCEPTION 'public schema has an unreviewed CREATE grant';
+  END IF;
+
   IF v_schema_owner = 'pg_database_owner' THEN
     IF v_database_owner <> v_runtime_role THEN
       RAISE EXCEPTION
@@ -380,7 +406,28 @@ BEGIN
       'social_monitor_public_schema_owner',
       'MEMBER'
     )
-    OR has_schema_privilege(v_runtime_role, 'public', 'CREATE') THEN
+    OR has_schema_privilege(v_runtime_role, 'public', 'CREATE')
+    OR EXISTS (
+      SELECT 1
+      FROM pg_namespace namespace
+      CROSS JOIN LATERAL aclexplode(
+        COALESCE(
+          namespace.nspacl,
+          acldefault('n', namespace.nspowner)
+        )
+      ) privilege
+      LEFT JOIN pg_roles grantee ON grantee.oid = privilege.grantee
+      WHERE namespace.nspname = 'public'
+        AND privilege.privilege_type = 'CREATE'
+        AND (
+          privilege.grantee = 0
+          OR grantee.rolname NOT IN (
+            'social_monitor_public_schema_owner',
+            v_admin_role,
+            'social_monitor_reader_summary_publication_owner'
+          )
+        )
+    ) THEN
     RAISE EXCEPTION
       'public schema ownership transfer is unsafe (owner=%, member=%, create=%)',
       (

--- a/scripts/check-reader-summary-publication-postgres.ts
+++ b/scripts/check-reader-summary-publication-postgres.ts
@@ -25,6 +25,8 @@ import {
   dropPublicationFixtureDatabaseAndRoles,
   grantLegacyMigrationOwnership,
   grantPublicationFixtureRuntimePrivileges,
+  makePublicationFixtureRuntimeDatabaseOwner,
+  publicationProtectedRolePresence,
   publicationDatabaseUrl,
   publicationRuntimeDatabaseUrl,
   quotePostgresIdentifier,
@@ -67,6 +69,7 @@ const publicationMigration =
   "20260716170000_reader_summary_fail_closed_publication";
 let ownerRolePreexisting = false;
 let capabilityRolePreexisting = false;
+let schemaOwnerRolePreexisting = false;
 let fixtureDatabaseCreated = false;
 let fixtureMigrationAdminRoleCreated = false;
 let fixtureRuntimeRoleCreated = false;
@@ -76,21 +79,10 @@ async function main(): Promise<void> {
     /^reader_summary_publication_test_[0-9a-f]{20}$/.test(databaseName),
     "temporary publication database name must be bounded",
   );
-  const protectedRoles = await serverAdmin.query<{ readonly rolname: string }>(
-    `SELECT rolname FROM pg_roles WHERE rolname = ANY($1::text[])`,
-    [[
-      "social_monitor_reader_summary_publication_owner",
-      "social_monitor_reader_summary_publication_runtime",
-    ]],
-  );
-  ownerRolePreexisting = protectedRoles.rows.some(
-    (row) =>
-      row.rolname === "social_monitor_reader_summary_publication_owner",
-  );
-  capabilityRolePreexisting = protectedRoles.rows.some(
-    (row) =>
-      row.rolname === "social_monitor_reader_summary_publication_runtime",
-  );
+  const protectedRoles = await publicationProtectedRolePresence(serverAdmin);
+  ownerRolePreexisting = protectedRoles.owner;
+  capabilityRolePreexisting = protectedRoles.capability;
+  schemaOwnerRolePreexisting = protectedRoles.schemaOwner;
   try {
     await serverAdmin.query(
       `CREATE ROLE ${quotePostgresIdentifier(migrationAdminRole)} LOGIN PASSWORD ${quotePostgresLiteral(migrationAdminPassword)}
@@ -109,6 +101,12 @@ async function main(): Promise<void> {
       serverAdminDatabaseUrl,
     });
     fixtureRuntimeRoleCreated = true;
+    await makePublicationFixtureRuntimeDatabaseOwner({
+      databaseName,
+      migrationAdminRole,
+      runtimeRole,
+      targetDatabaseUrl,
+    });
 
     preparePrePublicationMigrations();
     await grantLegacyMigrationOwnership(adminDatabaseUrl, runtimeRole);
@@ -256,6 +254,7 @@ async function main(): Promise<void> {
       runtimeRole,
       ownerRolePreexisting,
       capabilityRolePreexisting,
+      schemaOwnerRolePreexisting,
       fixtureDatabaseCreated,
       fixtureMigrationAdminRoleCreated,
       fixtureRuntimeRoleCreated,

--- a/scripts/check-reader-summary-publication-postgres.ts
+++ b/scripts/check-reader-summary-publication-postgres.ts
@@ -103,6 +103,7 @@ async function main(): Promise<void> {
     fixtureRuntimeRoleCreated = true;
     await makePublicationFixtureRuntimeDatabaseOwner({
       databaseName,
+      migrationAdminDatabaseUrl: adminDatabaseUrl,
       migrationAdminRole,
       runtimeRole,
       targetDatabaseUrl,

--- a/scripts/reader-summary-publication-postgres-privileges.ts
+++ b/scripts/reader-summary-publication-postgres-privileges.ts
@@ -7,6 +7,55 @@ import {
 } from "./reader-summary-publication-postgres18-regression";
 
 const protectedOwner = "social_monitor_reader_summary_publication_owner";
+const publicSchemaOwner = "social_monitor_public_schema_owner";
+
+export const publicationProtectedRolePresence = async (
+  serverAdmin: Pool,
+): Promise<{
+  readonly capability: boolean;
+  readonly owner: boolean;
+  readonly schemaOwner: boolean;
+}> => {
+  const protectedRoles = await serverAdmin.query<{
+    readonly rolname: string;
+  }>(
+    `SELECT rolname FROM pg_roles WHERE rolname = ANY($1::text[])`,
+    [[
+      publicSchemaOwner,
+      protectedOwner,
+      "social_monitor_reader_summary_publication_runtime",
+    ]],
+  );
+  const hasRole = (role: string): boolean =>
+    protectedRoles.rows.some((row) => row.rolname === role);
+  return {
+    capability: hasRole(
+      "social_monitor_reader_summary_publication_runtime",
+    ),
+    owner: hasRole(protectedOwner),
+    schemaOwner: hasRole(publicSchemaOwner),
+  };
+};
+
+export const makePublicationFixtureRuntimeDatabaseOwner = async (params: {
+  readonly databaseName: string;
+  readonly migrationAdminRole: string;
+  readonly runtimeRole: string;
+  readonly targetDatabaseUrl: string;
+}): Promise<void> => {
+  const admin = new Pool({ connectionString: params.targetDatabaseUrl, max: 1 });
+  try {
+    await admin.query(
+      `ALTER DATABASE ${quoteIdentifier(params.databaseName)}
+         OWNER TO ${quoteIdentifier(params.runtimeRole)};
+       GRANT USAGE, CREATE ON SCHEMA public
+         TO ${quoteIdentifier(params.migrationAdminRole)}
+         WITH GRANT OPTION`,
+    );
+  } finally {
+    await admin.end();
+  }
+};
 
 export const runReaderSummaryPublicationBootstrapSql = async (
   phase: "pre" | "post",
@@ -298,6 +347,7 @@ export const assertPublicationRoleMemberships = async (
         [migrationAdminRole, runtimeRole],
         [
           runtimeRole,
+          publicSchemaOwner,
           "social_monitor_reader_summary_publication_owner",
           "social_monitor_reader_summary_publication_runtime",
         ],
@@ -326,6 +376,20 @@ export const assertPublicationRoleMemberships = async (
           ),
         ),
       [
+        {
+          granted_role: publicSchemaOwner,
+          member_role: migrationAdminRole,
+          admin_option: true,
+          inherit_option: false,
+          set_option: false,
+        },
+        {
+          granted_role: publicSchemaOwner,
+          member_role: migrationAdminRole,
+          admin_option: false,
+          inherit_option: false,
+          set_option: true,
+        },
         {
           granted_role: "social_monitor_reader_summary_publication_owner",
           member_role: migrationAdminRole,
@@ -376,6 +440,24 @@ export const assertPublicationRoleMemberships = async (
       ),
       "publication role memberships must match the exact PostgreSQL 18 boundary",
     );
+    const schemaOwnerBootstrapGrant = memberships.rows.find(
+      (row) =>
+        row.granted_role === publicSchemaOwner &&
+        row.member_role === migrationAdminRole &&
+        row.grantor_superuser &&
+        row.admin_option &&
+        !row.inherit_option &&
+        !row.set_option,
+    );
+    const schemaOwnerSelfGrant = memberships.rows.find(
+      (row) =>
+        row.granted_role === publicSchemaOwner &&
+        row.member_role === migrationAdminRole &&
+        row.grantor_role === migrationAdminRole &&
+        !row.admin_option &&
+        !row.inherit_option &&
+        row.set_option,
+    );
     const ownerBootstrapGrant = memberships.rows.find(
       (row) =>
         row.granted_role ===
@@ -414,6 +496,14 @@ export const assertPublicationRoleMemberships = async (
         row.member_role === migrationAdminRole,
     );
     assert(
+      schemaOwnerBootstrapGrant !== undefined,
+      "public schema owner bootstrap grant is missing",
+    );
+    assert(
+      schemaOwnerSelfGrant !== undefined,
+      "public schema owner self grant is missing",
+    );
+    assert(
       ownerBootstrapGrant !== undefined,
       "publication owner bootstrap grant is missing",
     );
@@ -430,6 +520,14 @@ export const assertPublicationRoleMemberships = async (
       "publication capability runtime grant is missing",
     );
     assert(runtimeAdminGrant !== undefined, "runtime admin grant is missing");
+    assert(
+      schemaOwnerBootstrapGrant.grantor_superuser,
+      "public schema owner admin grant must use a bootstrap superuser",
+    );
+    assert(
+      schemaOwnerSelfGrant.grantor_role === migrationAdminRole,
+      "public schema owner set grant must be issued by the migration admin",
+    );
     assert(
       ownerBootstrapGrant.grantor_superuser,
       "publication owner admin grant must use a bootstrap superuser",
@@ -465,6 +563,7 @@ export const dropPublicationFixtureDatabaseAndRoles = async (params: {
   readonly runtimeRole: string;
   readonly ownerRolePreexisting: boolean;
   readonly capabilityRolePreexisting: boolean;
+  readonly schemaOwnerRolePreexisting: boolean;
   readonly fixtureDatabaseCreated: boolean;
   readonly fixtureMigrationAdminRoleCreated: boolean;
   readonly fixtureRuntimeRoleCreated: boolean;
@@ -492,6 +591,11 @@ export const dropPublicationFixtureDatabaseAndRoles = async (params: {
   if (!params.ownerRolePreexisting) {
     await params.serverAdmin.query(
       `DROP ROLE IF EXISTS social_monitor_reader_summary_publication_owner`,
+    );
+  }
+  if (!params.schemaOwnerRolePreexisting) {
+    await params.serverAdmin.query(
+      `DROP ROLE IF EXISTS ${publicSchemaOwner}`,
     );
   }
   if (params.fixtureMigrationAdminRoleCreated) {
@@ -542,6 +646,9 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
   const roles = await params.auditor.query<{
     readonly owner_login: boolean;
     readonly owner_superuser: boolean;
+    readonly schema_owner_login: boolean;
+    readonly schema_owner_superuser: boolean;
+    readonly schema_owner_createrole: boolean;
     readonly migration_admin_superuser: boolean;
     readonly migration_admin_createrole: boolean;
     readonly runtime_superuser: boolean;
@@ -551,6 +658,12 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
     `SELECT
        (SELECT rolcanlogin FROM pg_roles WHERE rolname = $2) AS owner_login,
        (SELECT rolsuper FROM pg_roles WHERE rolname = $2) AS owner_superuser,
+       (SELECT rolcanlogin FROM pg_roles WHERE rolname = $4)
+         AS schema_owner_login,
+       (SELECT rolsuper FROM pg_roles WHERE rolname = $4)
+         AS schema_owner_superuser,
+       (SELECT rolcreaterole FROM pg_roles WHERE rolname = $4)
+         AS schema_owner_createrole,
        (SELECT rolsuper FROM pg_roles WHERE rolname = $3)
          AS migration_admin_superuser,
        (SELECT rolcreaterole FROM pg_roles WHERE rolname = $3)
@@ -561,13 +674,21 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
          AS runtime_createrole,
        (SELECT rolbypassrls FROM pg_roles WHERE rolname = $1)
          AS runtime_bypassrls`,
-    [params.runtimeRole, protectedOwner, params.migrationAdminRole],
+    [
+      params.runtimeRole,
+      protectedOwner,
+      params.migrationAdminRole,
+      publicSchemaOwner,
+    ],
   );
   assertDeepEqual(
     roles.rows[0],
     {
       owner_login: false,
       owner_superuser: false,
+      schema_owner_login: false,
+      schema_owner_superuser: false,
+      schema_owner_createrole: false,
       migration_admin_superuser: false,
       migration_admin_createrole: true,
       runtime_superuser: false,
@@ -582,6 +703,7 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
     readonly publication_owner: string;
     readonly slot_owner: string;
     readonly function_owner: string;
+    readonly public_schema_owner: string;
     readonly security_definer: boolean;
     readonly function_config: readonly string[];
   }>(
@@ -596,6 +718,8 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
          WHERE oid = 'reader_summary_publication_slots'::regclass))
          AS slot_owner,
        pg_get_userbyid(proowner) AS function_owner,
+       pg_get_userbyid((SELECT nspowner FROM pg_namespace
+         WHERE nspname = 'public')) AS public_schema_owner,
        prosecdef AS security_definer,
        proconfig AS function_config
      FROM pg_proc
@@ -608,6 +732,7 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
       publication_owner: protectedOwner,
       slot_owner: protectedOwner,
       function_owner: protectedOwner,
+      public_schema_owner: publicSchemaOwner,
       security_definer: true,
       function_config: ["search_path=pg_catalog, public, pg_temp"],
     },
@@ -617,6 +742,7 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
   const identity = await params.runtime.query<{
     readonly current_user: string;
     readonly can_assume_owner: boolean;
+    readonly can_assume_schema_owner: boolean;
     readonly can_create_public: boolean;
     readonly can_publish: boolean;
     readonly can_insert_ledger: boolean;
@@ -627,6 +753,8 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
   }>(
     `SELECT current_user,
        pg_has_role(current_user, $1, 'MEMBER') AS can_assume_owner,
+       pg_has_role(current_user, $2, 'MEMBER')
+         AS can_assume_schema_owner,
        has_schema_privilege(current_user, 'public', 'CREATE')
          AS can_create_public,
        has_function_privilege(current_user,
@@ -641,13 +769,14 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
          'reader_summary_artifacts', 'TRIGGER') AS can_trigger_artifacts,
        has_table_privilege(current_user,
          'reader_summary_artifacts', 'TRUNCATE') AS can_truncate_artifacts`,
-    [protectedOwner],
+    [protectedOwner, publicSchemaOwner],
   );
   assertDeepEqual(
     identity.rows[0],
     {
       current_user: params.runtimeRole,
       can_assume_owner: false,
+      can_assume_schema_owner: false,
       can_create_public: false,
       can_publish: true,
       can_insert_ledger: false,
@@ -692,6 +821,11 @@ export const assertReaderSummaryPublicationPrivilegeBoundary = async (params: {
     () => params.runtime.query(`SET ROLE ${protectedOwner}`),
     "permission denied",
     "runtime must not assume the protected owner role",
+  );
+  await assertRejectsContaining(
+    () => params.runtime.query(`SET ROLE ${publicSchemaOwner}`),
+    "permission denied",
+    "runtime must not assume the public schema owner role",
   );
   await assertRejectsContaining(
     () =>

--- a/scripts/reader-summary-publication-postgres-privileges.ts
+++ b/scripts/reader-summary-publication-postgres-privileges.ts
@@ -39,11 +39,14 @@ export const publicationProtectedRolePresence = async (
 
 export const makePublicationFixtureRuntimeDatabaseOwner = async (params: {
   readonly databaseName: string;
+  readonly migrationAdminDatabaseUrl: string;
   readonly migrationAdminRole: string;
   readonly runtimeRole: string;
   readonly targetDatabaseUrl: string;
 }): Promise<void> => {
   const admin = new Pool({ connectionString: params.targetDatabaseUrl, max: 1 });
+  const rogueRole = `sm_public_schema_rogue_${params.runtimeRole.slice(-20)}`;
+  let rogueRoleCreated = false;
   try {
     await admin.query(
       `ALTER DATABASE ${quoteIdentifier(params.databaseName)}
@@ -52,7 +55,40 @@ export const makePublicationFixtureRuntimeDatabaseOwner = async (params: {
          TO ${quoteIdentifier(params.migrationAdminRole)}
          WITH GRANT OPTION`,
     );
+    await admin.query(
+      `CREATE ROLE ${quoteIdentifier(rogueRole)}
+         NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT
+         NOREPLICATION NOBYPASSRLS;
+       GRANT CREATE ON SCHEMA public TO ${quoteIdentifier(rogueRole)}`,
+    );
+    rogueRoleCreated = true;
+    try {
+      await assertRejectsContaining(
+        () =>
+          runReaderSummaryPublicationBootstrapSql(
+            "pre",
+            params.migrationAdminDatabaseUrl,
+            params.runtimeRole,
+          ),
+        "public schema has an unreviewed CREATE grant",
+        "bootstrap must reject an unreviewed public schema creator",
+      );
+    } finally {
+      await admin.query(
+        `REVOKE CREATE ON SCHEMA public
+           FROM ${quoteIdentifier(rogueRole)} CASCADE;
+         DROP ROLE ${quoteIdentifier(rogueRole)}`,
+      );
+      rogueRoleCreated = false;
+    }
   } finally {
+    if (rogueRoleCreated) {
+      await admin.query(
+        `REASSIGN OWNED BY ${quoteIdentifier(rogueRole)} TO CURRENT_USER;
+         DROP OWNED BY ${quoteIdentifier(rogueRole)};
+         DROP ROLE ${quoteIdentifier(rogueRole)}`,
+      ).catch(() => undefined);
+    }
     await admin.end();
   }
 };


### PR DESCRIPTION
## Summary
- move `public` from runtime-owned `pg_database_owner` to a dedicated NOLOGIN schema owner
- preserve retry-safe Prisma migration authority while removing runtime CREATE access
- reject rogue CREATE grants through exact ACL allowlists in preflight, pre, and post phases
- cover the production-like PostgreSQL 18 ownership topology, retry flow, and rogue-role regression

## Validation
- PostgreSQL 18 privilege/upgrade/replay/concurrency gate
- production deploy contract tests
- publication migrator validation (71 cases)
- TypeScript compile, ShellCheck, source-line cap, secret scan, diff check

Independent security review: approved after two P1 findings were fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Hardened public schema ownership and privilege boundaries during deployment.
  - Added safeguards against unauthorized schema creation, ownership changes, role inheritance, and privilege escalation.
  - Deployments now verify protected role memberships and reject unsafe configurations.

- **Reliability**
  - Strengthened preflight and post-migration validation to detect invalid public schema security states before completion.
  - Expanded automated coverage for unsafe ownership and permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR transfers ownership of the `public` schema from the dynamic `pg_database_owner` role to a dedicated NOLOGIN role `social_monitor_public_schema_owner`, preventing the runtime login from ever holding implicit CREATE authority on the schema.

- **Pre-migration** creates `social_monitor_public_schema_owner`, validates its attributes, temporarily grants the role to `v_runtime_role` (using `SET LOCAL ROLE`) to execute `ALTER SCHEMA public OWNER TO`, immediately revokes that membership inside the same transaction, and grants the migrator `CREATE WITH GRANT OPTION` so Prisma can run ordered migrations — all wrapped in `BEGIN/COMMIT`.
- **Post-migration** runs outside any top-level transaction: sets role to `social_monitor_public_schema_owner`, revokes CREATE from all parties (including the migrator via a dynamic DO block), then audits the final ACL and role membership shape inside `DO $bootstrap$`.
- **Catalog validation** adds a `public_schema_boundary_valid` lateral to the preflight query, checking ACL correctness in both the legacy (`pg_database_owner`) and migrated (`social_monitor_public_schema_owner`) states.

<h3>Confidence Score: 3/5</h3>

The ownership transfer logic is carefully designed and the pre-migration is fully atomic, but the post-migration's non-transactional REVOKE block creates a recovery gap if a session dies mid-flight.

The pre-migration is thorough and transactional. The post-migration's top-level REVOKE block auto-commits before the DO $bootstrap$ audit runs — a session crash between those two phases leaves the database in a state where CREATE has been stripped but the final membership and ACL shape has never been confirmed. A retry recovers (all operations are idempotent), but this is a meaningful departure from the atomicity guarantee established by pre-migration. Additionally, the allowlist asymmetry between the preflight boundary_valid legacy branch and the pre-migration's own rogue-grant check means a specific partial-rollback topology can result in a deployment being incorrectly blocked by the preflight while the pre-migration itself would proceed.

ops/deploy/reader-summary-publication-post-migration.sql warrants a second look on whether wrapping the early REVOKE block in BEGIN/COMMIT would break any intended semantics. The boundary_valid legacy-path allowlist in ops/deploy/reader-summary-publication-deploy-lib.sh should be aligned with the pre-migration allowlist in $schema_ownership_transfer$.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ops/deploy/reader-summary-publication-post-migration.sql | Adds an early top-level (auto-commit) REVOKE block and a DO $bootstrap$ audit. Lacks a BEGIN/COMMIT wrapper unlike pre-migration; also includes a redundant REVOKE from :"runtime_role". |
| ops/deploy/reader-summary-publication-pre-migration.sql | Adds role creation, attribute validation, membership checks, and the $schema_ownership_transfer$ DO block inside a BEGIN/COMMIT. Allowlist in $schema_ownership_transfer$ includes social_monitor_public_schema_owner while preflight equivalent does not. |
| ops/deploy/reader-summary-publication-deploy-lib.sh | Extends the catalog preflight query with public_schema_boundary_valid lateral covering both legacy and migrated ACL states. Delimiter count updated 19→20. |
| ops/deploy/reader-summary-publication-migrator-validation.test.sh | Adds field-20 invalid-catalog assertion, new catalog token checks. Coverage looks comprehensive. |
| scripts/reader-summary-publication-postgres-privileges.ts | Adds publicationProtectedRolePresence helper and makePublicationFixtureRuntimeDatabaseOwner. Rogue-role cleanup fallback path omits explicit REVOKE before DROP OWNED. |
| scripts/check-reader-summary-publication-postgres.ts | Thin harness wiring for new helpers; cleanup propagation is correct. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/reader-summary-publication-postgres-privileges.ts`, line 799-813 ([link](https://github.com/777genius/social-monitor/blob/667071c4fa71431552e7b87c0c7e9e29f70c47ad/scripts/reader-summary-publication-postgres-privileges.ts#L799-L813)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Rogue-role fallback cleanup doesn't revoke the schema privilege before `DROP ROLE`**

   The outer `try` block correctly revokes `CREATE ON SCHEMA public FROM rogueRole CASCADE` before dropping it. The `finally` fallback path (when `rogueRoleCreated` is still true) only runs `REASSIGN OWNED … DROP OWNED … DROP ROLE`. `DROP OWNED` removes objects *owned by* the role but does **not** revoke privileges *granted to* the role on objects owned by others (the public schema is owned by the migrator admin). If the inner revoke never ran, `DROP ROLE` may fail or leave a stale `pg_auth_members` row. Adding an explicit `REVOKE CREATE ON SCHEMA public FROM rogueRole CASCADE` before `DROP OWNED` in the fallback would make cleanup robust.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/reader-summary-publication-postgres-privileges.ts
   Line: 799-813

   Comment:
   **Rogue-role fallback cleanup doesn't revoke the schema privilege before `DROP ROLE`**

   The outer `try` block correctly revokes `CREATE ON SCHEMA public FROM rogueRole CASCADE` before dropping it. The `finally` fallback path (when `rogueRoleCreated` is still true) only runs `REASSIGN OWNED … DROP OWNED … DROP ROLE`. `DROP OWNED` removes objects *owned by* the role but does **not** revoke privileges *granted to* the role on objects owned by others (the public schema is owned by the migrator admin). If the inner revoke never ran, `DROP ROLE` may fail or leave a stale `pg_auth_members` row. Adding an explicit `REVOKE CREATE ON SCHEMA public FROM rogueRole CASCADE` before `DROP OWNED` in the fallback would make cleanup robust.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
ops/deploy/reader-summary-publication-post-migration.sql:17-33
**Post-migration REVOKE block is non-transactional, unlike pre-migration**

The pre-migration wraps every statement in a single `BEGIN/COMMIT`, so a session failure rolls back all changes atomically. Here, `SET ROLE`, each `REVOKE`, and the `DO $revoke_migrator_schema_create$` block all auto-commit individually (there is no outer `BEGIN`). If the session dies between the final `RESET ROLE` (line 33) and the `DO $bootstrap$` audit on line 53, CREATE privileges are already durably revoked but the audit has never confirmed the final membership and ACL shape. The system is left in an unaudited state that requires manual investigation before re-running. While all operations are idempotent so a retry recovers, the gap between the committed REVOKE and the unrun audit is a meaningful deviation from the pre-migration's atomicity guarantee.

### Issue 2 of 4
ops/deploy/reader-summary-publication-pre-migration.sql:328-352
**Pre-migration rogue-grant allowlist includes `social_monitor_public_schema_owner`; preflight legacy-branch allowlist does not**

Inside `$schema_ownership_transfer$` the rogue-CREATE check allows `'social_monitor_public_schema_owner'` to hold a CREATE grant in the legacy state (schema still owned by `pg_database_owner`). The equivalent check in the catalog validation query's legacy branch (in `deploy-lib.sh`) does **not** include `'social_monitor_public_schema_owner'` in its allowlist. If the role exists but the schema has not yet been transferred (e.g., a prior partial-run was rolled back leaving only the role), the preflight rejects the deployment (`boundary_valid = false`) while the pre-migration itself would proceed — causing a deployment to be incorrectly blocked rather than letting the pre-migration reject it with a clearer exception.

### Issue 3 of 4
ops/deploy/reader-summary-publication-post-migration.sql:18-24
**`REVOKE CREATE FROM :"runtime_role"` here is a no-op — already revoked in pre-migration**

The pre-migration's `$schema_ownership_transfer$` block explicitly revokes CREATE from `v_runtime_role` before committing. The redundant REVOKE is harmless but makes the post-migration look like the primary revoke for the runtime role, which could mislead future readers about where the revoke actually takes effect.

```suggestion
REVOKE CREATE ON SCHEMA public
FROM pg_database_owner,
  PUBLIC,
  social_monitor_reader_summary_publication_owner,
  social_monitor_reader_summary_publication_runtime
CASCADE;
```

### Issue 4 of 4
scripts/reader-summary-publication-postgres-privileges.ts:799-813
**Rogue-role fallback cleanup doesn't revoke the schema privilege before `DROP ROLE`**

The outer `try` block correctly revokes `CREATE ON SCHEMA public FROM rogueRole CASCADE` before dropping it. The `finally` fallback path (when `rogueRoleCreated` is still true) only runs `REASSIGN OWNED … DROP OWNED … DROP ROLE`. `DROP OWNED` removes objects *owned by* the role but does **not** revoke privileges *granted to* the role on objects owned by others (the public schema is owned by the migrator admin). If the inner revoke never ran, `DROP ROLE` may fail or leave a stale `pg_auth_members` row. Adding an explicit `REVOKE CREATE ON SCHEMA public FROM rogueRole CASCADE` before `DROP OWNED` in the fallback would make cleanup robust.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(db): reject unreviewed schema creat..."](https://github.com/777genius/social-monitor/commit/667071c4fa71431552e7b87c0c7e9e29f70c47ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45765676)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->