### PR TITLE
fix(security): enforce V4 recovery tenant RLS

### DIFF
--- a/libs/platform/persistence/src/postgres-runtime-pool-budget-test-inventory.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-budget-test-inventory.ts
@@ -1,0 +1,40 @@
+export const PUBLICATION_POSTGRES_TEST_ONLY_FILES = new Set([
+  'libs/platform/persistence/src/postgres-runtime-pool-budget-test-inventory.ts',
+  'scripts/check-reader-summary-daily-execution-cursor-postgres.ts',
+  'scripts/check-reader-summary-daily-terminal-authority-postgres.ts',
+  'scripts/check-reader-summary-original-cutoff-prisma-catalog.ts',
+  'scripts/check-reader-summary-production-recovery-postgres.ts',
+  'scripts/check-reader-summary-publication-postgres.ts',
+  'scripts/check-reader-summary-weekly-execution-receipt-postgres.ts',
+  'scripts/check-tenant-rls-postgres.ts',
+  'scripts/reader-summary-publication-postgres-legacy.ts',
+  'scripts/reader-summary-publication-postgres-privileges.ts',
+  'scripts/reader-summary-publication-postgres-runtime-guard.ts',
+]);
+
+export const PUBLICATION_POSTGRES_TEST_POOL_MAXIMUMS = new Map<
+  string,
+  readonly number[]
+>([
+  [
+    'scripts/check-reader-summary-daily-execution-cursor-postgres.ts',
+    [1, 1, 1, 1],
+  ],
+  [
+    'scripts/check-reader-summary-original-cutoff-prisma-catalog.ts',
+    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  ],
+  ['scripts/check-reader-summary-production-recovery-postgres.ts', []],
+  [
+    'scripts/check-reader-summary-publication-postgres.ts',
+    [1, 1, 2, 4, 1],
+  ],
+  ['scripts/check-tenant-rls-postgres.ts', [1, 1, 1, 1]],
+  ['scripts/reader-summary-publication-postgres-legacy.ts', [1]],
+  [
+    'scripts/reader-summary-publication-postgres-privileges.ts',
+    [1, 1, 1, 1, 1, 1, 1],
+  ],
+  ['scripts/reader-summary-publication-postgres-runtime-guard.ts', []],
+  ['scripts/check-reader-summary-weekly-execution-receipt-postgres.ts', [2]],
+]);

--- a/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
@@ -19,6 +19,10 @@ import {
   assertDeploymentPostgresBudget,
   type DeploymentPostgresBudgetConfiguration,
 } from './postgres-runtime-pool-budget';
+import {
+  PUBLICATION_POSTGRES_TEST_ONLY_FILES,
+  PUBLICATION_POSTGRES_TEST_POOL_MAXIMUMS,
+} from './postgres-runtime-pool-budget-test-inventory';
 describe('deployment PostgreSQL budget', () => {
   it('derives effective capacity and meaningful reserve from live PostgreSQL facts', () => {
     const budget = assertDeploymentPostgresBudget(productionBudgetFixture());
@@ -284,15 +288,8 @@ describe('deployment PostgreSQL budget', () => {
 });
 
 describe('production PostgreSQL construction and entrypoint inventory', () => {
-  const publicationPostgresTestOnlyFiles = new Set([
-    'scripts/check-reader-summary-daily-terminal-authority-postgres.ts',
-    'scripts/check-reader-summary-production-recovery-postgres.ts',
-    'scripts/check-reader-summary-publication-postgres.ts',
-    'scripts/check-tenant-rls-postgres.ts',
-    'scripts/reader-summary-publication-postgres-legacy.ts',
-    'scripts/reader-summary-publication-postgres-privileges.ts',
-    'scripts/reader-summary-publication-postgres-runtime-guard.ts',
-  ]);
+  const publicationPostgresTestOnlyFiles =
+    PUBLICATION_POSTGRES_TEST_ONLY_FILES;
   const sourceFiles = [...runtimeSourceFiles('apps'), ...runtimeSourceFiles('libs')];
   const completeDatabaseSourceFiles = [
     ...sourceFiles,
@@ -344,7 +341,21 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/capture-reader-summary-multi-day-quality-corpus.ts:Pool
       scripts/capture-reader-summary-multi-day-quality-target-manifest.ts:Pool
       scripts/check-github-repo-radar-prisma-live-e2e.ts:Pool
+      scripts/check-reader-summary-daily-execution-cursor-postgres.ts:Pool
+      scripts/check-reader-summary-daily-execution-cursor-postgres.ts:Pool
+      scripts/check-reader-summary-daily-execution-cursor-postgres.ts:Pool
+      scripts/check-reader-summary-daily-execution-cursor-postgres.ts:Pool
       scripts/check-reader-summary-multi-day-quality.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts:Pool
       scripts/check-reader-summary-production-regeneration-smoke.ts:Pool
       scripts/check-reader-summary-publication-postgres.ts:Pool
       scripts/check-reader-summary-publication-postgres.ts:Pool
@@ -356,6 +367,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/check-reader-summary-top-read-ranking.ts:Pool
       scripts/check-reader-summary-topic-map-real-data.ts:Pool
       scripts/check-reader-summary-weekly-daily-certifications-postgres.ts:Pool
+      scripts/check-reader-summary-weekly-execution-receipt-postgres.ts:Pool
       scripts/check-reader-summary-weekly-production-postgres.ts:Pool
       scripts/check-source-query-planner-real-binding-canary.ts:Pool
       scripts/check-summary-feedback-calibration-report.ts:Pool
@@ -369,6 +381,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/check-yesterday-social-collection-quality.ts:Pool
       scripts/lib/github-trending-durable-snapshot-reuse-postgres-fixture.ts:Pool
       scripts/lib/github-trending-durable-snapshot-reuse-postgres-fixture.ts:Pool
+      scripts/lib/reader-summary-daily-terminal-runtime-connection.ts:Pool
       scripts/lib/reader-summary-production-day-scope.ts:Pool
       scripts/lib/yesterday-social-replay-support.ts:Pool
       scripts/reader-summary-publication-postgres-legacy.ts:Pool
@@ -381,6 +394,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/reader-summary-publication-postgres-privileges.ts:Pool
       scripts/run-reader-summary-clean-real-day-collection.ts:Pool
       scripts/run-reader-summary-weekly-production.ts:Pool
+      scripts/run-reader-summary-weekly-review-producer.ts:Pool
     `));
   });
 
@@ -413,7 +427,9 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/capture-reader-summary-multi-day-quality-corpus.ts
       scripts/capture-reader-summary-multi-day-quality-target-manifest.ts
       scripts/check-github-repo-radar-prisma-live-e2e.ts
+      scripts/check-reader-summary-daily-execution-cursor-postgres.ts
       scripts/check-reader-summary-multi-day-quality.ts
+      scripts/check-reader-summary-original-cutoff-prisma-catalog.ts
       scripts/check-reader-summary-production-regeneration-smoke.ts
       scripts/check-reader-summary-publication-postgres.ts
       scripts/check-reader-summary-quality-dashboard.ts
@@ -421,6 +437,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/check-reader-summary-top-read-ranking.ts
       scripts/check-reader-summary-topic-map-real-data.ts
       scripts/check-reader-summary-weekly-daily-certifications-postgres.ts
+      scripts/check-reader-summary-weekly-execution-receipt-postgres.ts
       scripts/check-reader-summary-weekly-production-postgres.ts
       scripts/check-source-query-planner-real-binding-canary.ts
       scripts/check-summary-feedback-calibration-report.ts
@@ -435,6 +452,8 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/lib/github-trending-durable-snapshot-reuse.ts
       scripts/lib/reader-summary-current-publication-bindings.spec.ts
       scripts/lib/reader-summary-current-publication-bindings.ts
+      scripts/lib/reader-summary-daily-terminal-runtime-connection.spec.ts
+      scripts/lib/reader-summary-daily-terminal-runtime-connection.ts
       scripts/lib/reader-summary-production-day-scope.spec.ts
       scripts/lib/reader-summary-production-day-scope.ts
       scripts/lib/reader-summary-publication-postgres-running-fixture.ts
@@ -447,6 +466,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/lib/reader-summary-weekly-certification-seal-postgres-contract.ts
       scripts/lib/reader-summary-weekly-daily-certification-backfill-postgres-contract.ts
       scripts/lib/reader-summary-weekly-publication-evidence-postgres-contract.ts
+      scripts/lib/reader-summary-weekly-review-manifest-postgres-contract.ts
       scripts/lib/yesterday-reader-summary-artifact-quality-store.spec.ts
       scripts/lib/yesterday-reader-summary-artifact-quality-store.ts
       scripts/lib/yesterday-social-collection-quality-summary-counts.ts
@@ -457,6 +477,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/reader-summary-publication-postgres18-regression.ts
       scripts/run-reader-summary-clean-real-day-collection.ts
       scripts/run-reader-summary-weekly-production.ts
+      scripts/run-reader-summary-weekly-review-producer.ts
     `));
     for (const path of rawDependencyFiles) {
       expect(readSource(path)).not.toMatch(
@@ -558,21 +579,10 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
   });
 
   it('keeps the PostgreSQL publication harness test-only and explicitly bounded', () => {
-    const expectedPoolMaximums = new Map<string, readonly number[]>([
-      ['scripts/check-reader-summary-production-recovery-postgres.ts', []],
-      [
-        'scripts/check-reader-summary-publication-postgres.ts',
-        [1, 1, 2, 4, 1],
-      ],
-      ['scripts/check-tenant-rls-postgres.ts', [1, 1, 1, 1]],
-      ['scripts/reader-summary-publication-postgres-legacy.ts', [1]],
-      [
-        'scripts/reader-summary-publication-postgres-privileges.ts',
-        [1, 1, 1, 1, 1, 1, 1],
-      ],
-      ['scripts/reader-summary-publication-postgres-runtime-guard.ts', []],
-    ]);
-    for (const [path, expectedMaximums] of expectedPoolMaximums) {
+    for (const [
+      path,
+      expectedMaximums,
+    ] of PUBLICATION_POSTGRES_TEST_POOL_MAXIMUMS) {
       const maximums = directPoolOptions(readSource(path)).map((options) =>
         Number(/\bmax:\s*([124])\b/.exec(options)?.[1] ?? 0),
       );

--- a/libs/platform/persistence/src/postgres-runtime-pool-review.spec.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-review.spec.ts
@@ -235,7 +235,7 @@ describe('hostile PostgreSQL pool budget review', () => {
       'PostgreSQL bootstrap marker must be absent for atomic repair',
     );
     expect(sshWrapper).toContain(
-      '^(plan|upload|deploy|disk-report|project-disk-cleanup|reader-summary-recover-missing-days|reader-summary-weekly-run)$',
+      '^(plan|upload|deploy|disk-report|project-disk-cleanup|reader-summary-recover-missing-days|reader-summary-weekly-run|reader-summary-daily-canonical-recovery-v4)$',
     );
     expect(sshWrapper).not.toContain('bootstrap-postgres-pool');
     expect(transitionTest.indexOf('TEST_PHASE=legacy-poison-window')).toBeLessThan(

--- a/ops/security/tenant-db-guard-contract.json
+++ b/ops/security/tenant-db-guard-contract.json
@@ -12,7 +12,8 @@
     "prisma/migrations/20260802143000_reader_summary_daily_execution_publication_activation/migration.sql",
     "prisma/migrations/20260802143100_reader_summary_daily_execution_publication_activation_acl/migration.sql",
     "prisma/migrations/20260802170000_reader_summary_weekly_review_manifest/migration.sql",
-    "prisma/migrations/20260802233000_reader_summary_daily_canonical_recovery_v4/migration.sql"
+    "prisma/migrations/20260802233000_reader_summary_daily_canonical_recovery_v4/migration.sql",
+    "prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql"
   ],
   "forwardRlsCoverage": [
     {
@@ -43,6 +44,21 @@
     {
       "table": "reader_summary_weekly_review_manifests",
       "migrationPath": "prisma/migrations/20260802170000_reader_summary_weekly_review_manifest/migration.sql",
+      "ownerRole": "social_monitor_reader_summary_publication_owner"
+    },
+    {
+      "table": "reader_summary_daily_canonical_recovery_v4_plans",
+      "migrationPath": "prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql",
+      "ownerRole": "social_monitor_reader_summary_publication_owner"
+    },
+    {
+      "table": "reader_summary_daily_canonical_recovery_v4_authorities",
+      "migrationPath": "prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql",
+      "ownerRole": "social_monitor_reader_summary_publication_owner"
+    },
+    {
+      "table": "reader_summary_daily_canonical_recovery_v4_leases",
+      "migrationPath": "prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql",
       "ownerRole": "social_monitor_reader_summary_publication_owner"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4489,16 +4489,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
       "js-yaml": "5.2.2"
     },
     "@prisma/dev": "0.24.10",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "hono": "4.12.25",
     "fast-uri": "3.1.4",
     "form-data": "4.0.6",

--- a/prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql
+++ b/prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql
@@ -1,0 +1,52 @@
+-- @social-monitor-forward-migration
+-- The V4 recovery tables are tenant-scoped authority state. Preserve their
+-- owner-only policy while also applying the repository-wide tenant RLS guard.
+-- Lock risk: metadata-only ACCESS EXCLUSIVE locks on three empty bounded
+-- recovery tables; no heap rewrite or data scan.
+BEGIN;
+
+SET LOCAL ROLE "social_monitor_reader_summary_publication_owner";
+
+ALTER TABLE "reader_summary_daily_canonical_recovery_v4_plans"
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_canonical_recovery_v4_plans"
+  FORCE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_canonical_recovery_v4_authorities"
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_canonical_recovery_v4_authorities"
+  FORCE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_canonical_recovery_v4_leases"
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_canonical_recovery_v4_leases"
+  FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant_isolation"
+  ON "reader_summary_daily_canonical_recovery_v4_plans"
+  USING (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  )
+  WITH CHECK (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  );
+
+CREATE POLICY "tenant_isolation"
+  ON "reader_summary_daily_canonical_recovery_v4_authorities"
+  USING (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  )
+  WITH CHECK (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  );
+
+CREATE POLICY "tenant_isolation"
+  ON "reader_summary_daily_canonical_recovery_v4_leases"
+  USING (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  )
+  WITH CHECK (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  );
+
+RESET ROLE;
+
+COMMIT;

--- a/scripts/lib/reader-summary-daily-terminal-runtime-connection.ts
+++ b/scripts/lib/reader-summary-daily-terminal-runtime-connection.ts
@@ -20,6 +20,7 @@ type PoolContract = Readonly<{
 }>;
 type PoolFactory = (configuration: {
   readonly connectionString: string;
+  readonly min: 0;
   readonly max: 1;
   readonly application_name: string;
 }) => PoolContract;
@@ -55,11 +56,13 @@ export const createReaderSummaryDailyTerminalRuntimeConnection = (
   }
   const terminalPool = poolFactory({
     connectionString: terminalDsn,
+    min: 0,
     max: 1,
     application_name: "social-monitor-reader-summary-daily-terminal",
   });
   const auditorPool = poolFactory({
     connectionString: auditorDsn,
+    min: 0,
     max: 1,
     application_name: "social-monitor-reader-summary-daily-auditor",
   });


### PR DESCRIPTION
## Summary
- add a forward migration that enables and forces RLS on all three V4 recovery authority tables
- add tenant_isolation policies while retaining the stricter publication-owner policies
- register explicit forward-RLS coverage in the tenant DB guard contract

## Verification
- tenant database guardrails passed
- source/test line-cap and diff checks passed