### PR TITLE
fix(summary): permit first closed-day provider receipt

### DIFF
--- a/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
+++ b/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
@@ -23,6 +23,34 @@ describe("daily reader-summary provider catch-up", () => {
     ).toEqual(defaultCleanRealDayCollectionProviderKeys);
   });
 
+  it("collects every provider for a new closed day when database rows predate the first receipt", () => {
+    const plan = planDailyProviderCatchUp({
+      collectionDate: "2026-07-26",
+      evaluatedAt,
+      existingReport: null,
+      databaseProviderCounts: {
+        "github-trending-page": 20,
+        "hacker-news": 174,
+        reddit: 143,
+        rss: 78,
+      },
+    });
+
+    expect(plan.collectionPolicy).toBe("previous_day");
+    expect(plan.barrierMessage).toBeNull();
+    expect(plan.providerKeysToCollect).toEqual(
+      defaultCleanRealDayCollectionProviderKeys,
+    );
+    expect(plan.providerStates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          providerKey: "hacker-news",
+          reasonCodes: ["database_rows_require_exact_full_collection"],
+        }),
+      ]),
+    );
+  });
+
   it("retries only providers that are missing, failed, or not ready", () => {
     const existingReport = report([
       readyScan("github-trending-page"),

--- a/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
+++ b/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
@@ -282,6 +282,33 @@ describe("daily reader-summary provider catch-up", () => {
     expect(plan.providerKeysToCollect).toEqual([]);
   });
 
+  it("recollects a provider after exact-day DB growth over a failed scan", () => {
+    const existingReport = report([
+      readyScan("github-trending-page"),
+      readyScan("hacker-news"),
+      readyScan("reddit"),
+      readyScan("rss"),
+      failedScan("x-twitter"),
+    ]);
+    const plan = planDailyProviderCatchUp({
+      collectionDate: "2026-07-27",
+      evaluatedAt,
+      existingReport,
+      databaseProviderCounts: {
+        ...existingReport.targetWindow.providerCounts,
+        "x-twitter": 42,
+      },
+    });
+
+    expect(plan.barrierMessage).toBeNull();
+    expect(plan.providerKeysToCollect).toEqual(["x-twitter"]);
+    expect(plan.providerStates[4]).toMatchObject({
+      providerKey: "x-twitter",
+      state: "unavailable",
+      policy: "blocking",
+    });
+  });
+
   it("blocks a DB count decrease below successful exact-day evidence", () => {
     const existingReport = report(
       defaultCleanRealDayCollectionProviderKeys.map(readyScan),

--- a/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
+++ b/scripts/lib/reader-summary-daily-provider-catch-up.spec.ts
@@ -302,7 +302,11 @@ describe("daily reader-summary provider catch-up", () => {
 
     expect(plan.barrierMessage).toBeNull();
     expect(plan.providerKeysToCollect).toEqual(["x-twitter"]);
-    expect(plan.providerStates[4]).toMatchObject({
+    expect(
+      plan.providerStates.find(
+        (providerState) => providerState.providerKey === "x-twitter",
+      ),
+    ).toMatchObject({
       providerKey: "x-twitter",
       state: "unavailable",
       policy: "blocking",

--- a/scripts/lib/reader-summary-daily-provider-catch-up.ts
+++ b/scripts/lib/reader-summary-daily-provider-catch-up.ts
@@ -75,8 +75,10 @@ export const planDailyProviderCatchUp = (params: {
     );
   }
   const allowUnprovenExistingRows =
-    params.allowUnprovenExistingRowsForExactFullCollection === true &&
-    previousReport === null;
+    previousReport === null &&
+    isExactFullProviderCollection(requiredProviderKeys) &&
+    (collectionPolicy.collectionPolicy === "previous_day" ||
+      params.allowUnprovenExistingRowsForExactFullCollection === true);
   if (
     previousReport !== null &&
     (previousReport.schemaVersion !== 1 ||

--- a/scripts/lib/reader-summary-daily-provider-catch-up.ts
+++ b/scripts/lib/reader-summary-daily-provider-catch-up.ts
@@ -282,8 +282,12 @@ const catchUpState = (params: {
     );
   }
   const provenCollectionFeedItemCount = collectionFeedItemCount as number;
+  const databaseGrewAfterFailedScan =
+    scans[0]!.status !== "succeeded" &&
+    params.databaseFeedItemCount > provenCollectionFeedItemCount;
   if (
     provenCollectionFeedItemCount !== params.databaseFeedItemCount &&
+    !databaseGrewAfterFailedScan &&
     !(
       scans[0]!.status === "succeeded" &&
       params.databaseFeedItemCount >= provenCollectionFeedItemCount


### PR DESCRIPTION
Fix the production daily E2E blocker observed on the automatic 2026-08-14 trigger.

- allow the first exact full previous-day pass to collect all providers when DB rows predate the receipt
- keep current-day and historical fail-closed behavior
- add regression coverage for the automatic yesterday flow

Production evidence before fix: timer started at 00:15 UTC, 415 dated posts existed, but the missing receipt caused all providers to be classified unsafe before acquisition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily catch-up collection when database records predate the first receipt.
  * Correctly supports full-provider collections from the previous day and explicitly enabled historical collections.
  * Allows recollection when database records increased after a failed scan, while preserving unavailable status when appropriate.
  * Added coverage for these catch-up and recollection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->