### PR TITLE
test(summary): align weekly ownership audit

### DIFF
--- a/ops/deploy/weekly-runner-production.test.sh
+++ b/ops/deploy/weekly-runner-production.test.sh
@@ -131,7 +131,10 @@ grep -F 'function_capability_acl_count === "0"' "$weekly_seal_contract" \
   in_owner_list && /^    \)/ { in_owner_list = 0 }
   END { print count + 0 }
 ' "$publication_post_migration") -eq 1 ]]
-grep -F 'IF v_owner_count <> 5 THEN' "$publication_post_migration" >/dev/null
+grep -F 'IF v_v4_table_count NOT IN (0, 3)' \
+  "$publication_post_migration" >/dev/null
+grep -F 'OR v_owner_count <> 5 + v_v4_table_count THEN' \
+  "$publication_post_migration" >/dev/null
 [[ $(awk '
   /^DO \$bootstrap\$/ { in_bootstrap = 1 }
   in_bootstrap && /FROM unnest\(ARRAY\[/ {


### PR DESCRIPTION
Update the weekly shell gate to assert the new fail-closed optional V4 ownership count. Verified in Linux with the existing shell-test image; recovery maintenance gate passed.