### PR TITLE
fix(summary): retry providers after verified database growth

### DIFF
--- a/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
+++ b/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
@@ -282,6 +282,33 @@ describe("daily reader-summary provider catch-up", () => {
     expect(plan.providerKeysToCollect).toEqual([]);
   });
 
+  it("recollects a provider after exact-day DB growth over a failed scan", () => {
+    const existingReport = report([
+      readyScan("github-trending-page"),
+      readyScan("hacker-news"),
+      readyScan("reddit"),
+      readyScan("rss"),
+      failedScan("x-twitter"),
+    ]);
+    const plan = planDailyProviderCatchUp({
+      collectionDate: "2026-07-27",
+      evaluatedAt,
+      existingReport,
+      databaseProviderCounts: {
+        ...existingReport.targetWindow.providerCounts,
+        "x-twitter": 42,
+      },
+    });
+
+    expect(plan.barrierMessage).toBeNull();
+    expect(plan.providerKeysToCollect).toEqual(["x-twitter"]);
+    expect(plan.providerStates[4]).toMatchObject({
+      providerKey: "x-twitter",
+      state: "unavailable",
+      policy: "blocking",
+    });
+  });
+
   it("blocks a DB count decrease below successful exact-day evidence", () => {
     const existingReport = report(
       defaultCleanRealDayCollectionProviderKeys.map(readyScan),

--- a/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
+++ b/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
@@ -302,7 +302,11 @@ describe("daily reader-summary provider catch-up", () => {
 
     expect(plan.barrierMessage).toBeNull();
     expect(plan.providerKeysToCollect).toEqual(["x-twitter"]);
-    expect(plan.providerStates[4]).toMatchObject({
+    expect(
+      plan.providerStates.find(
+        (providerState) => providerState.providerKey === "x-twitter",
+      ),
+    ).toMatchObject({
       providerKey: "x-twitter",
       state: "unavailable",
       policy: "blocking",

--- a/scripts/lib/reader-summary-daily-provider-catch-up.ts
+++ b/scripts/lib/reader-summary-daily-provider-catch-up.ts
@@ -282,8 +282,12 @@ const catchUpState = (params: {
     );
   }
   const provenCollectionFeedItemCount = collectionFeedItemCount as number;
+  const databaseGrewAfterFailedScan =
+    scans[0]!.status !== "succeeded" &&
+    params.databaseFeedItemCount > provenCollectionFeedItemCount;
   if (
     provenCollectionFeedItemCount !== params.databaseFeedItemCount &&
+    !databaseGrewAfterFailedScan &&
     !(
       scans[0]!.status === "succeeded" &&
       params.databaseFeedItemCount >= provenCollectionFeedItemCount


### PR DESCRIPTION
## What
- allow an exact-day provider retry when the production database grew after a failed scan
- keep the provider blocking until a new successful scan proves readiness
- keep decreases and unrelated mismatches fail-closed

## Proof
- focused Jest suite: 20/20 passed

## Production impact
Unblocks historical daily summary recovery after independently retried X collection without weakening the quality gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved daily provider catch-up handling when a previous scan failed and new data becomes available.
  - Prevented unnecessary collection barriers in this recovery scenario.
  - Ensured only the affected provider is rescheduled while its unavailable state is preserved.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->