### PR TITLE
fix(security): enforce daily execution tenant RLS

### DIFF
--- a/ops/security/tenant-db-guard-contract.json
+++ b/ops/security/tenant-db-guard-contract.json
@@ -13,7 +13,8 @@
     "prisma/migrations/20260802143100_reader_summary_daily_execution_publication_activation_acl/migration.sql",
     "prisma/migrations/20260802170000_reader_summary_weekly_review_manifest/migration.sql",
     "prisma/migrations/20260802233000_reader_summary_daily_canonical_recovery_v4/migration.sql",
-    "prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql"
+    "prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql",
+    "prisma/migrations/20260803174000_reader_summary_daily_execution_tenant_rls/migration.sql"
   ],
   "forwardRlsCoverage": [
     {
@@ -60,6 +61,21 @@
       "table": "reader_summary_daily_canonical_recovery_v4_leases",
       "migrationPath": "prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql",
       "ownerRole": "social_monitor_reader_summary_publication_owner"
+    },
+    {
+      "table": "reader_summary_daily_execution_cursors",
+      "migrationPath": "prisma/migrations/20260803174000_reader_summary_daily_execution_tenant_rls/migration.sql",
+      "ownerRole": "social_monitor_public_schema_owner"
+    },
+    {
+      "table": "reader_summary_daily_source_authorities",
+      "migrationPath": "prisma/migrations/20260803174000_reader_summary_daily_execution_tenant_rls/migration.sql",
+      "ownerRole": "social_monitor_public_schema_owner"
+    },
+    {
+      "table": "reader_summary_daily_model_jobs",
+      "migrationPath": "prisma/migrations/20260803174000_reader_summary_daily_execution_tenant_rls/migration.sql",
+      "ownerRole": "social_monitor_public_schema_owner"
     },
     {
       "table": "webhook_secrets",

--- a/prisma/migrations/20260803174000_reader_summary_daily_execution_tenant_rls/migration.sql
+++ b/prisma/migrations/20260803174000_reader_summary_daily_execution_tenant_rls/migration.sql
@@ -1,0 +1,77 @@
+-- @social-monitor-forward-migration
+-- Daily cursor, source authority and model receipt state are tenant-scoped.
+-- Keep direct tenant access scope-filtered while the reviewed schema owner and
+-- daily publication definer retain the authority required by fenced functions.
+-- Lock risk: metadata-only ACCESS EXCLUSIVE locks on three bounded daily state
+-- tables; no heap rewrite or data scan.
+BEGIN;
+
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
+ALTER TABLE "reader_summary_daily_execution_cursors"
+  OWNER TO "social_monitor_public_schema_owner";
+ALTER TABLE "reader_summary_daily_source_authorities"
+  OWNER TO "social_monitor_public_schema_owner";
+ALTER TABLE "reader_summary_daily_model_jobs"
+  OWNER TO "social_monitor_public_schema_owner";
+
+SET LOCAL ROLE "social_monitor_public_schema_owner";
+
+ALTER TABLE "reader_summary_daily_execution_cursors"
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_execution_cursors"
+  FORCE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_source_authorities"
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_source_authorities"
+  FORCE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_model_jobs"
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_daily_model_jobs"
+  FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant_isolation"
+  ON "reader_summary_daily_execution_cursors"
+  USING (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  )
+  WITH CHECK (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  );
+CREATE POLICY "daily_execution_authority"
+  ON "reader_summary_daily_execution_cursors"
+  FOR ALL TO "social_monitor_public_schema_owner",
+    "social_monitor_reader_summary_daily_publication_definer"
+  USING (TRUE) WITH CHECK (TRUE);
+
+CREATE POLICY "tenant_isolation"
+  ON "reader_summary_daily_source_authorities"
+  USING (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  )
+  WITH CHECK (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  );
+CREATE POLICY "daily_execution_authority"
+  ON "reader_summary_daily_source_authorities"
+  FOR ALL TO "social_monitor_public_schema_owner",
+    "social_monitor_reader_summary_daily_publication_definer"
+  USING (TRUE) WITH CHECK (TRUE);
+
+CREATE POLICY "tenant_isolation"
+  ON "reader_summary_daily_model_jobs"
+  USING (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  )
+  WITH CHECK (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  );
+CREATE POLICY "daily_execution_authority"
+  ON "reader_summary_daily_model_jobs"
+  FOR ALL TO "social_monitor_public_schema_owner",
+    "social_monitor_reader_summary_daily_publication_definer"
+  USING (TRUE) WITH CHECK (TRUE);
+
+RESET ROLE;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- move the three daily execution authority tables under the reviewed schema owner
- enable and force tenant RLS on cursor, source authority and model receipt state
- retain fenced function access for the schema owner and daily publication definer

## Verification
- full local PostgreSQL 18 tenant RLS isolation gate passed
- tenant DB static guard and source line-cap passed