### PR TITLE
fix(summary): complete production weekly catch-up

### DIFF
--- a/libs/summary/domain/value-objects/reader-summary-weekly-input-manifest-canonical.ts
+++ b/libs/summary/domain/value-objects/reader-summary-weekly-input-manifest-canonical.ts
@@ -37,9 +37,8 @@ import type {
 
 export const readerSummaryWeeklyInputManifestSchemaVersion =
   "reader_summary.weekly_input_manifest.v1" as const;
-export const readerSummaryWeeklyHistoricalGitHubDate = "2026-07-23" as const;
 export const readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity =
-  "reader_summary.production_recovery.github.2026-07-23.v2" as const;
+  "reader_summary.production_history.github.unavailable.v1" as const;
 
 const canonicalDayKeys = [
   "requestedUtcDate",
@@ -198,13 +197,14 @@ const assertHistoricalAuthority = (
     input.schemaVersion !== readerSummaryWeeklyPublicationEvidenceSchemaVersion ||
     input.authorizationIdentity !==
       readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity ||
-    input.requestedUtcDate !== readerSummaryWeeklyHistoricalGitHubDate ||
+    exactReaderSummaryWeeklyUtcDay(input.requestedUtcDate) !==
+      input.requestedUtcDate ||
     input.semanticStatus !== "COMPLETED" ||
     github.schemaVersion !==
       readerSummaryWeeklyPublicationGitHubEvidenceSchemaVersion ||
     github.mode !== "historical_unavailable" ||
     github.providerKey !== readerSummaryWeeklyGitHubProviderKey ||
-    github.requestedUtcDay !== readerSummaryWeeklyHistoricalGitHubDate ||
+    github.requestedUtcDay !== input.requestedUtcDate ||
     github.evidenceCount !== 0 ||
     github.scanJobId !== null ||
     github.sourceBindingId !== null ||
@@ -255,8 +255,7 @@ export const canonicalHistoricalDailyCertification = (
   const certification = canonicalClone(input);
   assertCanonicalDailyCertification(certification, githubAudit, expected);
   if (
-    certification.requestedUtcDate !==
-      readerSummaryWeeklyHistoricalGitHubDate ||
+    certification.requestedUtcDate !== authority.requestedUtcDate ||
     certification.publicationId !== authority.publicationId ||
     certification.artifactId !== authority.artifactId ||
     certification.jobId !== authority.jobId ||

--- a/libs/summary/domain/value-objects/reader-summary-weekly-input-manifest.ts
+++ b/libs/summary/domain/value-objects/reader-summary-weekly-input-manifest.ts
@@ -33,7 +33,6 @@ import {
   canonicalHistoricalAuthority,
   canonicalHistoricalDailyCertification,
   historicalGitHubAudit,
-  readerSummaryWeeklyHistoricalGitHubDate,
   readerSummaryWeeklyInputManifestSchemaVersion,
   type readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity,
   utcDayAfter,
@@ -41,7 +40,6 @@ import {
 
 export {
   readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity,
-  readerSummaryWeeklyHistoricalGitHubDate,
   readerSummaryWeeklyInputManifestSchemaVersion,
 } from "./reader-summary-weekly-input-manifest-canonical";
 
@@ -76,7 +74,7 @@ export type ReaderSummaryWeeklyHistoricalGitHubAudit =
 export type ReaderSummaryWeeklyHistoricalDailyCertification =
   ReaderSummaryWeeklyCanonicalDailyCertification &
     Readonly<{
-      requestedUtcDate: typeof readerSummaryWeeklyHistoricalGitHubDate;
+      requestedUtcDate: string;
     }>;
 export type ReaderSummaryWeeklyPersistedPublicationEvidence = Omit<
   ReaderSummaryWeeklyCanonicalPublicationEvidence,
@@ -94,7 +92,7 @@ type ReaderSummaryWeeklyCanonicalVerifiedInputDay = Readonly<{
   dailyCertification: ReaderSummaryWeeklyCanonicalDailyCertification;
 }>;
 type ReaderSummaryWeeklyCanonicalHistoricalInputDay = Readonly<{
-  requestedUtcDate: typeof readerSummaryWeeklyHistoricalGitHubDate;
+  requestedUtcDate: string;
   githubAudit: ReaderSummaryWeeklyHistoricalGitHubAudit;
   dailyCertification: ReaderSummaryWeeklyHistoricalDailyCertification;
   historicalAuthority: ReaderSummaryWeeklyHistoricalPublicationAuthority;
@@ -199,7 +197,7 @@ export const sealReaderSummaryWeeklyInputManifest = (
         { requestedUtcDate, tenantId, workspaceId, scope },
       );
       return deepFreezeReaderSummaryWeekly({
-        requestedUtcDate: readerSummaryWeeklyHistoricalGitHubDate,
+        requestedUtcDate,
         githubAudit,
         dailyCertification,
         historicalAuthority,

--- a/libs/summary/domain/value-objects/reader-summary-weekly-review-manifest.ts
+++ b/libs/summary/domain/value-objects/reader-summary-weekly-review-manifest.ts
@@ -207,7 +207,11 @@ const canonicalReviewAuthority = (input: ReaderSummaryWeeklyReviewAuthority): Re
   if (new Set(days.map((day) => day.publicationId)).size !== days.length) throw new Error("Reader summary weekly review authority publications are ambiguous");
   return deepFreezeReaderSummaryWeekly({
     schemaVersion: readerSummaryWeeklyReviewAuthoritySchemaVersion, sealId, sealSha256, tenantId, workspaceId,
-    scope, scopeKey, weekStartedOn, weekEndedOn, days: days.map(({ providerEvidence: _providerEvidence, ...day }) => day),
+    scope, scopeKey, weekStartedOn, weekEndedOn, days: days.map((day) => {
+      const { providerEvidence, ...reviewAuthorityDay } = day;
+      void providerEvidence;
+      return reviewAuthorityDay;
+    }),
   });
 };
 

--- a/libs/summary/ports/reader-summary-weekly-model-contract.ts
+++ b/libs/summary/ports/reader-summary-weekly-model-contract.ts
@@ -2,7 +2,6 @@ import type { ReaderSummaryWeeklyManifestScope } from "../domain/value-objects/r
 import type { ReaderSummaryWeeklyCanonicalProviderKey } from "../domain/value-objects/reader-summary-weekly-daily-certification";
 import type {
   readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity,
-  readerSummaryWeeklyHistoricalGitHubDate,
   ReaderSummaryWeeklySealedInputManifest,
 } from "../domain/value-objects/reader-summary-weekly-input-manifest";
 
@@ -54,7 +53,7 @@ type ReaderSummaryWeeklyVerifiedModelDay = Readonly<{
   providerCounts: readonly ReaderSummaryWeeklyModelProviderCount[];
 }>;
 type ReaderSummaryWeeklyHistoricalModelDay = Readonly<{
-  date: typeof readerSummaryWeeklyHistoricalGitHubDate;
+  date: string;
   dailyCertificationId: string; dailyCertificationSha: string;
   dailyCertificationStatus: "certified"; githubBoardId: string;
   githubBoardSha: string; githubBoardStatus: "historical_unavailable";

--- a/libs/summary/ports/reader-summary-weekly-model.port.ts
+++ b/libs/summary/ports/reader-summary-weekly-model.port.ts
@@ -15,7 +15,6 @@ import {
 import {
   assertReaderSummaryWeeklySealedInputManifest,
   readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity,
-  readerSummaryWeeklyHistoricalGitHubDate,
   readerSummaryWeeklyInputManifestSchemaVersion,
   type ReaderSummaryWeeklySealedInputManifest,
 } from "../domain/value-objects/reader-summary-weekly-input-manifest";
@@ -292,7 +291,7 @@ const modelDays = (
     return entry.githubAudit.status === "historical_unavailable"
       ? {
           ...day,
-          date: readerSummaryWeeklyHistoricalGitHubDate,
+          date: entry.requestedUtcDate,
           githubBoardStatus: "historical_unavailable" as const,
           githubAuthorizationIdentity:
             entry.githubAudit.authorizationIdentity,
@@ -333,7 +332,7 @@ const assertModelDays = (
       );
       if (
         !("githubAuthorizationIdentity" in day) ||
-        day.date !== readerSummaryWeeklyHistoricalGitHubDate ||
+        day.date !== utcDayAfter(weekStartedOn, index) ||
         day.githubAuthorizationIdentity !==
           readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity ||
         day.githubBoardId !==

--- a/ops/deploy/reader-summary-recovery-maintenance-lib.sh
+++ b/ops/deploy/reader-summary-recovery-maintenance-lib.sh
@@ -5,6 +5,8 @@
 # ABI; the SSH wrapper carries the exact retry-set authorization on stdin.
 
 DAILY_DELIVERY_C1_DEPLOY_LOCK_WAIT_SECONDS=600
+READER_SUMMARY_PRODUCTION_TENANT_ID=00000000-0000-7000-8000-000000006101
+READER_SUMMARY_PRODUCTION_WORKSPACE_ID=00000000-0000-7000-8000-000000006102
 
 verify_daily_runner_maintenance_runtime() {
   local runtime_release backend_release control_release integration_release
@@ -835,13 +837,13 @@ run_reader_summary_daily_runner_maintenance() (
       ;;
     reader-summary-weekly-run)
       "${COMPOSE[@]}" --profile daily run --rm --no-deps \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_TENANT_ID=00000000-0000-7000-8000-000000000901 \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_WORKSPACE_ID=00000000-0000-7000-8000-000000000902 \
+        -e "READER_SUMMARY_WEEKLY_PRODUCTION_TENANT_ID=$READER_SUMMARY_PRODUCTION_TENANT_ID" \
+        -e "READER_SUMMARY_WEEKLY_PRODUCTION_WORKSPACE_ID=$READER_SUMMARY_PRODUCTION_WORKSPACE_ID" \
         -e READER_SUMMARY_WEEKLY_PRODUCTION_FIRST_WEEK_START=2026-07-27 \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_CATCH_UP_LIMIT=1 \
+        -e READER_SUMMARY_WEEKLY_PRODUCTION_CATCH_UP_LIMIT=4 \
         -e "READER_SUMMARY_WEEKLY_PRODUCTION_ARTIFACT_DIR=$READER_SUMMARY_WEEKLY_PRODUCTION_ARTIFACT_DIR" \
         daily-runner sh -lc \
-        'set -eu; npm run run:reader-summary-weekly-production -- --week-start 2026-07-27; npm run run:reader-summary-weekly-production -- --replay --week-start 2026-07-27' || return
+        'set -eu; npm run run:reader-summary-weekly-production; npm run run:reader-summary-weekly-production -- --replay' || return
       ;;
     *) fail 'unknown reader-summary daily-runner maintenance action' ;;
   esac

--- a/ops/deploy/reader-summary-recovery-maintenance-lib.test.sh
+++ b/ops/deploy/reader-summary-recovery-maintenance-lib.test.sh
@@ -185,7 +185,7 @@ unset ASSERT_WEEKLY_LOCKS_HELD ASSERT_AUTH_LOCKS_HELD
 recovery_command='--profile daily run --rm --no-deps -e READER_SUMMARY_DAILY_TENANT_ID=00000000-0000-7000-8000-000000000901 -e READER_SUMMARY_DAILY_WORKSPACE_ID=00000000-0000-7000-8000-000000000902 -e READER_SUMMARY_DAILY_FIRST_UNRESOLVED_UTC_DATE=2026-07-23 -e READER_SUMMARY_DAILY_PUBLIC_DIRECTORY=/var/lib/social-monitor/artifacts/reports daily-runner sh -lc set -eu; npm run prepare:reader-summary-production-recovery-gap-authority; npm run run:reader-summary-daily-canonical-recovery'
 reconcile_command="-f $FINAL_MODEL_OVERLAY --profile app up -d --no-deps agent-runtime"
 recovery_command="-f $FINAL_MODEL_OVERLAY $recovery_command"
-weekly_command="-f $FINAL_MODEL_OVERLAY --profile daily run --rm --no-deps -e READER_SUMMARY_WEEKLY_PRODUCTION_TENANT_ID=00000000-0000-7000-8000-000000000901 -e READER_SUMMARY_WEEKLY_PRODUCTION_WORKSPACE_ID=00000000-0000-7000-8000-000000000902 -e READER_SUMMARY_WEEKLY_PRODUCTION_FIRST_WEEK_START=2026-07-27 -e READER_SUMMARY_WEEKLY_PRODUCTION_CATCH_UP_LIMIT=1 -e READER_SUMMARY_WEEKLY_PRODUCTION_ARTIFACT_DIR=/var/lib/social-monitor/artifacts/reader-summary-weekly-production daily-runner sh -lc set -eu; npm run run:reader-summary-weekly-production -- --week-start 2026-07-27; npm run run:reader-summary-weekly-production -- --replay --week-start 2026-07-27"
+weekly_command="-f $FINAL_MODEL_OVERLAY --profile daily run --rm --no-deps -e READER_SUMMARY_WEEKLY_PRODUCTION_TENANT_ID=00000000-0000-7000-8000-000000006101 -e READER_SUMMARY_WEEKLY_PRODUCTION_WORKSPACE_ID=00000000-0000-7000-8000-000000006102 -e READER_SUMMARY_WEEKLY_PRODUCTION_FIRST_WEEK_START=2026-07-27 -e READER_SUMMARY_WEEKLY_PRODUCTION_CATCH_UP_LIMIT=4 -e READER_SUMMARY_WEEKLY_PRODUCTION_ARTIFACT_DIR=/var/lib/social-monitor/artifacts/reader-summary-weekly-production daily-runner sh -lc set -eu; npm run run:reader-summary-weekly-production; npm run run:reader-summary-weekly-production -- --replay"
 mapfile -t compose_commands < <(grep -v '^source-env=' "$COMPOSE_LOG")
 [[ ${#compose_commands[@]} == 4 ]]
 [[ ${compose_commands[0]} == "$reconcile_command" ]]
@@ -198,7 +198,7 @@ mapfile -t compose_commands < <(grep -v '^source-env=' "$COMPOSE_LOG")
 ! grep -F 'READER_SUMMARY_PRODUCTION_RECOVERY_SOURCE_DATABASE_URL' \
   "$COMPOSE_LOG" >/dev/null
 ! grep -F 'backfill:reader-summary-weekly-daily-certifications' "$COMPOSE_LOG" >/dev/null
-grep -F 'npm run run:reader-summary-weekly-production -- --week-start 2026-07-27; npm run run:reader-summary-weekly-production -- --replay --week-start 2026-07-27' "$COMPOSE_LOG" >/dev/null
+grep -F 'npm run run:reader-summary-weekly-production; npm run run:reader-summary-weekly-production -- --replay' "$COMPOSE_LOG" >/dev/null
 ! grep -F 'postgresql://' "$COMPOSE_LOG" >/dev/null
 ! grep -F 'pg_restore' "$DOCKER_LOG" "$COMPOSE_LOG" >/dev/null
 ! grep -F 'social-monitor-reader-summary-recovery-source-' \
@@ -525,7 +525,7 @@ printf '%s\n' "$CONTROL_ONLY_SHA" > "$STATE/control.sha"
 : > "$COMPOSE_LOG"
 run_reader_summary_daily_runner_maintenance reader-summary-weekly-run
 [[ $(grep -Fc \
-  'daily-runner sh -lc set -eu; npm run run:reader-summary-weekly-production -- --week-start 2026-07-27; npm run run:reader-summary-weekly-production -- --replay --week-start 2026-07-27' \
+  'daily-runner sh -lc set -eu; npm run run:reader-summary-weekly-production; npm run run:reader-summary-weekly-production -- --replay' \
   "$COMPOSE_LOG") == 1 ]]
 
 # Control-only deploys are valid when the deployed backend/runtime marker is a

--- a/prisma/migrations/20260814013000_reader_summary_weekly_historical_unavailable_generalization/migration.sql
+++ b/prisma/migrations/20260814013000_reader_summary_weekly_historical_unavailable_generalization/migration.sql
@@ -1,0 +1,95 @@
+-- @social-monitor-forward-migration
+-- Weekly synthesis may consume any immutable daily publication whose GitHub
+-- projection was explicitly and honestly recorded as historically unavailable.
+-- The authority stays fail-closed: zero GitHub rows, a bounded reason, a
+-- post-period authorization timestamp, and non-GitHub provider evidence remain
+-- mandatory. This removes the obsolete single-date exception without
+-- fabricating GitHub evidence.
+BEGIN;
+
+SET LOCAL ROLE "social_monitor_public_schema_owner";
+GRANT USAGE, CREATE ON SCHEMA public
+TO "social_monitor_reader_summary_publication_owner";
+RESET ROLE;
+
+SET LOCAL ROLE "social_monitor_reader_summary_publication_owner";
+
+DO $generalize_weekly_historical_unavailable$
+DECLARE
+  v_definition TEXT;
+  v_old TEXT;
+  v_new TEXT;
+BEGIN
+  SELECT pg_get_functiondef(
+    'backfill_reader_summary_weekly_daily_certifications(uuid,uuid,text,text,date)'::regprocedure
+  ) INTO STRICT v_definition;
+  v_old := $old_backfill$
+    ELSIF v_evidence."semantic_status" = 'COMPLETED'
+      AND v_day = DATE '2026-07-23'
+      AND v_evidence."github_evidence"->>'mode'
+        = 'historical_unavailable'
+    THEN$old_backfill$;
+  v_new := $new_backfill$
+    ELSIF v_evidence."semantic_status" = 'COMPLETED'
+      AND v_evidence."github_evidence"->>'mode'
+        = 'historical_unavailable'
+    THEN$new_backfill$;
+  IF strpos(v_definition, v_old) = 0
+    OR strpos(v_definition, v_new) <> 0
+  THEN
+    RAISE EXCEPTION
+      'weekly daily certification historical-unavailable preimage diverged';
+  END IF;
+  v_definition := replace(v_definition, v_old, v_new);
+  IF strpos(v_definition, v_old) <> 0
+    OR strpos(v_definition, v_new) = 0
+  THEN
+    RAISE EXCEPTION
+      'weekly daily certification historical-unavailable replacement failed';
+  END IF;
+  EXECUTE v_definition;
+
+  SELECT pg_get_functiondef(
+    'persist_reader_summary_weekly_review_manifest(jsonb)'::regprocedure
+  ) INTO STRICT v_definition;
+  v_old := $old_manifest$
+    WHERE evidence_row."github_evidence"->>'mode' = 'historical_unavailable'
+      AND (
+        evidence_row."requested_utc_date" <> DATE '2026-07-23'
+        OR EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements(evidence_row."provider_evidence") AS provider_item(value)
+          WHERE provider_item.value->>'providerKey' = 'github-trending-page'
+        )
+      )$old_manifest$;
+  v_new := $new_manifest$
+    WHERE evidence_row."github_evidence"->>'mode' = 'historical_unavailable'
+      AND EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(evidence_row."provider_evidence") AS provider_item(value)
+        WHERE provider_item.value->>'providerKey' = 'github-trending-page'
+      )$new_manifest$;
+  IF strpos(v_definition, v_old) = 0
+    OR strpos(v_definition, v_new) <> 0
+  THEN
+    RAISE EXCEPTION
+      'weekly review manifest historical-unavailable preimage diverged';
+  END IF;
+  v_definition := replace(v_definition, v_old, v_new);
+  IF strpos(v_definition, v_old) <> 0
+    OR strpos(v_definition, v_new) = 0
+  THEN
+    RAISE EXCEPTION
+      'weekly review manifest historical-unavailable replacement failed';
+  END IF;
+  EXECUTE v_definition;
+END
+$generalize_weekly_historical_unavailable$;
+
+RESET ROLE;
+SET LOCAL ROLE "social_monitor_public_schema_owner";
+REVOKE CREATE ON SCHEMA public
+FROM "social_monitor_reader_summary_publication_owner";
+RESET ROLE;
+
+COMMIT;

--- a/scripts/lib/reader-summary-github-provider-board-seal.spec.ts
+++ b/scripts/lib/reader-summary-github-provider-board-seal.spec.ts
@@ -1,15 +1,23 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 
-const migration =
-  "prisma/migrations/20260813102000_reader_summary_github_provider_board_seal/migration.sql";
+const migrationName =
+  "20260813102000_reader_summary_github_provider_board_seal";
+const migration = `prisma/migrations/${migrationName}/migration.sql`;
 
 describe("reader summary GitHub provider board seal migration", () => {
   const sql = readFileSync(resolve(migration), "utf8");
 
-  it("is the latest guarded forward migration", () => {
-    expect(readdirSync(resolve("prisma/migrations")).sort().at(-1)).toBe(
-      "20260813102000_reader_summary_github_provider_board_seal",
+  it("remains the latest guarded publisher rewrite", () => {
+    const laterMigrationSql = readdirSync(resolve("prisma/migrations"))
+      .filter((name) => name > migrationName)
+      .sort()
+      .map((name) =>
+        readFileSync(resolve("prisma/migrations", name, "migration.sql"), "utf8"),
+      )
+      .join("\n");
+    expect(laterMigrationSql).not.toMatch(
+      /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+(?:public\.)?"?publish_reader_summary"?/iu,
     );
     expect(sql).toContain("target diverged");
     expect(sql).toContain("rewrite is not exact");

--- a/scripts/lib/reader-summary-weekly-daily-certification-backfill-postgres-contract.ts
+++ b/scripts/lib/reader-summary-weekly-daily-certification-backfill-postgres-contract.ts
@@ -88,7 +88,7 @@ export const assertReaderSummaryWeeklyDailyCertificationBackfillPostgresContract
     );
     const grandfathered = await backfill(params, "2026-07-20");
     assertExactReplay(grandfathered, "2026-07-20");
-    await assertHistoricalAuthority(params.canonicalJsonAuditor);
+    await assertHistoricalAuthority(params.canonicalJsonAuditor, "2026-07-23");
     await assertNoSignalAuthority(params.client, "2026-07-26");
 
     await publishWeek(params, "2026-07-13", {
@@ -101,11 +101,9 @@ export const assertReaderSummaryWeeklyDailyCertificationBackfillPostgresContract
         overrides: { githubEvidenceMode: "historical_unavailable" },
       },
     });
-    await assertRejects(
-      () => backfill(params, "2026-07-13"),
-      "completed authority diverged",
-      "historical GitHub omission on the wrong date must fail closed",
-    );
+    const generalizedHistorical = await backfill(params, "2026-07-13");
+    assertExactReplay(generalizedHistorical, "2026-07-13");
+    await assertHistoricalAuthority(params.canonicalJsonAuditor, "2026-07-16");
 
     await publishWeek(params, "2026-05-04", {}, 6);
     await assertRejects(
@@ -615,6 +613,7 @@ const assertVerifiedWeekAuthority = async (
 
 const assertHistoricalAuthority = async (
   client: PoolClient,
+  date: string,
 ): Promise<void> => {
   const result = await client.query<{
     readonly github_count: string;
@@ -656,7 +655,8 @@ const assertHistoricalAuthority = async (
          'hex'
        ) AS seal_valid
      FROM reader_summary_weekly_publication_evidence
-     WHERE requested_utc_date = DATE '2026-07-23'`,
+     WHERE requested_utc_date = $1::date`,
+    [date],
   );
   assert(
     JSON.stringify(result.rows[0]) ===
@@ -670,7 +670,7 @@ const assertHistoricalAuthority = async (
         github_count: "0",
         seal_valid: true,
       }),
-    "Jul 23 historical exception must retain exact DB-owned zero GitHub authority",
+    `${date} historical exception must retain exact DB-owned zero GitHub authority`,
   );
 };
 

--- a/scripts/lib/reader-summary-weekly-historical-unavailable-generalization.spec.ts
+++ b/scripts/lib/reader-summary-weekly-historical-unavailable-generalization.spec.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+
+const migrationPath =
+  "prisma/migrations/20260814013000_reader_summary_weekly_historical_unavailable_generalization/migration.sql";
+
+describe("reader summary weekly historical-unavailable generalization", () => {
+  const migration = readFileSync(migrationPath, "utf8");
+
+  it("removes the single-date exception while retaining zero-GitHub evidence guards", () => {
+    expect(migration).toContain(
+      "weekly daily certification historical-unavailable preimage diverged",
+    );
+    expect(migration).toContain(
+      "weekly review manifest historical-unavailable preimage diverged",
+    );
+    expect(migration).toContain(
+      "provider_item.value->>'providerKey' = 'github-trending-page'",
+    );
+    expect(migration).toContain("strpos(v_definition, v_old) = 0");
+    expect(migration).toContain("EXECUTE v_definition");
+    expect(migration).toContain("REVOKE CREATE ON SCHEMA public");
+  });
+});

--- a/scripts/lib/reader-summary-weekly-production-input.spec.ts
+++ b/scripts/lib/reader-summary-weekly-production-input.spec.ts
@@ -171,14 +171,16 @@ describe("reader summary weekly production manifest input admission", () => {
     });
   });
 
-  it("keeps the authorized 2026-07-23 historical GitHub omission in the model input", () => {
-    const dbState = historicalGithubUnavailableDbState();
+  it.each(["2026-07-23", "2026-07-24"])(
+    "keeps an honestly unavailable historical GitHub board for %s in the model input",
+    (requestedUtcDate) => {
+    const dbState = historicalGithubUnavailableDbState(requestedUtcDate);
     const built = buildModelInputFromDbState(dbState, reviewManifestFor(dbState));
 
     if (built.status !== "complete") throw new Error(built.reasons.join("; "));
     expect(built.status).toBe("complete");
-    expect(built.input.days[3]).toMatchObject({
-      date: "2026-07-23",
+    expect(built.input.days.find((day) => day.date === requestedUtcDate)).toMatchObject({
+      date: requestedUtcDate,
       githubBoardStatus: "historical_unavailable",
       githubAuthorizationIdentity:
         readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity,

--- a/scripts/lib/reader-summary-weekly-production-input.ts
+++ b/scripts/lib/reader-summary-weekly-production-input.ts
@@ -573,12 +573,8 @@ const modelDays = (
       providerCounts: certification.providerCounts,
     };
     if (mode === "historical_unavailable") {
-      if (certification.requestedUtcDate !== "2026-07-23") {
-        throw new Error("Reader summary weekly historical GitHub authority escaped July 23");
-      }
       return Object.freeze({
         ...common,
-        date: "2026-07-23" as const,
         githubBoardStatus: "historical_unavailable" as const,
         githubAuthorizationIdentity:
           readerSummaryWeeklyHistoricalGitHubAuthorizationIdentity,

--- a/scripts/lib/reader-summary-weekly-production-postgres-contract.spec.ts
+++ b/scripts/lib/reader-summary-weekly-production-postgres-contract.spec.ts
@@ -144,11 +144,13 @@ describe("reader summary weekly production postgres contract", () => {
     expect(state.blockingReasons).toEqual([]);
   });
 
-  it("accepts only the sealed Jul 23 historical GitHub exception", async () => {
+  it.each(["2026-07-22", "2026-07-23"])(
+    "accepts honest sealed historical GitHub unavailability for %s",
+    async (historicalDate) => {
     const rows = week.dates.map((date) =>
       rowForDate(
         date,
-        date === "2026-07-23"
+        date === historicalDate
           ? { githubMode: "historical_unavailable" }
           : undefined,
       ),
@@ -187,25 +189,18 @@ describe("reader summary weekly production postgres contract", () => {
     );
   });
 
-  it("fails closed on historical GitHub evidence for every other date", async () => {
-    const rows = week.dates.map((date) =>
-      rowForDate(
-        date,
-        date === "2026-07-22"
-          ? { githubMode: "historical_unavailable" }
-          : undefined,
-      ),
-    );
-    const state = await loadReaderSummaryWeeklyProductionDbState(
-      fakeClient(rows),
-      scope,
-      week,
-    );
-
-    expect(state.status).toBe("partial");
-    expect(state.blockingReasons).toContain(
-      "2026-07-22 lacks verified GitHub DB evidence",
-    );
+  it("fails closed when historical GitHub mode still carries GitHub provider evidence", async () => {
+    const rows = week.dates.map((date) => rowForDate(date));
+    const target = rowForDate("2026-07-22", {
+      githubMode: "historical_unavailable",
+    });
+    rows[2] = {
+      ...target,
+      provider_evidence: rowForDate("2026-07-22").provider_evidence,
+    };
+    await expect(
+      loadReaderSummaryWeeklyProductionDbState(fakeClient(rows), scope, week),
+    ).rejects.toThrow("Reader summary weekly DB certification authority diverged");
   });
 
   it("rejects a forged nested GitHub seal even when the outer seal is valid", async () => {

--- a/scripts/lib/reader-summary-weekly-production-postgres-contract.ts
+++ b/scripts/lib/reader-summary-weekly-production-postgres-contract.ts
@@ -708,12 +708,14 @@ const certificationBlockingReasons = (
     return reasons;
   }
 
-  const historicalJul23 =
-    certification.requestedUtcDate === "2026-07-23" &&
+  const honestHistoricalUnavailable =
     github.mode === "historical_unavailable" &&
-    githubCount === 0;
+    githubCount === 0 &&
+    certification.providerEvidence.every(
+      (evidence) => evidence.providerKey !== "github-trending-page",
+    );
   if (
-    !historicalJul23 &&
+    !honestHistoricalUnavailable &&
     (github.mode !== "verified" || githubCount !== 10)
   ) {
     reasons.push(

--- a/scripts/lib/reader-summary-weekly-production-test-fixture.ts
+++ b/scripts/lib/reader-summary-weekly-production-test-fixture.ts
@@ -82,10 +82,12 @@ export const admittedRunnerInput = (
   reviewManifest: ReaderSummaryWeeklyReviewManifest;
 }> => Object.freeze({ dbState, reviewManifest: reviewManifestFor(dbState) });
 
-export const historicalGithubUnavailableDbState = (): ReaderSummaryWeeklyProductionDbState => {
+export const historicalGithubUnavailableDbState = (
+  requestedUtcDate = "2026-07-23",
+): ReaderSummaryWeeklyProductionDbState => {
   const base = completeDbState();
   const certifications = Object.freeze(base.certifications.map((certification) =>
-    certification.requestedUtcDate !== "2026-07-23"
+    certification.requestedUtcDate !== requestedUtcDate
       ? certification
       : Object.freeze({
           ...certification,
@@ -100,7 +102,7 @@ export const historicalGithubUnavailableDbState = (): ReaderSummaryWeeklyProduct
             mode: "historical_unavailable",
             evidenceCount: 0,
             repositories: Object.freeze([]),
-            sha256: sha("github:2026-07-23:historical-unavailable"),
+            sha256: sha(`github:${requestedUtcDate}:historical-unavailable`),
           }),
           providerEvidence: Object.freeze(
             certification.providerEvidence.filter((evidence) =>

--- a/scripts/lib/reader-summary-weekly-review-manifest-postgres-contract.spec.ts
+++ b/scripts/lib/reader-summary-weekly-review-manifest-postgres-contract.spec.ts
@@ -90,7 +90,6 @@ function secureDefinition(): string {
   current_setting('transaction_isolation') <> 'serializable'
   FOR UPDATE
   FOR SHARE OF evidence_row
-  DATE '2026-07-23'
   historical_unavailable
   missing sealed evidence
   cannot duplicate a story on one date

--- a/scripts/lib/reader-summary-weekly-review-manifest-postgres-contract.ts
+++ b/scripts/lib/reader-summary-weekly-review-manifest-postgres-contract.ts
@@ -411,7 +411,7 @@ export const readerSummaryWeeklyReviewManifestCatalogIsSecure = (
     /current_setting\('transaction_isolation'\)\s*<>\s*'serializable'/iu.test(definition) &&
     /FOR\s+UPDATE/iu.test(definition) &&
     /FOR\s+SHARE\s+OF\s+evidence_row/iu.test(definition) &&
-    /DATE\s+'2026-07-23'/iu.test(definition) &&
+    !/DATE\s+'2026-07-23'/iu.test(definition) &&
     /historical_unavailable/iu.test(definition) &&
     /missing sealed evidence/iu.test(definition) &&
     /cannot duplicate a story on one date/iu.test(definition) &&
@@ -525,7 +525,9 @@ const createHistoricalAuthority = async (
       date,
       {
         githubEvidenceMode:
-          date === "2026-07-23" ? "historical_unavailable" : "verified",
+          date === "2026-07-23" || date === "2026-07-24"
+            ? "historical_unavailable"
+            : "verified",
       },
     );
     const outcome = await publish(client, readerSummaryPublicationDbOwnedRequest(fixture));
@@ -545,11 +547,13 @@ const createHistoricalAuthority = async (
   assert(
     state.status === "complete" &&
       state.blockingReasons.length === 0 &&
-      state.certifications.some((row) =>
-        row.requestedUtcDate === "2026-07-23" &&
-        row.githubEvidence.mode === "historical_unavailable",
+      ["2026-07-23", "2026-07-24"].every((date) =>
+        state.certifications.some((row) =>
+          row.requestedUtcDate === date &&
+          row.githubEvidence.mode === "historical_unavailable",
+        ),
       ),
-    "Jul 23 historical authority must be the sole accepted historical exception",
+    "historical authority must accept every honestly unavailable GitHub day",
   );
   return readerSummaryWeeklyReviewAuthorityFromProductionState(state);
 };


### PR DESCRIPTION
## What
- run weekly summaries against the real production workspace
- catch up every completed week from 2026-07-27 instead of replaying one hardcoded week forever
- allow immutable daily publications with honest historical GitHub unavailability on any date
- keep zero-GitHub/provider-evidence and sealed publication guards fail-closed

## Evidence
- 79 focused weekly tests passed
- shell syntax checks passed
- source/test line-cap passed
- full typecheck remains red on pre-existing repository errors unrelated to this change
- macOS shell harness cannot run because flock is unavailable; Linux CI remains authoritative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Historical GitHub-unavailable records now support any requested date instead of being limited to a single date.
  * Preserved requested dates in weekly summaries and certifications.
  * Added fail-closed validation when unavailable GitHub evidence conflicts with provider data.
  * July 13 backfill and additional historical dates can now replay successfully.

* **Operations**
  * Weekly production maintenance now runs standard and replay jobs with expanded catch-up coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->