### PR TITLE
test(summary): fix recovery release gates

### DIFF
--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -321,6 +321,8 @@ run_release_b() (
     printf 'bootstrap-marker\n' >> "$BRIDGE_EVENTS"
     printf '%s\n' "$1" > "$STATE/postgres-pool-bootstrap.sha"
   }
+  # fake_compose is invoked indirectly through the COMPOSE command array below.
+  # shellcheck disable=SC2317,SC2329
   fake_compose() {
     printf 'compose:%s\n' "$*" >> "$BRIDGE_EVENTS"
     [[ " $* " != *' rabbitmq '* ]] || \

--- a/ops/deploy/reader-summary-publication-signal-regression.test.sh
+++ b/ops/deploy/reader-summary-publication-signal-regression.test.sh
@@ -19,8 +19,12 @@ RELEASE_SHA=0123456789abcdef0123456789abcdef01234567
 # Production keeps collection before the canonical terminal. The terminal
 # receives the pinned date and owns the only production publication path.
 grep -F 'npm run run:reader-summary-clean-real-day-collection' "$DAILY_RUN" >/dev/null
+# This source assertion intentionally matches a literal shell variable reference.
+# shellcheck disable=SC2016
 grep -F 'READER_SUMMARY_DAILY_FIRST_UNRESOLVED_UTC_DATE="$requested_date"' \
   "$DAILY_RUN" >/dev/null
+# This source assertion intentionally matches a literal shell variable reference.
+# shellcheck disable=SC2016
 grep -F 'READER_SUMMARY_DAILY_PUBLIC_DIRECTORY="$public_dir"' \
   "$DAILY_RUN" >/dev/null
 grep -F 'scripts/run-reader-summary-daily-terminal.ts' "$DAILY_RUN" >/dev/null

--- a/scripts/check-reader-summary-production-recovery-postgres.ts
+++ b/scripts/check-reader-summary-production-recovery-postgres.ts
@@ -191,6 +191,7 @@ const migrationWorkspace =
 const deferredCanonicalRecoveryMigrations = [
   "20260802233000_reader_summary_daily_canonical_recovery_v4",
   "20260802233100_reader_summary_daily_canonical_recovery_v4_security",
+  "20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls",
 ] as const;
 let ownerRolePreexisting = false;
 let capabilityRolePreexisting = false;


### PR DESCRIPTION
Fix the two exact release-gate regressions blocking deployment of the daily/weekly summary recovery release.

- defer the V4 tenant-RLS migration with its base and security migrations in the PostgreSQL recovery fixture
- document intentional indirect shell invocation for ShellCheck
- document literal shell-source assertions for ShellCheck

Local proof:
- ShellCheck 0.11.0: green
- RabbitMQ bridge regression in Linux container: green
- daily publication signal regression in Linux container: green
- source line cap and diff check: green