### PR TITLE
fix(summary): grant bounded verifier migration ownership

### DIFF
--- a/prisma/migrations/20260814021000_reader_summary_daily_v4_scope_isolation/migration.sql
+++ b/prisma/migrations/20260814021000_reader_summary_daily_v4_scope_isolation/migration.sql
@@ -5,7 +5,13 @@
 BEGIN;
 
 SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
 SET LOCAL ROLE "social_monitor_public_schema_owner";
+GRANT USAGE, CREATE ON SCHEMA public
+TO "social_monitor_reader_summary_publication_owner";
+RESET ROLE;
+
+SET LOCAL ROLE "social_monitor_reader_summary_publication_owner";
 
 CREATE OR REPLACE FUNCTION public."verify_reader_summary_daily_canonical_recovery_v4_provenance"(
   target_tenant_id UUID,
@@ -78,4 +84,9 @@ END;
 $validate_daily_v4_scope_isolation$;
 
 RESET ROLE;
+SET LOCAL ROLE "social_monitor_public_schema_owner";
+REVOKE CREATE ON SCHEMA public
+FROM "social_monitor_reader_summary_publication_owner";
+RESET ROLE;
+
 COMMIT;

--- a/scripts/lib/reader-summary-daily-v4-scope-isolation.spec.ts
+++ b/scripts/lib/reader-summary-daily-v4-scope-isolation.spec.ts
@@ -6,6 +6,14 @@ const migration = readFileSync(resolve(
 ), "utf8");
 
 describe("Daily V4 recovery scope isolation", () => {
+  it("replaces the verifier through its owning publication role", () => {
+    expect(migration).toContain("GRANT USAGE, CREATE ON SCHEMA public");
+    expect(migration).toContain(
+      'SET LOCAL ROLE "social_monitor_reader_summary_publication_owner"',
+    );
+    expect(migration).toContain("REVOKE CREATE ON SCHEMA public");
+  });
+
   it("keeps the legacy recovery verifier on its reviewed scope", () => {
     expect(migration).toContain(
       "c_tenant_id CONSTANT UUID := '00000000-0000-7000-8000-000000000901'",


### PR DESCRIPTION
## What\n- grant the verifier owner a bounded schema migration window\n- revoke CREATE immediately after replacement\n- preserve the production-scope isolation fix from #94\n\n## Verification\n- full PostgreSQL 18 publication privilege/upgrade/replay/concurrency gate passed on the hosting server\n- focused Jest contract: 3/3 passed