### PR TITLE
test(summary): align recovery fixtures

### DIFF
--- a/scripts/lib/reader-summary-daily-publication-finalizer.spec.ts
+++ b/scripts/lib/reader-summary-daily-publication-finalizer.spec.ts
@@ -51,8 +51,12 @@ describe("CanonicalReaderSummaryDailyPublicationFinalizer", () => {
     await expect(finalizer.publish(input())).resolves.toMatchObject({
       publicationId: captured().publicationId,
     });
-    writeFileSync(join(directory,
-      "durable-reader-summary-2026-07-31.v1.json"), "conflict");
+    const evidencePath = join(
+      directory,
+      "durable-reader-summary-2026-07-31.v1.json",
+    );
+    rmSync(evidencePath);
+    writeFileSync(evidencePath, "conflict");
     await expect(finalizer.publish(input())).rejects.toThrow(/invalid|bind/u);
   });
 

--- a/scripts/lib/reader-summary-production-day-report.spec.ts
+++ b/scripts/lib/reader-summary-production-day-report.spec.ts
@@ -712,7 +712,7 @@ function evidenceFixture(withDatasetGuard = false) {
       readerSummaryId,
       period: productionDayUtcPeriod(collectionDate),
       lineage: {
-        modelVersion: "codex:gpt-5.5:xhigh",
+        modelVersion: "codex:gpt-5.6-sol:xhigh",
         providerVersion: "agent-runtime",
       },
       content: { topicMap: { generatedBy: "agent-runtime" } },

--- a/scripts/lib/reader-summary-production-day-reuse-provenance.spec.ts
+++ b/scripts/lib/reader-summary-production-day-reuse-provenance.spec.ts
@@ -89,7 +89,7 @@ describe("historical production-day reuse provenance", () => {
         readFileSync(frontendFixturePath, "utf8"),
       ) as { readerSummaryArtifact: { lineage: { modelVersion: string } } };
       frontend.readerSummaryArtifact.lineage.modelVersion =
-        "codex:gpt-5.5:xhigh-modified";
+        "codex:gpt-5.6-sol:xhigh-modified";
       writeFileSync(frontendFixturePath, `${JSON.stringify(frontend)}\n`);
 
       expect(() =>
@@ -225,7 +225,7 @@ function evidenceFixture() {
       readerSummaryId: "11111111-1111-4111-8111-111111111111",
       period: productionDayUtcPeriod(collectionDate),
       lineage: {
-        modelVersion: "codex:gpt-5.5:xhigh",
+        modelVersion: "codex:gpt-5.6-sol:xhigh",
         providerVersion: "agent-runtime",
       },
       content: { topicMap: { generatedBy: "agent-runtime" } },


### PR DESCRIPTION
Align the affected summary fixtures with current immutable provenance and publication semantics.

- use the current gpt-5.6-sol executor lineage in historical evidence fixtures
- model a conflicting public file by replacing its directory entry instead of overwriting mode 0444

Local Linux proof: 3 suites, 63/63 tests green.