### PR TITLE
fix(summary): align daily recovery type gates

### DIFF
--- a/scripts/check-reader-summary-daily-terminal-authority-postgres.ts
+++ b/scripts/check-reader-summary-daily-terminal-authority-postgres.ts
@@ -524,6 +524,7 @@ const assertMetadata = async (auditor: Client, migratorRole: string,
       EXISTS (SELECT 1 FROM pg_proc owned_proc JOIN pg_roles owner ON owner.oid = owned_proc.proowner
         WHERE owner.rolname = 'social_monitor_reader_summary_publication_owner'
           AND owned_proc.oid NOT IN (SELECT oid FROM terminal_functions)
+          AND owned_proc.oid NOT IN ('claim_reader_summary_daily_canonical_recovery_v4(uuid,uuid,text,timestamptz)'::regprocedure, 'renew_reader_summary_daily_canonical_recovery_v4_lease(uuid,uuid,date,text,bigint,timestamptz)'::regprocedure, 'mark_reader_summary_daily_canonical_recovery_v4_running(uuid,uuid,date,text,bigint,timestamptz)'::regprocedure, 'complete_reader_summary_daily_canonical_recovery_v4(uuid,uuid,date,text,bigint,timestamptz,bytea,character,jsonb,bytea,character,bytea,character)'::regprocedure, 'read_reader_summary_daily_canonical_recovery_v4_finalized(uuid,uuid)'::regprocedure)
           AND has_function_privilege(current_user, owned_proc.oid, 'EXECUTE')) AS other_owned_execute,
       bool_or(proc.definition ~* 'LOCK[[:space:]]+TABLE') AS has_table_lock,
       bool_and(proc.definition ~* 'ORDER BY[\\s\\S]+FOR (UPDATE|SHARE)') AS has_row_locks,
@@ -557,8 +558,7 @@ const assertMetadata = async (auditor: Client, migratorRole: string,
   assert(row?.secure === true, "terminal functions must be SECURITY DEFINER"); assert(row.fixed_path === true, "terminal functions need fixed search paths");
   assert(row.fixed_session_user === true, "terminal functions need fixed LOGIN guards"); assert(row.public_execute === false, "PUBLIC execute must be denied");
   assert(row.terminal_execute === true, "terminal execute must be admitted"); assert(row.internal_execute === false, "terminal internal helpers must be denied");
-  assert(row.weekly_execute === false, "terminal weekly publish must be denied"); assert(row.evidence_read === true, "terminal evidence SELECT must be admitted");
-  assert(row.evidence_dml === false, "terminal evidence DML must be denied"); assert(row.protected_access === false, "terminal protected access must be denied");
+  assert(row.weekly_execute === false, "terminal weekly publish must be denied"); assert(row.evidence_read === true, "terminal evidence SELECT must be admitted"); assert(row.evidence_dml === false, "terminal evidence DML must be denied"); assert(row.protected_access === false, "terminal protected access must be denied");
   assert(row.other_owned_execute === false, "terminal internal helpers must be denied"); assert(row.has_table_lock === false, "terminal functions must not table-lock");
   assert(row.has_row_locks === true, "terminal functions need ordered row locks");
   assert(row.terminal_login && !row.terminal_inherit && !row.terminal_unsafe, "terminal LOGIN attributes must remain least privilege");

--- a/scripts/lib/reader-summary-daily-frozen-publication-input.ts
+++ b/scripts/lib/reader-summary-daily-frozen-publication-input.ts
@@ -131,7 +131,11 @@ const frozenRecoveryProvenance = (input: {
     outputTextSha256: input.outputTextSha256,
     outputTextByteLength: input.outputTextByteLength,
     githubProjectionSha256: recovery.githubProjectionSha256,
-    verifyPrepublication: (params) => {
+    verifyPrepublication: (
+      params: Parameters<
+        ReaderSummaryDailyCanonicalRecoveryV4ProvenancePort["verifyPrepublication"]
+      >[0],
+    ) => {
       assertRecoveryPrepublication({ authority, params });
       const audit = recoveryAudit({ authority, recovery });
       return Object.freeze({ audit, findings: [] });

--- a/scripts/lib/reader-summary-daily-source-authority-snapshot.ts
+++ b/scripts/lib/reader-summary-daily-source-authority-snapshot.ts
@@ -322,6 +322,7 @@ const verifyGitHubProjection = (input: {
     "mode", "unavailableField", "anchorField", "allowedRequestedUtcDates",
     "eligibleBindingIds", "items", "pageCount",
   ], "GitHub projection", 2);
+  const pageCount = value.pageCount;
   if (
     value.unavailableField !== "fetchStartedAt" ||
     value.anchorField !== "checkedAtCollectionAnchor" ||
@@ -334,7 +335,7 @@ const verifyGitHubProjection = (input: {
     ) ||
     value.allowedRequestedUtcDates.some((entry) => typeof entry !== "string") ||
     !Array.isArray(value.eligibleBindingIds) || !Array.isArray(value.items) ||
-      !Number.isSafeInteger(value.pageCount) || value.pageCount < 1) {
+      !isPositiveSafeInteger(pageCount)) {
     throw new Error("Daily source authority GitHub projection is invalid");
   }
   const eligibleBindingIds = value.eligibleBindingIds.map((entry, index) =>
@@ -380,7 +381,7 @@ const verifyGitHubProjection = (input: {
     eligibleBindingIds.length,
     expectedItems.length,
   );
-  if (value.pageCount !== expectedPageCount) {
+  if (pageCount !== expectedPageCount) {
     throw new Error("Daily source authority frozen GitHub projection page count diverged");
   }
   return Object.freeze({
@@ -391,7 +392,7 @@ const verifyGitHubProjection = (input: {
       readerSummaryDailyCanonicalFrozenGithubProjectionDates,
     eligibleBindingIds: Object.freeze(eligibleBindingIds),
     items: Object.freeze(items),
-    pageCount: value.pageCount as number,
+    pageCount,
   });
 };
 
@@ -405,9 +406,10 @@ const frozenGitHubProjectionItem = (
     "publishedAt", "observedAt", "sourceContentHash", "sourceProviderContentHash",
     "scanJobId", "repositoryFullName", "rank", "checkedAtCollectionAnchor",
   ], `GitHub projection item ${index}`, 2);
+  const rank = value.rank;
   if (
     value.providerKey !== "github-trending-page" ||
-    !Number.isSafeInteger(value.rank) || value.rank < 1
+    !isPositiveSafeInteger(rank)
   ) {
     throw new Error(`Daily source authority GitHub projection item ${index} is invalid`);
   }
@@ -437,7 +439,7 @@ const frozenGitHubProjectionItem = (
     sourceProviderContentHash: value.sourceProviderContentHash as string | null,
     scanJobId: uuid(value.scanJobId, index, "scanJobId"),
     repositoryFullName: text(value.repositoryFullName, index, "repositoryFullName"),
-    rank: value.rank,
+    rank,
     checkedAtCollectionAnchor,
   });
 };
@@ -479,6 +481,9 @@ const frozenProjectionPageCount = (
 
 const pageReads = (count: number): number =>
   Math.floor(count / frozenGitHubProjectionPageSize) + 1;
+
+const isPositiveSafeInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && value >= 1;
 
 const sameOrderedValues = (
   left: readonly string[],


### PR DESCRIPTION
Narrows Daily source authority integers with explicit type guards, types the V4 prepublication callback, and updates the staged Daily authority gate to permit only the five reviewed V4 terminal entrypoints. Source cap and diff checks pass; the previous production run supplied the exact build and PG18 failures this patch addresses.