### PR TITLE
fix(frontend): separate selected posts from top posts

### DIFF
--- a/apps/frontend/features/summaries/docs/ubiquitous_language.md
+++ b/apps/frontend/features/summaries/docs/ubiquitous_language.md
@@ -16,6 +16,11 @@ language.
   quality state and `ReaderAction`.
 - Top Read: a user-readable item selected for review. It has a normalized
   `signalScore` plus provider-native `providerMetrics`.
+- More Selected Post: additional evidence selected for the Summary but not
+  promoted into the curated Top Reads. The UI keeps it in a separate section
+  and orders it by normalized Signal, independent source confirmation,
+  confidence and matched-interest breadth. Provider-native metrics are not
+  compared across platforms.
 - Top Read Feedback Target: the concrete feed/source item identity used when a
   user rates a Top Read with 1-5 stars. It is recorded for review learning
   only and must not directly reorder results until a capped ranking policy

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts.dart
@@ -4,7 +4,7 @@ const _githubTrendingProviderKey = readerSummaryGitHubTrendingProviderKey;
 
 enum _TopPostSort { editorial, engagement }
 
-enum _TopPostBoard { posts, githubTrending }
+enum _TopPostBoard { topPosts, moreSelected, githubTrending }
 
 /// "Top posts" board: sortable, filterable editorial picks with an optional
 /// engagement view.
@@ -47,17 +47,14 @@ class _ReaderSummaryTopPostsState extends State<ReaderSummaryTopPosts> {
   @override
   void initState() {
     super.initState();
-    _board = _availableTopPostBoard(widget.projection.items);
+    _board = _availableTopPostBoard(widget.projection);
   }
 
   @override
   void didUpdateWidget(covariant ReaderSummaryTopPosts oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!widget.projection.hasSameDatasetAs(oldWidget.projection)) {
-      _board = _availableTopPostBoard(
-        widget.projection.items,
-        preferred: _board,
-      );
+      _board = _availableTopPostBoard(widget.projection, preferred: _board);
     }
   }
 
@@ -70,17 +67,19 @@ class _ReaderSummaryTopPostsState extends State<ReaderSummaryTopPosts> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final postItems = widget.projection.posts;
+    final topPostItems = widget.projection.curatedPosts;
+    final moreSelectedItems = widget.projection.moreSelectedPosts;
     final githubTrendingItems = widget.projection.githubTrendingPosts;
     final activeBoard = _board;
     final boardItems = switch (activeBoard) {
-      _TopPostBoard.posts => postItems,
+      _TopPostBoard.topPosts => topPostItems,
+      _TopPostBoard.moreSelected => moreSelectedItems,
       _TopPostBoard.githubTrending => githubTrendingItems,
     };
     final filtered = orderTopPosts(
       boardItems.where((item) => !_hiddenProviders.contains(item.providerKey)),
       byEngagement:
-          activeBoard == _TopPostBoard.posts &&
+          activeBoard == _TopPostBoard.topPosts &&
           _sort == _TopPostSort.engagement,
     );
     final reservePreviewSpace = filtered.any(
@@ -94,7 +93,8 @@ class _ReaderSummaryTopPostsState extends State<ReaderSummaryTopPosts> {
         _TopPostsHeader(
           board: activeBoard,
           sort: _sort,
-          postCount: postItems.length,
+          topPostCount: topPostItems.length,
+          moreSelectedPostCount: moreSelectedItems.length,
           githubTrendingCount: githubTrendingItems.length,
           curatedTopPostCount: widget.projection.curatedPosts.length,
           selectedPostCount: widget.selectedPostCount,
@@ -207,7 +207,8 @@ class _TopPostsHeader extends StatelessWidget {
   const _TopPostsHeader({
     required this.board,
     required this.sort,
-    required this.postCount,
+    required this.topPostCount,
+    required this.moreSelectedPostCount,
     required this.githubTrendingCount,
     required this.curatedTopPostCount,
     required this.selectedPostCount,
@@ -222,7 +223,8 @@ class _TopPostsHeader extends StatelessWidget {
 
   final _TopPostBoard board;
   final _TopPostSort sort;
-  final int postCount;
+  final int topPostCount;
+  final int moreSelectedPostCount;
   final int githubTrendingCount;
   final int curatedTopPostCount;
   final int selectedPostCount;
@@ -255,7 +257,7 @@ class _TopPostsHeader extends StatelessWidget {
       runSpacing: AppSpacing.sm,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        if (board == _TopPostBoard.posts) ...[
+        if (board == _TopPostBoard.topPosts) ...[
           Text(
             'Sort by',
             style: textTheme.labelSmall?.copyWith(
@@ -265,13 +267,15 @@ class _TopPostsHeader extends StatelessWidget {
             ),
           ),
           _TopPostSortMenu(sort: sort, onSortChanged: onSortChanged),
-          if (providerKeys.isNotEmpty)
-            _TopPostFilterMenu(
-              providerKeys: providerKeys,
-              hiddenProviders: hiddenProviders,
-              onProviderToggled: onProviderToggled,
-            ),
+        ] else if (board == _TopPostBoard.moreSelected) ...[
+          const _MoreSelectedSortIndicator(),
         ],
+        if (board != _TopPostBoard.githubTrending && providerKeys.isNotEmpty)
+          _TopPostFilterMenu(
+            providerKeys: providerKeys,
+            hiddenProviders: hiddenProviders,
+            onProviderToggled: onProviderToggled,
+          ),
         _TopPostViewToggle(
           denseView: denseView,
           onDenseViewChanged: onDenseViewChanged,
@@ -285,7 +289,8 @@ class _TopPostsHeader extends StatelessWidget {
       children: [
         _TopPostBoardToggle(
           board: board,
-          postCount: postCount,
+          topPostCount: topPostCount,
+          moreSelectedPostCount: moreSelectedPostCount,
           githubTrendingCount: githubTrendingCount,
           onChanged: onBoardChanged,
         ),
@@ -319,27 +324,27 @@ class _TopPostsHeader extends StatelessWidget {
 }
 
 _TopPostBoard _availableTopPostBoard(
-  Iterable<TopRead> items, {
+  ReaderSummaryTopPostsProjection projection, {
   _TopPostBoard? preferred,
 }) {
-  var hasPosts = false;
-  var hasGitHubTrending = false;
-  for (final item in items) {
-    if (isGitHubTrendingTopPost(item)) {
-      hasGitHubTrending = true;
-    } else {
-      hasPosts = true;
-    }
-  }
+  final hasTopPosts = projection.curatedPosts.isNotEmpty;
+  final hasMoreSelected = projection.moreSelectedPosts.isNotEmpty;
+  final hasGitHubTrending = projection.githubTrendingPosts.isNotEmpty;
 
-  if (preferred == _TopPostBoard.posts && hasPosts) {
-    return _TopPostBoard.posts;
+  if (preferred == _TopPostBoard.topPosts && hasTopPosts) {
+    return _TopPostBoard.topPosts;
+  }
+  if (preferred == _TopPostBoard.moreSelected && hasMoreSelected) {
+    return _TopPostBoard.moreSelected;
   }
   if (preferred == _TopPostBoard.githubTrending && hasGitHubTrending) {
     return _TopPostBoard.githubTrending;
   }
-  if (hasPosts) {
-    return _TopPostBoard.posts;
+  if (hasTopPosts) {
+    return _TopPostBoard.topPosts;
+  }
+  if (hasMoreSelected) {
+    return _TopPostBoard.moreSelected;
   }
   if (hasGitHubTrending) {
     return _TopPostBoard.githubTrending;
@@ -362,11 +367,13 @@ String _topPostBoardSubtitle(
   required int selectedPostCount,
 }) {
   return switch (board) {
-    _TopPostBoard.posts =>
+    _TopPostBoard.topPosts =>
       curatedTopPostCount == 1
           ? '1 editorial pick from $selectedPostCount selected'
           : '$curatedTopPostCount editorial picks from '
                 '$selectedPostCount selected',
+    _TopPostBoard.moreSelected =>
+      'Additional selected evidence, ordered by Signal and support strength',
     _TopPostBoard.githubTrending =>
       'Top 10 repositories in GitHub Trending order',
   };

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_controls.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_controls.dart
@@ -1,5 +1,39 @@
 part of 'reader_summary_brief_surface.dart';
 
+class _MoreSelectedSortIndicator extends StatelessWidget {
+  const _MoreSelectedSortIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+    return Tooltip(
+      message:
+          'Normalized Signal, independent source support, confidence, '
+          'then matched interests.',
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.auto_awesome_outlined,
+            size: 16,
+            color: colorScheme.primary,
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          Text(
+            'Sorted by usefulness',
+            style: textTheme.labelSmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _TopPostSortMenu extends StatelessWidget {
   const _TopPostSortMenu({required this.sort, required this.onSortChanged});
 
@@ -75,7 +109,7 @@ class _TopPostFilterMenu extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     return PopupMenuButton<String>(
       key: const ValueKey('reader-summary-top-posts-filters'),
-      tooltip: 'Filter top posts by source',
+      tooltip: 'Filter posts by source',
       position: PopupMenuPosition.under,
       onSelected: onProviderToggled,
       itemBuilder: (context) => [

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_reveal_trigger.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_reveal_trigger.dart
@@ -57,7 +57,7 @@ class _TopPostsRevealTriggerState extends State<_TopPostsRevealTrigger> {
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
       child: Center(
         child: Text(
-          'More top posts available',
+          'More selected posts available',
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
             color: colorScheme.onSurfaceVariant,
             letterSpacing: 0,

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_sliver.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_sliver.dart
@@ -49,9 +49,9 @@ class _ReaderSummaryTopPostsSliverState
   @override
   void initState() {
     super.initState();
-    _board = _availableTopPostBoard(widget.projection.items);
+    _board = _availableTopPostBoard(widget.projection);
     _continuation = TopPostsContinuationWindow(
-      initialVisibleCount: readerSummaryCuratedTopPostLimit,
+      initialVisibleCount: topPostsContinuationBatchSize,
     );
     _refreshBoardItems();
   }
@@ -79,12 +79,10 @@ class _ReaderSummaryTopPostsSliverState
     );
     final periodChanged = widget.period != oldWidget.period;
     if (datasetChanged || periodChanged) {
-      _continuation.reset(
-        initialVisibleCount: readerSummaryCuratedTopPostLimit,
-      );
+      _continuation.reset(initialVisibleCount: topPostsContinuationBatchSize);
       _requireFreshUserScroll();
     }
-    _board = _availableTopPostBoard(widget.projection.items, preferred: _board);
+    _board = _availableTopPostBoard(widget.projection, preferred: _board);
     _refreshBoardItems();
   }
 
@@ -99,11 +97,11 @@ class _ReaderSummaryTopPostsSliverState
     final colorScheme = Theme.of(context).colorScheme;
     final activeBoard = _board;
     final filtered = _filteredItems;
-    final visibleItemCount = activeBoard == _TopPostBoard.posts
+    final visibleItemCount = activeBoard == _TopPostBoard.moreSelected
         ? _continuation.visibleItemCount(filtered.length)
         : filtered.length;
     final hasMoreItems =
-        activeBoard == _TopPostBoard.posts &&
+        activeBoard == _TopPostBoard.moreSelected &&
         visibleItemCount < filtered.length;
     final sliverItemCount = hasMoreItems
         ? math.max(1, visibleItemCount * 2)
@@ -115,7 +113,8 @@ class _ReaderSummaryTopPostsSliverState
           child: _TopPostsHeader(
             board: activeBoard,
             sort: _sort,
-            postCount: widget.projection.posts.length,
+            topPostCount: widget.projection.curatedPosts.length,
+            moreSelectedPostCount: widget.projection.moreSelectedPosts.length,
             githubTrendingCount: widget.projection.githubTrendingPosts.length,
             curatedTopPostCount: widget.projection.curatedPosts.length,
             selectedPostCount: widget.selectedPostCount,
@@ -226,7 +225,7 @@ class _ReaderSummaryTopPostsSliverState
 
   bool _revealMoreItems(int generation) {
     if (!mounted ||
-        _board != _TopPostBoard.posts ||
+        _board != _TopPostBoard.moreSelected ||
         generation != _continuation.generation ||
         _userScrollSerial <= _lastRevealUserScrollSerial ||
         _continuation.visibleItemCount(_filteredItems.length) >=
@@ -247,7 +246,7 @@ class _ReaderSummaryTopPostsSliverState
   }
 
   void _resetContinuation() {
-    _continuation.reset(initialVisibleCount: readerSummaryCuratedTopPostLimit);
+    _continuation.reset(initialVisibleCount: topPostsContinuationBatchSize);
     _requireFreshUserScroll();
   }
 
@@ -270,7 +269,8 @@ class _ReaderSummaryTopPostsSliverState
 
   void _refreshBoardItems() {
     _boardItems = switch (_board) {
-      _TopPostBoard.posts => widget.projection.posts,
+      _TopPostBoard.topPosts => widget.projection.curatedPosts,
+      _TopPostBoard.moreSelected => widget.projection.moreSelectedPosts,
       _TopPostBoard.githubTrending => widget.projection.githubTrendingPosts,
     };
     _providerKeys = {
@@ -279,7 +279,7 @@ class _ReaderSummaryTopPostsSliverState
     _filteredItems = orderTopPosts(
       _boardItems.where((item) => !_hiddenProviders.contains(item.providerKey)),
       byEngagement:
-          _board == _TopPostBoard.posts && _sort == _TopPostSort.engagement,
+          _board == _TopPostBoard.topPosts && _sort == _TopPostSort.engagement,
     );
     _reservePreviewSpace = _filteredItems.any(
       (item) => item.previewMedia != null,

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_tabs.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_tabs.dart
@@ -3,13 +3,15 @@ part of 'reader_summary_brief_surface.dart';
 class _TopPostBoardToggle extends StatelessWidget {
   const _TopPostBoardToggle({
     required this.board,
-    required this.postCount,
+    required this.topPostCount,
+    required this.moreSelectedPostCount,
     required this.githubTrendingCount,
     required this.onChanged,
   });
 
   final _TopPostBoard board;
-  final int postCount;
+  final int topPostCount;
+  final int moreSelectedPostCount;
   final int githubTrendingCount;
   final ValueChanged<_TopPostBoard> onChanged;
 
@@ -31,7 +33,7 @@ class _TopPostBoardToggle extends StatelessWidget {
             child: Align(
               alignment: AlignmentDirectional.centerStart,
               child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 420),
+                constraints: const BoxConstraints(maxWidth: 620),
                 child: Row(
                   children: [
                     Expanded(
@@ -40,11 +42,24 @@ class _TopPostBoardToggle extends StatelessWidget {
                           'reader-summary-top-posts-board-posts',
                         ),
                         label: 'Top posts',
-                        count: postCount,
+                        count: topPostCount,
                         showCount: showCounts,
-                        selected: board == _TopPostBoard.posts,
+                        selected: board == _TopPostBoard.topPosts,
                         leading: const Icon(Icons.article_outlined, size: 17),
-                        onPressed: () => onChanged(_TopPostBoard.posts),
+                        onPressed: () => onChanged(_TopPostBoard.topPosts),
+                      ),
+                    ),
+                    Expanded(
+                      child: _TopPostBoardToggleSegment(
+                        key: const ValueKey(
+                          'reader-summary-top-posts-board-more-selected',
+                        ),
+                        label: 'More selected posts',
+                        count: moreSelectedPostCount,
+                        showCount: showCounts,
+                        selected: board == _TopPostBoard.moreSelected,
+                        leading: const Icon(Icons.playlist_add, size: 17),
+                        onPressed: () => onChanged(_TopPostBoard.moreSelected),
                       ),
                     ),
                     Expanded(

--- a/apps/frontend/features/summaries/lib/src/presentation/view_models/more_selected_posts_ranking.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/view_models/more_selected_posts_ranking.dart
@@ -1,0 +1,62 @@
+import '../../domain/entities/top_read.dart';
+
+/// Orders non-curated summary evidence by comparable usefulness signals.
+///
+/// Provider-native metrics are intentionally excluded: Reddit upvotes,
+/// Hacker News points and X likes do not share a meaningful scale.
+List<TopRead> orderMoreSelectedPostsByUsefulness(Iterable<TopRead> items) {
+  final indexed = items.indexed.toList(growable: false);
+  indexed.sort((left, right) {
+    final usefulnessOrder = _compareUsefulness(left.$2, right.$2);
+    return usefulnessOrder != 0 ? usefulnessOrder : left.$1.compareTo(right.$1);
+  });
+  return indexed.map((entry) => entry.$2).toList(growable: false);
+}
+
+int _compareUsefulness(TopRead left, TopRead right) {
+  final signalOrder = right.signalScore.value.compareTo(left.signalScore.value);
+  if (signalOrder != 0) {
+    return signalOrder;
+  }
+
+  final confirmationOrder = _uniqueCount(
+    right.confirmedProviderKeys,
+  ).compareTo(_uniqueCount(left.confirmedProviderKeys));
+  if (confirmationOrder != 0) {
+    return confirmationOrder;
+  }
+
+  final confidenceLevelOrder = _confidenceLevel(
+    right,
+  ).compareTo(_confidenceLevel(left));
+  if (confidenceLevelOrder != 0) {
+    return confidenceLevelOrder;
+  }
+
+  final confidenceScoreOrder = _safeScore(
+    right.confidence.score,
+  ).compareTo(_safeScore(left.confidence.score));
+  if (confidenceScoreOrder != 0) {
+    return confidenceScoreOrder;
+  }
+
+  return _uniqueCount(
+    right.matchedInterestIds,
+  ).compareTo(_uniqueCount(left.matchedInterestIds));
+}
+
+int _confidenceLevel(TopRead item) =>
+    switch (item.confidence.level.trim().toLowerCase()) {
+      'high' => 3,
+      'medium' => 2,
+      'low' => 1,
+      _ => 0,
+    };
+
+double _safeScore(double value) => value.isFinite ? value : 0;
+
+int _uniqueCount(Iterable<String> values) => values
+    .map((value) => value.trim().toLowerCase())
+    .where((value) => value.isNotEmpty)
+    .toSet()
+    .length;

--- a/apps/frontend/features/summaries/lib/src/presentation/view_models/reader_summary_top_posts_projection.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/view_models/reader_summary_top_posts_projection.dart
@@ -1,5 +1,6 @@
 import '../../domain/aggregates/reader_summary.dart';
 import '../formatters/top_post_metrics.dart';
+import 'more_selected_posts_ranking.dart';
 
 const readerSummaryCuratedTopPostLimit = 8;
 const readerSummaryGitHubTrendingProviderKey = 'github-trending-page';
@@ -7,16 +8,14 @@ const readerSummaryGitHubTrendingProviderKey = 'github-trending-page';
 final class ReaderSummaryTopPostsProjection {
   ReaderSummaryTopPostsProjection._({
     required this.curatedPosts,
-    required this.continuationPosts,
-    required this.posts,
+    required this.moreSelectedPosts,
     required this.githubTrendingPosts,
     required this.items,
     required List<String> datasetOrder,
   }) : _datasetOrder = datasetOrder;
 
   final List<TopRead> curatedPosts;
-  final List<TopRead> continuationPosts;
-  final List<TopRead> posts;
+  final List<TopRead> moreSelectedPosts;
   final List<TopRead> githubTrendingPosts;
   final List<TopRead> items;
   final List<String> _datasetOrder;
@@ -45,41 +44,43 @@ ReaderSummaryTopPostsProjection readerSummaryTopPostsProjection(
   final curatedPosts = editorialTopReads
       .take(readerSummaryCuratedTopPostLimit)
       .toList(growable: false);
-  // Preserve backend order while keeping the first identity across the
-  // complete non-GitHub continuation.
-  final continuationPosts = List<TopRead>.unmodifiable(
-    _stableUniquePosts(
-      [
-        ...editorialTopReads.skip(readerSummaryCuratedTopPostLimit),
-        ...summary.content.selectedPosts.where(
-          (item) => !isGitHubTrendingTopPost(item),
-        ),
-      ],
-      seenIdentities: {
-        for (final item in curatedPosts) readerSummaryTopPostIdentity(item),
-      },
+  final moreSelectedPosts = List<TopRead>.unmodifiable(
+    orderMoreSelectedPostsByUsefulness(
+      _stableUniquePosts(
+        [
+          ...editorialTopReads.skip(readerSummaryCuratedTopPostLimit),
+          ...summary.content.selectedPosts.where(
+            (item) => !isGitHubTrendingTopPost(item),
+          ),
+        ],
+        seenIdentities: {
+          for (final item in curatedPosts) readerSummaryTopPostIdentity(item),
+        },
+      ),
     ),
   );
-  final posts = List<TopRead>.unmodifiable([
-    ...curatedPosts,
-    ...continuationPosts,
-  ]);
   final githubTrendingPosts = List<TopRead>.unmodifiable(
     orderGitHubTrendingPosts(
       summary.content.selectedPosts.where(isGitHubTrendingTopPost),
     ),
   );
-  final items = List<TopRead>.unmodifiable([...posts, ...githubTrendingPosts]);
+  final items = List<TopRead>.unmodifiable([
+    ...curatedPosts,
+    ...moreSelectedPosts,
+    ...githubTrendingPosts,
+  ]);
 
   return ReaderSummaryTopPostsProjection._(
     curatedPosts: List<TopRead>.unmodifiable(curatedPosts),
-    continuationPosts: continuationPosts,
-    posts: posts,
+    moreSelectedPosts: moreSelectedPosts,
     githubTrendingPosts: githubTrendingPosts,
     items: items,
     datasetOrder: List<String>.unmodifiable([
       'curated:${curatedPosts.length}',
-      for (final item in posts) 'post:${readerSummaryTopPostIdentity(item)}',
+      for (final item in curatedPosts)
+        'curated-post:${readerSummaryTopPostIdentity(item)}',
+      for (final item in moreSelectedPosts)
+        'more-selected:${readerSummaryTopPostIdentity(item)}',
       for (final item in githubTrendingPosts)
         'github:${readerSummaryTopPostIdentity(item)}',
     ]),

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_continuation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_continuation_test.dart
@@ -7,7 +7,7 @@ import 'package:social_monitor_summaries/src/presentation/components/reader_summ
 import '../../support/top_posts_test_fixtures.dart';
 
 void main() {
-  testWidgets('starts at eight and reveals two automatic batches on scroll', (
+  testWidgets('keeps Top at eight and batches More selected on scroll', (
     tester,
   ) async {
     _configureView(tester);
@@ -19,18 +19,12 @@ void main() {
     expect(find.text('Curated 0'), findsOneWidget);
     expect(find.text('Continuation 0'), findsNothing);
     expect(find.textContaining('Load more'), findsNothing);
-    expect(_topPostSliverChildCount(tester), 16);
+    expect(_topPostSliverChildCount(tester), 15);
 
-    await tester.scrollUntilVisible(
-      find.text('Continuation 2'),
-      420,
-      scrollable: find.byType(Scrollable).first,
-      maxScrolls: 100,
-    );
+    await tester.tap(_moreSelectedBoard());
     await tester.pumpAndSettle();
 
-    expect(find.text('Continuation 2'), findsOneWidget);
-    expect(_topPostSliverChildCount(tester), 64);
+    expect(_topPostSliverChildCount(tester), 48);
 
     await tester.scrollUntilVisible(
       find.text('Continuation 28'),
@@ -41,7 +35,18 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Continuation 28'), findsOneWidget);
-    expect(_topPostSliverChildCount(tester), 112);
+    expect(_topPostSliverChildCount(tester), 96);
+
+    await tester.scrollUntilVisible(
+      find.text('Continuation 55'),
+      420,
+      scrollable: find.byType(Scrollable).first,
+      maxScrolls: 100,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Continuation 55'), findsOneWidget);
+    expect(_topPostSliverChildCount(tester), 119);
   });
 
   testWidgets('does not reveal a visible sentinel before user scroll', (
@@ -52,7 +57,7 @@ void main() {
     await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
     await tester.pumpAndSettle();
 
-    expect(_topPostSliverChildCount(tester), 16);
+    expect(_topPostSliverChildCount(tester), 15);
     expect(find.text('Continuation 0'), findsNothing);
   });
 
@@ -71,8 +76,7 @@ void main() {
     await tester.pumpWidget(_TopPostsTestApp(summary: summary));
     await tester.pumpAndSettle();
 
-    expect(_topPostSliverChildCount(tester), 16);
-    expect(find.text('Selected 8'), findsNothing);
+    expect(_topPostSliverChildCount(tester), 23);
 
     await tester.scrollUntilVisible(
       find.text('Selected 8'),
@@ -86,7 +90,7 @@ void main() {
     expect(_topPostSliverChildCount(tester), 23);
   });
 
-  testWidgets('dedupes top reads while filling eight unique initial posts', (
+  testWidgets('dedupes top reads without filling Top from selected posts', (
     tester,
   ) async {
     _configureView(tester);
@@ -119,9 +123,12 @@ void main() {
     await tester.pumpWidget(_TopPostsTestApp(summary: summary));
     await tester.pumpAndSettle();
 
-    expect(_topPostSliverChildCount(tester), 16);
+    expect(_topPostSliverChildCount(tester), 5);
     expect(find.text('Duplicate inside top reads'), findsNothing);
     expect(find.text('Selected 5'), findsNothing);
+
+    await tester.tap(_moreSelectedBoard());
+    await tester.pumpAndSettle();
 
     await tester.scrollUntilVisible(
       find.text('Selected 8'),
@@ -132,7 +139,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Selected 8'), findsOneWidget);
-    expect(_topPostSliverChildCount(tester), 23);
+    expect(_topPostSliverChildCount(tester), 17);
   });
 
   testWidgets('keeps continuation on an equivalent dataset rebuild', (
@@ -142,20 +149,22 @@ void main() {
 
     await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
     await tester.pumpAndSettle();
+    await tester.tap(_moreSelectedBoard());
+    await tester.pumpAndSettle();
     await tester.scrollUntilVisible(
-      find.text('Continuation 2'),
+      find.text('Continuation 28'),
       420,
       scrollable: find.byType(Scrollable).first,
       maxScrolls: 100,
     );
     await tester.pumpAndSettle();
-    expect(_topPostSliverChildCount(tester), 64);
+    expect(_topPostSliverChildCount(tester), 96);
 
     await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
     await tester.pumpAndSettle();
 
-    expect(find.text('Continuation 2'), findsOneWidget);
-    expect(_topPostSliverChildCount(tester), 64);
+    expect(find.text('Continuation 28'), findsOneWidget);
+    expect(_topPostSliverChildCount(tester), 96);
     expect(tester.takeException(), isNull);
   });
 
@@ -166,21 +175,21 @@ void main() {
 
     await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
     await tester.pumpAndSettle();
+    await tester.tap(_moreSelectedBoard());
+    await tester.pumpAndSettle();
     await tester.scrollUntilVisible(
-      find.text('Continuation 2'),
+      find.text('Continuation 28'),
       420,
       scrollable: find.byType(Scrollable).first,
       maxScrolls: 100,
     );
     await tester.pumpAndSettle();
-    expect(_topPostSliverChildCount(tester), 64);
+    expect(_topPostSliverChildCount(tester), 96);
 
-    await tester.scrollUntilVisible(
-      find.text('Curated 0'),
-      -420,
-      scrollable: find.byType(Scrollable).first,
-      maxScrolls: 100,
-    );
+    tester
+        .state<ScrollableState>(find.byType(Scrollable).first)
+        .position
+        .jumpTo(0);
     await tester.pumpAndSettle();
     await tester.pumpWidget(
       _TopPostsTestApp(
@@ -196,7 +205,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(_topPostSliverChildCount(tester), 16);
+    expect(_topPostSliverChildCount(tester), 48);
   });
 }
 
@@ -204,6 +213,9 @@ int _topPostSliverChildCount(WidgetTester tester) {
   final sliver = tester.widget<SliverList>(find.byType(SliverList));
   return sliver.delegate.estimatedChildCount!;
 }
+
+Finder _moreSelectedBoard() =>
+    find.byKey(const ValueKey('reader-summary-top-posts-board-more-selected'));
 
 ReaderSummary _continuationSummary({SummaryPeriod? period}) {
   return topPostsSummaryFixture(

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_continuation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_continuation_test.dart
@@ -56,9 +56,12 @@ void main() {
 
     await tester.pumpWidget(_TopPostsTestApp(summary: _continuationSummary()));
     await tester.pumpAndSettle();
+    await tester.tap(_moreSelectedBoard());
+    await tester.pumpAndSettle();
 
-    expect(_topPostSliverChildCount(tester), 15);
-    expect(find.text('Continuation 0'), findsNothing);
+    expect(_topPostSliverChildCount(tester), 48);
+    expect(find.text('Continuation 0'), findsOneWidget);
+    expect(find.text('Continuation 24'), findsNothing);
   });
 
   testWidgets('keeps selected continuation reachable with zero top reads', (

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_sliver_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_top_posts_sliver_test.dart
@@ -10,7 +10,7 @@ import 'package:social_monitor_summaries/src/presentation/view_models/reader_sum
 import '../../support/summaries_test_fixtures.dart';
 
 void main() {
-  testWidgets('shows both tabs and keeps top posts selected by default', (
+  testWidgets('shows all boards and keeps top posts selected by default', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(320, 700);
@@ -35,6 +35,12 @@ void main() {
       findsOneWidget,
     );
     expect(
+      find.byKey(
+        const ValueKey('reader-summary-top-posts-board-more-selected'),
+      ),
+      findsOneWidget,
+    );
+    expect(
       find.byKey(const ValueKey('reader-summary-top-posts-board-github')),
       findsOneWidget,
     );
@@ -54,7 +60,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('reveals more top posts as the user scrolls', (tester) async {
+  testWidgets('keeps posts after eight in More selected', (tester) async {
     tester.view.physicalSize = const Size(1100, 700);
     tester.view.devicePixelRatio = 1;
     addTearDown(() {
@@ -73,6 +79,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Lazy top post 30'), findsNothing);
+
+    await tester.tap(
+      find.byKey(
+        const ValueKey('reader-summary-top-posts-board-more-selected'),
+      ),
+    );
+    await tester.pumpAndSettle();
 
     await tester.scrollUntilVisible(
       find.text('Lazy top post 30'),
@@ -162,20 +175,25 @@ void main() {
       await tester.pumpWidget(_TestApp(summary: summary));
       await tester.pumpAndSettle();
 
-      expect(find.bySemanticsLabel('Top posts, 3 items'), findsOneWidget);
+      expect(find.bySemanticsLabel('Top posts, 2 items'), findsOneWidget);
       expect(find.text('2 editorial picks from 3 selected'), findsOneWidget);
       expect(find.text('Backend editorial winner'), findsOneWidget);
       expect(find.text('Higher engagement runner-up'), findsOneWidget);
+      expect(find.text('Long-tail selected evidence'), findsNothing);
 
-      await tester.scrollUntilVisible(
-        find.text('Long-tail selected evidence'),
-        320,
-        scrollable: find.byType(Scrollable).first,
-        maxScrolls: 20,
+      await tester.tap(
+        find.byKey(
+          const ValueKey('reader-summary-top-posts-board-more-selected'),
+        ),
       );
       await tester.pumpAndSettle();
 
+      expect(
+        find.bySemanticsLabel('More selected posts, 1 items'),
+        findsOneWidget,
+      );
       expect(find.text('Long-tail selected evidence'), findsOneWidget);
+      expect(find.text('Sorted by usefulness'), findsOneWidget);
 
       await tester.ensureVisible(
         find.byKey(const ValueKey('reader-summary-top-posts-board-github')),
@@ -206,7 +224,10 @@ void main() {
     final projection = readerSummaryTopPostsProjection(summary);
 
     expect(projection.curatedPosts, isEmpty);
-    expect(projection.posts.single.title, 'Long-tail selected evidence');
+    expect(
+      projection.moreSelectedPosts.single.title,
+      'Long-tail selected evidence',
+    );
     expect(projection.githubTrendingPosts, isEmpty);
   });
 

--- a/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
@@ -409,7 +409,7 @@ void main() {
     );
   });
 
-  testWidgets('workspace summary renders the top ten reader reads', (
+  testWidgets('workspace summary separates reads after the top eight', (
     tester,
   ) async {
     final store = _store([
@@ -431,16 +431,15 @@ void main() {
       findsOneWidget,
     );
 
-    final scrollable = find.byType(Scrollable).first;
-    final lastPost = find.byKey(const ValueKey('reader-summary-top-post-10'));
-    for (var i = 0; i < 40 && !tester.any(lastPost); i += 1) {
-      await tester.drag(scrollable, const Offset(0, -320));
-      await tester.pumpAndSettle();
-    }
-    expect(
-      find.byKey(const ValueKey('reader-summary-top-post-10')),
-      findsOneWidget,
+    expect(find.text('repo-radar/project-11'), findsNothing);
+
+    await tester.tap(
+      find.byKey(
+        const ValueKey('reader-summary-top-posts-board-more-selected'),
+      ),
     );
+    await tester.pumpAndSettle();
+
     expect(find.text('repo-radar/project-11'), findsWidgets);
   });
 

--- a/apps/frontend/features/summaries/test/presentation/view_models/more_selected_posts_ranking_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/view_models/more_selected_posts_ranking_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.dart';
+import 'package:social_monitor_summaries/src/presentation/view_models/more_selected_posts_ranking.dart';
+
+import '../../support/top_posts_test_fixtures.dart';
+
+void main() {
+  test('uses normalized Signal as the primary usefulness criterion', () {
+    final strongerSupport = topPostFixture(
+      title: 'Stronger support',
+      signalScore: 1.5,
+      confidenceLevel: 'high',
+      confidenceScore: 0.95,
+      confirmedProviderKeys: const ['reddit', 'hacker-news'],
+      matchedInterestIds: const ['ai', 'dart'],
+    );
+    final strongerSignal = topPostFixture(
+      title: 'Stronger signal',
+      signalScore: 1.6,
+      confidenceLevel: 'low',
+      confidenceScore: 0.2,
+    );
+
+    expect(
+      _titles(
+        orderMoreSelectedPostsByUsefulness([strongerSupport, strongerSignal]),
+      ),
+      ['Stronger signal', 'Stronger support'],
+    );
+  });
+
+  test('breaks Signal ties with evidence quality and matched interests', () {
+    final items = [
+      topPostFixture(title: 'Stable first'),
+      topPostFixture(title: 'Stable second'),
+      topPostFixture(
+        title: 'More interests',
+        matchedInterestIds: const ['ai', 'dart'],
+      ),
+      topPostFixture(title: 'Higher confidence score', confidenceScore: 0.8),
+      topPostFixture(title: 'High confidence', confidenceLevel: 'high'),
+      topPostFixture(
+        title: 'Independent support',
+        confidenceLevel: 'low',
+        confirmedProviderKeys: const ['reddit', 'hacker-news'],
+      ),
+    ];
+
+    expect(_titles(orderMoreSelectedPostsByUsefulness(items)), [
+      'Independent support',
+      'High confidence',
+      'Higher confidence score',
+      'More interests',
+      'Stable first',
+      'Stable second',
+    ]);
+  });
+
+  test('does not compare provider-native engagement across sources', () {
+    final first = topPostFixture(
+      title: 'Reddit item',
+      providerMetrics: const [ProviderMetric(label: 'Upvotes', value: '1')],
+    );
+    final second = topPostFixture(
+      title: 'Hacker News item',
+      providerKey: 'hacker-news',
+      providerMetrics: const [ProviderMetric(label: 'Points', value: '500')],
+    );
+
+    expect(_titles(orderMoreSelectedPostsByUsefulness([first, second])), [
+      'Reddit item',
+      'Hacker News item',
+    ]);
+  });
+}
+
+List<String> _titles(Iterable<TopRead> items) =>
+    items.map((item) => item.title).toList(growable: false);

--- a/apps/frontend/features/summaries/test/presentation/view_models/reader_summary_top_posts_projection_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/view_models/reader_summary_top_posts_projection_test.dart
@@ -50,20 +50,19 @@ void main() {
       for (var index = 2; index < 8; index += 1) 'Editorial $index',
       'Legacy position 10',
     ]);
-    expect(projection.continuationPosts.map((item) => item.title), [
+    expect(projection.moreSelectedPosts.map((item) => item.title), [
       'Selected A',
       'Selected B',
     ]);
     expect(projection.curatedPosts, hasLength(8));
-    expect(projection.posts, hasLength(10));
     expect(
-      projection.posts.map(readerSummaryTopPostIdentity).toSet(),
-      hasLength(projection.posts.length),
+      projection.items.map(readerSummaryTopPostIdentity).toSet(),
+      hasLength(projection.items.length),
     );
     expect(projection.githubTrendingPosts, isEmpty);
   });
 
-  test('fills eight unique initial posts from selected continuation', () {
+  test('does not promote selected posts into the editorial top eight', () {
     final summary = topPostsSummaryFixture(
       topReads: [
         topPostFixture(
@@ -100,13 +99,10 @@ void main() {
       'Curated 1',
       'Curated 2',
     ]);
-    expect(projection.posts.take(8).map((item) => item.title), [
-      'Curated 0',
-      'Curated 1',
-      'Curated 2',
-      for (var index = 0; index < 5; index += 1) 'Selected $index',
+    expect(projection.moreSelectedPosts.map((item) => item.title), [
+      for (var index = 0; index < 9; index += 1) 'Selected $index',
     ]);
-    expect(projection.posts, hasLength(12));
+    expect(projection.items, hasLength(12));
   });
 
   test(
@@ -161,7 +157,8 @@ void main() {
       ),
     );
 
-    expect(projection.posts, isEmpty);
+    expect(projection.curatedPosts, isEmpty);
+    expect(projection.moreSelectedPosts, isEmpty);
     expect(projection.githubTrendingPosts.map((item) => item.title), [
       for (var rank = 1; rank <= 10; rank += 1) 'selected/repo-$rank',
     ]);
@@ -180,7 +177,8 @@ void main() {
       topPostsSummaryFixture(topReads: _githubBoard(prefix: 'fallback')),
     );
 
-    expect(projection.posts, isEmpty);
+    expect(projection.curatedPosts, isEmpty);
+    expect(projection.moreSelectedPosts, isEmpty);
     expect(projection.githubTrendingPosts, isEmpty);
   });
 

--- a/apps/frontend/features/summaries/test/support/top_posts_test_fixtures.dart
+++ b/apps/frontend/features/summaries/test/support/top_posts_test_fixtures.dart
@@ -10,20 +10,25 @@ TopRead topPostFixture({
   int? githubRank,
   List<ProviderMetric>? providerMetrics,
   List<String> citationIds = const [],
+  double signalScore = 1,
+  String confidenceLevel = 'medium',
+  double confidenceScore = 0.6,
+  List<String> matchedInterestIds = const ['ai-developer-tools'],
+  List<String>? confirmedProviderKeys,
 }) {
   return TopRead(
     title: title,
     providerKey: providerKey,
     reason: '$title is relevant evidence.',
-    matchedInterestIds: const ['ai-developer-tools'],
+    matchedInterestIds: matchedInterestIds,
     matchedRules: const [],
-    signalScore: SignalScore.normalized(1),
-    confidence: const TopReadConfidence(
-      level: 'medium',
-      score: 0.6,
+    signalScore: SignalScore.normalized(signalScore),
+    confidence: TopReadConfidence(
+      level: confidenceLevel,
+      score: confidenceScore,
       rationale: 'Test evidence.',
     ),
-    confirmedProviderKeys: [providerKey],
+    confirmedProviderKeys: confirmedProviderKeys ?? [providerKey],
     providerMetrics:
         providerMetrics ??
         [


### PR DESCRIPTION
## Summary

- keep Top posts limited to the eight editorial top reads
- move remaining selected evidence into a separate More selected posts board
- rank additional evidence by normalized Signal, source support, confidence, and matched interests
- keep provider-native engagement metrics out of cross-provider ranking

## Verification

- fvm flutter analyze
- fvm flutter test app/test/architecture/frontend_architecture_boundaries_test.dart
- fvm flutter test features/summaries/test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “More selected posts” board alongside Top Posts and GitHub Trends.
  * Additional selected posts are ranked by usefulness and loaded separately from curated posts.
  * Updated labels, counts, tooltips, sorting indicators, filtering behavior, and loading controls.
  * Preserved curated Top Posts separately so additional selections do not replace editorial results.

* **Documentation**
  * Added the “More Selected Post” terminology and its ranking guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->