### PR TITLE
fix(summary): close recovery PostgreSQL admin pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "check:summary-policy-rest": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-policy-rest-smoke.ts",
     "check:summary-persistence": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-prisma-persistence.ts",
     "recover:reader-summary-production": "node scripts/run-with-timeout.mjs --timeout-ms 2400000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/recover-reader-summary-production.ts",
-    "check:reader-summary-production-recovery-postgres": "node scripts/run-with-timeout.mjs --timeout-ms 240000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-reader-summary-production-recovery-postgres.ts",
+    "check:reader-summary-production-recovery-postgres": "node scripts/run-with-timeout.mjs --timeout-ms 300000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-reader-summary-production-recovery-postgres.ts",
     "check:reader-summary-daily-canonical-recovery-postgres18": "bash ops/deploy/daily-canonical-recovery-postgres18.test.sh",
     "check:reader-summary-daily-canonical-recovery-production": "bash ops/deploy/daily-canonical-recovery-production.test.sh",
     "check:reader-summary-original-cutoff-prisma-catalog": "node scripts/run-with-timeout.mjs --timeout-ms 300000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-reader-summary-original-cutoff-prisma-catalog.ts",

--- a/scripts/check-reader-summary-production-recovery-postgres.ts
+++ b/scripts/check-reader-summary-production-recovery-postgres.ts
@@ -478,21 +478,25 @@ const main = async (): Promise<void> => {
     }
   } finally {
     removeReaderSummaryPublicationMigrationWorkspace(migrationWorkspace);
-    await dropPublicationFixtureDatabaseAndRoles({
-      serverAdmin,
-      databaseName,
-      migrationAdminRole,
-      runtimeRole,
-      ownerRolePreexisting,
-      capabilityRolePreexisting,
-      schemaOwnerRolePreexisting,
-      tenantSystemCapabilityRolePreexisting,
-      dailyActivationDefinerRolePreexisting,
-      fixtureDatabaseCreated,
-      fixtureMigrationAdminRoleCreated,
-      fixtureRuntimeRoleCreated,
-      fixtureDailyTerminalRoleCreated,
-    });
+    try {
+      await dropPublicationFixtureDatabaseAndRoles({
+        serverAdmin,
+        databaseName,
+        migrationAdminRole,
+        runtimeRole,
+        ownerRolePreexisting,
+        capabilityRolePreexisting,
+        schemaOwnerRolePreexisting,
+        tenantSystemCapabilityRolePreexisting,
+        dailyActivationDefinerRolePreexisting,
+        fixtureDatabaseCreated,
+        fixtureMigrationAdminRoleCreated,
+        fixtureRuntimeRoleCreated,
+        fixtureDailyTerminalRoleCreated,
+      });
+    } finally {
+      await serverAdmin.end();
+    }
   }
   console.log(
     "Reader summary production recovery PostgreSQL authority gate OK",


### PR DESCRIPTION
The mandatory PG18 gate completed successfully but its process stayed alive until the 240-second watchdog because the administrative Pool was never closed.

- always close the admin Pool in fixture cleanup
- allow a 5-minute watchdog for the observed ~237-second full PG18 proof plus cleanup

Evidence from run 30838671238: authority gate printed OK, then timed out with exit 124. Diff and source-line cap are green.