### PR TITLE
fix(summary): narrow daily recovery integers

### DIFF
--- a/scripts/lib/reader-summary-daily-source-authority-snapshot.ts
+++ b/scripts/lib/reader-summary-daily-source-authority-snapshot.ts
@@ -483,7 +483,7 @@ const pageReads = (count: number): number =>
   Math.floor(count / frozenGitHubProjectionPageSize) + 1;
 
 const isPositiveSafeInteger = (value: unknown): value is number =>
-  Number.isSafeInteger(value) && value >= 1;
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 1;
 
 const sameOrderedValues = (
   left: readonly string[],


### PR DESCRIPTION
Completes the strict integer type guard with an explicit number check, resolving the remaining TypeScript build error from production run 30834409595. Diff and source cap checks pass.