### PR TITLE
fix(summary): unblock recovery release gates

### DIFF
--- a/ops/deploy/reader-summary-publication-post-migration.sql
+++ b/ops/deploy/reader-summary-publication-post-migration.sql
@@ -235,6 +235,7 @@ DECLARE
   )::NAME;
   v_constraint_count INTEGER;
   v_owner_count INTEGER;
+  v_v4_table_count INTEGER;
   v_trigger_count INTEGER;
   v_function RECORD;
   v_role RECORD;
@@ -301,12 +302,26 @@ BEGIN
       'reader_summary_artifacts',
       'reader_summary_publications',
       'reader_summary_publication_slots',
+      'reader_summary_daily_canonical_recovery_v4_plans',
+      'reader_summary_daily_canonical_recovery_v4_authorities',
+      'reader_summary_daily_canonical_recovery_v4_leases',
       'reader_summary_weekly_publication_evidence',
       'reader_summary_weekly_review_manifests'
     )
     AND owner.rolname =
       'social_monitor_reader_summary_publication_owner';
-  IF v_owner_count <> 5 THEN
+  SELECT count(*) INTO v_v4_table_count
+  FROM pg_class relation
+  JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+  WHERE namespace.nspname = 'public'
+    AND relation.relkind IN ('r', 'p')
+    AND relation.relname IN (
+      'reader_summary_daily_canonical_recovery_v4_plans',
+      'reader_summary_daily_canonical_recovery_v4_authorities',
+      'reader_summary_daily_canonical_recovery_v4_leases'
+    );
+  IF v_v4_table_count NOT IN (0, 3)
+    OR v_owner_count <> 5 + v_v4_table_count THEN
     RAISE EXCEPTION 'protected reader summary tables have unsafe owners';
   END IF;
 
@@ -745,11 +760,14 @@ BEGIN
       'reader_summary_production_recovery_dry_runs',
       'reader_summary_recovery_receipts',
       'reader_summary_weekly_certification_seals',
-      'reader_summary_weekly_review_manifests'
+      'reader_summary_weekly_review_manifests',
+      'reader_summary_daily_canonical_recovery_v4_plans',
+      'reader_summary_daily_canonical_recovery_v4_authorities',
+      'reader_summary_daily_canonical_recovery_v4_leases'
     ]) protected_table(name)
     WHERE has_table_privilege(
       'social_monitor_reader_summary_daily_terminal',
-      'public.' || protected_table.name,
+      to_regclass('public.' || protected_table.name),
       'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
     )
   ) THEN

--- a/ops/deploy/reader-summary-publication-pre-migration.sql
+++ b/ops/deploy/reader-summary-publication-pre-migration.sql
@@ -671,6 +671,9 @@ BEGIN
         'reader_summary_production_recovery_dry_runs',
         'reader_summary_production_recovery_leases',
         'reader_summary_recovery_receipts', 'reader_summary_weekly_certification_seals',
+        'reader_summary_daily_canonical_recovery_v4_plans',
+        'reader_summary_daily_canonical_recovery_v4_authorities',
+        'reader_summary_daily_canonical_recovery_v4_leases',
         'reader_summary_weekly_publication_evidence',
         'reader_summary_weekly_review_manifests'
       )
@@ -699,6 +702,9 @@ BEGIN
         'reader_summary_production_recovery_dry_runs',
         'reader_summary_production_recovery_leases',
         'reader_summary_recovery_receipts', 'reader_summary_weekly_certification_seals',
+        'reader_summary_daily_canonical_recovery_v4_plans',
+        'reader_summary_daily_canonical_recovery_v4_authorities',
+        'reader_summary_daily_canonical_recovery_v4_leases',
         'reader_summary_weekly_publication_evidence',
         'reader_summary_weekly_review_manifests'
       )
@@ -735,6 +741,9 @@ BEGIN
         'reader_summary_production_recovery_dry_runs',
         'reader_summary_production_recovery_leases',
         'reader_summary_recovery_receipts', 'reader_summary_weekly_certification_seals',
+        'reader_summary_daily_canonical_recovery_v4_plans',
+        'reader_summary_daily_canonical_recovery_v4_authorities',
+        'reader_summary_daily_canonical_recovery_v4_leases',
         'reader_summary_weekly_publication_evidence',
         'reader_summary_weekly_review_manifests'
       )
@@ -921,6 +930,9 @@ BEGIN
         'reader_summary_production_recovery_dry_runs',
         'reader_summary_production_recovery_leases',
         'reader_summary_recovery_receipts', 'reader_summary_weekly_certification_seals',
+        'reader_summary_daily_canonical_recovery_v4_plans',
+        'reader_summary_daily_canonical_recovery_v4_authorities',
+        'reader_summary_daily_canonical_recovery_v4_leases',
         'reader_summary_weekly_publication_evidence',
         'reader_summary_weekly_review_manifests'
       )
@@ -958,8 +970,8 @@ BEGIN
     FROM unnest(ARRAY['reader_summary_artifacts', 'reader_summary_publications', 'reader_summary_publication_slots', 'reader_summary_weekly_publication_evidence']) evidence_table(name)
     WHERE NOT has_table_privilege('social_monitor_reader_summary_daily_terminal', 'public.' || evidence_table.name, 'SELECT') OR has_table_privilege('social_monitor_reader_summary_daily_terminal', 'public.' || evidence_table.name, 'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
   ) OR EXISTS (SELECT 1
-    FROM unnest(ARRAY['reader_summary_jobs', 'reader_summary_production_recovery_leases', 'reader_summary_production_recovery_days', 'reader_summary_production_recovery_dry_runs', 'reader_summary_recovery_receipts', 'reader_summary_weekly_certification_seals', 'reader_summary_weekly_review_manifests']) protected_table(name)
-    WHERE has_table_privilege('social_monitor_reader_summary_daily_terminal', 'public.' || protected_table.name, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+    FROM unnest(ARRAY['reader_summary_jobs', 'reader_summary_production_recovery_leases', 'reader_summary_production_recovery_days', 'reader_summary_production_recovery_dry_runs', 'reader_summary_recovery_receipts', 'reader_summary_weekly_certification_seals', 'reader_summary_weekly_review_manifests', 'reader_summary_daily_canonical_recovery_v4_plans', 'reader_summary_daily_canonical_recovery_v4_authorities', 'reader_summary_daily_canonical_recovery_v4_leases']) protected_table(name)
+    WHERE has_table_privilege('social_monitor_reader_summary_daily_terminal', to_regclass('public.' || protected_table.name), 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
   ) THEN RAISE EXCEPTION 'daily terminal evidence authority is unsafe';
   ELSIF has_function_privilege('social_monitor_reader_summary_publication_runtime', 'public.claim_reader_summary_daily_terminal(uuid,uuid,uuid,text)', 'EXECUTE')
     OR has_function_privilege(v_runtime_role, 'public.claim_reader_summary_daily_terminal(uuid,uuid,uuid,text)', 'EXECUTE') OR NOT has_function_privilege('social_monitor_reader_summary_daily_terminal', 'public.claim_reader_summary_daily_terminal(uuid,uuid,uuid,text)', 'EXECUTE')

--- a/ops/security/secret-scan-allowlist.json
+++ b/ops/security/secret-scan-allowlist.json
@@ -38,6 +38,9 @@
     "^whsec_(?:test|fake|generated)[A-Za-z0-9._-]*$"
   ],
   "allowedValuesByPath": {
+    "ops/deploy/daily-canonical-recovery-postgres18.test.sh": [
+      "daily_recovery_local_test_password"
+    ],
     "ops/deploy/reader-summary-publication-migrator-validation.test.sh": [
       "$ROOT/secrets/db/reader-summary-publication-admin-url",
       "redacted-test-password",

--- a/prisma/migrations/20260802233000_reader_summary_daily_canonical_recovery_v4/migration.sql
+++ b/prisma/migrations/20260802233000_reader_summary_daily_canonical_recovery_v4/migration.sql
@@ -1790,6 +1790,7 @@ DECLARE
   v_authority JSONB;
   v_authority_bytes BYTEA;
   v_authority_sha TEXT;
+  v_matching_legacy_authority_count INTEGER;
 BEGIN
   IF current_setting('transaction_isolation') <> 'serializable'
     OR current_setting('transaction_read_only') <> 'off' THEN
@@ -1800,6 +1801,30 @@ BEGIN
     WHERE "tenant_id" = c_tenant_id AND "workspace_id" = c_workspace_id
   ) THEN
     PERFORM public."assert_reader_summary_daily_canonical_recovery_v4_binding"();
+    RETURN;
+  END IF;
+  -- Normal ordered baseline upgrades do not carry the two immutable recovery
+  -- authorities. Preserve that empty state, but keep every partial matching
+  -- authority fail-closed through the full legacy assertion below.
+  SELECT count(*)::INTEGER INTO v_matching_legacy_authority_count
+  FROM public."reader_summary_production_recovery_leases" AS lease
+  WHERE lease."tenant_id" = c_tenant_id
+    AND lease."workspace_id" = c_workspace_id
+    AND (
+      (lease."canonical_record"->>'schemaVersion' =
+        'reader_summary.production_recovery_authority.v2'
+       AND lease."canonical_record"->'requestedUtcDates' = jsonb_build_array(
+         '2026-07-23', '2026-07-24', '2026-07-25',
+         '2026-07-26', '2026-07-27', '2026-07-28'
+       ))
+      OR
+      (lease."canonical_record"->>'schemaVersion' =
+        'reader_summary.production_recovery_gap_authority.v3'
+       AND lease."canonical_record"->'requestedUtcDates' = jsonb_build_array(
+         '2026-07-29', '2026-07-30', '2026-07-31'
+       ))
+    );
+  IF v_matching_legacy_authority_count = 0 THEN
     RETURN;
   END IF;
   v_first := public."reader_summary_daily_canonical_recovery_v4_plan_ordered"();

--- a/scripts/lib/reader-summary-weekly-publication-evidence-postgres-contract.ts
+++ b/scripts/lib/reader-summary-weekly-publication-evidence-postgres-contract.ts
@@ -887,12 +887,8 @@ const assertCanonicalJsonParityAndBounds = async (
   }
 };
 const assertCanonicalFunctionsAreHardened = async (
-  canonicalJsonAuditor: PoolClient,
-): Promise<void> => {
-  const result = await canonicalJsonAuditor.query<{
-    readonly hardened_count: string;
-    readonly semantics_constraint_count: string;
-  }>(
+  canonicalJsonAuditor: PoolClient): Promise<void> => {
+  const result = await canonicalJsonAuditor.query<{ readonly hardened_count: string; readonly semantics_constraint_count: string }>(
     `SELECT
        (SELECT count(*)::text
           FROM pg_proc procedure
@@ -903,13 +899,18 @@ const assertCanonicalFunctionsAreHardened = async (
            'reader_summary_weekly_canonical_json_unbounded(jsonb)'::regprocedure,
            'reader_summary_weekly_canonical_json(jsonb)'::regprocedure,
            'guard_reader_summary_weekly_publication_evidence()'::regprocedure,
+           'record_reader_summary_weekly_publication_evidence_base(uuid)'::regprocedure,
+           'record_reader_summary_daily_canonical_recovery_v4_evidence(uuid)'::regprocedure,
            'record_reader_summary_weekly_publication_evidence(uuid)'::regprocedure,
            'publish_reader_summary_legacy_v1(jsonb)'::regprocedure,
            'publish_reader_summary_pre_evidence(jsonb)'::regprocedure,
            'publish_reader_summary(jsonb)'::regprocedure
          ])
-           AND procedure.proconfig =
-             ARRAY['search_path=pg_catalog, public, pg_temp']::text[])
+           AND procedure.proconfig = CASE WHEN procedure.proname IN (
+             'record_reader_summary_daily_canonical_recovery_v4_evidence',
+             'record_reader_summary_weekly_publication_evidence'
+           ) THEN ARRAY['search_path=pg_catalog']::text[]
+           ELSE ARRAY['search_path=pg_catalog, public, pg_temp']::text[] END)
          AS hardened_count,
        (SELECT count(*)::text
           FROM pg_constraint constraint_row
@@ -921,7 +922,7 @@ const assertCanonicalFunctionsAreHardened = async (
            AND constraint_row.convalidated) AS semantics_constraint_count`,
   );
   assert(
-    result.rows[0]?.hardened_count === "10" &&
+    result.rows[0]?.hardened_count === "12" &&
       result.rows[0]?.semantics_constraint_count === "1",
     "publication evidence functions or semantic constraint are not hardened",
   );


### PR DESCRIPTION
## Summary
- allow clean ordered baselines while keeping partial Daily V4 authority fail-closed
- register all V4 tables in publication ownership and terminal privilege audits
- document the scoped PostgreSQL test password placeholder
- recognize the stricter V4 evidence function search path

## Verified
- full Daily V4 PostgreSQL 18 authority/replay gate
- publication migration, privilege, replay and concurrency gate
- secret scan, source cap, ESLint and diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment validation for optional daily recovery components, supporting installations where all, or none, of the components are present.
  * Prevented unnecessary recovery setup when no matching legacy recovery authorities exist.
  * Expanded security audits to cover daily recovery tables and publication ownership controls.

* **Security**
  * Strengthened database function hardening checks, including stricter search-path validation for evidence-recording operations.
  * Updated security scanning safeguards for local recovery testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->