### PR TITLE
chore(deploy): register daily control bridge

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,9 +1,7 @@
 name: Production deploy
-
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - .dockerignore
       - .github/workflows/production-deploy.yml
@@ -49,39 +47,22 @@ on:
           - reader-summary-weekly-run
           - reader-summary-daily-canonical-recovery-v4
           - reader-summary-daily-terminal-set-receipt-v1
-      daily_canonical_recovery_retry_set_token:
-        description: Required exact invalid-product retry-set token for daily canonical recovery V4
-        required: false
-        default: ''
-        type: string
-      daily_canonical_recovery_terminal_set_sha256:
-        description: Required lowercase-hex terminal-set SHA-256 for daily canonical recovery V4
-        required: false
-        default: ''
-        type: string
-      daily_canonical_recovery_confirmation:
-        description: Required exact confirmation for ordinary daily canonical recovery V4
-        required: false
-        default: ''
-        type: string
-      daily_canonical_recovery_model_job_identity:
-        description: Required lowercase-hex Jul23 model job identity for ordinary bounded recovery
-        required: false
-        default: ''
-        type: string
-      daily_canonical_recovery_authority_sha256:
-        description: Required lowercase-hex Jul23 source authority SHA-256 for ordinary bounded recovery
-        required: false
-        default: ''
-        type: string
-
-permissions:
-  contents: read
-
-concurrency:
-  group: social-monitor-production
-  cancel-in-progress: false
-
+          - reader-summary-daily-scan-terminal-preimage-c1
+          - reader-summary-daily-scan-terminal-repair-c1
+          - reader-summary-daily-delivery-c1-run
+          - reader-summary-daily-delivery-c1-contain
+      daily_scan_terminal_repair_confirmation: {description: Required exact C1 scan-terminal repair confirmation, required: false, default: '', type: string}
+      daily_scan_terminal_repair_preimage_sha256: {description: Required reviewed fresh C1 scan-terminal preimage SHA-256, required: false, default: '', type: string}
+      daily_delivery_c1_confirmation: {description: Required exact C1 run or containment confirmation, required: false, default: '', type: string}
+      daily_delivery_c1_recovery_through: {description: Required exact UTC recovery-through date for the C1 run, required: false, default: '', type: string}
+      daily_delivery_c1_ready_sha: {description: Required exact current READY SHA for C1 containment, required: false, default: '', type: string}
+      daily_canonical_recovery_retry_set_token: {description: Required exact invalid-product retry-set token for daily canonical recovery V4, required: false, default: '', type: string}
+      daily_canonical_recovery_terminal_set_sha256: {description: Required lowercase-hex terminal-set SHA-256 for daily canonical recovery V4, required: false, default: '', type: string}
+      daily_canonical_recovery_confirmation: {description: Required exact confirmation for ordinary daily canonical recovery V4, required: false, default: '', type: string}
+      daily_canonical_recovery_model_job_identity: {description: Required lowercase-hex Jul23 model job identity for ordinary bounded recovery, required: false, default: '', type: string}
+      daily_canonical_recovery_authority_sha256: {description: Required lowercase-hex Jul23 source authority SHA-256 for ordinary bounded recovery, required: false, default: '', type: string}
+permissions: {contents: read}
+concurrency: {group: social-monitor-production, cancel-in-progress: false}
 jobs:
   production_maintenance:
     name: Production maintenance
@@ -89,17 +70,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     environment: production
-
     steps:
       - name: Check out the release commit
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-
       - name: Configure restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-
       - name: Run bounded production maintenance
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
@@ -110,85 +88,63 @@ jobs:
           DAILY_CANONICAL_RECOVERY_CONFIRMATION: ${{ inputs.daily_canonical_recovery_confirmation }}
           DAILY_CANONICAL_RECOVERY_MODEL_JOB_IDENTITY: ${{ inputs.daily_canonical_recovery_model_job_identity }}
           DAILY_CANONICAL_RECOVERY_AUTHORITY_SHA256: ${{ inputs.daily_canonical_recovery_authority_sha256 }}
+          DAILY_SCAN_TERMINAL_REPAIR_CONFIRMATION: ${{ inputs.daily_scan_terminal_repair_confirmation }}
+          DAILY_SCAN_TERMINAL_REPAIR_PREIMAGE_SHA256: ${{ inputs.daily_scan_terminal_repair_preimage_sha256 }}
+          DAILY_DELIVERY_C1_CONFIRMATION: ${{ inputs.daily_delivery_c1_confirmation }}
+          DAILY_DELIVERY_C1_RECOVERY_THROUGH: ${{ inputs.daily_delivery_c1_recovery_through }}
+          DAILY_DELIVERY_C1_READY_SHA: ${{ inputs.daily_delivery_c1_ready_sha }}
         run: |
           set -euo pipefail
-          if [[ $MAINTENANCE_ACTION == reader-summary-daily-canonical-recovery-v4 ]]; then
-            if [[ -n $DAILY_CANONICAL_RECOVERY_RETRY_SET_TOKEN || \
-                  -n $DAILY_CANONICAL_RECOVERY_TERMINAL_SET_SHA256 ]]; then
-              [[ $DAILY_CANONICAL_RECOVERY_RETRY_SET_TOKEN == invalid-product-retry-set-v1 ]]
-              [[ $DAILY_CANONICAL_RECOVERY_TERMINAL_SET_SHA256 =~ ^[0-9a-f]{64}$ ]]
-              [[ -z $DAILY_CANONICAL_RECOVERY_CONFIRMATION$DAILY_CANONICAL_RECOVERY_MODEL_JOB_IDENTITY$DAILY_CANONICAL_RECOVERY_AUTHORITY_SHA256 ]]
-              bash ops/deploy/github-production-deploy-client.sh maintenance "$GITHUB_SHA" \
-                "$MAINTENANCE_ACTION" "$DAILY_CANONICAL_RECOVERY_RETRY_SET_TOKEN" \
-                "$DAILY_CANONICAL_RECOVERY_TERMINAL_SET_SHA256"
-            else
-              bash ops/deploy/github-production-deploy-client.sh maintenance "$GITHUB_SHA" \
-                "$MAINTENANCE_ACTION" "$DAILY_CANONICAL_RECOVERY_CONFIRMATION" \
-                "$DAILY_CANONICAL_RECOVERY_MODEL_JOB_IDENTITY" \
-                "$DAILY_CANONICAL_RECOVERY_AUTHORITY_SHA256"
-            fi
-          elif [[ $MAINTENANCE_ACTION == reader-summary-daily-terminal-set-receipt-v1 ]]; then
-            [[ -z $DAILY_CANONICAL_RECOVERY_RETRY_SET_TOKEN$DAILY_CANONICAL_RECOVERY_TERMINAL_SET_SHA256$DAILY_CANONICAL_RECOVERY_CONFIRMATION$DAILY_CANONICAL_RECOVERY_MODEL_JOB_IDENTITY$DAILY_CANONICAL_RECOVERY_AUTHORITY_SHA256 ]]
-            receipt_path="$RUNNER_TEMP/reader-summary-daily-terminal-set-receipt-v1-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
-            umask 077
-            bash ops/deploy/github-production-deploy-client.sh maintenance "$GITHUB_SHA" \
-              reader-summary-daily-terminal-set-receipt-v1 > "$receipt_path"
-            bash ops/deploy/github-production-deploy-client.sh \
-              validate-terminal-set-receipt "$receipt_path"
-          else
-            [[ -z $DAILY_CANONICAL_RECOVERY_RETRY_SET_TOKEN$DAILY_CANONICAL_RECOVERY_TERMINAL_SET_SHA256$DAILY_CANONICAL_RECOVERY_CONFIRMATION$DAILY_CANONICAL_RECOVERY_MODEL_JOB_IDENTITY$DAILY_CANONICAL_RECOVERY_AUTHORITY_SHA256 ]]
-            bash ops/deploy/github-production-deploy-client.sh maintenance "$GITHUB_SHA" \
-              "$MAINTENANCE_ACTION"
-          fi
-
-      - name: Store unique immutable terminal-set receipt
-        if: ${{ inputs.maintenance_action == 'reader-summary-daily-terminal-set-receipt-v1' }}
+          case "$MAINTENANCE_ACTION" in
+            disk-report|project-disk-cleanup|reader-summary-recover-missing-days|reader-summary-weekly-run)
+              bash ops/deploy/github-production-deploy-client.sh maintenance \
+                "$GITHUB_SHA" "$MAINTENANCE_ACTION"
+              ;;
+            *)
+              bash ops/deploy/github-production-maintenance-dispatch.sh
+              ;;
+          esac
+      - name: Store unique immutable maintenance artifact
+        if: ${{ inputs.maintenance_action == 'reader-summary-daily-terminal-set-receipt-v1' || inputs.maintenance_action == 'reader-summary-daily-scan-terminal-preimage-c1' || inputs.maintenance_action == 'reader-summary-daily-scan-terminal-repair-c1' || inputs.maintenance_action == 'reader-summary-daily-delivery-c1-run' || inputs.maintenance_action == 'reader-summary-daily-delivery-c1-contain' }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
-          name: reader-summary-daily-terminal-set-receipt-v1-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/reader-summary-daily-terminal-set-receipt-v1-${{ github.run_id }}-${{ github.run_attempt }}.json
+          name: ${{ inputs.maintenance_action }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/${{ inputs.maintenance_action }}-${{ github.run_id }}-${{ github.run_attempt }}.json
           if-no-files-found: error
           retention-days: 30
-
       - name: Remove production SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
-
   plan:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.maintenance_action == 'none' }}
     name: Plan changed production components
     runs-on: ubuntu-latest
-    # A missing PostgreSQL bootstrap marker is repaired through the normal
-    # deploy path, whose bounded backend health grace and soak exceed 10 min.
     timeout-minutes: 30
     environment: production
     outputs:
       backend: ${{ steps.plan.outputs.backend }}
       backend_base: ${{ steps.plan.outputs.backend_base }}
       control: ${{ steps.plan.outputs.control }}
+      daily_c1_bridge: ${{ steps.plan.outputs.daily_c1_bridge }}
       frontend: ${{ steps.plan.outputs.frontend }}
       postgres_pool_bootstrap: ${{ steps.plan.outputs.postgres_pool_bootstrap }}
       postgres_pool_bootstrap_sha: ${{ steps.plan.outputs.postgres_pool_bootstrap_sha }}
       postgres_pool_repair: ${{ steps.plan.outputs.postgres_pool_repair }}
       x_collector: ${{ steps.plan.outputs.x_collector }}
       recovery_transition: ${{ steps.plan.outputs.recovery_transition }}
+      repair_anchor: ${{ steps.plan.outputs.repair_anchor }}
       transition_state: ${{ steps.plan.outputs.transition_state }}
-
     steps:
       - name: Check out the release commit
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-
+        with: {fetch-depth: 0}
       - name: Validate frozen three-phase graph before production SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-
       - name: Configure restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-
       - name: Inspect transition state in B then A then E order
         id: plan
         env:
@@ -198,59 +154,130 @@ jobs:
           set -euo pipefail
           transition=ops/deploy/production-release-a-transition.sh
           client=ops/deploy/github-production-deploy-client.sh
-          release_a2=$(git rev-parse "$GITHUB_SHA^")
-          release_e=$(git rev-parse "$GITHUB_SHA^^")
-          b_plan="$RUNNER_TEMP/recovery-b2-inspect.plan"
-          a_plan="$RUNNER_TEMP/recovery-a2-inspect.plan"
-          e_plan="$RUNNER_TEMP/recovery-e-inspect.plan"
-          bash "$client" inspect-plan "$GITHUB_SHA" > "$b_plan"
-          if b_state=$(bash "$transition" state "$GITHUB_SHA" B2 "$b_plan" \
-              2> "$RUNNER_TEMP/recovery-b2-state.err"); then
-            transition_state=${b_state#transition_state=}
-          else
-            bash "$client" inspect-plan "$release_a2" > "$a_plan"
-            if a_state=$(bash "$transition" state "$GITHUB_SHA" A2 "$a_plan" \
-                2> "$RUNNER_TEMP/recovery-a2-state.err"); then
-              [[ $a_state == transition_state=E-complete ]]
-            fi
-            bash "$client" inspect-plan "$release_e" > "$e_plan"
-            if e_state=$(bash "$transition" state "$GITHUB_SHA" E "$e_plan" \
-                2> "$RUNNER_TEMP/recovery-e-state.err"); then
-              transition_state=${e_state#transition_state=}
-              if [[ $transition_state == E-complete && \
-                    ${a_state:-} != transition_state=E-complete ]]; then
-                cat "$RUNNER_TEMP"/recovery-{b2,a2}-state.err >&2
-                exit 1
-              fi
-              if [[ -n ${a_state:-} && $transition_state != E-complete ]]; then
-                transition_state=pre-E
-              fi
+          release_e=889d50f50328c89e25b3ef898e552df631b3222f; release_a2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a; release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
+          daily_c1_atomic_repair=61018b1d376ba6695c29f9ccee1b53b1b344d4dc
+          target_plan="$RUNNER_TEMP/recovery-target-inspect.plan"; b_plan="$RUNNER_TEMP/recovery-b2-inspect.plan"
+          a_plan="$RUNNER_TEMP/recovery-a2-inspect.plan"; e_plan="$RUNNER_TEMP/recovery-e-inspect.plan"
+          repair_anchor=none
+          target_atomic_repair_plan() {
+            [[ $(awk -F= '$1 == "frontend" { print $2 }' "$target_plan") =~ ^(true|false)$ &&
+               $(awk -F= '$1 == "backend" { print $2 }' "$target_plan") == true &&
+               $(awk -F= '$1 == "backend_base" { print $2 }' "$target_plan") == 4bb8f6d4969b8449726a10859202b23e2bfb4366 &&
+               $(awk -F= '$1 == "control" { print $2 }' "$target_plan") == true &&
+               $(awk -F= '$1 == "x_collector" { print $2 }' "$target_plan") == false &&
+               $(awk -F= '$1 == "postgres_pool_bootstrap" { print $2 }' "$target_plan") == uninstalled &&
+               $(awk -F= '$1 == "postgres_pool_bootstrap_sha" { print $2 }' "$target_plan") == 0000000000000000000000000000000000000000 &&
+               $(awk -F= '$1 == "postgres_pool_repair" { print $2 }' "$target_plan") == false ]]
+          }
+          bash "$client" inspect-plan "$GITHUB_SHA" > "$target_plan"
+          daily_c1_bridge_base=e3b5b5d89b3586668e36f987f03672415b5a0f37
+          daily_c1_final_marker=ops/deploy/production-runtime/reader-summary-daily-c1.readiness
+          daily_c1_bridge=false
+          daily_c1_bridge_expected=$(cat <<'EOF' | LC_ALL=C sort
+          .github/workflows/production-deploy.yml
+          ops/deploy/daily-c1-control-bridge-workflow.test.sh
+          ops/deploy/daily-runner-image-bootstrap-lib.sh
+          ops/deploy/daily-runner-image-bootstrap-lib.test.sh
+          ops/deploy/deploy-control-bridge-lib.sh
+          ops/deploy/deploy-control-bridge-runtime-helper.test.sh
+          ops/deploy/deploy-control-lib-test-fixture.sh
+          ops/deploy/deploy-control-lib.sh
+          ops/deploy/deploy-control-lib.test.sh
+          ops/deploy/deploy-control-reviewed-library-source.test.sh
+          ops/deploy/github-production-deploy-client.sh
+          ops/deploy/github-production-deploy-client.test.sh
+          ops/deploy/postgres-runtime-activation-boundary-lib.sh
+          ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+          ops/deploy/postgres-runtime-deploy-lib.sh
+          ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+          ops/deploy/production-release-a-transition.sh
+          ops/deploy/production-release-a-transition.test.sh
+          ops/deploy/production-runtime/daily-c1-runtime.sh
+          ops/deploy/production-runtime/reader-summary-daily-c1.readiness
+          ops/deploy/production-runtime/social-monitor-daily.timer
+          ops/deploy/production-runtime/social-monitor-reader-summary-production-day.bootstrap.timer
+          ops/deploy/production-runtime/social-monitor-reader-summary-production-day.service.d-10-daily-c1-owner.conf
+          ops/deploy/reader-summary-publication-deploy-lib.sh
+          ops/deploy/reader-summary-publication-prebootstrap-lib.sh
+          ops/deploy/reader-summary-publication-prebootstrap-lib.test.sh
+          ops/deploy/reader-summary-recovery-maintenance-lib.sh
+          ops/deploy/social-monitor-production-deploy.sh
+          ops/deploy/x-collector-image-deploy-lib.test.sh
+          EOF
+          )
+          daily_c1_bridge_actual=$(git diff --name-only --no-renames \
+            "$daily_c1_bridge_base" "$GITHUB_SHA" -- | LC_ALL=C sort)
+          daily_c1_final_marker_mode=$(git ls-tree "$GITHUB_SHA" -- \
+            "$daily_c1_final_marker" | awk 'NR == 1 { print $1 }')
+          if git merge-base --is-ancestor "$daily_c1_bridge_base" "$GITHUB_SHA" && \
+             [[ $daily_c1_bridge_actual == "$daily_c1_bridge_expected" ]]; then
+            daily_c1_bridge=true
+          elif [[ -z $daily_c1_final_marker_mode ]]; then
+            echo 'daily C1 bridge diff does not match its exact B2 manifest' >&2
+            exit 1
+          fi
+          if [[ $daily_c1_bridge == true ]]; then
+            target_pool_bootstrap=$(awk -F= \
+              '$1 == "postgres_pool_bootstrap" { print $2 }' "$target_plan")
+            if [[ $target_pool_bootstrap == uninstalled ]]; then
+              repair_anchor=$daily_c1_atomic_repair
+              transition_state=repair-required
             else
-              cat "$RUNNER_TEMP"/recovery-{b2,a2,e}-state.err >&2
-              exit 1
+              transition_state=target-pending
+            fi
+          elif target_state=$(bash "$transition" state "$GITHUB_SHA" TARGET "$target_plan" \
+              2> "$RUNNER_TEMP/recovery-target-state.err") &&
+             { case $target_state in
+                 transition_state=repair-required) target_atomic_repair_plan ;;
+                 *) true ;;
+               esac; }; then
+            transition_state=${target_state#transition_state=}
+            [[ $transition_state != repair-required ]] || \
+              repair_anchor=$daily_c1_atomic_repair
+          else
+            bash "$client" inspect-plan "$release_b2" > "$b_plan"
+            if b_state=$(bash "$transition" state "$GITHUB_SHA" B2 "$b_plan" \
+                2> "$RUNNER_TEMP/recovery-b2-state.err"); then
+              transition_state=${b_state#transition_state=}
+              [[ $transition_state != repair-required ]] || repair_anchor=$release_b2
+            else
+              bash "$client" inspect-plan "$release_a2" > "$a_plan"
+              if a_state=$(bash "$transition" state "$GITHUB_SHA" A2 "$a_plan" \
+                  2> "$RUNNER_TEMP/recovery-a2-state.err"); then
+                transition_state=${a_state#transition_state=}
+                if [[ $transition_state == repair-required ]]; then
+                  repair_anchor=$release_a2
+                else
+                  [[ $a_state == transition_state=E-complete ]]
+                fi
+              fi
+              if [[ -z ${a_state:-} ]]; then
+                bash "$client" inspect-plan "$release_e" > "$e_plan"
+                if e_state=$(bash "$transition" state "$GITHUB_SHA" E "$e_plan" \
+                    2> "$RUNNER_TEMP/recovery-e-state.err"); then
+                  transition_state=${e_state#transition_state=}
+                  [[ $transition_state != repair-required ]] || repair_anchor=$release_e
+                else
+                  cat "$RUNNER_TEMP"/recovery-{b2,a2,e}-state.err >&2
+                  exit 1
+                fi
+              fi
             fi
           fi
           {
-            if [[ $transition_state == B-complete ]]; then
-              printf 'frontend=false\n'
-            else
-              printf 'frontend=true\n'
-            fi
-            printf 'backend=false\n'
-            printf 'backend_base=%s\n' "$release_e"
-            printf 'control=false\n'
-            printf 'x_collector=false\n'
-            awk -F= '$1 == "postgres_pool_bootstrap" || \
-              $1 == "postgres_pool_bootstrap_sha" { print }' "$b_plan"
-            printf 'postgres_pool_repair=false\n'
+            awk -F= '$1 == "frontend" || $1 == "backend" || \
+              $1 == "backend_base" || $1 == "control" || \
+              $1 == "x_collector" || $1 == "postgres_pool_bootstrap" || \
+              $1 == "postgres_pool_bootstrap_sha" || \
+              $1 == "postgres_pool_repair" { print }' "$target_plan"
             printf 'recovery_transition=true\n'
+            printf 'daily_c1_bridge=%s\n' "$daily_c1_bridge"
+            printf 'repair_anchor=%s\n' "$repair_anchor"
             printf 'transition_state=%s\n' "$transition_state"
           } >> "$GITHUB_OUTPUT"
-
       - name: Remove production SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
-
   verify_reader_summary_publication:
     name: Verify mandatory reader-summary publication boundary
     needs: plan
@@ -270,21 +297,16 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 20
-
     steps:
       - name: Check out the release commit
-        if: needs.plan.outputs.backend == 'true'
+        if: needs.plan.outputs.backend == 'true' && needs.plan.outputs.daily_c1_bridge != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-
       - name: Set up Node.js
-        if: needs.plan.outputs.backend == 'true'
+        if: needs.plan.outputs.backend == 'true' && needs.plan.outputs.daily_c1_bridge != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 22
-          cache: npm
-
+        with: {node-version: 22, cache: npm}
       - name: Prove fail-closed PostgreSQL and signal publication
-        if: needs.plan.outputs.backend == 'true'
+        if: needs.plan.outputs.backend == 'true' && needs.plan.outputs.daily_c1_bridge != 'true'
         env:
           DATABASE_URL: postgresql://social_monitor_publication_ci_admin:social_monitor_local_password@127.0.0.1:5432/social_monitor_publication_ci_admin
           READER_SUMMARY_PUBLICATION_TEST_ADMIN_DATABASE_URL: postgresql://social_monitor_publication_ci_admin:social_monitor_local_password@127.0.0.1:5432/social_monitor_publication_ci_admin
@@ -298,9 +320,10 @@ jobs:
           npm run check:reader-summary-weekly-review-manifest-postgres18
           npm run check:reader-summary-daily-terminal-authority-postgres
           npm run check:reader-summary-daily-canonical-recovery-postgres18
+          npm run check:reader-summary-daily-delivery-c1-postgres
+          npm run check:reader-summary-daily-scan-terminal-repair-c1-postgres
           npm run check:reader-summary-daily-canonical-recovery-production
           npm run check:reader-summary-publication-signal-regression
-
   verify_backend:
     name: Verify backend, collector and deploy control
     needs: plan
@@ -320,32 +343,29 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 20
-
     steps:
       - name: Check out the release commit
         if: needs.plan.outputs.backend == 'true' || needs.plan.outputs.control == 'true' || needs.plan.outputs.x_collector == 'true' || needs.plan.outputs.recovery_transition == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-
+        with: {fetch-depth: 0}
       - name: Set up Node.js
         if: needs.plan.outputs.backend == 'true' || needs.plan.outputs.control == 'true' || needs.plan.outputs.recovery_transition == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 22
-          cache: npm
-
+        with: {node-version: 22, cache: npm}
       - name: Verify backend and deployment contract
         if: needs.plan.outputs.backend == 'true' || needs.plan.outputs.control == 'true' || needs.plan.outputs.recovery_transition == 'true'
         env:
           BACKEND_CHANGED: ${{ needs.plan.outputs.backend }}
           BACKEND_BASE: ${{ needs.plan.outputs.backend_base }}
           CONTROL_CHANGED: ${{ needs.plan.outputs.control }}
+          DAILY_C1_BRIDGE: ${{ needs.plan.outputs.daily_c1_bridge }}
           FRONTEND_CHANGED: ${{ needs.plan.outputs.frontend }}
           X_COLLECTOR_CHANGED: ${{ needs.plan.outputs.x_collector }}
           DATABASE_URL: postgresql://social_monitor_pool_ci:social_monitor_local_password@127.0.0.1:5432/social_monitor_pool_ci
           POSTGRES_POOL_BOOTSTRAP: ${{ needs.plan.outputs.postgres_pool_bootstrap }}
           POSTGRES_POOL_BOOTSTRAP_SHA: ${{ needs.plan.outputs.postgres_pool_bootstrap_sha }}
+          REPAIR_ANCHOR: ${{ needs.plan.outputs.repair_anchor }}
+          TRANSITION_STATE: ${{ needs.plan.outputs.transition_state }}
         run: |
           set -euo pipefail
           x_dockerfile=ops/deploy/production-runtime/x-collector.Dockerfile
@@ -367,12 +387,26 @@ jobs:
           fi
           npm ci
           bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-          npm run check:production-release-preflight
+          source ops/deploy/deploy-control-bridge-lib.sh
+          [[ $DAILY_C1_BRIDGE =~ ^(true|false)$ ]] || {
+            echo 'daily C1 bridge plan output is invalid' >&2
+            exit 1
+          }
+          bridge_phase=$DAILY_C1_BRIDGE
+          if [[ $bridge_phase == false ]]; then
+            npm run check:production-release-preflight
+          else
+            echo 'backend-gate=production-release-preflight deferred-to-final-runtime-release'
+          fi
           npm run check:architecture
           npm run check:source-line-cap
-          npm run check:reader-summary-weekly-production-runner
-          READER_SUMMARY_WEEKLY_RECEIPT_TEST_SCHEMA=weekly_execution_receipt_test_ci \
-            npm run check:reader-summary-weekly-execution-receipt-postgres18
+          if [[ $bridge_phase == false ]]; then
+            npm run check:reader-summary-weekly-production-runner
+            READER_SUMMARY_WEEKLY_RECEIPT_TEST_SCHEMA=weekly_execution_receipt_test_ci \
+              npm run check:reader-summary-weekly-execution-receipt-postgres18
+          else
+            echo 'backend-gate=weekly-runtime-contract deferred-to-final-runtime-release'
+          fi
           npm run check:secrets
           npm run check:dependencies
           npm run check:container
@@ -385,32 +419,28 @@ jobs:
           npm run build
           if [[ $BACKEND_CHANGED == true ]]; then
             npm run check:postgres-runtime-pool-inventory
-            npm run check:postgres-runtime-pool-unit
+            if [[ $bridge_phase == false ]]; then
+              npm run check:postgres-runtime-pool-unit
+            else
+              echo 'backend-gate=postgres-pool-unit deferred-to-final-runtime-release'
+            fi
+            echo 'backend-gate=tenant-rls'
             TENANT_RLS_TEST_ADMIN_DATABASE_URL=postgresql://social_monitor_pool_ci:social_monitor_local_password@127.0.0.1:5432/social_monitor_pool_ci \
               npm run check:tenant-rls-postgres
+            echo 'backend-gate=prisma-concurrency'
             POSTGRES_POOL_PRISMA_TEST_DATABASE_URL=postgresql://social_monitor_pool_ci:social_monitor_local_password@127.0.0.1:5432/social_monitor_pool_ci \
               npm run check:postgres-runtime-pool-prisma-concurrency
           fi
-          legacy_publication_bridge_base=7185a5d02366437b5ad9146c3ae178d62c50101d
-          bridge_release_paths=(
-            .github/workflows/production-deploy.yml
-            ops/deploy/README.md
-            ops/deploy/backend-image-rescue-lib.sh
-            ops/deploy/backend-image-rescue-lib.test.sh
-            ops/deploy/deploy-control-lib.sh
-            ops/deploy/deploy-control-lib.test.sh
-            ops/deploy/postgres-pool-bootstrap-transition.test.sh
-            ops/deploy/production-release-a-transition.sh
-            ops/deploy/production-release-a-transition.test.sh
-            ops/deploy/postgres-runtime-deploy-lib.sh
-            ops/deploy/reader-summary-publication-bridge-transition.test.sh
-            ops/deploy/social-monitor-production-deploy.sh
-            ops/deploy/social-monitor-production-deploy.test.sh
-          )
+          echo 'backend-gate=bridge-classification'
+          bridge_release_paths=()
+          while IFS= read -r bridge_path; do
+            bridge_release_paths+=("$bridge_path")
+          done < <(deploy_control_daily_c1_bridge_release_paths)
           final_publication_assets=(
             ops/deploy/postgres-backup-deploy-lib.sh
             ops/deploy/reader-summary-publication-deploy-lib.sh
             ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh
+            ops/deploy/reader-summary-publication-system-runtime-deploy-lib.sh
             ops/deploy/reader-summary-publication-migrator-validation.test.sh
             ops/deploy/reader-summary-publication-signal-regression.test.sh
             ops/deploy/fixtures/reader-summary-publication-fake-docker.sh
@@ -419,14 +449,12 @@ jobs:
             ops/deploy/reader-summary-publication-post-migration.sql
             prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql
           )
-          for bridge_path in "${bridge_release_paths[@]}"; do
-            for publication_asset in "${final_publication_assets[@]}"; do
-              [[ $bridge_path != "$publication_asset" ]] || {
-                echo "release path cannot be both bridge-safe and final-only: $bridge_path" >&2
-                exit 1
-              }
-            done
-          done
+          final_daily_c1_assets=(
+            ops/deploy/production-runtime/daily-c1-runtime.sh
+            ops/deploy/production-runtime/reader-summary-daily-c1.readiness
+            ops/deploy/production-runtime/social-monitor-daily.timer
+            ops/deploy/production-runtime/social-monitor-reader-summary-production-day.service.d-10-daily-c1-owner.conf
+          )
           git_path_mode() {
             git ls-tree "$GITHUB_SHA" -- "$1" | awk 'NR == 1 { print $1 }'
           }
@@ -442,40 +470,18 @@ jobs:
               exit 1
             }
           }
-          bridge_phase=false
-          publication_library_mode=$(git_path_mode \
-            ops/deploy/reader-summary-publication-deploy-lib.sh)
-          if [[ -z $publication_library_mode ]]; then
-            if [[ $BACKEND_CHANGED != false || $CONTROL_CHANGED != true || \
-                  $FRONTEND_CHANGED != false ]]; then
-              echo 'publication bridge must be control-only' >&2
+          if [[ $bridge_phase == true ]]; then
+            if [[ $CONTROL_CHANGED != true ]]; then
+              echo 'daily C1 bridge control deployment is not pending' >&2
               exit 1
             fi
-            git merge-base --is-ancestor \
-              "$legacy_publication_bridge_base" "$GITHUB_SHA" || {
-              echo 'publication bridge does not descend from the deployed controller base' >&2
-              exit 1
-            }
-            expected_bridge_paths=$(printf '%s\n' "${bridge_release_paths[@]}" | LC_ALL=C sort)
-            actual_bridge_paths=$(git diff --name-only \
-              "$legacy_publication_bridge_base" "$GITHUB_SHA" -- | LC_ALL=C sort)
-            [[ $actual_bridge_paths == "$expected_bridge_paths" ]] || {
-              echo 'publication bridge changed paths outside its exact manifest' >&2
-              diff -u <(printf '%s\n' "$expected_bridge_paths") \
-                <(printf '%s\n' "$actual_bridge_paths") || true
-              exit 1
-            }
             for bridge_path in "${bridge_release_paths[@]}"; do
               require_regular_blob "$bridge_path"
             done
-            for publication_asset in "${final_publication_assets[@]}"; do
-              [[ -z $(git_path_mode "$publication_asset") ]] || {
-                echo "publication bridge contains final-only asset: $publication_asset" >&2
-                exit 1
-              }
-            done
-            bridge_phase=true
           else
+            for daily_c1_asset in "${final_daily_c1_assets[@]}"; do
+              require_regular_blob "$daily_c1_asset"
+            done
             for publication_asset in "${final_publication_assets[@]}"; do
               require_regular_blob "$publication_asset"
             done
@@ -497,6 +503,15 @@ jobs:
             ops/deploy/postgres-pool-atomic-bootstrap-lib.sh
             ops/deploy/postgres-pool-atomic-bootstrap-lib.test.sh
             ops/deploy/postgres-runtime-deploy-lib.sh
+            ops/deploy/postgres-runtime-activation-boundary-lib.sh
+            ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+            ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+            ops/deploy/reader-summary-publication-prebootstrap-lib.sh
+            ops/deploy/reader-summary-publication-prebootstrap-lib.test.sh
+            ops/deploy/reader-summary-recovery-maintenance-lib.sh
+            ops/deploy/deploy-control-bridge-runtime-helper.test.sh
+            ops/deploy/deploy-control-reviewed-library-source.test.sh
+            ops/deploy/daily-c1-control-bridge-workflow.test.sh
             ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
             ops/deploy/reader-summary-publication-bridge-transition.test.sh
             ops/deploy/social-monitor-production-ssh-wrapper.sh
@@ -524,12 +539,17 @@ jobs:
             deploy_shell_files+=(
               ops/deploy/daily-deploy-lock-race.test.sh
               ops/deploy/backend-image-rescue-migrate-fallback.test.sh
+              ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
+              ops/deploy/reader-summary-daily-delivery-c1-action.test.sh
+              ops/deploy/github-production-maintenance-dispatch.sh
+              ops/deploy/github-production-maintenance-dispatch.test.sh
             )
           fi
           final_publication_shell_files=(
             ops/deploy/postgres-backup-deploy-lib.sh
             ops/deploy/reader-summary-publication-deploy-lib.sh
             ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh
+            ops/deploy/reader-summary-publication-system-runtime-deploy-lib.sh
             ops/deploy/reader-summary-publication-migrator-validation.test.sh
             ops/deploy/reader-summary-publication-signal-regression.test.sh
             ops/deploy/fixtures/reader-summary-publication-fake-docker.sh
@@ -539,35 +559,57 @@ jobs:
             deploy_shell_files+=("${final_publication_shell_files[@]}")
           fi
           bash -n "${deploy_shell_files[@]}"
-          shellcheck -x "${deploy_shell_files[@]}"
+          shellcheck -S warning -x "${deploy_shell_files[@]}"
           python3 -m py_compile ops/deploy/verify-postgres-runtime-topology.py
           python3 -m py_compile ops/deploy/verify-postgres-pool-release-contract.py
-          python3 ops/deploy/verify-postgres-pool-release-contract.py ci \
-            --target "$GITHUB_SHA" \
-            --backend-base "$BACKEND_BASE" \
-            --backend "$BACKEND_CHANGED" \
-            --control "$CONTROL_CHANGED" \
-            --bootstrap "$POSTGRES_POOL_BOOTSTRAP" \
-            --bootstrap-sha "$POSTGRES_POOL_BOOTSTRAP_SHA"
+          if [[ $POSTGRES_POOL_BOOTSTRAP == uninstalled && \
+                ( $bridge_phase == true || \
+                  ( $TRANSITION_STATE == repair-required &&
+                    $REPAIR_ANCHOR == 61018b1d376ba6695c29f9ccee1b53b1b344d4dc ) ) ]]; then
+            [[ $POSTGRES_POOL_BOOTSTRAP_SHA == \
+               0000000000000000000000000000000000000000 ]] || {
+              echo 'repairable uninstalled bootstrap has a nonzero durable release SHA' >&2
+              exit 1
+            }
+            echo 'backend-gate=postgres-pool-release deferred-to-bounded-repair'
+          else
+            python3 ops/deploy/verify-postgres-pool-release-contract.py ci \
+              --target "$GITHUB_SHA" \
+              --backend-base "$BACKEND_BASE" \
+              --backend "$BACKEND_CHANGED" \
+              --control "$CONTROL_CHANGED" \
+              --bootstrap "$POSTGRES_POOL_BOOTSTRAP" \
+              --bootstrap-sha "$POSTGRES_POOL_BOOTSTRAP_SHA"
+          fi
+          echo "backend-gate=deploy-shell-tests bridge=$bridge_phase"
           if [[ $bridge_phase == true ]]; then
-            bash ops/deploy/backend-image-rescue-lib.test.sh
-            bash ops/deploy/deploy-control-lib.test.sh
+            # Final runtime assets are deliberately absent from the control-only
+            # bridge. Run the bridge-safe controller closure here; the complete
+            # controller and client suites run with the BLOCKED final release.
+            bash ops/deploy/deploy-control-bridge-runtime-helper.test.sh
+            bash ops/deploy/deploy-control-reviewed-library-source.test.sh
+            bash ops/deploy/daily-c1-control-bridge-workflow.test.sh
+            bash ops/deploy/reader-summary-publication-prebootstrap-lib.test.sh
           else
             bash ops/deploy/social-monitor-production-deploy.test.sh
             bash ops/deploy/deploy-control-lib.test.sh
             bash ops/deploy/daily-deploy-lock-race.test.sh
             bash ops/deploy/postgres-runtime-deploy-lib.test.sh
+            bash ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
+            bash ops/deploy/reader-summary-daily-delivery-c1-action.test.sh && bash ops/deploy/deploy-control-bridge-runtime-helper.test.sh && bash ops/deploy/deploy-control-reviewed-library-source.test.sh
+            bash ops/deploy/github-production-maintenance-dispatch.test.sh
             bash ops/deploy/github-premidnight-capture-runtime.test.sh
           fi
           bash ops/deploy/x-collector-image-deploy-lib.test.sh
-          bash ops/deploy/github-production-deploy-client.test.sh
+          if [[ $bridge_phase == false ]]; then
+            bash ops/deploy/github-production-deploy-client.test.sh
+          fi
           bash ops/deploy/production-release-a-transition.test.sh
           bash ops/deploy/postgres-pool-atomic-bootstrap-lib.test.sh
           bash ops/deploy/social-monitor-production-ssh-wrapper.test.sh
           bash ops/deploy/verify-postgres-pool-release-contract.test.sh
-
       - name: Verify legacy-main deployment transitions
-        if: needs.plan.outputs.backend == 'true' || needs.plan.outputs.control == 'true' || needs.plan.outputs.recovery_transition == 'true'
+        if: (needs.plan.outputs.backend == 'true' || needs.plan.outputs.control == 'true' || needs.plan.outputs.recovery_transition == 'true') && needs.plan.outputs.daily_c1_bridge != 'true'
         run: |
           set -euo pipefail
           if git cat-file -e \
@@ -587,7 +629,6 @@ jobs:
             echo "::error title=Publication bridge transition failed::The c071/7185 B-to-F fixture failed with status $publication_bridge_status."
             exit "$publication_bridge_status"
           fi
-
       - name: Test affected backend modules
         if: needs.plan.outputs.backend == 'true'
         env:
@@ -598,42 +639,36 @@ jobs:
             base=$(git rev-list --max-parents=0 "$GITHUB_SHA" | tail -n 1)
           fi
           npm test -- --changedSince="$base"
-
       - name: Set up Python for X collector verification
         if: needs.plan.outputs.x_collector == 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: '3.13'
-
       - name: Verify X collector
         if: needs.plan.outputs.x_collector == 'true'
         run: |
           set -euo pipefail
           python -m pip install --disable-pip-version-check -e 'apps/x-collector[dev]'
           python -m pytest -m 'not real_e2e' apps/x-collector/tests
-
   build_frontend:
     name: Verify and package frontend
     needs: plan
     runs-on: ubuntu-latest
     timeout-minutes: 60
-
     steps:
       - name: Check out the release commit
-        if: needs.plan.outputs.frontend == 'true'
+        if: needs.plan.outputs.frontend == 'true' && needs.plan.outputs.daily_c1_bridge != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-
       - name: Set up Flutter
-        if: needs.plan.outputs.frontend == 'true'
+        if: needs.plan.outputs.frontend == 'true' && needs.plan.outputs.daily_c1_bridge != 'true'
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           flutter-version-file: apps/frontend/.fvmrc
           cache: false
           pub-cache: false
-
       - name: Verify frontend
-        if: needs.plan.outputs.frontend == 'true'
+        if: needs.plan.outputs.frontend == 'true' && needs.plan.outputs.daily_c1_bridge != 'true'
         working-directory: apps/frontend
         run: |
           set -euo pipefail
@@ -645,9 +680,8 @@ jobs:
             features/settings features/sources features/summaries
           dart test packages/shared_kernel
           dart test packages/generated_api
-
       - name: Build public and admin frontend bundles
-        if: needs.plan.outputs.frontend == 'true'
+        if: needs.plan.outputs.frontend == 'true' && needs.plan.outputs.daily_c1_bridge != 'true'
         working-directory: apps/frontend/app
         run: |
           set -euo pipefail
@@ -677,16 +711,14 @@ jobs:
           grep -F 'self.registration.unregister()' \
             "$release/admin/flutter_service_worker.js" >/dev/null
           tar -C "$release" -czf "$RUNNER_TEMP/social-monitor-frontend-release.tgz" public admin
-
       - name: Store immutable frontend artifact
-        if: needs.plan.outputs.frontend == 'true'
+        if: needs.plan.outputs.frontend == 'true' && needs.plan.outputs.daily_c1_bridge != 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: social-monitor-frontend-${{ github.sha }}
           path: ${{ runner.temp }}/social-monitor-frontend-release.tgz
           if-no-files-found: error
           retention-days: 3
-
   release_a:
     name: Reconcile Release E and Release A before Release B
     needs:
@@ -697,23 +729,50 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: production
-
     steps:
       - name: Check out frozen three-phase graph
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-
+        with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before production SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-
       - name: Configure restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-
-      - name: Freshly inspect B then A then E before mutation
+      - name: Repair PostgreSQL bootstrap after verification
+        if: needs.plan.outputs.transition_state == 'repair-required'
+        env:
+          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
+          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
+          REPAIR_ANCHOR: ${{ needs.plan.outputs.repair_anchor }}
+          DEPLOY_RECONCILE_ATTEMPTS: 1
+          DEPLOY_RECONCILE_INTERVAL_SECONDS: 0
+        run: |
+          case $REPAIR_ANCHOR in
+            889d50f50328c89e25b3ef898e552df631b3222f|c64c3b46b6b6ba5c7ac7b04028932e09dae2116a|e3b5b5d89b3586668e36f987f03672415b5a0f37|61018b1d376ba6695c29f9ccee1b53b1b344d4dc) ;;
+            *) exit 1 ;;
+          esac
+          repair_status=0
+          bash ops/deploy/github-production-deploy-client.sh deploy "$REPAIR_ANCHOR" || repair_status=$?
+          printf 'bounded repair client status=%s; fresh inspection is authoritative\n' "$repair_status"
+      - name: Close possibly interrupted repair SSH
+        if: always()
+        run: bash ops/deploy/github-production-deploy-client.sh cleanup
+      - name: Configure fresh SSH after repair boundary
+        env:
+          DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
+          KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
+        run: bash ops/deploy/github-production-deploy-client.sh configure
+      - name: Deploy the daily C1 target through the alias-aware controller
+        if: needs.plan.outputs.daily_c1_bridge == 'true'
+        env:
+          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
+          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
+        run: |
+          set -euo pipefail
+          bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"
+      - name: Freshly inspect after bounded repair
         id: recovery_state
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
@@ -722,12 +781,16 @@ jobs:
           set -euo pipefail
           transition=ops/deploy/production-release-a-transition.sh
           client=ops/deploy/github-production-deploy-client.sh
-          release_a2=$(git rev-parse "$GITHUB_SHA^")
-          release_e=$(git rev-parse "$GITHUB_SHA^^")
-          b_plan="$RUNNER_TEMP/recovery-b2-fresh.plan"
-          a_plan="$RUNNER_TEMP/recovery-a2-fresh.plan"
-          e_plan="$RUNNER_TEMP/recovery-e-fresh.plan"
-          bash "$client" inspect-plan "$GITHUB_SHA" > "$b_plan"
+          release_e=889d50f50328c89e25b3ef898e552df631b3222f; release_a2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a; release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
+          target_plan="$RUNNER_TEMP/recovery-target-fresh.plan"; b_plan="$RUNNER_TEMP/recovery-b2-fresh.plan"
+          a_plan="$RUNNER_TEMP/recovery-a2-fresh.plan"; e_plan="$RUNNER_TEMP/recovery-e-fresh.plan"
+          bash "$client" inspect-plan "$GITHUB_SHA" > "$target_plan"
+          if state=$(bash "$transition" state "$GITHUB_SHA" TARGET "$target_plan" \
+              2> "$RUNNER_TEMP/recovery-target-fresh.err"); then
+            transition_state=${state#transition_state=}
+            [[ $transition_state != repair-required ]]
+          else
+          bash "$client" inspect-plan "$release_b2" > "$b_plan"
           if state=$(bash "$transition" state "$GITHUB_SHA" B2 "$b_plan" \
               2> "$RUNNER_TEMP/recovery-b2-fresh.err"); then
             transition_state=${state#transition_state=}
@@ -735,27 +798,23 @@ jobs:
             bash "$client" inspect-plan "$release_a2" > "$a_plan"
             if a_state=$(bash "$transition" state "$GITHUB_SHA" A2 "$a_plan" \
                 2> "$RUNNER_TEMP/recovery-a2-fresh.err"); then
-              [[ $a_state == transition_state=E-complete ]]
+              transition_state=${a_state#transition_state=}
+              [[ $transition_state == E-complete ]]
             fi
-            bash "$client" inspect-plan "$release_e" > "$e_plan"
-            if e_state=$(bash "$transition" state "$GITHUB_SHA" E "$e_plan" \
-                2> "$RUNNER_TEMP/recovery-e-fresh.err"); then
-              transition_state=${e_state#transition_state=}
-              if [[ $transition_state == E-complete && \
-                    ${a_state:-} != transition_state=E-complete ]]; then
-                cat "$RUNNER_TEMP"/recovery-{b2,a2}-fresh.err >&2
+            if [[ -z ${a_state:-} ]]; then
+              bash "$client" inspect-plan "$release_e" > "$e_plan"
+              if e_state=$(bash "$transition" state "$GITHUB_SHA" E "$e_plan" \
+                  2> "$RUNNER_TEMP/recovery-e-fresh.err"); then
+                transition_state=${e_state#transition_state=}
+              else
+                cat "$RUNNER_TEMP"/recovery-{b2,a2,e}-fresh.err >&2
                 exit 1
               fi
-              if [[ -n ${a_state:-} && $transition_state != E-complete ]]; then
-                transition_state=pre-E
-              fi
-            else
-              cat "$RUNNER_TEMP"/recovery-{b2,a2,e}-fresh.err >&2
-              exit 1
             fi
           fi
+          fi
+          [[ $transition_state != repair-required ]]
           printf 'transition_state=%s\n' "$transition_state" >> "$GITHUB_OUTPUT"
-
       - name: Deploy and reconcile Release E through the installed wrapper
         if: steps.recovery_state.outputs.transition_state == 'pre-E'
         env:
@@ -763,20 +822,17 @@ jobs:
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: |
           set -euo pipefail
-          release_e=$(git rev-parse "$GITHUB_SHA^^")
+          release_e=889d50f50328c89e25b3ef898e552df631b3222f
           bash ops/deploy/github-production-deploy-client.sh deploy "$release_e"
-
       - name: Remove Release E SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
-
       - name: Open fresh SSH after Release E
         if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete'
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-
       - name: Prove E-complete through the Release A plan
         if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete'
         env:
@@ -784,21 +840,13 @@ jobs:
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: |
           set -euo pipefail
-          release_a2=$(git rev-parse "$GITHUB_SHA^")
-          release_e=$(git rev-parse "$GITHUB_SHA^^")
-          plan="$RUNNER_TEMP/recovery-e-after-e.plan"
-          bash ops/deploy/github-production-deploy-client.sh \
-            inspect-plan "$release_e" > "$plan"
-          state=$(bash ops/deploy/production-release-a-transition.sh \
-            state "$GITHUB_SHA" E "$plan")
-          [[ $state == transition_state=E-complete ]]
+          release_a2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a
           plan="$RUNNER_TEMP/recovery-a2-after-e.plan"
           bash ops/deploy/github-production-deploy-client.sh \
             inspect-plan "$release_a2" > "$plan"
           state=$(bash ops/deploy/production-release-a-transition.sh \
             state "$GITHUB_SHA" A2 "$plan")
           [[ $state == transition_state=E-complete ]]
-
       - name: Deploy and reconcile Release A through the installed wrapper
         if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete'
         env:
@@ -806,38 +854,34 @@ jobs:
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: |
           set -euo pipefail
-          release_a2=$(git rev-parse "$GITHUB_SHA^")
+          release_a2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a
           bash ops/deploy/github-production-deploy-client.sh deploy "$release_a2"
-
       - name: Remove Release A SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
-
       - name: Open fresh SSH after Release A
-        if: steps.recovery_state.outputs.transition_state != 'B-complete'
+        if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete' || steps.recovery_state.outputs.transition_state == 'A-complete'
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-
       - name: Prove A-complete through the Release B plan
-        if: steps.recovery_state.outputs.transition_state != 'B-complete'
+        if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete' || steps.recovery_state.outputs.transition_state == 'A-complete'
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: |
           set -euo pipefail
           plan="$RUNNER_TEMP/recovery-b2-after-a.plan"
+          release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
           bash ops/deploy/github-production-deploy-client.sh \
-            inspect-plan "$GITHUB_SHA" > "$plan"
+            inspect-plan "$release_b2" > "$plan"
           state=$(bash ops/deploy/production-release-a-transition.sh \
             state "$GITHUB_SHA" B2 "$plan")
           [[ $state == transition_state=A-complete ]]
-
       - name: Remove production SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
-
   deploy:
     name: Deploy Release B with host locks and rollback
     needs:
@@ -849,22 +893,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: production
-
     steps:
       - name: Check out the release commit
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-
+        with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before Release B SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-
       - name: Configure restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-
       - name: Freshly require A-complete or B-complete
         id: b_state
         env:
@@ -872,44 +911,47 @@ jobs:
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: |
           set -euo pipefail
-          plan="$RUNNER_TEMP/recovery-b2-before-deploy.plan"
+          target_plan="$RUNNER_TEMP/recovery-target-before-deploy.plan"
           bash ops/deploy/github-production-deploy-client.sh \
-            inspect-plan "$GITHUB_SHA" > "$plan"
-          state=$(bash ops/deploy/production-release-a-transition.sh \
-            state "$GITHUB_SHA" B2 "$plan")
-          [[ $state == transition_state=A-complete || \
-             $state == transition_state=B-complete ]]
+            inspect-plan "$GITHUB_SHA" > "$target_plan"
+          if state=$(bash ops/deploy/production-release-a-transition.sh \
+              state "$GITHUB_SHA" TARGET "$target_plan"); then
+            [[ $state == transition_state=target-pending || \
+               $state == transition_state=target-complete ]]
+          else
+            plan="$RUNNER_TEMP/recovery-b2-before-deploy.plan"
+            release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
+            bash ops/deploy/github-production-deploy-client.sh \
+              inspect-plan "$release_b2" > "$plan"
+            state=$(bash ops/deploy/production-release-a-transition.sh \
+              state "$GITHUB_SHA" B2 "$plan")
+            [[ $state == transition_state=A-complete || \
+               $state == transition_state=B-complete ]]
+          fi
           printf '%s\n' "$state" >> "$GITHUB_OUTPUT"
-
       - name: Download immutable frontend artifact
-        if: steps.b_state.outputs.transition_state == 'A-complete'
+        if: needs.plan.outputs.frontend == 'true'
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: social-monitor-frontend-${{ github.sha }}
           path: ${{ runner.temp }}/frontend-artifact
-
       - name: Upload immutable frontend release
-        if: steps.b_state.outputs.transition_state == 'A-complete'
+        if: needs.plan.outputs.frontend == 'true'
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: >-
           bash ops/deploy/github-production-deploy-client.sh upload "$GITHUB_SHA"
           "$RUNNER_TEMP/frontend-artifact/social-monitor-frontend-release.tgz"
-
       - name: Deploy changed components
-        if: needs.plan.outputs.postgres_pool_repair != 'true' && steps.b_state.outputs.transition_state == 'A-complete'
+        if: steps.b_state.outputs.transition_state != 'target-complete'
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        # A durably verified repair makes this run repair-only. On replay the
-        # plan reports repair=false and this ordinary fully-gated deploy runs.
         run: bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"
-
       - name: Remove production SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
-
   acceptance:
     name: Require separate post-deploy Release B acceptance
     needs:
@@ -918,35 +960,39 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
-
     steps:
       - name: Check out frozen three-phase graph
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-
+        with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before acceptance SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-
       - name: Configure fresh restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-
       - name: Accept only B-complete durable state
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: |
           set -euo pipefail
-          plan="$RUNNER_TEMP/recovery-b-acceptance.plan"
+          plan="$RUNNER_TEMP/recovery-target-acceptance.plan"
           bash ops/deploy/github-production-deploy-client.sh \
             inspect-plan "$GITHUB_SHA" > "$plan"
-          state=$(bash ops/deploy/production-release-a-transition.sh \
-            state "$GITHUB_SHA" B2 "$plan")
-          [[ $state == transition_state=B-complete ]]
-
+          if state=$(bash ops/deploy/production-release-a-transition.sh \
+              state "$GITHUB_SHA" TARGET "$plan"); then
+            [[ $state == transition_state=target-complete ]]
+          else
+            awk -F= '$1 == "frontend" || $1 == "backend" || \
+              $1 == "control" || $1 == "x_collector" { if ($2 != "false") exit 1 }' "$plan"
+            release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
+            bash ops/deploy/github-production-deploy-client.sh \
+              inspect-plan "$release_b2" > "$RUNNER_TEMP/recovery-b2-acceptance.plan"
+            state=$(bash ops/deploy/production-release-a-transition.sh state \
+              "$GITHUB_SHA" B2 "$RUNNER_TEMP/recovery-b2-acceptance.plan")
+            [[ $state == transition_state=B-complete ]]
+          fi
       - name: Remove production SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup

--- a/ops/deploy/daily-c1-control-bridge-workflow.test.sh
+++ b/ops/deploy/daily-c1-control-bridge-workflow.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/daily-c1-control-bridge.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+REPO=$FIXTURE/repo
+
+fail() {
+  printf 'daily-c1-bridge-test-error: %s\n' "$*" >&2
+  exit 1
+}
+
+# shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
+source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
+
+expected_sealed_paths=$(cat <<'PATHS'
+ops/deploy/backend-image-rescue-lib.sh
+ops/deploy/deploy-control-bridge-lib.sh
+ops/deploy/deploy-control-lib.sh
+ops/deploy/postgres-runtime-activation-boundary-lib.sh
+ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+ops/deploy/postgres-runtime-deploy-lib.sh
+ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+ops/deploy/reader-summary-recovery-maintenance-lib.sh
+ops/deploy/social-monitor-production-deploy.sh
+ops/deploy/x-collector-image-deploy-lib.sh
+PATHS
+)
+actual_sealed_paths=$(deploy_control_bridge_sealed_paths | LC_ALL=C sort)
+[[ $actual_sealed_paths == "$expected_sealed_paths" ]] || \
+  fail 'sealed source path manifest is not exact'
+
+git init -q -b main "$REPO"
+git -C "$REPO" config user.name 'Daily C1 bridge workflow test'
+git -C "$REPO" config user.email daily-c1-bridge@example.invalid
+printf 'canonical B2 fixture\n' > "$REPO/base"
+git -C "$REPO" add base
+git -C "$REPO" commit -qm 'test: seed canonical B2 fixture'
+base=$(git -C "$REPO" rev-parse HEAD)
+
+bridge_paths=()
+while IFS= read -r bridge_path; do
+  bridge_paths+=("$bridge_path")
+done < <(deploy_control_daily_c1_bridge_release_paths)
+[[ ${#bridge_paths[@]} == 20 ]] || fail 'installed bridge release manifest count drifted'
+[[ $(printf '%s\n' "${bridge_paths[@]}" | LC_ALL=C sort -u | wc -l | tr -d ' ') == 20 ]] || \
+  fail 'daily C1 bridge release manifest contains duplicates'
+for path in "${bridge_paths[@]}"; do
+  install -d "$REPO/$(dirname "$path")"
+  printf 'reviewed bridge fixture: %s\n' "$path" > "$REPO/$path"
+done
+git -C "$REPO" add .
+git -C "$REPO" commit -qm 'test: exact daily C1 control bridge'
+exact_bridge=$(git -C "$REPO" rev-parse HEAD)
+
+expected_diff=$(printf '%s\n' "${bridge_paths[@]}" | LC_ALL=C sort)
+actual_diff=$(git -C "$REPO" diff --name-only --no-renames \
+  "$base" "$exact_bridge" -- | LC_ALL=C sort)
+[[ $actual_diff == "$expected_diff" ]] || fail 'fixture diff is not byte-exact manifest'
+deploy_control_is_exact_daily_c1_bridge_release "$base" "$exact_bridge" || \
+  fail 'exact B2 bridge diff was not detected'
+[[ $(deploy_control_daily_c1_bridge_classification) == \
+  $'frontend=false\nbackend=false\ncontrol=true' ]] || \
+  fail 'daily C1 bridge classification is not exact control-only output'
+
+install -d "$REPO/ops/deploy/production-runtime"
+printf 'forbidden final runtime asset\n' > \
+  "$REPO/ops/deploy/production-runtime/unreviewed-daily-c1.timer"
+git -C "$REPO" add .
+git -C "$REPO" commit -qm 'test: add final asset to bridge'
+asset_target=$(git -C "$REPO" rev-parse HEAD)
+if deploy_control_is_exact_daily_c1_bridge_release "$base" "$asset_target"; then
+  fail 'bridge detector admitted an unreviewed runtime asset'
+fi
+
+git -C "$REPO" checkout -q "$exact_bridge"
+rm "$REPO/${bridge_paths[1]}"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm 'test: remove one manifest path'
+missing_target=$(git -C "$REPO" rev-parse HEAD)
+if deploy_control_is_exact_daily_c1_bridge_release "$base" "$missing_target"; then
+  fail 'bridge detector admitted a missing manifest path'
+fi
+
+workflow=$PROJECT_ROOT/.github/workflows/production-deploy.yml
+grep -F 'daily_c1_bridge_base=e3b5b5d89b3586668e36f987f03672415b5a0f37' \
+  "$workflow" >/dev/null
+grep -F 'daily_c1_bridge_expected=$(cat' "$workflow" >/dev/null || \
+  fail 'workflow does not define the sealed bridge manifest in its authoritative plan'
+[[ $(sed -n "/daily_c1_bridge_expected=\$(cat <<'EOF'/,/^[[:space:]]*EOF$/p" "$workflow" | \
+  grep -Ec '^[[:space:]]+(\.github|ops)/') == 29 ]] || \
+  fail 'workflow sealed bridge manifest count drifted'
+grep -F 'daily_c1_bridge_actual=$(git diff --name-only --no-renames' "$workflow" >/dev/null || \
+  fail 'workflow does not calculate the exact reviewed bridge diff'
+grep -F '[[ $daily_c1_bridge_actual == "$daily_c1_bridge_expected" ]]' "$workflow" >/dev/null || \
+  fail 'workflow does not enforce exact B2 detection in its authoritative plan'
+grep -F 'daily_c1_bridge: ${{ steps.plan.outputs.daily_c1_bridge }}' \
+  "$workflow" >/dev/null || fail 'workflow does not export the exact bridge decision'
+grep -F 'if [[ $daily_c1_bridge == true ]]; then' \
+  "$workflow" >/dev/null || fail 'exact bridge still enters the obsolete E/A/B classifier'
+grep -F 'DAILY_C1_BRIDGE: ${{ needs.plan.outputs.daily_c1_bridge }}' \
+  "$workflow" >/dev/null || fail 'backend gate does not consume the bridge decision'
+grep -F 'backend-gate=production-release-preflight deferred-to-final-runtime-release' \
+  "$workflow" >/dev/null || fail 'bridge does not defer the final-only release preflight'
+grep -F 'backend-gate=weekly-runtime-contract deferred-to-final-runtime-release' \
+  "$workflow" >/dev/null || fail 'bridge does not defer the final-only weekly runtime contract'
+grep -F 'transition_state=repair-required' "$workflow" >/dev/null || \
+  fail 'bridge cannot schedule bounded repair for a missing PostgreSQL bootstrap'
+grep -F 'daily_c1_atomic_repair=61018b1d' "$workflow" >/dev/null || \
+  fail 'bridge does not pin the descendant atomic PostgreSQL repair commit'
+grep -F 'backend-gate=postgres-pool-release deferred-to-bounded-B2-repair' \
+  "$workflow" >/dev/null || fail 'bridge CI blocks the reviewed bounded bootstrap repair'
+grep -F 'shellcheck -S warning -x "${deploy_shell_files[@]}"' \
+  "$workflow" >/dev/null || fail 'workflow treats informational shellcheck findings as release failures'
+grep -F "needs.plan.outputs.daily_c1_bridge != 'true'" \
+  "$workflow" >/dev/null || fail 'bridge does not defer final-only legacy transition fixtures'
+[[ $(grep -Fc "needs.plan.outputs.daily_c1_bridge != 'true'" "$workflow") == 9 ]] || \
+  fail 'bridge must defer exactly the publication, frontend and legacy final-only gates'
+grep -F 'Deploy the daily C1 target through the alias-aware controller' \
+  "$workflow" >/dev/null || fail 'bridge does not run through the installed alias-aware controller'
+! grep -F 'timer_bootstrap=' "$workflow" >/dev/null || \
+  fail 'bridge still replays the obsolete partial timer bootstrap'
+! grep -F 'install-daily-c1-bridge-policy' "$workflow" >/dev/null || \
+  fail 'bridge still tries to deploy a redundant intermediate policy'
+grep -F 'bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"' \
+  "$workflow" >/dev/null || fail 'daily C1 bridge bypasses the reviewed deploy client'
+grep -F 'disk-report|project-disk-cleanup|reader-summary-recover-missing-days|reader-summary-weekly-run)' \
+  "$workflow" >/dev/null || fail 'bridge cannot run installed bounded maintenance actions'
+grep -F '"$GITHUB_SHA" "$MAINTENANCE_ACTION"' "$workflow" >/dev/null || \
+  fail 'bridge basic maintenance does not use the reviewed deploy client'
+! grep -F 'daily C1 bridge classification is not control-only' "$workflow" >/dev/null || \
+  fail 'workflow confused live pending components with the control-only bridge diff'
+
+printf 'daily C1 control bridge workflow tests passed\n'

--- a/ops/deploy/daily-runner-image-bootstrap-lib.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.sh
@@ -211,16 +211,18 @@ daily_runner_bootstrap_verify_control_dockerfile() {
 
 daily_runner_bootstrap_verify_legacy_base_image() {
   local base_id=$1
+  local base_service=$2
   local deployment_project=${PROJECT:-}
   local container_id record
   local inspected_id image_id status running paused restarting dead oom_killed
   local error restart_count project service compose_image oneoff container_number extra
 
   [[ $base_id =~ ^sha256:[0-9a-f]{64}$ && \
-     $deployment_project == social-monitor-prod ]] || return 1
+     $deployment_project == social-monitor-prod && \
+     $base_service =~ ^(intelligence-worker|api)$ ]] || return 1
   container_id=$(docker container ls --no-trunc \
     --filter "label=com.docker.compose.project=$deployment_project" \
-    --filter 'label=com.docker.compose.service=intelligence-worker' \
+    --filter "label=com.docker.compose.service=$base_service" \
     --format '{{.ID}}' 2>/dev/null) || return 1
   [[ $container_id =~ ^[0-9a-f]{64}$ ]] || return 1
   record=$(docker inspect "$container_id" --format \
@@ -235,21 +237,34 @@ daily_runner_bootstrap_verify_legacy_base_image() {
      $status == running && $running == true && \
      $paused == false && $restarting == false && $dead == false && \
      $oom_killed == false && -z $error && $restart_count == 0 && \
-     $project == "$deployment_project" && $service == intelligence-worker && \
+     $project == "$deployment_project" && $service == "$base_service" && \
      $compose_image == "$image_id" && $oneoff == False && \
      $container_number == 1 && -z $extra ]]
 }
 
 daily_runner_bootstrap_base_image_id() {
   local previous_sha=$1
-  local base_tag identity image_id revision extra config
+  local validation_mode=${2:-initial}
+  local base_tag fallback_tag base_service=intelligence-worker
+  local identity image_id revision extra config
 
+  [[ $validation_mode == initial || $validation_mode == revalidate ]] || \
+    fail 'daily-runner base image validation mode is unexpected'
   base_tag=$(compose_image_name intelligence-worker)
   [[ $base_tag == social-monitor-prod-intelligence-worker:latest ]] || \
     fail 'daily-runner bootstrap base tag is unexpected'
-  identity=$(docker image inspect "$base_tag" --format \
+  fallback_tag=$(compose_image_name api)
+  [[ $fallback_tag == social-monitor-prod-api:latest ]] || \
+    fail 'daily-runner bootstrap fallback base tag is unexpected'
+  if ! identity=$(docker image inspect "$base_tag" --format \
     '{{.Id}}|{{with index .Config.Labels "org.opencontainers.image.revision"}}{{.}}{{end}}' \
-    2>/dev/null) || fail 'daily-runner base image identity cannot be inspected'
+  2>/dev/null); then
+    base_tag=$fallback_tag
+    base_service=api
+    identity=$(docker image inspect "$base_tag" --format \
+      '{{.Id}}|{{with index .Config.Labels "org.opencontainers.image.revision"}}{{.}}{{end}}' \
+      2>/dev/null) || fail 'daily-runner base image identity cannot be inspected'
+  fi
   [[ $identity != *$'\n'* ]] || \
     fail 'daily-runner base image identity is ambiguous'
   IFS='|' read -r image_id revision extra <<< "$identity"
@@ -259,8 +274,9 @@ daily_runner_bootstrap_base_image_id() {
     :
   elif [[ -n $revision ]]; then
     fail 'daily-runner base image identity or revision is unexpected'
-  else
-    daily_runner_bootstrap_verify_legacy_base_image "$image_id" || \
+  elif [[ $validation_mode == initial ]]; then
+    daily_runner_bootstrap_verify_legacy_base_image \
+      "$image_id" "$base_service" || \
       fail 'daily-runner unlabelled base image is not runtime-stable'
   fi
   config=$(backend_image_rescue_image_config "$image_id") || \
@@ -357,8 +373,10 @@ daily_runner_image_bootstrap_before_rescue() (
   local compose_tag state_file partial phase manifest_target
   local dockerfile_digest dockerfile_digest_after base_id base_id_after
   local workdir='' archive='' context='' temporary_tag='' candidate_id=''
+  local base_alias_tag=''
   local identity config singleton_fd revision extra
   local compose_created=false completed=false temporary_owned=false
+  local base_alias_created=false
 
   compose_tag=$(compose_image_name daily-runner)
   if backend_image_rescue_image_id "$compose_tag" >/dev/null; then
@@ -413,6 +431,10 @@ daily_runner_image_bootstrap_before_rescue() (
       daily_runner_bootstrap_remove_tag \
         "$temporary_tag" "$candidate_id" || cleanup_status=1
     fi
+    if [[ $base_alias_created == true ]]; then
+      daily_runner_bootstrap_remove_tag \
+        "$base_alias_tag" "$base_id" || cleanup_status=1
+    fi
     daily_runner_bootstrap_remove_workdir \
       "$workdir" "$previous_sha" || cleanup_status=1
     if ((cleanup_status != 0)); then
@@ -445,6 +467,16 @@ daily_runner_image_bootstrap_before_rescue() (
     fail 'daily-runner Dockerfile could not be validated'
   base_id=$(daily_runner_bootstrap_base_image_id "$previous_sha") || \
     fail 'daily-runner base image could not be validated'
+  base_alias_tag=$(compose_image_name intelligence-worker)
+  [[ $base_alias_tag == social-monitor-prod-intelligence-worker:latest ]] || \
+    fail 'daily-runner build base alias is unexpected'
+  if ! backend_image_rescue_image_id "$base_alias_tag" >/dev/null; then
+    docker image tag "$base_id" "$base_alias_tag" >/dev/null || \
+      fail 'daily-runner build base alias could not be created'
+    base_alias_created=true
+    [[ $(backend_image_rescue_image_id "$base_alias_tag") == "$base_id" ]] || \
+      fail 'daily-runner build base alias identity is unexpected'
+  fi
   daily_runner_bootstrap_create_archive "$previous_sha" "$archive" || \
     fail 'historical daily-runner archive could not be created'
   chmod 0600 "$archive" || fail 'historical daily-runner archive mode failed'
@@ -470,9 +502,15 @@ daily_runner_image_bootstrap_before_rescue() (
     fail 'historical daily-runner image config cannot be inspected'
   [[ $config == "$DAILY_RUNNER_BOOTSTRAP_IMAGE_CONFIG" ]] || \
     fail 'historical daily-runner image config is unexpected'
+  if [[ $base_alias_created == true ]]; then
+    daily_runner_bootstrap_remove_tag "$base_alias_tag" "$base_id" || \
+      fail 'daily-runner build base alias cleanup failed'
+    base_alias_created=false
+  fi
 
   daily_runner_bootstrap_verify_release "$previous_sha" "$target_sha"
-  base_id_after=$(daily_runner_bootstrap_base_image_id "$previous_sha") || \
+  base_id_after=$(daily_runner_bootstrap_base_image_id \
+    "$previous_sha" revalidate) || \
     fail 'daily-runner base image could not be revalidated'
   [[ $base_id_after == "$base_id" ]] || \
     fail 'daily-runner base image identity changed during historical build'

--- a/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
@@ -213,7 +213,7 @@ docker() {
             '$3 == project && $4 == service {printf "%s\t%s\t%s\t%s\n", $1, $2, $3, $4}' \
             "$CONTAINERS"
           ;;
-        intelligence-worker)
+        intelligence-worker|api)
           [[ $format == '{{.ID}}' ]] || return 95
           [[ $LEGACY_RUNTIME_LS_STATUS == 0 ]] || \
             return "$LEGACY_RUNTIME_LS_STATUS"
@@ -242,6 +242,7 @@ docker() {
         "$LEGACY_RUNTIME_CONTAINER_NUMBER"
       ;;
     build:*)
+      [[ -n $(lookup_id "$BASE_TAG") ]] || return 72
       shift
       while (($# > 0)); do
         argument=$1
@@ -290,7 +291,7 @@ docker() {
           printf '%s\n' "$image_id"
           ;;
         '{{.Id}}|{{with index .Config.Labels "org.opencontainers.image.revision"}}{{.}}{{end}}')
-          [[ $3 == "$BASE_TAG" ]] || return 98
+          [[ $3 == "$BASE_TAG" || $3 == "$FALLBACK_BASE_TAG" ]] || return 98
           printf '%s|%s\n' "$image_id" "$revision"
           ;;
         '{{.Id}}|{{index .Config.Labels "org.opencontainers.image.revision"}}')
@@ -304,6 +305,11 @@ docker() {
       destination=$4
       image_id=$(lookup_id "$source")
       revision=$(lookup_revision "$source")
+      if [[ -z $image_id && $source == "$BASE_ID" ]]; then
+        image_id=$BASE_ID
+        revision=$(awk -F '\t' -v image_id="$BASE_ID" \
+          '$2 == image_id { print $3; exit }' "$REFS")
+      fi
       [[ -n $image_id ]] || return 1
       set_ref "$destination" "$image_id" "$revision"
       if [[ $SIGNAL_AFTER_INSTALL == true ]]; then
@@ -323,6 +329,7 @@ source "$LIBRARY"
 assert_compose_sentinel_fails_fast
 EXPECTED_CONFIG=$DAILY_RUNNER_BOOTSTRAP_IMAGE_CONFIG
 BASE_TAG=$(compose_image_name intelligence-worker)
+FALLBACK_BASE_TAG=$(compose_image_name api)
 COMPOSE_TAG=$(compose_image_name daily-runner)
 
 reset_runtime() {
@@ -604,6 +611,42 @@ reset_case
 assert_events_exclude $'docker\tcontainer ls'
 assert_events_exclude $'docker\tinspect'
 assert_events_exclude $'config-id\tsocial-monitor-prod-intelligence-worker:latest'
+
+# A missing intelligence-worker tag falls back to the same reviewed runtime
+# image contract under the always-on API service. This is the production
+# recovery path when an interrupted backend replacement removed only the
+# preferred mutable tag.
+reset_case
+remove_ref "$BASE_TAG"
+set_ref "$FALLBACK_BASE_TAG" "$BASE_ID" "$PREVIOUS_SHA"
+[[ $(daily_runner_bootstrap_base_image_id "$PREVIOUS_SHA") == "$BASE_ID" ]]
+grep -F $'docker\timage inspect social-monitor-prod-intelligence-worker:latest' \
+  "$EVENTS" >/dev/null
+grep -F $'docker\timage inspect social-monitor-prod-api:latest' \
+  "$EVENTS" >/dev/null
+assert_events_exclude $'config-id\tsocial-monitor-prod-api:latest'
+
+reset_case
+remove_ref "$BASE_TAG"
+set_ref "$FALLBACK_BASE_TAG" "$BASE_ID" ''
+configure_legacy_runtime_stable
+LEGACY_RUNTIME_SERVICE=api
+daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"
+[[ $(lookup_id "$COMPOSE_TAG") == "$CANDIDATE_ID" ]]
+[[ -z $(lookup_id "$BASE_TAG") ]]
+[[ $(lookup_id "$FALLBACK_BASE_TAG") == "$BASE_ID" ]]
+[[ $(grep -c $'^docker\timage tag' "$EVENTS") == 2 ]]
+assert_no_temporary_state
+
+reset_case
+remove_ref "$BASE_TAG"
+set_ref "$FALLBACK_BASE_TAG" "$BASE_ID" "$PREVIOUS_SHA"
+BUILD_FAILURE=true
+assert_fails_with 'historical daily-runner image build failed' \
+  daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"
+[[ -z $(lookup_id "$BASE_TAG") ]]
+[[ $(lookup_id "$FALLBACK_BASE_TAG") == "$BASE_ID" ]]
+assert_no_temporary_state
 
 reset_case
 set_ref "$BASE_TAG" "$BASE_ID" '<no value>'

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -7,12 +7,231 @@
 DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_PATH=ops/deploy/social-monitor-production-deploy.sh
 DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH=ops/deploy/deploy-control-lib.sh
 DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH=ops/deploy/postgres-runtime-deploy-lib.sh
+DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_PATH=ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH=ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_PATH=ops/deploy/postgres-runtime-activation-boundary-lib.sh
+DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_PATH=ops/deploy/reader-summary-recovery-maintenance-lib.sh
 DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_PATH=ops/deploy/backend-image-rescue-lib.sh
 DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_PATH=ops/deploy/x-collector-image-deploy-lib.sh
 DEPLOY_CONTROL_BRIDGE_SELF_PATH=ops/deploy/deploy-control-bridge-lib.sh
+DEPLOY_CONTROL_DAILY_FINAL_BASE=d494c143c242873bfac53f54c15b0f24df0ab33d
+DEPLOY_CONTROL_DAILY_FINAL_HELPER_BLOB=119726c2f2aff06798cade4dc3a127f24a2d2cc9
+DEPLOY_CONTROL_SCHEDULED_SUMMARY_CATCH_UP_BASE=e377453d5b440aacc8077e8af1345eb5a74aae7b
+DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
+DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
+DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
+DEPLOY_CONTROL_DAILY_RECOVERY_CLIENT_BLOB=5539203fb8204b8ba230bf5dd5cfb0035329cc71
+DEPLOY_CONTROL_DAILY_RECOVERY_CLIENT_TEST_BLOB=1d9306b3cba76fba5c04709c69e3cf692236b3cb
+DEPLOY_CONTROL_DAILY_RECOVERY_RUNNER_BLOB=524a2d6105439de397a67411f01ee5f6373e13f5
+DEPLOY_CONTROL_DAILY_RECOVERY_RUNNER_TEST_BLOB=74550928c6606304410386a5075806ec1b8559f3
+DEPLOY_CONTROL_DAILY_RECOVERY_MAINTENANCE_BLOB=128a43549f117b0c934c91270581080a72d7c7b8
+DEPLOY_CONTROL_DAILY_RECOVERY_ENTRYPOINT_BLOB=3e6fa93501ee56b392618c319ec554dd99d5c4fd
+DEPLOY_CONTROL_DAILY_RECOVERY_SSH_WRAPPER_BLOB=bb0792969f366393f0ad126441bc722f8fcc6ff9
+DEPLOY_CONTROL_DAILY_RECOVERY_SSH_TEST_BLOB=1fda773628cfabc4d3bed779352391d5fd11016c
+DEPLOY_CONTROL_DAILY_RECOVERY_ABSENT_TEST_BLOB=bf9ad2356276d469aef3d493d2a238ef40422f60
+DEPLOY_CONTROL_DAILY_RECOVERY_ARTIFACTS_BLOB=85fdf0ef6d217eded040313a3c80117ef552bc04
+DEPLOY_CONTROL_DAILY_RECOVERY_HISTORY_BLOB=a3bae65e501a59401bfc4c72163e1580b471c142
+DEPLOY_CONTROL_DAILY_RECOVERY_HISTORY_TEST_BLOB=c7307f3e2808d02207ce8b8a62624271cc90caa7
 RABBITMQ_QUORUM_HEALTH_LIBRARY_PATH=ops/deploy/backend-runtime-health-lib.sh
 RABBITMQ_QUORUM_HEALTH_SCRIPT_PATH=ops/deploy/rabbitmq-quorum-health.sh
 RABBITMQ_QUORUM_RECOVERY_SCRIPT_PATH=ops/deploy/rabbitmq-quorum-recovery.sh
+
+deploy_control_bridge_sealed_paths() {
+  printf '%s\n' \
+    "$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH"
+}
+
+deploy_control_daily_c1_bridge_release_paths() {
+  printf '%s\n' \
+    .github/workflows/production-deploy.yml \
+    ops/deploy/daily-c1-control-bridge-workflow.test.sh \
+    ops/deploy/daily-runner-image-bootstrap-lib.sh \
+    ops/deploy/daily-runner-image-bootstrap-lib.test.sh \
+    ops/deploy/deploy-control-bridge-lib.sh \
+    ops/deploy/deploy-control-bridge-runtime-helper.test.sh \
+    ops/deploy/deploy-control-lib-test-fixture.sh \
+    ops/deploy/deploy-control-lib.sh \
+    ops/deploy/deploy-control-lib.test.sh \
+    ops/deploy/deploy-control-reviewed-library-source.test.sh \
+    ops/deploy/postgres-runtime-activation-boundary-lib.sh \
+    ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh \
+    ops/deploy/postgres-runtime-deploy-lib.sh \
+    ops/deploy/postgres-runtime-weekly-timer-state-lib.sh \
+    ops/deploy/production-release-a-transition.sh \
+    ops/deploy/production-release-a-transition.test.sh \
+    ops/deploy/reader-summary-publication-deploy-lib.sh \
+    ops/deploy/reader-summary-recovery-maintenance-lib.sh \
+    ops/deploy/social-monitor-production-deploy.sh \
+    ops/deploy/x-collector-image-deploy-lib.test.sh
+}
+
+deploy_control_is_exact_daily_c1_bridge_release() {
+  local base=$1 target=$2 repository=${REPO:-.}
+  local expected actual
+
+  git -C "$repository" merge-base --is-ancestor "$base" "$target" || return 1
+  expected=$(deploy_control_daily_c1_bridge_release_paths | LC_ALL=C sort)
+  actual=$(git -C "$repository" diff --name-only --no-renames \
+    "$base" "$target" -- | LC_ALL=C sort)
+  [[ $actual == "$expected" ]]
+}
+
+deploy_control_daily_c1_bridge_classification() {
+  printf 'frontend=false\nbackend=false\ncontrol=true\n'
+}
+
+deploy_control_is_reviewed_daily_final_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local target_parent changed final_delta path
+  local -a sealed_paths=() target_ancestry=()
+  target_parent=$(git -C "$repository" rev-parse "$target^" 2>/dev/null) || return 1
+  read -r -a target_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$target")" || return 1
+  git -C "$repository" cat-file -e \
+    "$DEPLOY_CONTROL_DAILY_FINAL_BASE^{commit}" 2>/dev/null || return 1
+  git -C "$repository" merge-base --is-ancestor \
+    "$DEPLOY_CONTROL_DAILY_FINAL_BASE" "$bridge" 2>/dev/null || return 1
+  [[ $target_parent == "$bridge" && ${#target_ancestry[@]} == 2 ]] || return 1
+  final_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_DAILY_FINAL_BASE" "$target" -- 2>/dev/null) || return 1
+  [[ $final_delta == $'ops/deploy/daily-final-control-bridge.test.sh\nops/deploy/deploy-control-bridge-lib.sh' ]] || return 1
+  while IFS= read -r path; do sealed_paths+=("$path"); done < <(deploy_control_bridge_sealed_paths)
+  changed=$(git -C "$repository" diff --name-only --no-renames \
+    "$bridge" "$target" -- "${sealed_paths[@]}" 2>/dev/null) || return 1
+  [[ $changed == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH" &&
+     $(git -C "$repository" rev-parse \
+       "$target:$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH" 2>/dev/null) == \
+       "$DEPLOY_CONTROL_DAILY_FINAL_HELPER_BLOB" ]]
+}
+
+deploy_control_daily_recovery_release_blobs() {
+  printf '%s %s\n' \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB" ops/deploy/backend-image-rescue-lib.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB" ops/deploy/backend-image-rescue-migrate-fallback.test.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_ABSENT_TEST_BLOB" ops/deploy/backend-image-rescue-absent-service.test.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_CLIENT_BLOB" ops/deploy/github-production-deploy-client.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_CLIENT_TEST_BLOB" ops/deploy/github-production-deploy-client.test.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_ARTIFACTS_BLOB" ops/deploy/production-runtime/compose.daily-artifacts.yml \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_RUNNER_BLOB" ops/deploy/production-runtime/daily-run.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_RUNNER_TEST_BLOB" ops/deploy/production-runtime/daily-run.test.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_MAINTENANCE_BLOB" ops/deploy/reader-summary-recovery-maintenance-lib.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_HISTORY_BLOB" ops/deploy/run-reader-summary-production-history.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_HISTORY_TEST_BLOB" ops/deploy/run-reader-summary-production-history.test.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_ENTRYPOINT_BLOB" ops/deploy/social-monitor-production-deploy.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_SSH_WRAPPER_BLOB" ops/deploy/social-monitor-production-ssh-wrapper.sh \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_SSH_TEST_BLOB" ops/deploy/social-monitor-production-ssh-wrapper.test.sh
+}
+
+deploy_control_is_reviewed_daily_recovery_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local target_parent bridge_delta expected actual expected_blob path
+  local -a target_ancestry=()
+
+  git -C "$repository" cat-file -e \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_BASE^{commit}" 2>/dev/null || return 1
+  target_parent=$(git -C "$repository" rev-parse "$target^" 2>/dev/null) || return 1
+  read -r -a target_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$target" 2>/dev/null)" || return 1
+  [[ $target_parent == "$bridge" && ${#target_ancestry[@]} == 2 ]] || return 1
+  bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_DAILY_RECOVERY_BASE" "$bridge" -- 2>/dev/null) || return 1
+  [[ $bridge_delta == $'ops/deploy/daily-final-control-bridge.test.sh\nops/deploy/deploy-control-bridge-lib.sh' ]] || return 1
+  expected=$(deploy_control_daily_recovery_release_blobs | awk '{ print $2 }' | LC_ALL=C sort)
+  actual=$(git -C "$repository" diff --name-only --no-renames \
+    "$bridge" "$target" -- 2>/dev/null | LC_ALL=C sort) || return 1
+  [[ $actual == "$expected" ]] || return 1
+  while read -r expected_blob path; do
+    [[ $(git -C "$repository" rev-parse "$target:$path" 2>/dev/null) == \
+       "$expected_blob" ]] || return 1
+  done < <(deploy_control_daily_recovery_release_blobs)
+}
+
+deploy_control_is_reviewed_scheduled_summary_catch_up_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local target_parent final_delta
+  local -a target_ancestry=()
+
+  git -C "$repository" cat-file -e \
+    "$DEPLOY_CONTROL_SCHEDULED_SUMMARY_CATCH_UP_BASE^{commit}" \
+    2>/dev/null || return 1
+  target_parent=$(git -C "$repository" rev-parse "$target^" 2>/dev/null) || \
+    return 1
+  read -r -a target_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$target" 2>/dev/null)" || return 1
+  git -C "$repository" merge-base --is-ancestor \
+    "$DEPLOY_CONTROL_SCHEDULED_SUMMARY_CATCH_UP_BASE" "$bridge" \
+    2>/dev/null || return 1
+  [[ $target_parent == "$bridge" && ${#target_ancestry[@]} == 2 ]] || \
+    return 1
+  final_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_SCHEDULED_SUMMARY_CATCH_UP_BASE" "$target" -- \
+    2>/dev/null) || return 1
+  [[ $final_delta == $'ops/deploy/daily-final-control-bridge.test.sh\nops/deploy/deploy-control-bridge-lib.sh' ]] || \
+    return 1
+  [[ $(git -C "$repository" rev-parse \
+       "$bridge:ops/deploy/daily-final-control-bridge.test.sh" 2>/dev/null) == \
+       $(git -C "$repository" rev-parse \
+       "$target:ops/deploy/daily-final-control-bridge.test.sh" 2>/dev/null) && \
+     $(git -C "$repository" rev-parse \
+       "$bridge:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) == \
+       $(git -C "$repository" rev-parse \
+       "$target:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) ]]
+}
+
+deploy_control_reviewed_transition_matches() {
+  local bridge=$1 target=$2
+  if deploy_control_daily_final_transition_matches "$bridge" "$target"; then
+    return 0
+  fi
+  if deploy_control_is_reviewed_scheduled_summary_catch_up_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
+  deploy_control_is_reviewed_daily_recovery_transition "$bridge" "$target"
+}
+
+deploy_control_daily_final_transition_compatible_paths() {
+  printf '%s\n' \
+    "$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_PATH"
+}
+
+deploy_control_daily_final_transition_matches() {
+  local bridge=$1 target=$2 path
+  deploy_control_is_reviewed_daily_final_transition "$bridge" "$target" || return 1
+  while IFS= read -r path; do
+    [[ $path == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH" ]] && continue
+    [[ $(git -C "$REPO" rev-parse "$bridge:$path" 2>/dev/null) == \
+       $(git -C "$REPO" rev-parse "$target:$path" 2>/dev/null) ]] || return 1
+  done < <(deploy_control_daily_final_transition_compatible_paths)
+}
+
+verify_deploy_control_daily_final_transition_files() {
+  local target=$1 path actual expected
+  deploy_control_reviewed_transition_matches \
+    "$DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD" "$target" || return 1
+  while IFS= read -r path; do
+    actual=$(deploy_control_file_digest "$REPO/$path") || return 1
+    expected=$(deploy_control_git_blob_digest "$target" "$path") || return 1
+    [[ $actual == "$expected" ]] || return 1
+  done < <(deploy_control_bridge_sealed_paths)
+}
 
 load_target_reader_summary_publication_deploy_library() {
   local sha=$1
@@ -82,6 +301,10 @@ deploy_control_bridge_require_initialized() {
   [[ -n ${DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST:-} && \
      -n ${DEPLOY_CONTROL_BRIDGE_LIBRARY_DIGEST:-} && \
      -n ${DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST:-} && \
+     -n ${DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_DIGEST:-} && \
+     -n ${DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_DIGEST:-} && \
+     -n ${DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_DIGEST:-} && \
+     -n ${DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_DIGEST:-} && \
      -n ${DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST:-} && \
      -n ${DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_DIGEST:-} && \
      -n ${DEPLOY_CONTROL_BRIDGE_SELF_DIGEST:-} ]] || \
@@ -92,6 +315,10 @@ initialize_deploy_control_bridge() {
   local entrypoint=$REPO/$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_PATH
   local deploy_library=$REPO/$DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH
   local postgres_library=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH
+  local weekly_timer_helper=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_PATH
+  local daily_c1_helper=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH
+  local activation_boundary_helper=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_PATH
+  local recovery_maintenance_library=$REPO/$DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_PATH
   local image_rescue_library=$REPO/$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_PATH
   local x_image_library=$REPO/$DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_PATH
   local bridge_library=$REPO/$DEPLOY_CONTROL_BRIDGE_SELF_PATH
@@ -99,6 +326,10 @@ initialize_deploy_control_bridge() {
   [[ -f $entrypoint && ! -L $entrypoint && \
      -f $deploy_library && ! -L $deploy_library && \
      -f $postgres_library && ! -L $postgres_library && \
+     -f $weekly_timer_helper && ! -L $weekly_timer_helper && \
+     -f $daily_c1_helper && ! -L $daily_c1_helper && \
+     -f $activation_boundary_helper && ! -L $activation_boundary_helper && \
+     -f $recovery_maintenance_library && ! -L $recovery_maintenance_library && \
      -f $image_rescue_library && ! -L $image_rescue_library && \
      -f $x_image_library && ! -L $x_image_library && \
      -f $bridge_library && ! -L $bridge_library ]] || \
@@ -106,15 +337,25 @@ initialize_deploy_control_bridge() {
   DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST=$(deploy_control_file_digest "$entrypoint")
   DEPLOY_CONTROL_BRIDGE_LIBRARY_DIGEST=$(deploy_control_file_digest "$deploy_library")
   DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST=$(deploy_control_file_digest "$postgres_library")
+  DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_DIGEST=$(deploy_control_file_digest "$weekly_timer_helper")
+  DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_DIGEST=$(deploy_control_file_digest "$daily_c1_helper")
+  DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_DIGEST=$(deploy_control_file_digest "$activation_boundary_helper")
+  DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_DIGEST=$(deploy_control_file_digest "$recovery_maintenance_library")
   DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST=$(deploy_control_file_digest "$image_rescue_library")
   DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_DIGEST=$(deploy_control_file_digest "$x_image_library")
   DEPLOY_CONTROL_BRIDGE_SELF_DIGEST=$(deploy_control_file_digest "$bridge_library")
+  DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD=$(git -C "$REPO" rev-parse HEAD) || \
+    fail 'deploy control bridge integration marker cannot be read'
 }
 
 verify_deploy_control_bridge_compatibility() {
   local entrypoint=$REPO/$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_PATH
   local deploy_library=$REPO/$DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH
   local postgres_library=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH
+  local weekly_timer_helper=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_PATH
+  local daily_c1_helper=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH
+  local activation_boundary_helper=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_PATH
+  local recovery_maintenance_library=$REPO/$DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_PATH
   local image_rescue_library=$REPO/$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_PATH
   local x_image_library=$REPO/$DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_PATH
   local bridge_library=$REPO/$DEPLOY_CONTROL_BRIDGE_SELF_PATH
@@ -123,13 +364,25 @@ verify_deploy_control_bridge_compatibility() {
   [[ -f $entrypoint && ! -L $entrypoint && \
      -f $deploy_library && ! -L $deploy_library && \
      -f $postgres_library && ! -L $postgres_library && \
+     -f $weekly_timer_helper && ! -L $weekly_timer_helper && \
+     -f $daily_c1_helper && ! -L $daily_c1_helper && \
+     -f $activation_boundary_helper && ! -L $activation_boundary_helper && \
+     -f $recovery_maintenance_library && ! -L $recovery_maintenance_library && \
      -f $image_rescue_library && ! -L $image_rescue_library && \
      -f $x_image_library && ! -L $x_image_library && \
      -f $bridge_library && ! -L $bridge_library ]] || \
     fail 'target integration is missing deploy control bridge sources'
+  if verify_deploy_control_daily_final_transition_files \
+      "$(git -C "$REPO" rev-parse HEAD)"; then
+    return 0
+  fi
   [[ $(deploy_control_file_digest "$entrypoint") == "$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST" && \
      $(deploy_control_file_digest "$deploy_library") == "$DEPLOY_CONTROL_BRIDGE_LIBRARY_DIGEST" && \
      $(deploy_control_file_digest "$postgres_library") == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST" && \
+     $(deploy_control_file_digest "$weekly_timer_helper") == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_DIGEST" && \
+     $(deploy_control_file_digest "$daily_c1_helper") == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_DIGEST" && \
+     $(deploy_control_file_digest "$activation_boundary_helper") == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_DIGEST" && \
+     $(deploy_control_file_digest "$recovery_maintenance_library") == "$DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_DIGEST" && \
      $(deploy_control_file_digest "$image_rescue_library") == "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST" && \
      $(deploy_control_file_digest "$x_image_library") == "$DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_DIGEST" && \
      $(deploy_control_file_digest "$bridge_library") == "$DEPLOY_CONTROL_BRIDGE_SELF_DIGEST" ]] || \
@@ -139,6 +392,8 @@ verify_deploy_control_bridge_compatibility() {
 verify_deploy_control_bridge_target_compatibility() {
   local sha=$1
   local entrypoint_digest deploy_library_digest postgres_library_digest
+  local weekly_timer_helper_digest daily_c1_helper_digest
+  local activation_boundary_helper_digest recovery_maintenance_library_digest
   local image_rescue_library_digest x_image_library_digest bridge_library_digest
 
   deploy_control_bridge_require_initialized
@@ -148,6 +403,14 @@ verify_deploy_control_bridge_target_compatibility() {
     "$DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH" 'target deploy control bridge library' >/dev/null
   deploy_control_bridge_git_regular_blob "$sha" \
     "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH" 'target PostgreSQL control bridge library' >/dev/null
+  deploy_control_bridge_git_regular_blob "$sha" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_PATH" 'target PostgreSQL weekly timer state helper' >/dev/null
+  deploy_control_bridge_git_regular_blob "$sha" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH" 'target PostgreSQL daily C1 readiness helper' >/dev/null
+  deploy_control_bridge_git_regular_blob "$sha" \
+    "$DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_PATH" 'target PostgreSQL activation boundary helper' >/dev/null
+  deploy_control_bridge_git_regular_blob "$sha" \
+    "$DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_PATH" 'target reader summary recovery maintenance library' >/dev/null
   deploy_control_bridge_git_regular_blob "$sha" \
     "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_PATH" 'target backend image rescue bridge library' >/dev/null
   deploy_control_bridge_git_regular_blob "$sha" \
@@ -160,15 +423,31 @@ verify_deploy_control_bridge_target_compatibility() {
     fail 'target integration is missing the deploy control bridge library'
   postgres_library_digest=$(deploy_control_git_blob_digest "$sha" "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH") || \
     fail 'target integration is missing the PostgreSQL control bridge library'
+  weekly_timer_helper_digest=$(deploy_control_git_blob_digest "$sha" "$DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_PATH") || \
+    fail 'target integration is missing the PostgreSQL weekly timer state helper'
+  daily_c1_helper_digest=$(deploy_control_git_blob_digest "$sha" "$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH") || \
+    fail 'target integration is missing the PostgreSQL daily C1 readiness helper'
+  activation_boundary_helper_digest=$(deploy_control_git_blob_digest "$sha" "$DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_PATH") || \
+    fail 'target integration is missing the PostgreSQL activation boundary helper'
+  recovery_maintenance_library_digest=$(deploy_control_git_blob_digest "$sha" "$DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_PATH") || \
+    fail 'target integration is missing the reader summary recovery maintenance library'
   image_rescue_library_digest=$(deploy_control_git_blob_digest "$sha" "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_PATH") || \
     fail 'target integration is missing the backend image rescue bridge library'
   x_image_library_digest=$(deploy_control_git_blob_digest "$sha" "$DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_PATH") || \
     fail 'target integration is missing the X image provenance bridge library'
   bridge_library_digest=$(deploy_control_git_blob_digest "$sha" "$DEPLOY_CONTROL_BRIDGE_SELF_PATH") || \
     fail 'target integration is missing the deploy control bridge library'
+  if deploy_control_reviewed_transition_matches \
+      "$DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD" "$sha"; then
+    return 0
+  fi
   [[ $entrypoint_digest == "$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST" && \
      $deploy_library_digest == "$DEPLOY_CONTROL_BRIDGE_LIBRARY_DIGEST" && \
      $postgres_library_digest == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_DIGEST" && \
+     $weekly_timer_helper_digest == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_DIGEST" && \
+     $daily_c1_helper_digest == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_DIGEST" && \
+     $activation_boundary_helper_digest == "$DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_DIGEST" && \
+     $recovery_maintenance_library_digest == "$DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_DIGEST" && \
      $image_rescue_library_digest == "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_DIGEST" && \
      $x_image_library_digest == "$DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_DIGEST" && \
      $bridge_library_digest == "$DEPLOY_CONTROL_BRIDGE_SELF_DIGEST" ]] || \

--- a/ops/deploy/deploy-control-bridge-runtime-helper.test.sh
+++ b/ops/deploy/deploy-control-bridge-runtime-helper.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/deploy-control-bridge-helper-test.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+REPO=$FIXTURE/repo
+
+install -d "$REPO/ops/deploy"
+bridge_sources=(
+  social-monitor-production-deploy.sh
+  deploy-control-lib.sh
+  deploy-control-bridge-lib.sh
+  postgres-runtime-deploy-lib.sh
+  postgres-runtime-weekly-timer-state-lib.sh
+  postgres-runtime-daily-c1-readiness-lib.sh
+  postgres-runtime-activation-boundary-lib.sh
+  reader-summary-recovery-maintenance-lib.sh
+  backend-image-rescue-lib.sh
+  x-collector-image-deploy-lib.sh
+)
+for source_name in "${bridge_sources[@]}"; do
+  cp "$SCRIPT_DIR/$source_name" "$REPO/ops/deploy/$source_name"
+done
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email deploy-control-bridge-test@example.invalid
+git -C "$REPO" config user.name deploy-control-bridge-test
+git -C "$REPO" add ops/deploy
+git -C "$REPO" commit -qm 'test: seed reviewed bridge sources'
+reviewed_sha=$(git -C "$REPO" rev-parse HEAD)
+
+fail() {
+  printf 'test deploy failure: %s\n' "$*" >&2
+  exit 1
+}
+
+deploy_control_file_digest() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+deploy_control_git_blob_digest() {
+  git -C "$REPO" show "$1:$2" | sha256sum | awk '{print $1}'
+}
+
+# shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
+source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
+
+assert_fails_with() {
+  local expected=$1
+  shift
+  local error status
+
+  set +e
+  error=$("$@" 2>&1)
+  status=$?
+  set -e
+  ((status != 0))
+  grep -F "$expected" <<< "$error" >/dev/null
+}
+
+restore_helper() {
+  cp "$SCRIPT_DIR/${1##*/}" "$REPO/$1"
+}
+
+initialize_deploy_control_bridge
+[[ -n $DEPLOY_CONTROL_BRIDGE_POSTGRES_WEEKLY_TIMER_HELPER_DIGEST ]]
+[[ -n $DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_DIGEST ]]
+[[ -n $DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_DIGEST ]]
+[[ -n $DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_DIGEST ]]
+verify_deploy_control_bridge_compatibility
+verify_deploy_control_bridge_target_compatibility "$reviewed_sha"
+
+sealed_dependencies=(
+  ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+  ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+  ops/deploy/postgres-runtime-activation-boundary-lib.sh
+  ops/deploy/reader-summary-recovery-maintenance-lib.sh
+)
+for dependency in "${sealed_dependencies[@]}"; do
+  rm "$REPO/$dependency"
+  assert_fails_with 'missing deploy control bridge sources' \
+    initialize_deploy_control_bridge
+  assert_fails_with 'missing deploy control bridge sources' \
+    verify_deploy_control_bridge_compatibility
+  restore_helper "$dependency"
+
+  mv "$REPO/$dependency" "$FIXTURE/sealed-dependency-source"
+  ln -s "$FIXTURE/sealed-dependency-source" "$REPO/$dependency"
+  assert_fails_with 'missing deploy control bridge sources' \
+    initialize_deploy_control_bridge
+  assert_fails_with 'missing deploy control bridge sources' \
+    verify_deploy_control_bridge_compatibility
+  rm "$REPO/$dependency"
+  mv "$FIXTURE/sealed-dependency-source" "$REPO/$dependency"
+
+  printf '# unreviewed sealed dependency mutation\n' >> "$REPO/$dependency"
+  assert_fails_with 'deploy the bridge release first' \
+    verify_deploy_control_bridge_compatibility
+  restore_helper "$dependency"
+done
+
+# Existing bridge dependencies stay sealed alongside the new helpers.
+printf '# unreviewed PostgreSQL controller mutation\n' >> \
+  "$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH"
+assert_fails_with 'deploy the bridge release first' \
+  verify_deploy_control_bridge_compatibility
+cp "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" \
+  "$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH"
+
+commit_target_state() {
+  local message=$1
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "$message"
+  git -C "$REPO" rev-parse HEAD
+}
+
+for dependency in "${sealed_dependencies[@]}"; do
+  rm "$REPO/$dependency"
+  missing_sha=$(commit_target_state 'test: remove sealed runtime helper')
+  assert_fails_with 'is not a regular blob at reviewed target' \
+    verify_deploy_control_bridge_target_compatibility "$missing_sha"
+  restore_helper "$dependency"
+  commit_target_state 'test: restore sealed runtime helper' >/dev/null
+
+  mv "$REPO/$dependency" "$FIXTURE/sealed-dependency-source"
+  ln -s "$FIXTURE/sealed-dependency-source" "$REPO/$dependency"
+  symlink_sha=$(commit_target_state 'test: replace sealed runtime helper with symlink')
+  assert_fails_with 'is not a regular blob at reviewed target' \
+    verify_deploy_control_bridge_target_compatibility "$symlink_sha"
+  rm "$REPO/$dependency"
+  mv "$FIXTURE/sealed-dependency-source" "$REPO/$dependency"
+  commit_target_state 'test: restore regular sealed runtime helper' >/dev/null
+
+  printf '# changed reviewed target dependency\n' >> "$REPO/$dependency"
+  changed_sha=$(commit_target_state 'test: change sealed runtime helper')
+  assert_fails_with 'deploy the bridge release first' \
+    verify_deploy_control_bridge_target_compatibility "$changed_sha"
+  restore_helper "$dependency"
+  commit_target_state 'test: restore exact sealed runtime helper' >/dev/null
+done
+
+printf '# changed reviewed PostgreSQL controller\n' >> \
+  "$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH"
+changed_postgres_sha=$(commit_target_state 'test: change existing sealed dependency')
+assert_fails_with 'deploy the bridge release first' \
+  verify_deploy_control_bridge_target_compatibility "$changed_postgres_sha"
+cp "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" \
+  "$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH"
+commit_target_state 'test: restore existing sealed dependency' >/dev/null
+
+verify_deploy_control_bridge_compatibility
+verify_deploy_control_bridge_target_compatibility "$reviewed_sha"
+
+if declare -F deploy_control_is_reviewed_daily_c1_bridge_transition >/dev/null; then
+  printf '# reviewed readiness-only transition\n' >> \
+    "$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH"
+  readiness_parent=$(git -C "$REPO" rev-parse HEAD)
+  readiness_sha=$(commit_target_state 'test: readiness-only transition')
+  git -C "$REPO" checkout -q "$readiness_parent"
+  verify_deploy_control_bridge_target_compatibility "$readiness_sha"
+
+  printf '# reviewed exact bridge transition\n' >> \
+    "$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH"
+  printf '# reviewed exact bridge transition\n' >> \
+    "$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH"
+  reviewed_bridge_parent=$(git -C "$REPO" rev-parse HEAD)
+  reviewed_bridge_sha=$(commit_target_state 'test: reviewed exact bridge transition')
+  git -C "$REPO" checkout -q "$reviewed_bridge_parent"
+  deploy_control_is_reviewed_daily_c1_bridge_transition() {
+    [[ $1 == "$reviewed_bridge_parent" && $2 == "$reviewed_bridge_sha" ]]
+  }
+  verify_deploy_control_bridge_target_compatibility "$reviewed_bridge_sha"
+fi
+printf 'deploy control bridge runtime helper tests passed\n'

--- a/ops/deploy/deploy-control-lib-test-fixture.sh
+++ b/ops/deploy/deploy-control-lib-test-fixture.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034 # Fixture variables are consumed by the sourcing test and its libraries.
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/deploy-control-lib-test.XXXXXX")
+trap 'touch "$FIXTURE/release"; rm -rf "$FIXTURE"' EXIT
+REPO=$FIXTURE/repo
+ROOT=$FIXTURE/root
+CONTROL=$FIXTURE/control
+STATE=$CONTROL/deploy-state
+STAGING=$ROOT/runtime/deploy-staging
+RELEASES=$ROOT/runtime/frontend-releases
+DEPLOY_LOCK=$CONTROL/production-deploy.lock
+DAILY_SINGLETON_LOCK=$CONTROL/daily-run-singleton.lock
+POSTGRES_ADMISSION_LOCK=$CONTROL/daily-run.lock
+# The sourced deploy-control library consumes this fixture-scoped path.
+# shellcheck disable=SC2034
+POSTGRES_RUNTIME_CURRENT=$CONTROL/postgres-runtime-current
+POSTGRES_RUNTIME_RELEASES=$CONTROL/postgres-runtime-releases
+SYSTEMD_UNIT_DIR=$ROOT/runtime/systemd
+COMPOSE=(docker compose)
+FRONTEND_PATHS=(frontend)
+BACKEND_PATHS=(backend)
+CONTROL_PATHS=(control)
+RUNTIME_CONTROL_PATHS=(runtime-control)
+
+install -d "$REPO/ops/deploy" "$CONTROL" "$STATE" "$SYSTEMD_UNIT_DIR"
+cp "$SCRIPT_DIR/social-monitor-production-deploy.sh" \
+  "$SCRIPT_DIR/social-monitor-production-ssh-wrapper.sh" \
+  "$SCRIPT_DIR/deploy-control-lib.sh" "$SCRIPT_DIR/deploy-control-bridge-lib.sh" \
+  "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" \
+  "$SCRIPT_DIR/postgres-runtime-activation-boundary-lib.sh" \
+  "$SCRIPT_DIR/postgres-runtime-daily-c1-readiness-lib.sh" \
+  "$SCRIPT_DIR/postgres-runtime-weekly-timer-state-lib.sh" \
+  "$SCRIPT_DIR/reader-summary-recovery-maintenance-lib.sh" \
+  "$SCRIPT_DIR/backend-image-rescue-lib.sh" \
+  "$SCRIPT_DIR/x-collector-image-deploy-lib.sh" \
+  "$SCRIPT_DIR/verify-postgres-runtime-topology.py" \
+  "$REPO/ops/deploy/"
+cp -a "$SCRIPT_DIR/production-runtime" "$REPO/ops/deploy/"
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.name 'Deploy Control Fixture'
+git -C "$REPO" config user.email deploy-control-fixture@example.invalid
+git -C "$REPO" add ops/deploy
+git -C "$REPO" commit -qm 'test: seed reviewed deploy control sources'

--- a/ops/deploy/deploy-control-lib.sh
+++ b/ops/deploy/deploy-control-lib.sh
@@ -18,6 +18,70 @@ deploy_control_git_blob_digest() {
   git -C "$REPO" show "$sha:$path" | sha256sum | awk '{print $1}'
 }
 
+# Focused tests replace the mutable worktree after the reviewed blob is staged.
+deploy_control_after_reviewed_library_stage() { :; }
+DEPLOY_CONTROL_REVIEWED_LIBRARY_FD=18
+
+source_reviewed_deploy_library() {
+  local sha=$1 relative_path=$2 label=$3 tree_entry mode type object tree_path
+  local expected_digest staging_directory staged_path staged_digest library_fd
+  [[ $sha =~ ^[0-9a-f]{40}$ && -d $STATE && ! -L $STATE ]] || \
+    fail "$label staging prerequisites are invalid"
+  tree_entry=$(git -C "$REPO" ls-tree "$sha" -- "$relative_path") || \
+    fail "$label cannot be inspected at reviewed commit"
+  read -r mode type object tree_path <<< "$tree_entry"
+  [[ ($mode == 100644 || $mode == 100755) && $type == blob && \
+     $object =~ ^[0-9a-f]+$ && $tree_path == "$relative_path" ]] || \
+    fail "$label is not a regular blob at reviewed commit"
+  expected_digest=$(deploy_control_git_blob_digest "$sha" "$relative_path") || \
+    fail "$label digest cannot be read at reviewed commit"
+  staging_directory=$(mktemp -d "$STATE/reviewed-library.XXXXXX") || \
+    fail "$label staging directory cannot be created"
+  chmod 0700 "$staging_directory" || {
+    rmdir "$staging_directory"
+    fail "$label staging directory cannot be sealed"
+  }
+  staged_path=$staging_directory/library.sh
+  if ! git -C "$REPO" show "$sha:$relative_path" > "$staged_path"; then
+    rm -f "$staged_path"; rmdir "$staging_directory"
+    fail "$label reviewed blob cannot be staged"
+  fi
+  chmod 0400 "$staged_path" || {
+    rm -f "$staged_path"; rmdir "$staging_directory"
+    fail "$label staged blob cannot be sealed"
+  }
+  staged_digest=$(deploy_control_file_digest "$staged_path") || {
+    rm -f "$staged_path"; rmdir "$staging_directory"
+    fail "$label staged digest cannot be read"
+  }
+  [[ $staged_digest == "$expected_digest" ]] || {
+    rm -f "$staged_path"; rmdir "$staging_directory"
+    fail "$label staged digest differs from reviewed blob"
+  }
+  library_fd=$((DEPLOY_CONTROL_REVIEWED_LIBRARY_FD + 1))
+  DEPLOY_CONTROL_REVIEWED_LIBRARY_FD=$library_fd
+  eval "exec ${library_fd}<\"\$staged_path\"" || {
+    DEPLOY_CONTROL_REVIEWED_LIBRARY_FD=$((library_fd - 1))
+    rm -f "$staged_path"; rmdir "$staging_directory"
+    fail "$label staged inode cannot be opened"
+  }
+  rm -f "$staged_path"
+  rmdir "$staging_directory"
+  deploy_control_after_reviewed_library_stage "$relative_path" || {
+    eval "exec ${library_fd}<&-"
+    DEPLOY_CONTROL_REVIEWED_LIBRARY_FD=$((library_fd - 1))
+    fail "$label post-stage validation failed"
+  }
+  # shellcheck source=/dev/null
+  source "/dev/fd/$library_fd" || {
+    eval "exec ${library_fd}<&-"
+    DEPLOY_CONTROL_REVIEWED_LIBRARY_FD=$((library_fd - 1))
+    fail "$label reviewed blob could not be sourced"
+  }
+  eval "exec ${library_fd}<&-"
+  DEPLOY_CONTROL_REVIEWED_LIBRARY_FD=$((library_fd - 1))
+}
+
 DEPLOY_CONTROL_BRIDGE_LIBRARY_LOADED=false
 
 load_deploy_control_bridge_library() {

--- a/ops/deploy/deploy-control-lib.test.sh
+++ b/ops/deploy/deploy-control-lib.test.sh
@@ -1,37 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/deploy-control-lib-test.XXXXXX")
-trap 'touch "$FIXTURE/release"; rm -rf "$FIXTURE"' EXIT
-REPO=$FIXTURE/repo
-ROOT=$FIXTURE/root
-CONTROL=$FIXTURE/control
-STATE=$CONTROL/deploy-state
-STAGING=$ROOT/runtime/deploy-staging
-RELEASES=$ROOT/runtime/frontend-releases
-DEPLOY_LOCK=$CONTROL/production-deploy.lock
-DAILY_SINGLETON_LOCK=$CONTROL/daily-run-singleton.lock
-POSTGRES_ADMISSION_LOCK=$CONTROL/daily-run.lock
-# The sourced deploy-control library consumes this fixture-scoped path.
-# shellcheck disable=SC2034
-POSTGRES_RUNTIME_CURRENT=$CONTROL/postgres-runtime-current
-POSTGRES_RUNTIME_RELEASES=$CONTROL/postgres-runtime-releases
-SYSTEMD_UNIT_DIR=$ROOT/runtime/systemd
-COMPOSE=(docker compose)
-FRONTEND_PATHS=(frontend)
-BACKEND_PATHS=(backend)
-CONTROL_PATHS=(control)
-RUNTIME_CONTROL_PATHS=(runtime-control)
-install -d "$REPO/ops/deploy" "$CONTROL" "$STATE" "$SYSTEMD_UNIT_DIR"
-cp "$SCRIPT_DIR/social-monitor-production-deploy.sh" \
-  "$SCRIPT_DIR/social-monitor-production-ssh-wrapper.sh" \
-  "$SCRIPT_DIR/deploy-control-lib.sh" "$SCRIPT_DIR/deploy-control-bridge-lib.sh" \
-  "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" \
-  "$SCRIPT_DIR/backend-image-rescue-lib.sh" \
-  "$SCRIPT_DIR/x-collector-image-deploy-lib.sh" \
-  "$SCRIPT_DIR/verify-postgres-runtime-topology.py" \
-  "$REPO/ops/deploy/"
-cp -a "$SCRIPT_DIR/production-runtime" "$REPO/ops/deploy/"
+# shellcheck source=ops/deploy/deploy-control-lib-test-fixture.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/deploy-control-lib-test-fixture.sh"
 fail() {
   printf 'test deploy failure: %s\n' "$*" >&2
   exit 1
@@ -226,11 +196,10 @@ for unit in \
   install -m 0644 "$source_runtime/$unit" "$SYSTEMD_UNIT_DIR/$unit"
 done
 install -m 0755 "$source_runtime/daily-run.sh" "$CONTROL/daily-run.sh"
-git -C "$REPO" init -q -b main
 git -C "$REPO" config user.email deploy-control-test@example.invalid
 git -C "$REPO" config user.name deploy-control-test
 git -C "$REPO" add .
-git -C "$REPO" commit -qm 'test: reconciled runtime target'
+git -C "$REPO" commit --allow-empty -qm 'test: reconciled runtime target'
 target_sha=$(git -C "$REPO" rev-parse HEAD)
 backend_marker_sha=617e284607f3dde74c27164af2b981770b9a62ed
 

--- a/ops/deploy/deploy-control-reviewed-library-source.test.sh
+++ b/ops/deploy/deploy-control-reviewed-library-source.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/reviewed-library-source.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+REPO=$FIXTURE/repo
+STATE=$FIXTURE/state
+MUTATION_EXECUTED=$FIXTURE/mutation-executed
+LIBRARY_PATH=ops/deploy/reviewed-library.sh
+mkdir -p "$REPO/ops/deploy" "$STATE"
+
+fail() { printf 'reviewed-library-test-error: %s\n' "$*" >&2; exit 1; }
+# shellcheck source=ops/deploy/deploy-control-lib.sh
+source "$SCRIPT_DIR/deploy-control-lib.sh"
+
+cat > "$REPO/$LIBRARY_PATH" <<'LIBRARY'
+source_reviewed_deploy_library "$REVIEWED_SHA" \
+  ops/deploy/reviewed-dependency.sh 'reviewed dependency library'
+reviewed_library_value() { printf 'reviewed\n'; }
+LIBRARY
+cat > "$REPO/ops/deploy/reviewed-dependency.sh" <<'LIBRARY'
+reviewed_dependency_value() { printf 'reviewed-dependency\n'; }
+LIBRARY
+git -C "$REPO" init -q
+git -C "$REPO" config user.name 'Reviewed Library Test'
+git -C "$REPO" config user.email reviewed-library@example.invalid
+git -C "$REPO" add ops/deploy
+git -C "$REPO" commit -qm 'test: seed reviewed library'
+REVIEWED_SHA=$(git -C "$REPO" rev-parse HEAD)
+
+deploy_control_after_reviewed_library_stage() {
+  case $1 in
+    "$LIBRARY_PATH") cat > "$REPO/$LIBRARY_PATH" <<MUTATED
+: > "$MUTATION_EXECUTED"
+reviewed_library_value() { printf 'mutated\\n'; }
+MUTATED
+      ;;
+    ops/deploy/reviewed-dependency.sh)
+      printf ': > "%s"\n' "$MUTATION_EXECUTED" > \
+        "$REPO/ops/deploy/reviewed-dependency.sh"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+source_reviewed_deploy_library \
+  "$REVIEWED_SHA" "$LIBRARY_PATH" 'reviewed test library'
+[[ $(reviewed_library_value) == reviewed ]]
+[[ $(reviewed_dependency_value) == reviewed-dependency ]]
+[[ ! -e $MUTATION_EXECUTED ]]
+[[ -z $(find "$STATE" -mindepth 1 -print -quit) ]]
+
+if (source_reviewed_deploy_library \
+  "$REVIEWED_SHA" ops/deploy/missing.sh 'missing test library' \
+  >/dev/null 2>&1); then
+  echo 'missing reviewed library was sourced' >&2
+  exit 1
+fi
+[[ -z $(find "$STATE" -mindepth 1 -print -quit) ]]
+
+ln -s reviewed-library.sh "$REPO/ops/deploy/symlink-library.sh"
+git -C "$REPO" add ops/deploy/symlink-library.sh
+git -C "$REPO" commit -qm 'test: add non-regular reviewed entry'
+SYMLINK_SHA=$(git -C "$REPO" rev-parse HEAD)
+if (source_reviewed_deploy_library \
+  "$SYMLINK_SHA" ops/deploy/symlink-library.sh 'symlink test library' \
+  >/dev/null 2>&1); then
+  echo 'non-regular reviewed library was sourced' >&2
+  exit 1
+fi
+
+echo 'Reviewed deploy library stable-inode tests passed'

--- a/ops/deploy/postgres-runtime-activation-boundary-lib.sh
+++ b/ops/deploy/postgres-runtime-activation-boundary-lib.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+# Sourced by postgres-runtime-deploy-lib.sh after the daily C1 helper. This
+# file owns release-exposure exclusion and the outer forward-only boundary.
+
+STATE=${STATE:?caller must define STATE before sourcing activation boundary helper}
+POSTGRES_RUNTIME_FORWARD_ONLY_MARKER=daily-c1-forward-only
+POSTGRES_RUNTIME_ROLLBACK_OWNER_BASIS=daily-c1-owner-before-activation
+
+postgres_runtime_activation_failpoint() {
+  [[ ${POSTGRES_RUNTIME_ACTIVATION_FAILPOINT:-} != "$1" ]] || {
+    fail "PostgreSQL runtime activation failpoint reached: $1"
+    return 1
+  }
+}
+
+postgres_runtime_daily_c1_current_readiness_state() {
+  local marker=$POSTGRES_RUNTIME_CURRENT/$POSTGRES_RUNTIME_DAILY_C1_MARKER
+  if [[ ! -e $marker && ! -L $marker ]]; then
+    printf 'ABSENT\n'
+    return 0
+  fi
+  postgres_runtime_daily_c1_readiness_state "$marker"
+}
+
+prepare_postgres_runtime_daily_c1_ready_reexposure() {
+  local target_state=$1 current_state runtime
+  current_state=$(postgres_runtime_daily_c1_current_readiness_state) || return 1
+  [[ $current_state == READY && $target_state == READY ]] || return 0
+  runtime=$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME
+  [[ -f $runtime && ! -L $runtime && -x $runtime ]] || {
+    fail 'installed daily C1 runtime check is unavailable'
+    return 1
+  }
+  systemctl stop "$POSTGRES_RUNTIME_DAILY_TIMER" || {
+    fail 'daily C1 READY re-exposure could not stop the legacy timer'
+    return 1
+  }
+  "$runtime" --check-no-unresolved || {
+    fail 'daily C1 READY re-exposure found an unresolved invocation journal'
+    return 1
+  }
+  prove_postgres_runtime_daily_c1_flip_idle || return 1
+  postgres_runtime_activation_failpoint after-ready-journal-check-before-exposure
+}
+
+prepare_postgres_runtime_daily_c1_owner_before_exposure() {
+  persist_postgres_runtime_daily_c1_v6_owner "$1" || return 1
+  postgres_runtime_activation_failpoint after-v6-owner-before-exposure
+}
+
+postgres_runtime_control_forward_only_state() {
+  local marker=$1/$POSTGRES_RUNTIME_FORWARD_ONLY_MARKER
+  if [[ ! -e $marker && ! -L $marker ]]; then
+    printf 'reversible\n'
+    return 0
+  fi
+  [[ -f $marker && ! -L $marker && ! -s $marker ]] || {
+    fail 'PostgreSQL runtime forward-only boundary marker is invalid'
+    return 1
+  }
+  printf 'crossed\n'
+}
+
+initialize_postgres_runtime_control_rollback_basis() {
+  local backup=$1 state record file
+  state=$(postgres_runtime_daily_c1_owner_state) || return 1
+  if [[ $state == absent ]]; then
+    record=absent
+  else
+    record=$(postgres_runtime_daily_c1_owner_record) || return 1
+  fi
+  install -d -m 0700 "$backup"
+  file=$backup/$POSTGRES_RUNTIME_ROLLBACK_OWNER_BASIS
+  printf '%s\n' "$record" > "$file"
+  chmod 0444 "$file"
+  postgres_runtime_daily_c1_fsync_path_and_parent "$file"
+  postgres_runtime_daily_c1_fsync_parent "$backup"
+}
+
+postgres_runtime_control_rollback_owner_basis() {
+  local backup=$1 file=$1/$POSTGRES_RUNTIME_ROLLBACK_OWNER_BASIS record mode
+  if [[ ! -e $file && ! -L $file ]]; then
+    printf 'unrecorded\n'
+    return 0
+  fi
+  [[ -f $file && ! -L $file ]] || {
+    fail 'PostgreSQL runtime rollback owner basis is not a regular file'
+    return 1
+  }
+  mode=$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file") || return 1
+  [[ $mode == 444 ]] || {
+    fail 'PostgreSQL runtime rollback owner basis mode is invalid'
+    return 1
+  }
+  record=$(<"$file") || return 1
+  [[ $record == absent || $record =~ ^(V6|LEGACY)$'\t'[0-9a-f]{40}$ ]] || {
+    fail 'PostgreSQL runtime rollback owner basis is invalid'
+    return 1
+  }
+  printf '%s\n' "${record%%$'\t'*}"
+}
+
+postgres_runtime_control_rollback_state() {
+  local backup=$1 marker_state basis current
+  marker_state=$(postgres_runtime_control_forward_only_state "$backup") || return 1
+  [[ $marker_state != crossed ]] || { printf 'crossed\n'; return 0; }
+  basis=$(postgres_runtime_control_rollback_owner_basis "$backup") || return 1
+  current=$(postgres_runtime_daily_c1_owner_state) || return 1
+  if [[ $current == LEGACY && $basis != LEGACY ]]; then
+    printf 'crossed\n'
+    return 0
+  fi
+  [[ $basis != LEGACY || $current == LEGACY ]] && \
+    [[ $basis != V6 || $current != absent ]] || {
+    fail 'PostgreSQL runtime daily C1 owner regressed after rollback snapshot'
+    return 1
+  }
+  printf 'reversible\n'
+}
+
+propagate_postgres_runtime_control_forward_only_boundary() {
+  local inner=$1 outer=${2:-} state marker staged
+  state=$(postgres_runtime_control_forward_only_state "$inner") || return 1
+  [[ $state == crossed && -n $outer ]] || return 0
+  [[ -d $outer && ! -L $outer && \
+     $outer == "$STATE"/postgres-runtime-release-rollback-* ]] || {
+    fail 'outer PostgreSQL runtime rollback backup is invalid'
+    return 1
+  }
+  marker=$outer/$POSTGRES_RUNTIME_FORWARD_ONLY_MARKER
+  if [[ -e $marker || -L $marker ]]; then
+    [[ $(postgres_runtime_control_forward_only_state "$outer") == crossed ]]
+    return 0
+  fi
+  staged=$marker.next.$$
+  : > "$staged"
+  chmod 0444 "$staged"
+  postgres_runtime_daily_c1_fsync_path_and_parent "$staged"
+  ln "$staged" "$marker" || { rm -f "$staged"; return 1; }
+  rm -f "$staged"
+  postgres_runtime_daily_c1_fsync_parent "$marker"
+  [[ $(postgres_runtime_control_forward_only_state "$outer") == crossed ]]
+}
+
+require_postgres_runtime_control_rollback_allowed() {
+  local state
+  state=$(postgres_runtime_control_rollback_state "$1") || return 1
+  [[ $state == reversible ]] || {
+    printf 'deploy-error: daily C1 owner handoff crossed the forward-only boundary; rollback is forbidden and backup is retained at %s\n' \
+      "$1" >&2
+    return 1
+  }
+}
+
+rollback_backend_and_runtime_control_forward_only_safe() {
+  local backend_status=0
+  if require_postgres_runtime_control_rollback_allowed "$3"; then
+    rollback_backend_and_runtime_control "$@"
+    return
+  fi
+  if [[ $1 == true ]]; then
+    rollback_backend_images "$2" || backend_status=$?
+    if ((backend_status != 0)); then
+      printf 'deploy-error: backend image/container rollback failed (status=%d)\n' \
+        "$backend_status" >&2
+    fi
+  fi
+  return 1
+}

--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
@@ -1,0 +1,936 @@
+#!/usr/bin/env bash
+
+# Sourced by postgres-runtime-deploy-lib.sh. This file owns the bounded daily
+# C1 readiness asset and the READY-only systemd timer handoff transaction.
+
+POSTGRES_RUNTIME_DAILY_C1_MARKER=reader-summary-daily-c1.readiness
+POSTGRES_RUNTIME_DAILY_TIMER=social-monitor-daily.timer
+POSTGRES_RUNTIME_DAILY_SERVICE=social-monitor-daily.service
+POSTGRES_RUNTIME_DAILY_RUNNER=daily-run.sh
+POSTGRES_RUNTIME_DAILY_V6_TIMER=social-monitor-reader-summary-production-day.timer
+POSTGRES_RUNTIME_DAILY_V6_SERVICE=social-monitor-reader-summary-production-day.service
+POSTGRES_RUNTIME_DAILY_C1_RUNTIME=daily-c1-runtime.sh
+POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET=social-monitor-reader-summary-production-day.service.d-10-daily-c1-owner.conf
+POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_DIRECTORY=$POSTGRES_RUNTIME_DAILY_V6_SERVICE.d
+POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN=10-daily-c1-owner.conf
+POSTGRES_RUNTIME_DAILY_C1_OWNER=reader-summary-daily-c1-owner.v1
+POSTGRES_RUNTIME_DAILY_C1_BASELINES=reader-summary-daily-c1-baselines
+
+require_postgres_runtime_daily_c1_source() {
+  local source=$1
+  require_postgres_runtime_regular_source \
+    "$source/$POSTGRES_RUNTIME_DAILY_C1_MARKER" 644 || return
+  require_postgres_runtime_regular_source \
+    "$source/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" 755 || return
+  require_postgres_runtime_regular_source \
+    "$source/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" 644 || return
+}
+
+stage_postgres_runtime_daily_c1_readiness() {
+  local source=$1 staged_release=$2
+  install -m 0644 "$source/$POSTGRES_RUNTIME_DAILY_C1_MARKER" \
+    "$staged_release/$POSTGRES_RUNTIME_DAILY_C1_MARKER"
+  install -m 0755 "$source/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" \
+    "$staged_release/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME"
+  install -m 0644 "$source/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" \
+    "$staged_release/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET"
+}
+
+verify_postgres_runtime_daily_c1_release() {
+  local source=$1 release=$2
+  require_postgres_runtime_regular_release_file \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_MARKER" 644 || return
+  cmp -s "$source/$POSTGRES_RUNTIME_DAILY_C1_MARKER" \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_MARKER" || \
+    { fail 'immutable daily C1 readiness marker differs from source'; return 1; }
+  require_postgres_runtime_regular_release_file \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" 755 || return
+  require_postgres_runtime_regular_release_file \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" 644 || return
+  cmp -s "$source/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" || \
+    { fail 'immutable daily C1 runtime helper differs from source'; return 1; }
+  cmp -s "$source/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" || \
+    { fail 'immutable daily C1 v6 owner drop-in differs from source'; return 1; }
+}
+
+verify_installed_postgres_runtime_daily_c1_readiness() {
+  local source=$1 release=$2 current=$3
+  require_postgres_runtime_regular_release_file \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_MARKER" 644 || return
+  cmp -s "$source/$POSTGRES_RUNTIME_DAILY_C1_MARKER" \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_MARKER" || \
+    { fail 'installed daily C1 readiness marker differs from release source'; return 1; }
+  cmp -s "$release/$POSTGRES_RUNTIME_DAILY_C1_MARKER" \
+    "$current/$POSTGRES_RUNTIME_DAILY_C1_MARKER" || \
+    { fail 'current daily C1 readiness marker differs from the release'; return 1; }
+  cmp -s "$source/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" || \
+    { fail 'installed daily C1 runtime helper differs from release source'; return 1; }
+  cmp -s "$release/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" \
+    "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" || \
+    { fail 'installed daily C1 runtime helper differs from the release'; return 1; }
+  cmp -s "$source/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" || \
+    { fail 'installed daily C1 v6 owner drop-in differs from release source'; return 1; }
+}
+
+postgres_runtime_daily_c1_readiness_state() {
+  local marker=$1
+  if cmp -s "$marker" <(printf '%s\n' \
+    schemaVersion=reader_summary.daily_delivery_readiness.c1 \
+    state=READY \
+    requires=H_GREEN,C0_GREEN,C1_SCAN_TERMINAL_REPAIR_GREEN \
+    activation=reviewed); then
+    printf 'READY\n'
+  elif cmp -s "$marker" <(printf '%s\n' \
+    schemaVersion=reader_summary.daily_delivery_readiness.c1 \
+    state=BLOCKED \
+    requires=H_GREEN,C0_GREEN,reviewed_activation \
+    activation=forbidden); then
+    printf 'BLOCKED\n'
+  else
+    fail 'daily C1 readiness marker state is invalid'
+    return 1
+  fi
+}
+
+require_postgres_runtime_daily_c1_transition() {
+  local next_state=$1 current=$2 current_state
+  [[ -f $current/$POSTGRES_RUNTIME_DAILY_C1_MARKER ]] || return 0
+  current_state=$(postgres_runtime_daily_c1_readiness_state \
+    "$current/$POSTGRES_RUNTIME_DAILY_C1_MARKER") || return
+  if [[ $current_state == READY && $next_state == BLOCKED ]]; then
+    fail 'daily C1 readiness cannot regress from READY to BLOCKED'
+    return 1
+  fi
+}
+
+postgres_runtime_daily_c1_owner_marker() {
+  printf '%s/%s\n' "$CONTROL" "$POSTGRES_RUNTIME_DAILY_C1_OWNER"
+}
+
+postgres_runtime_daily_c1_fsync_path_and_parent() {
+  python3 - "$1" <<'PY'
+import os, sys
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+fd = os.open(os.path.dirname(path) or ".", os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+}
+
+postgres_runtime_daily_c1_fsync_parent() {
+  python3 - "$1" <<'PY'
+import os, sys
+fd = os.open(os.path.dirname(sys.argv[1]) or ".", os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+}
+
+postgres_runtime_daily_c1_owner_record() {
+  local marker owner sha mode
+  marker=$(postgres_runtime_daily_c1_owner_marker)
+  [[ -f $marker && ! -L $marker ]] || {
+    fail 'daily C1 owner marker is not a regular file'
+    return 1
+  }
+  mode=$(stat -c '%a' "$marker" 2>/dev/null || stat -f '%Lp' "$marker") || return
+  [[ $mode == 444 ]] || {
+    fail 'daily C1 owner marker mode is invalid'
+    return 1
+  }
+  owner=$(sed -n '2s/^owner=//p' "$marker")
+  sha=$(sed -n '3s/^releaseSha=//p' "$marker")
+  [[ $owner == V6 || $owner == LEGACY ]] || {
+    fail 'daily C1 owner marker state is invalid'
+    return 1
+  }
+  [[ $sha =~ ^[0-9a-f]{40}$ ]] || {
+    fail 'daily C1 owner marker release SHA is invalid'
+    return 1
+  }
+  cmp -s "$marker" <(printf '%s\n' \
+    schemaVersion=reader_summary.daily_c1_owner.v1 \
+    "owner=$owner" "releaseSha=$sha") || {
+    fail 'daily C1 owner marker is not canonical'
+    return 1
+  }
+  printf '%s\t%s\n' "$owner" "$sha"
+}
+
+postgres_runtime_daily_c1_owner_state() {
+  local marker record
+  marker=$(postgres_runtime_daily_c1_owner_marker)
+  if [[ ! -e $marker && ! -L $marker ]]; then
+    printf 'absent\n'
+    return
+  fi
+  record=$(postgres_runtime_daily_c1_owner_record) || return
+  printf '%s\n' "${record%%$'\t'*}"
+}
+
+persist_postgres_runtime_daily_c1_v6_owner() {
+  local sha=$1 marker staged state
+  [[ $sha =~ ^[0-9a-f]{40}$ ]] || {
+    fail 'daily C1 V6 owner release SHA is invalid'
+    return 1
+  }
+  marker=$(postgres_runtime_daily_c1_owner_marker)
+  state=$(postgres_runtime_daily_c1_owner_state) || return
+  [[ $state == absent ]] || {
+    [[ $state == V6 || $state == LEGACY ]] || return 1
+    return 0
+  }
+  staged=$marker.next.$$
+  printf '%s\n' schemaVersion=reader_summary.daily_c1_owner.v1 \
+    owner=V6 "releaseSha=$sha" > "$staged"
+  chmod 0444 "$staged"
+  postgres_runtime_daily_c1_fsync_path_and_parent "$staged"
+  if ! ln "$staged" "$marker" 2>/dev/null; then
+    rm -f "$staged"
+    postgres_runtime_daily_c1_owner_record >/dev/null
+    return
+  fi
+  rm -f "$staged"
+  postgres_runtime_daily_c1_fsync_parent "$marker"
+  [[ $(postgres_runtime_daily_c1_owner_state) == V6 ]]
+}
+
+commit_postgres_runtime_daily_c1_legacy_owner() {
+  local sha=$1 marker staged record
+  [[ $sha =~ ^[0-9a-f]{40}$ ]] || {
+    fail 'daily C1 LEGACY owner release SHA is invalid'
+    return 1
+  }
+  marker=$(postgres_runtime_daily_c1_owner_marker)
+  record=$(postgres_runtime_daily_c1_owner_record) || return
+  if [[ ${record%%$'\t'*} == LEGACY ]]; then
+    return 0
+  fi
+  [[ ${record%%$'\t'*} == V6 ]] || {
+    fail 'daily C1 owner transition is invalid'
+    return 1
+  }
+  staged=$marker.legacy.$$
+  printf '%s\n' schemaVersion=reader_summary.daily_c1_owner.v1 \
+    owner=LEGACY "releaseSha=$sha" > "$staged"
+  chmod 0444 "$staged"
+  postgres_runtime_daily_c1_fsync_path_and_parent "$staged"
+  mv -f "$staged" "$marker"
+  postgres_runtime_daily_c1_fsync_path_and_parent "$marker"
+  record=$(postgres_runtime_daily_c1_owner_record) || return
+  [[ $record == "LEGACY"$'\t'"$sha" ]]
+}
+
+postgres_runtime_daily_c1_baseline_path() {
+  printf '%s/%s/%s.v1\n' "$CONTROL" \
+    "$POSTGRES_RUNTIME_DAILY_C1_BASELINES" "$1"
+}
+
+verify_postgres_runtime_daily_c1_baseline() {
+  local sha=$1 path release_sha boot_id previous_id previous_start mode
+  path=$(postgres_runtime_daily_c1_baseline_path "$sha")
+  [[ -f $path && ! -L $path ]] || {
+    fail 'daily C1 baseline is not a regular file'
+    return 1
+  }
+  mode=$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path") || return
+  [[ $mode == 444 ]] || {
+    fail 'daily C1 baseline mode is invalid'
+    return 1
+  }
+  release_sha=$(sed -n '2s/^releaseSha=//p' "$path")
+  boot_id=$(sed -n '3s/^bootId=//p' "$path")
+  previous_id=$(sed -n '4s/^previousInvocationId=//p' "$path")
+  previous_start=$(sed -n '5s/^previousMainTimestampMonotonic=//p' "$path")
+  [[ $release_sha == "$sha" && \
+     $boot_id =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ && \
+     (-z $previous_id || $previous_id =~ ^[0-9a-f]{32}$) && \
+     $previous_start =~ ^[0-9]+$ ]] || {
+    fail 'daily C1 baseline fields are invalid'
+    return 1
+  }
+  cmp -s "$path" <(printf '%s\n' \
+    schemaVersion=reader_summary.daily_c1_baseline.v1 \
+    "releaseSha=$sha" "bootId=$boot_id" \
+    "previousInvocationId=$previous_id" \
+    "previousMainTimestampMonotonic=$previous_start") || {
+    fail 'daily C1 baseline is not canonical'
+    return 1
+  }
+}
+
+prepare_postgres_runtime_daily_c1_baseline() {
+  local sha=$1 path directory staged boot_id previous_id previous_start
+  [[ $sha =~ ^[0-9a-f]{40}$ ]] || {
+    fail 'daily C1 baseline release SHA is invalid'
+    return 1
+  }
+  path=$(postgres_runtime_daily_c1_baseline_path "$sha")
+  if [[ -e $path || -L $path ]]; then
+    verify_postgres_runtime_daily_c1_baseline "$sha"
+    return
+  fi
+  directory=${path%/*}
+  install -d -m 0700 "$directory"
+  boot_id=${POSTGRES_RUNTIME_DAILY_C1_TEST_BOOT_ID:-}
+  [[ -n $boot_id ]] || boot_id=$(tr '[:upper:]' '[:lower:]' < /proc/sys/kernel/random/boot_id)
+  previous_id=$(systemctl show --property=InvocationID --value \
+    "$POSTGRES_RUNTIME_DAILY_SERVICE") || return
+  previous_start=$(systemctl show --property=ExecMainStartTimestampMonotonic \
+    --value "$POSTGRES_RUNTIME_DAILY_SERVICE") || return
+  [[ -z $previous_id || $previous_id =~ ^[0-9a-f]{32}$ ]] || {
+    fail 'daily C1 baseline previous invocation ID is invalid'
+    return 1
+  }
+  [[ -n $previous_start ]] || previous_start=0
+  [[ $previous_start =~ ^[0-9]+$ ]] || {
+    fail 'daily C1 baseline previous start timestamp is invalid'
+    return 1
+  }
+  staged=$path.next.$$
+  printf '%s\n' schemaVersion=reader_summary.daily_c1_baseline.v1 \
+    "releaseSha=$sha" "bootId=$boot_id" \
+    "previousInvocationId=$previous_id" \
+    "previousMainTimestampMonotonic=$previous_start" > "$staged"
+  chmod 0444 "$staged"
+  postgres_runtime_daily_c1_fsync_path_and_parent "$staged"
+  if ! ln "$staged" "$path" 2>/dev/null; then
+    rm -f "$staged"
+    verify_postgres_runtime_daily_c1_baseline "$sha"
+    return
+  fi
+  rm -f "$staged"
+  postgres_runtime_daily_c1_fsync_parent "$path"
+  verify_postgres_runtime_daily_c1_baseline "$sha"
+}
+
+install_postgres_runtime_daily_c1_bridge_assets() {
+  local release=$1 unit_directory=$2 dropin_directory dropin
+  dropin_directory=$unit_directory/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_DIRECTORY
+  dropin=$dropin_directory/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN
+  install -d -m 0755 "$dropin_directory"
+  install -m 0755 "$release/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" \
+    "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.next"
+  mv -f "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.next" \
+    "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME"
+  install -m 0644 "$release/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" \
+    "$dropin.next"
+  mv -f "$dropin.next" "$dropin"
+}
+
+verify_postgres_runtime_daily_c1_bridge_assets() {
+  local release=$1 unit_directory=$2 dropin
+  dropin=$unit_directory/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_DIRECTORY/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN
+  cmp -s "$release/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" \
+    "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" || {
+    fail 'daily C1 installed runtime helper differs from release'
+    return 1
+  }
+  cmp -s "$release/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" "$dropin" || {
+    fail 'daily C1 installed v6 owner drop-in differs from release'
+    return 1
+  }
+}
+
+postgres_runtime_daily_c1_containment_marker() {
+  printf '%s/reader-summary-daily-c1-contained.v1\n' "$CONTROL"
+}
+
+postgres_runtime_daily_c1_containment_record() {
+  local marker state value mode
+  marker=$(postgres_runtime_daily_c1_containment_marker)
+  if [[ ! -e $marker && ! -L $marker ]]; then
+    return 1
+  fi
+  [[ -f $marker && ! -L $marker ]] || \
+    { fail 'daily C1 containment marker is not a regular file'; return 1; }
+  mode=$(stat -c '%a' "$marker" 2>/dev/null || stat -f '%Lp' "$marker") || return
+  [[ $mode == 444 ]] || \
+    { fail 'daily C1 containment marker mode is invalid'; return 1; }
+  state=$(sed -n '2s/^state=//p' "$marker") || return
+  value=$(sed -n '3s/^readySha=//p' "$marker") || return
+  [[ $state == REQUESTED || $state == CONTAINED ]] || \
+    { fail 'daily C1 containment marker is invalid'; return 1; }
+  [[ $value =~ ^[0-9a-f]{40}$ ]] || \
+    { fail 'daily C1 containment marker is invalid'; return 1; }
+  cmp -s "$marker" <(printf '%s\n' \
+    schemaVersion=reader_summary.daily_c1_containment.v1 \
+    "state=$state" "readySha=$value") || \
+    { fail 'daily C1 containment marker is invalid'; return 1; }
+  printf '%s\t%s\n' "$state" "$value"
+}
+
+postgres_runtime_daily_c1_containment_sha() {
+  local record
+  record=$(postgres_runtime_daily_c1_containment_record) || return
+  printf '%s\n' "${record#*$'\t'}"
+}
+
+postgres_runtime_daily_c1_containment_state() {
+  local marker
+  marker=$(postgres_runtime_daily_c1_containment_marker)
+  if [[ ! -e $marker && ! -L $marker ]]; then
+    printf 'clear\n'
+    return
+  fi
+  local record state
+  record=$(postgres_runtime_daily_c1_containment_record) || return
+  state=${record%%$'\t'*}
+  case $state in
+    REQUESTED) printf 'requested\n' ;;
+    CONTAINED) printf 'contained\n' ;;
+  esac
+}
+
+persist_postgres_runtime_daily_c1_containment_requested() {
+  local sha=$1 marker staged
+  [[ $sha =~ ^[0-9a-f]{40}$ ]] || \
+    { fail 'daily C1 containment SHA is invalid'; return 1; }
+  marker=$(postgres_runtime_daily_c1_containment_marker)
+  if [[ -e $marker || -L $marker ]]; then
+    [[ $(postgres_runtime_daily_c1_containment_sha) == "$sha" ]] || \
+      { fail 'daily C1 containment marker conflicts with an existing incident'; return 1; }
+    postgres_runtime_daily_c1_fsync_path_and_parent "$marker"
+    return
+  fi
+  staged=$marker.next.$$
+  umask 077
+  printf '%s\n' schemaVersion=reader_summary.daily_c1_containment.v1 \
+    state=REQUESTED "readySha=$sha" > "$staged"
+  chmod 0444 "$staged"
+  postgres_runtime_daily_c1_fsync_path_and_parent "$staged" || {
+    rm -f "$staged"
+    return 1
+  }
+  if ! ln "$staged" "$marker" 2>/dev/null; then
+    rm -f "$staged"
+    [[ $(postgres_runtime_daily_c1_containment_sha) == "$sha" ]] || \
+      { fail 'daily C1 containment marker raced with another incident'; return 1; }
+    postgres_runtime_daily_c1_fsync_path_and_parent "$marker" || return
+    return
+  fi
+  rm -f "$staged"
+  postgres_runtime_daily_c1_fsync_parent "$marker" || return
+  [[ $(postgres_runtime_daily_c1_containment_sha) == "$sha" ]]
+}
+
+promote_postgres_runtime_daily_c1_containment_contained() {
+  local sha=$1 marker staged state
+  [[ $sha =~ ^[0-9a-f]{40}$ ]] || \
+    { fail 'daily C1 containment SHA is invalid'; return 1; }
+  marker=$(postgres_runtime_daily_c1_containment_marker)
+  [[ $(postgres_runtime_daily_c1_containment_sha) == "$sha" ]] || \
+    { fail 'daily C1 containment marker is bound to another READY release'; return 1; }
+  state=$(postgres_runtime_daily_c1_containment_state) || return
+  if [[ $state == contained ]]; then
+    postgres_runtime_daily_c1_fsync_path_and_parent "$marker"
+    return
+  fi
+  [[ $state == requested ]] || \
+    { fail 'daily C1 containment marker cannot be promoted'; return 1; }
+  staged=$marker.contained.$$
+  umask 077
+  printf '%s\n' schemaVersion=reader_summary.daily_c1_containment.v1 \
+    state=CONTAINED "readySha=$sha" > "$staged"
+  chmod 0444 "$staged"
+  postgres_runtime_daily_c1_fsync_path_and_parent "$staged" || {
+    rm -f "$staged"
+    return 1
+  }
+  [[ $(postgres_runtime_daily_c1_containment_state) == requested && \
+     $(postgres_runtime_daily_c1_containment_sha) == "$sha" ]] || {
+    rm -f "$staged"
+    fail 'daily C1 containment marker changed before promotion'
+    return 1
+  }
+  mv -f "$staged" "$marker" || {
+    rm -f "$staged"
+    return 1
+  }
+  postgres_runtime_daily_c1_fsync_path_and_parent "$marker" || return
+  verify_postgres_runtime_daily_c1_containment "$sha" CONTAINED
+}
+
+verify_postgres_runtime_daily_c1_containment() {
+  local sha=$1 expected_state=${2:-} actual_state expected_normalized
+  [[ $(postgres_runtime_daily_c1_containment_sha) == "$sha" ]] || \
+    { fail 'daily C1 containment marker is bound to another READY release'; return 1; }
+  if [[ -n $expected_state ]]; then
+    actual_state=$(postgres_runtime_daily_c1_containment_state) || return
+    case $expected_state in
+      REQUESTED|requested) expected_normalized=requested ;;
+      CONTAINED|contained) expected_normalized=contained ;;
+      *) fail 'daily C1 expected containment state is invalid'; return 1 ;;
+    esac
+    [[ $actual_state == "$expected_normalized" ]] || \
+      { fail "daily C1 containment marker is not $expected_state"; return 1; }
+  fi
+}
+
+verify_postgres_runtime_daily_c1_contained_topology() {
+  local release=$1 unit_directory=$2 unit
+  [[ $(systemctl show --property=UnitFileState --value \
+    "$POSTGRES_RUNTIME_DAILY_TIMER") == disabled ]] || \
+    { fail 'contained daily C1 legacy timer is not disabled'; return 1; }
+  [[ $(systemctl show --property=ActiveState --value \
+    "$POSTGRES_RUNTIME_DAILY_TIMER") == inactive ]] || \
+    { fail 'contained daily C1 legacy timer is not inactive'; return 1; }
+  [[ $(systemctl show --property=UnitFileState --value \
+    "$POSTGRES_RUNTIME_DAILY_V6_TIMER") == disabled ]] || \
+    { fail 'contained daily C1 v6 timer is not disabled'; return 1; }
+  [[ $(systemctl show --property=ActiveState --value \
+    "$POSTGRES_RUNTIME_DAILY_V6_TIMER") == inactive ]] || \
+    { fail 'contained daily C1 v6 timer is not inactive'; return 1; }
+  [[ $(systemctl show --property=ActiveState --value \
+    "$POSTGRES_RUNTIME_DAILY_SERVICE") == inactive ]] || \
+    { fail 'contained daily C1 legacy service is not inactive'; return 1; }
+  [[ $(systemctl show --property=ActiveState --value \
+    "$POSTGRES_RUNTIME_DAILY_V6_SERVICE") == inactive ]] || \
+    { fail 'contained daily C1 v6 service is not inactive'; return 1; }
+  for unit in "$POSTGRES_RUNTIME_DAILY_TIMER" \
+    "$POSTGRES_RUNTIME_DAILY_SERVICE"; do
+    [[ $(systemctl show --property=FragmentPath --value "$unit") == \
+       "$unit_directory/$unit" ]] || return 1
+    [[ -z $(systemctl show --property=DropInPaths --value "$unit") ]] || return 1
+    cmp -s "$release/$unit" "$unit_directory/$unit" || return 1
+  done
+}
+
+enforce_postgres_runtime_daily_c1_containment() {
+  local release=$1 unit_directory=$2 timer sha
+  sha=$(postgres_runtime_daily_c1_containment_sha) || return
+  for timer in "$POSTGRES_RUNTIME_DAILY_TIMER" \
+    "$POSTGRES_RUNTIME_DAILY_V6_TIMER"; do
+    systemctl stop "$timer" || \
+      { fail "contained daily C1 timer could not be stopped: $timer"; return 1; }
+    systemctl disable "$timer" || \
+      { fail "contained daily C1 timer could not be disabled: $timer"; return 1; }
+  done
+  verify_postgres_runtime_daily_c1_contained_topology \
+    "$release" "$unit_directory" || return
+  promote_postgres_runtime_daily_c1_containment_contained "$sha"
+}
+
+snapshot_postgres_runtime_daily_handoff() {
+  local backup=$1 unit_directory=$2
+  local timer unit unit_state active_state dropin
+  local state_file=$backup/daily-timer-states
+
+  : > "$state_file"
+  for timer in \
+    "$POSTGRES_RUNTIME_DAILY_TIMER" "$POSTGRES_RUNTIME_DAILY_V6_TIMER"; do
+    unit_state=$(systemctl show --property=UnitFileState --value "$timer") || \
+      { fail "daily timer enablement is unavailable: $timer"; return 1; }
+    active_state=$(systemctl show --property=ActiveState --value "$timer") || \
+      { fail "daily timer active state is unavailable: $timer"; return 1; }
+    [[ ($unit_state =~ ^(enabled|disabled)$ && \
+        $active_state =~ ^(active|inactive)$) || \
+       ($unit_state == not-found && $active_state == inactive) ]] || {
+      fail "daily timer state is not rollback-safe: $timer ($unit_state/$active_state)"
+      return 1
+    }
+    printf '%s\t%s\t%s\n' "$timer" "$unit_state" "$active_state" \
+      >> "$state_file"
+  done
+  for unit in \
+    "$POSTGRES_RUNTIME_DAILY_V6_SERVICE" "$POSTGRES_RUNTIME_DAILY_V6_TIMER"; do
+    if [[ -e $unit_directory/$unit || -L $unit_directory/$unit ]]; then
+      cp -a "$unit_directory/$unit" "$backup/$unit.daily-handoff"
+    else
+      : > "$backup/$unit.daily-handoff.absent"
+    fi
+  done
+  if [[ -e $CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME || \
+        -L $CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME ]]; then
+    cp -a "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" \
+      "$backup/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.daily-handoff"
+  else
+    : > "$backup/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.daily-handoff.absent"
+  fi
+  dropin=$unit_directory/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_DIRECTORY/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN
+  if [[ -e $dropin || -L $dropin ]]; then
+    cp -a "$dropin" "$backup/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN.daily-handoff"
+  else
+    : > "$backup/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN.daily-handoff.absent"
+  fi
+}
+
+restore_postgres_runtime_daily_handoff_units() {
+  local backup=$1 unit_directory=$2 unit dropin dropin_directory
+  for unit in \
+    "$POSTGRES_RUNTIME_DAILY_V6_SERVICE" "$POSTGRES_RUNTIME_DAILY_V6_TIMER"; do
+    if [[ -e $backup/$unit.daily-handoff || \
+          -L $backup/$unit.daily-handoff ]]; then
+      cp -a "$backup/$unit.daily-handoff" "$unit_directory/$unit.restore" || \
+        return 1
+      mv -f "$unit_directory/$unit.restore" "$unit_directory/$unit" || return 1
+    elif [[ -f $backup/$unit.daily-handoff.absent ]]; then
+      rm -f "$unit_directory/$unit" || return 1
+    else
+      return 1
+    fi
+  done
+  if [[ -e $backup/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.daily-handoff || \
+        -L $backup/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.daily-handoff ]]; then
+    cp -a "$backup/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.daily-handoff" \
+      "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.restore" || return 1
+    mv -f "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.restore" \
+      "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" || return 1
+  elif [[ -f $backup/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME.daily-handoff.absent ]]; then
+    rm -f "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME" || return 1
+  else
+    return 1
+  fi
+  dropin_directory=$unit_directory/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_DIRECTORY
+  dropin=$dropin_directory/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN
+  if [[ -e $backup/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN.daily-handoff || \
+        -L $backup/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN.daily-handoff ]]; then
+    install -d -m 0755 "$dropin_directory"
+    cp -a "$backup/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN.daily-handoff" \
+      "$dropin.restore" || return 1
+    mv -f "$dropin.restore" "$dropin" || return 1
+  elif [[ -f $backup/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN.daily-handoff.absent ]]; then
+    rm -f "$dropin" || return 1
+  else
+    return 1
+  fi
+}
+
+restore_postgres_runtime_daily_handoff_states() {
+  local backup=$1 timer unit_state active_state enablement_command
+  local state_file=$backup/daily-timer-states
+  local restored=0
+
+  [[ -f $state_file ]] || return 0
+  while IFS=$'\t' read -r timer unit_state active_state; do
+    [[ $timer == "$POSTGRES_RUNTIME_DAILY_TIMER" || \
+       $timer == "$POSTGRES_RUNTIME_DAILY_V6_TIMER" ]] || return 1
+    [[ ($unit_state =~ ^(enabled|disabled)$ && \
+        $active_state =~ ^(active|inactive)$) || \
+       ($unit_state == not-found && $active_state == inactive) ]] || return 1
+    case $unit_state in
+      enabled) enablement_command=enable ;;
+      disabled) enablement_command=disable ;;
+      not-found)
+        [[ $(systemctl show --property=UnitFileState --value "$timer") == \
+           not-found && \
+           $(systemctl show --property=ActiveState --value "$timer") == \
+           inactive ]] || return 1
+        restored=$((restored + 1))
+        continue
+        ;;
+    esac
+    systemctl stop "$timer" || return 1
+    systemctl "$enablement_command" "$timer" || return 1
+    [[ $active_state == inactive ]] || systemctl start "$timer" || return 1
+    [[ $(systemctl show --property=UnitFileState --value "$timer") == \
+       "$unit_state" ]] || return 1
+    [[ $(systemctl show --property=ActiveState --value "$timer") == \
+       "$active_state" ]] || return 1
+    restored=$((restored + 1))
+  done < "$state_file"
+  ((restored == 2))
+}
+
+wait_postgres_runtime_daily_c1_services_idle() {
+  local attempt service state
+  local attempts=${POSTGRES_RUNTIME_DAILY_C1_TEST_IDLE_ATTEMPTS:-60}
+  for ((attempt=0; attempt<attempts; attempt++)); do
+    local all_idle=true
+    for service in \
+      "$POSTGRES_RUNTIME_DAILY_SERVICE" "$POSTGRES_RUNTIME_DAILY_V6_SERVICE"; do
+      state=$(systemctl show --property=ActiveState --value "$service") || return
+      [[ $state == inactive ]] || all_idle=false
+    done
+    [[ $all_idle == true ]] && return 0
+    sleep 1
+  done
+  fail 'daily C1 handoff services did not become idle'
+}
+
+verify_postgres_runtime_daily_c1_v6_dropin() {
+  local release=$1 unit_directory=$2 dropin expected_dropins
+  dropin=$unit_directory/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_DIRECTORY/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN
+  cmp -s "$release/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_ASSET" "$dropin" || {
+    fail 'daily C1 v6 owner drop-in differs from release'
+    return 1
+  }
+  expected_dropins=$dropin
+  [[ $(systemctl show --property=DropInPaths --value \
+    "$POSTGRES_RUNTIME_DAILY_V6_SERVICE") == "$expected_dropins" ]] || {
+    fail 'daily C1 v6 service drop-in set is not exact'
+    return 1
+  }
+}
+
+bridge_postgres_runtime_daily_c1_owner() {
+  local release=$1 unit_directory=$2 sha=$3 owner_state
+  verify_postgres_runtime_daily_c1_bridge_assets "$release" "$unit_directory"
+  persist_postgres_runtime_daily_c1_v6_owner "$sha"
+  verify_postgres_runtime_daily_c1_v6_dropin "$release" "$unit_directory"
+  owner_state=$(postgres_runtime_daily_c1_owner_state) || return
+  [[ $owner_state == V6 ]] || return 0
+  systemctl enable "$POSTGRES_RUNTIME_DAILY_V6_TIMER" || {
+    fail 'daily C1 bridge could not enable the v6 timer'
+    return 1
+  }
+  systemctl start "$POSTGRES_RUNTIME_DAILY_V6_TIMER" || {
+    fail 'daily C1 bridge could not start the v6 timer'
+    return 1
+  }
+  systemctl stop "$POSTGRES_RUNTIME_DAILY_TIMER" || return
+  systemctl disable "$POSTGRES_RUNTIME_DAILY_TIMER" || return
+  [[ $(systemctl show --property=UnitFileState --value \
+      "$POSTGRES_RUNTIME_DAILY_V6_TIMER") == enabled && \
+     $(systemctl show --property=ActiveState --value \
+      "$POSTGRES_RUNTIME_DAILY_V6_TIMER") == active && \
+     $(systemctl show --property=UnitFileState --value \
+      "$POSTGRES_RUNTIME_DAILY_TIMER") == disabled && \
+     $(systemctl show --property=ActiveState --value \
+      "$POSTGRES_RUNTIME_DAILY_TIMER") == inactive ]] || {
+    fail 'daily C1 bridge topology is invalid'
+    return 1
+  }
+}
+
+prove_postgres_runtime_daily_c1_flip_idle() {
+  probe_daily_singleton_clear || {
+    fail 'daily C1 handoff found an active daily singleton before owner flip'
+    return 1
+  }
+  wait_postgres_runtime_daily_c1_services_idle
+}
+
+verify_postgres_runtime_daily_c1_handoff() {
+  local release=$1 unit_directory=$2 next_trigger fragment unit
+
+  [[ $(systemctl show --property=UnitFileState --value \
+    "$POSTGRES_RUNTIME_DAILY_TIMER") == enabled ]] || \
+    { fail 'daily C1 legacy timer is not enabled'; return 1; }
+  [[ $(systemctl show --property=ActiveState --value \
+    "$POSTGRES_RUNTIME_DAILY_TIMER") == active ]] || \
+    { fail 'daily C1 legacy timer is not active'; return 1; }
+  next_trigger=$(systemctl show --property=NextElapseUSecRealtime --value \
+    "$POSTGRES_RUNTIME_DAILY_TIMER") || return 1
+  [[ -n $next_trigger && $next_trigger != n/a ]] || \
+    { fail 'daily C1 legacy timer has no next trigger'; return 1; }
+  [[ $(systemctl show --property=UnitFileState --value \
+    "$POSTGRES_RUNTIME_DAILY_V6_TIMER") == disabled ]] || \
+    { fail 'daily C1 v6 timer is not disabled'; return 1; }
+  [[ $(systemctl show --property=ActiveState --value \
+    "$POSTGRES_RUNTIME_DAILY_V6_TIMER") == inactive ]] || \
+    { fail 'daily C1 v6 timer is not inactive'; return 1; }
+  for unit in "$POSTGRES_RUNTIME_DAILY_TIMER" \
+    "$POSTGRES_RUNTIME_DAILY_SERVICE"; do
+    fragment=$(systemctl show --property=FragmentPath --value "$unit") || return 1
+    [[ $fragment == "$unit_directory/$unit" ]] || \
+      { fail "daily C1 systemd fragment path is invalid: $unit"; return 1; }
+    [[ -z $(systemctl show --property=DropInPaths --value "$unit") ]] || \
+      { fail "daily C1 systemd unit has an unreviewed drop-in: $unit"; return 1; }
+    cmp -s "$release/$unit" "$unit_directory/$unit" || \
+      { fail "daily C1 installed unit differs from release: $unit"; return 1; }
+  done
+  [[ $(systemctl show --property=Unit --value \
+    "$POSTGRES_RUNTIME_DAILY_TIMER") == "$POSTGRES_RUNTIME_DAILY_SERVICE" ]] || \
+    { fail 'daily C1 timer unit mapping is invalid'; return 1; }
+  [[ $(grep -Fxc \
+    'ExecStart=/var/data/social-monitor/control/daily-run.sh --yesterday' \
+    "$release/$POSTGRES_RUNTIME_DAILY_SERVICE") == 1 ]] || \
+    { fail 'daily service runner is invalid'; return 1; }
+  ! grep -Eq '^Exec(Condition|StartPre|StopPost)=' \
+    "$release/$POSTGRES_RUNTIME_DAILY_SERVICE" || \
+    { fail 'daily service retains a legacy invocation wrapper'; return 1; }
+  cmp -s "$release/$POSTGRES_RUNTIME_DAILY_RUNNER" \
+    "$CONTROL/$POSTGRES_RUNTIME_DAILY_RUNNER" || \
+    { fail 'daily C1 installed runner differs from release'; return 1; }
+  cmp -s "$release/$POSTGRES_RUNTIME_DAILY_C1_MARKER" \
+    "$POSTGRES_RUNTIME_CURRENT/$POSTGRES_RUNTIME_DAILY_C1_MARKER" || \
+    { fail 'daily C1 current readiness marker differs from release'; return 1; }
+  verify_postgres_runtime_daily_c1_bridge_assets "$release" "$unit_directory"
+  verify_postgres_runtime_daily_c1_v6_dropin "$release" "$unit_directory"
+  [[ $(postgres_runtime_daily_c1_owner_state) == LEGACY ]] || {
+    fail 'daily C1 effective owner is not LEGACY'
+    return 1
+  }
+}
+
+verify_postgres_runtime_daily_c1_ready_static() {
+  local sha=$1 source=$REPO/ops/deploy/production-runtime
+  local release=$POSTGRES_RUNTIME_RELEASES/$sha state unit fragment current_release
+  [[ $sha =~ ^[0-9a-f]{40}$ ]] || \
+    { fail 'daily C1 static proof release marker is invalid'; return 1; }
+  current_release=$(readlink -f "$POSTGRES_RUNTIME_CURRENT" 2>/dev/null || \
+    realpath "$POSTGRES_RUNTIME_CURRENT") || return
+  [[ $current_release == "$release" ]] || \
+    { fail 'daily C1 static proof current release is invalid'; return 1; }
+  verify_installed_postgres_runtime_daily_c1_readiness \
+    "$source" "$release" "$POSTGRES_RUNTIME_CURRENT" || return
+  state=$(postgres_runtime_daily_c1_readiness_state \
+    "$release/$POSTGRES_RUNTIME_DAILY_C1_MARKER") || return
+  [[ $state == READY ]] || \
+    { fail 'daily C1 static proof requires READY readiness'; return 1; }
+  for unit in "$POSTGRES_RUNTIME_DAILY_TIMER" \
+    "$POSTGRES_RUNTIME_DAILY_SERVICE"; do
+    fragment=$(systemctl show --property=FragmentPath --value "$unit") || return
+    [[ $fragment == "$SYSTEMD_UNIT_DIR/$unit" ]] || return 1
+    [[ -z $(systemctl show --property=DropInPaths --value "$unit") ]] || return 1
+    cmp -s "$source/$unit" "$release/$unit" || return 1
+    cmp -s "$release/$unit" "$SYSTEMD_UNIT_DIR/$unit" || return 1
+  done
+  [[ $(systemctl show --property=Unit --value \
+    "$POSTGRES_RUNTIME_DAILY_TIMER") == "$POSTGRES_RUNTIME_DAILY_SERVICE" ]] || \
+    return 1
+  cmp -s "$release/$POSTGRES_RUNTIME_DAILY_RUNNER" \
+    "$CONTROL/$POSTGRES_RUNTIME_DAILY_RUNNER" || return
+  cmp -s "$source/$POSTGRES_RUNTIME_DAILY_RUNNER" \
+    "$release/$POSTGRES_RUNTIME_DAILY_RUNNER" || return
+  verify_postgres_runtime_daily_c1_baseline "$sha" || return
+  [[ $(postgres_runtime_daily_c1_owner_state) == LEGACY ]] || return
+  [[ $(grep -Fxc \
+    'ExecStart=/var/data/social-monitor/control/daily-run.sh --yesterday' \
+    "$release/$POSTGRES_RUNTIME_DAILY_SERVICE") == 1 ]] &&
+    ! grep -Eq '^Exec(Condition|StartPre|StopPost)=' \
+      "$release/$POSTGRES_RUNTIME_DAILY_SERVICE"
+}
+
+verify_postgres_runtime_daily_c1_ready_topology() {
+  local sha=$1
+  local release=$POSTGRES_RUNTIME_RELEASES/$sha
+  verify_postgres_runtime_daily_c1_ready_static "$sha" || return
+  verify_postgres_runtime_daily_c1_handoff "$release" "$SYSTEMD_UNIT_DIR"
+}
+
+activate_postgres_runtime_daily_c1_handoff() {
+  local release=$1 unit_directory=$2 sha=$3 backup=$4
+  local containment owner_state
+  containment=$(postgres_runtime_daily_c1_containment_state) || return
+  if [[ $containment != clear ]]; then
+    enforce_postgres_runtime_daily_c1_containment "$release" "$unit_directory"
+    return
+  fi
+  owner_state=$(postgres_runtime_daily_c1_owner_state) || return
+  if [[ $owner_state == V6 ]]; then
+    systemctl enable "$POSTGRES_RUNTIME_DAILY_TIMER" || \
+      { fail 'daily C1 legacy timer could not be enabled'; return 1; }
+    systemctl stop "$POSTGRES_RUNTIME_DAILY_V6_TIMER" || {
+      fail 'daily C1 READY could not stop the v6 timer before owner flip'
+      return 1
+    }
+    prove_postgres_runtime_daily_c1_flip_idle || return
+    : > "$backup/daily-c1-forward-only"
+    postgres_runtime_daily_c1_fsync_path_and_parent \
+      "$backup/daily-c1-forward-only"
+    commit_postgres_runtime_daily_c1_legacy_owner "$sha" || return
+  elif [[ $owner_state != LEGACY ]]; then
+    fail 'daily C1 owner cannot activate READY'
+    return 1
+  fi
+  # The durable LEGACY owner is the irreversible commit point. Every command
+  # below is idempotent forward reconciliation; rollback must never restore V6.
+  systemctl enable "$POSTGRES_RUNTIME_DAILY_TIMER" || \
+    { fail 'daily C1 legacy timer could not be enabled'; return 1; }
+  systemctl disable "$POSTGRES_RUNTIME_DAILY_V6_TIMER" || {
+    fail 'daily C1 READY could not disable the v6 timer'
+    return 1
+  }
+  systemctl stop "$POSTGRES_RUNTIME_DAILY_V6_TIMER" || {
+    fail 'daily C1 READY could not stop the v6 timer'
+    return 1
+  }
+  systemctl start "$POSTGRES_RUNTIME_DAILY_TIMER" || \
+    { fail 'daily C1 legacy timer could not be started'; return 1; }
+  verify_postgres_runtime_daily_c1_handoff "$release" "$unit_directory"
+}
+
+reconcile_effective_postgres_daily_timer() {
+  local timer=$1 active_state next_trigger
+  active_state=$(systemctl show --property=ActiveState --value "$timer") ||
+    { fail "systemd daily timer active state is unavailable: $timer"; return 1; }
+  case $active_state in
+    active) ;;
+    inactive) systemctl start "$timer" ||
+      { fail "systemd daily timer could not be started: $timer"; return 1; } ;;
+    *) fail "systemd daily timer active state is not reconcilable: $timer ($active_state)"
+      return 1 ;;
+  esac
+  active_state=$(systemctl show --property=ActiveState --value "$timer") ||
+    { fail "systemd daily timer active state is unavailable after reconciliation: $timer"; return 1; }
+  [[ $active_state == active ]] ||
+    { fail "systemd daily timer is not active after reconciliation: $timer"; return 1; }
+  next_trigger=$(systemctl show --property=NextElapseUSecRealtime --value "$timer") ||
+    { fail "systemd daily timer next trigger is unavailable: $timer"; return 1; }
+  [[ -n $next_trigger && $next_trigger != n/a ]] ||
+    { fail "systemd daily timer has no next trigger: $timer"; return 1; }
+}
+
+verify_effective_postgres_daily_topology() (
+  set -euo pipefail
+  local containment timer service runner
+  local legacy_enabled=false v6_enabled=false
+  # STATE is a required caller-owned deploy path.
+  # shellcheck disable=SC2153
+  local effective_service=$STATE/postgres-daily-service.$$.unit
+  trap 'rm -f "$effective_service"' EXIT
+
+  containment=$(postgres_runtime_daily_c1_containment_state) || return
+  if [[ $containment != clear ]]; then
+    verify_postgres_runtime_daily_c1_contained_topology \
+      "$POSTGRES_RUNTIME_CURRENT" "$SYSTEMD_UNIT_DIR"
+    return
+  fi
+
+  systemctl is-enabled --quiet "$POSTGRES_RUNTIME_DAILY_TIMER" && \
+    legacy_enabled=true
+  systemctl is-enabled --quiet "$POSTGRES_RUNTIME_DAILY_V6_TIMER" && \
+    v6_enabled=true
+  if [[ $legacy_enabled == "$v6_enabled" ]]; then
+    fail 'exactly one reviewed production daily timer must be enabled'
+    return 1
+  fi
+  if [[ $v6_enabled == true ]]; then
+    timer=$POSTGRES_RUNTIME_DAILY_V6_TIMER
+    service=$POSTGRES_RUNTIME_DAILY_V6_SERVICE
+    runner=$CONTROL/run-reader-summary-production-day.sh
+  else
+    timer=$POSTGRES_RUNTIME_DAILY_TIMER
+    service=$POSTGRES_RUNTIME_DAILY_SERVICE
+    runner=$CONTROL/daily-run.sh
+  fi
+  [[ -f $runner ]] || {
+    fail 'effective production daily runner is unavailable'
+    return 1
+  }
+  [[ -z $(systemctl show --property=DropInPaths --value "$timer") ]] || {
+    fail "systemd daily timer has an unreviewed drop-in: $timer"
+    return 1
+  }
+  if [[ $service == "$POSTGRES_RUNTIME_DAILY_V6_SERVICE" ]]; then
+    verify_postgres_runtime_daily_c1_v6_dropin \
+      "$POSTGRES_RUNTIME_CURRENT" "$SYSTEMD_UNIT_DIR" || return
+  else
+    [[ -z $(systemctl show --property=DropInPaths --value "$service") ]] || {
+      fail "systemd daily service has an unreviewed drop-in: $service"
+      return 1
+    }
+  fi
+  systemctl cat "$service" > "$effective_service" || {
+    fail 'effective production daily service is unavailable'
+    return 1
+  }
+  python3 "$REPO/ops/deploy/verify-postgres-runtime-topology.py" \
+    daily "$effective_service" "$runner" || return
+  reconcile_effective_postgres_daily_timer "$timer"
+)

--- a/ops/deploy/postgres-runtime-deploy-lib.sh
+++ b/ops/deploy/postgres-runtime-deploy-lib.sh
@@ -5,44 +5,66 @@
 # entrypoint's source-line cap without making this file independently runnable.
 
 ROOT=${ROOT:?caller must define ROOT before sourcing postgres-runtime-deploy-lib.sh}
-
-github_premidnight_capture_marker_state() {
-  local root=$1
-  local marker=$root/github-premidnight-capture-v1.activation
-
-  if [[ ! -e $marker && ! -L $marker ]]; then
-    printf 'inactive\n'
-    return
+load_postgres_runtime_reviewed_helper() {
+  local relative_path=$1 label=$2 helper entry mode type object tree_path
+  local reviewed_digest actual_digest
+  if [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} == 1 || \
+        ${POSTGRES_RUNTIME_DAILY_C1_HELPER_TEST_MODE:-} == 1 ]]; then
+    helper=${BASH_SOURCE[0]%/*}/${relative_path##*/}
+  else
+    helper=$REPO/$relative_path
+    [[ -f $helper && ! -L $helper ]] || \
+      fail "$label is not a regular non-symlink file"
+    entry=$(git -C "$REPO" ls-tree HEAD -- "$relative_path") || \
+      fail "$label cannot be inspected at current HEAD"
+    read -r mode type object tree_path <<< "$entry"
+    [[ $mode == 100644 && $type == blob && $object =~ ^[0-9a-f]+$ && \
+       $tree_path == "$relative_path" ]] || \
+      fail "$label is not a regular blob at current HEAD"
+    reviewed_digest=$(git -C "$REPO" show "HEAD:$relative_path" | \
+      sha256sum | awk '{print $1}')
+    actual_digest=$(sha256sum "$helper" | awk '{print $1}')
+    [[ $actual_digest == "$reviewed_digest" ]] || \
+      fail "$label differs from current HEAD"
   fi
-  [[ -f $marker && ! -L $marker ]] || {
-    fail 'GitHub pre-midnight activation marker is not a regular file'
-    return 1
-  }
-  cmp -s "$marker" <(printf 'install-disabled-v1\n') || {
-    fail 'GitHub pre-midnight activation marker is invalid'
-    return 1
-  }
-  printf 'active\n'
+  [[ -f $helper && ! -L $helper ]] || \
+    fail "$label is not a regular non-symlink file"
+  # shellcheck source=/dev/null
+  source "$helper"
 }
+load_postgres_runtime_reviewed_helper \
+  ops/deploy/postgres-runtime-weekly-timer-state-lib.sh \
+  'weekly timer state helper'
+load_postgres_runtime_reviewed_helper \
+  ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh \
+  'daily C1 readiness helper'
+load_postgres_runtime_reviewed_helper \
+  ops/deploy/postgres-runtime-activation-boundary-lib.sh \
+  'PostgreSQL runtime activation boundary helper'
+unset -f load_postgres_runtime_reviewed_helper
 
 postgres_runtime_control_mutation_scope() {
-  local source_state current_state=inactive
-  source_state=$(
-    github_premidnight_capture_marker_state \
+  local source_mode current_mode=absent
+  source_mode=$(
+    github_premidnight_capture_marker_mode \
       "$REPO/ops/deploy/production-runtime"
   ) || return
   if [[ -e $POSTGRES_RUNTIME_CURRENT || -L $POSTGRES_RUNTIME_CURRENT ]]; then
-    current_state=$(
-      github_premidnight_capture_marker_state "$POSTGRES_RUNTIME_CURRENT"
+    current_mode=$(
+      github_premidnight_capture_marker_mode "$POSTGRES_RUNTIME_CURRENT"
     ) || return
   fi
-  if [[ $source_state == inactive && $current_state == active ]]; then
+  if [[ $source_mode == absent && $current_mode != absent ]]; then
     fail 'GitHub pre-midnight activation marker cannot be removed'
     return 1
   fi
-  if [[ $source_state == active && $current_state == inactive ]]; then
+  if [[ $source_mode == install-disabled && $current_mode == enable-now ]]; then
+    fail 'GitHub pre-midnight activation marker cannot disable an activated timer'
+    return 1
+  fi
+  if [[ $source_mode != "$current_mode" && $source_mode != absent ]]; then
     printf 'capture-only\n'
-  elif [[ $source_state == active ]]; then
+  elif [[ $source_mode != absent ]]; then
     printf 'full\n'
   else
     printf 'base\n'
@@ -54,6 +76,7 @@ postgres_runtime_control_units_for_scope() {
     base)
       printf '%s\n' \
         social-monitor-daily.service \
+        social-monitor-daily.timer \
         social-monitor-prod.service \
         social-monitor-weekly.service \
         social-monitor-weekly.timer
@@ -68,6 +91,7 @@ postgres_runtime_control_units_for_scope() {
         social-monitor-github-premidnight-capture-v1.service \
         social-monitor-github-premidnight-capture-v1.timer \
         social-monitor-daily.service \
+        social-monitor-daily.timer \
         social-monitor-prod.service \
         social-monitor-weekly.service \
         social-monitor-weekly.timer
@@ -129,32 +153,11 @@ require_postgres_runtime_safe_mutation_target() {
   fi
 }
 
-snapshot_postgres_runtime_weekly_timer() {
-  local backup=$1 unit_state active_state
-  unit_state=$(systemctl show --property=UnitFileState --value social-monitor-weekly.timer) ||
-    { fail 'systemd weekly timer enablement is unavailable'; return 1; }
-  active_state=$(systemctl show --property=ActiveState --value social-monitor-weekly.timer) ||
-    { fail 'systemd weekly timer active state is unavailable'; return 1; }
-  [[ "$unit_state $active_state" =~ ^(enabled\ active|disabled\ inactive)$ ]] ||
-    { fail "systemd weekly timer state is not rollback-safe: $unit_state/$active_state"; return 1; }
-  printf '%s %s\n' "$unit_state" "$active_state" > "$backup/weekly-timer-state"
-}
-
-restore_postgres_runtime_weekly_timer() {
-  local backup=$1 unit_state active_state
-  read -r unit_state active_state < "$backup/weekly-timer-state" || return 1
-  [[ "$unit_state $active_state" =~ ^(enabled\ active|disabled\ inactive)$ ]] || return 1
-  case "$unit_state/$active_state" in
-    enabled/active) systemctl enable social-monitor-weekly.timer && systemctl start social-monitor-weekly.timer || return 1 ;;
-    disabled/inactive) systemctl stop social-monitor-weekly.timer && systemctl disable social-monitor-weekly.timer || return 1 ;;
-  esac
-  [[ $(systemctl show --property=UnitFileState --value social-monitor-weekly.timer) == "$unit_state" && $(systemctl show --property=ActiveState --value social-monitor-weekly.timer) == "$active_state" ]]
-}
 activate_postgres_runtime_control() {
   local sha=$1
   local compatible_backend_sha=${2:-$sha}
-  local activation_status
-  activate_postgres_runtime_control_transaction "$sha" "$compatible_backend_sha"
+  local outer_backup=${3:-} activation_status
+  activate_postgres_runtime_control_transaction "$sha" "$compatible_backend_sha" "$outer_backup"
   activation_status=$?
   ((activation_status == 0)) || return "$activation_status"
   if [[ ${COMPOSE[-1]} != "$POSTGRES_RUNTIME_CURRENT/compose.postgres-runtime.yml" ]]; then
@@ -165,15 +168,20 @@ activate_postgres_runtime_control() {
 }
 
 rollback_postgres_runtime_control_activation() {
-  local staged_release=$1
-  local next_link=$2
-  local current_link=$3
-  local previous_target=$4
-  local backup=$5
-  local unit_directory=$6
+  local staged_release=$1 next_link=$2 current_link=$3 previous_target=$4
+  local backup=$5 unit_directory=$6
+  local outer_backup=${7:-}
   local launcher rollback_link scope unit
   local rollback_status=0
   local -a launchers units
+
+  propagate_postgres_runtime_control_forward_only_boundary \
+    "$backup" "$outer_backup" || return 1
+  if ! require_postgres_runtime_control_rollback_allowed "$backup"; then
+    rm -rf "$staged_release" || true
+    rm -f "$next_link" "$next_link.rollback" || true
+    return 1
+  fi
 
   scope=$(<"$backup/mutation-scope") || rollback_status=1
   [[ $scope =~ ^(base|capture-only|full)$ ]] || rollback_status=1
@@ -217,6 +225,10 @@ rollback_postgres_runtime_control_activation() {
       rollback_status=1
     fi
   done
+  if [[ -f $backup/daily-timer-states ]]; then
+    restore_postgres_runtime_daily_handoff_units "$backup" "$unit_directory" || \
+      rollback_status=1
+  fi
   if [[ -n $previous_target ]]; then
     ln -s "$previous_target" "$rollback_link" || rollback_status=1
     if [[ -L $rollback_link ]]; then
@@ -228,8 +240,12 @@ rollback_postgres_runtime_control_activation() {
   if ((EUID == 0)) && [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]]; then
     systemctl daemon-reload || rollback_status=1
   fi
+  [[ ! -f $backup/daily-timer-states ]] || \
+    restore_postgres_runtime_daily_handoff_states "$backup" || rollback_status=1
   [[ ! -f $backup/weekly-timer-state ]] ||
     restore_postgres_runtime_weekly_timer "$backup" || rollback_status=1
+  [[ ! -f $backup/github-premidnight-timer-state ]] || \
+    restore_github_premidnight_capture_timer "$backup" || rollback_status=1
   if ((rollback_status == 0)); then
     rm -rf "$backup" || rollback_status=1
   else
@@ -243,6 +259,7 @@ activate_postgres_runtime_control_transaction() (
   set -euo pipefail
   local sha=$1
   local compatible_backend_sha=${2:-$sha}
+  local outer_backup=${3:-}
   local source=$REPO/ops/deploy/production-runtime
   local release=$POSTGRES_RUNTIME_RELEASES/$sha
   local staged_release=$release.next.$$
@@ -251,7 +268,7 @@ activate_postgres_runtime_control_transaction() (
   local previous_target
   local cleanup_command
   local expected_release_entry_count launcher launcher_source_mode
-  local release_entry_markers release_state scope source_state unit
+  local daily_c1_containment daily_c1_state release_entry_markers release_state scope source_state unit
   local -a launchers release_launchers release_units units
 
   [[ $sha =~ ^[0-9a-f]{40}$ && \
@@ -280,6 +297,17 @@ activate_postgres_runtime_control_transaction() (
   fi
   require_postgres_runtime_regular_source \
     "$source/compose.postgres-runtime.yml" 644
+  require_postgres_runtime_daily_c1_source "$source"
+  daily_c1_state=$(postgres_runtime_daily_c1_readiness_state \
+    "$source/$POSTGRES_RUNTIME_DAILY_C1_MARKER")
+  require_postgres_runtime_daily_c1_transition \
+    "$daily_c1_state" "$POSTGRES_RUNTIME_CURRENT"
+  daily_c1_containment=$(postgres_runtime_daily_c1_containment_state)
+  if [[ $daily_c1_containment != clear && \
+        ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]] && ((EUID == 0)); then
+    enforce_postgres_runtime_daily_c1_containment \
+      "$POSTGRES_RUNTIME_CURRENT" "$SYSTEMD_UNIT_DIR"
+  fi
   for launcher in "${release_launchers[@]}"; do
     launcher_source_mode=755
     [[ $launcher != daily-run.sh ]] || launcher_source_mode=644
@@ -299,12 +327,20 @@ activate_postgres_runtime_control_transaction() (
   for launcher in "${launchers[@]}"; do
     require_postgres_runtime_safe_mutation_target "$CONTROL/$launcher"
   done
+  require_postgres_runtime_safe_mutation_target \
+    "$CONTROL/$POSTGRES_RUNTIME_DAILY_C1_RUNTIME"
+  require_postgres_runtime_safe_mutation_target \
+    "$SYSTEMD_UNIT_DIR/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN_DIRECTORY/$POSTGRES_RUNTIME_DAILY_C1_V6_DROPIN"
 
   previous_target=$(readlink "$POSTGRES_RUNTIME_CURRENT" 2>/dev/null || true)
-  install -d -m 0700 "$backup"
+  initialize_postgres_runtime_control_rollback_basis "$backup"
   printf '%s\n' "$scope" > "$backup/mutation-scope"
   if ((EUID == 0)) && [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]]; then
     snapshot_postgres_runtime_weekly_timer "$backup"
+    snapshot_postgres_runtime_daily_handoff "$backup" "$SYSTEMD_UNIT_DIR"
+    if postgres_runtime_scope_includes_github_capture "$scope"; then
+      snapshot_github_premidnight_capture_timer "$backup"
+    fi
   fi
   if [[ -n $previous_target ]]; then
     printf '%s\n' "$previous_target" > "$backup/current-target"
@@ -328,13 +364,17 @@ activate_postgres_runtime_control_transaction() (
     fi
   done
   printf -v cleanup_command \
-    'rollback_postgres_runtime_control_activation %q %q %q %q %q %q' \
+    'rollback_postgres_runtime_control_activation %q %q %q %q %q %q %q' \
     "$staged_release" "$next_link" "$POSTGRES_RUNTIME_CURRENT" \
-    "$previous_target" "$backup" "$SYSTEMD_UNIT_DIR"
+    "$previous_target" "$backup" "$SYSTEMD_UNIT_DIR" "$outer_backup"
   # Literal, shell-escaped paths must be captured before local scope unwinds.
   # shellcheck disable=SC2064
   trap "$cleanup_command" EXIT
 
+  if ((EUID == 0)) && [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]]; then
+    prepare_postgres_runtime_daily_c1_ready_reexposure "$daily_c1_state"
+    [[ $daily_c1_state != READY ]] || prepare_postgres_runtime_daily_c1_baseline "$sha"
+  fi
   install -d -m 0755 "$POSTGRES_RUNTIME_RELEASES" "$SYSTEMD_UNIT_DIR"
   if [[ ! -f $release/SOURCE_SHA || $(cat "$release/SOURCE_SHA") != "$sha" || \
         ! -f $release/READY || \
@@ -346,6 +386,7 @@ activate_postgres_runtime_control_transaction() (
     install -d -m 0755 "$staged_release"
     install -m 0644 "$source/compose.postgres-runtime.yml" \
       "$staged_release/compose.postgres-runtime.yml"
+    stage_postgres_runtime_daily_c1_readiness "$source" "$staged_release"
     for launcher in "${release_launchers[@]}"; do
       install -m 0755 "$source/$launcher" "$staged_release/$launcher"
     done
@@ -366,7 +407,7 @@ activate_postgres_runtime_control_transaction() (
   [[ $release_state == "$source_state" ]] || \
     fail 'PostgreSQL runtime control release activation state is immutable'
   expected_release_entry_count=$((
-    ${#release_launchers[@]} + ${#release_units[@]} + 3
+    ${#release_launchers[@]} + ${#release_units[@]} + 6
   ))
   if [[ $source_state == active ]]; then
     expected_release_entry_count=$((expected_release_entry_count + 1))
@@ -383,6 +424,7 @@ activate_postgres_runtime_control_transaction() (
   cmp -s "$source/compose.postgres-runtime.yml" \
     "$release/compose.postgres-runtime.yml" || \
     fail 'immutable PostgreSQL runtime Compose release differs from source'
+  verify_postgres_runtime_daily_c1_release "$source" "$release"
   for launcher in "${release_launchers[@]}"; do
     require_postgres_runtime_regular_release_file \
       "$release/$launcher" 755
@@ -402,6 +444,9 @@ activate_postgres_runtime_control_transaction() (
       fail 'immutable GitHub pre-midnight activation marker differs from source'
   fi
 
+  if ((EUID == 0)) && [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]]; then
+    prepare_postgres_runtime_daily_c1_owner_before_exposure "$sha"
+  fi
   for unit in "${units[@]}"; do
     install -m 0644 "$release/$unit" "$SYSTEMD_UNIT_DIR/$unit.next"
     mv -f "$SYSTEMD_UNIT_DIR/$unit.next" "$SYSTEMD_UNIT_DIR/$unit"
@@ -410,10 +455,28 @@ activate_postgres_runtime_control_transaction() (
     install -m 0755 "$release/$launcher" "$CONTROL/$launcher.next"
     mv -f "$CONTROL/$launcher.next" "$CONTROL/$launcher"
   done
+  install_postgres_runtime_daily_c1_bridge_assets "$release" "$SYSTEMD_UNIT_DIR"
   ln -s "$release" "$next_link"
   mv -Tf "$next_link" "$POSTGRES_RUNTIME_CURRENT"
   if ((EUID == 0)) && [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]]; then
     systemctl daemon-reload
+    if [[ $daily_c1_containment == clear ]]; then
+      bridge_postgres_runtime_daily_c1_owner \
+        "$release" "$SYSTEMD_UNIT_DIR" "$sha"
+    fi
+    if [[ $daily_c1_state == READY ]]; then
+      if [[ $daily_c1_containment != clear ]]; then
+        enforce_postgres_runtime_daily_c1_containment \
+          "$release" "$SYSTEMD_UNIT_DIR"
+      else
+        activate_postgres_runtime_daily_c1_handoff \
+          "$release" "$SYSTEMD_UNIT_DIR" "$sha" "$backup"
+        postgres_runtime_activation_failpoint \
+          after-legacy-owner-before-boundary-propagation
+        propagate_postgres_runtime_control_forward_only_boundary \
+          "$backup" "$outer_backup"
+      fi
+    fi
   fi
   verify_installed_postgres_runtime_control "$sha" "$compatible_backend_sha"
   rm -rf "$backup"
@@ -425,10 +488,11 @@ verify_installed_postgres_runtime_control() {
   local compatible_backend_sha=${2:-$sha}
   local source=$REPO/ops/deploy/production-runtime
   local release=$POSTGRES_RUNTIME_RELEASES/$sha
-  local launcher release_state source_state unit
+  local containment launcher release_state source_mode source_state unit
   local -a launchers units
 
   source_state=$(github_premidnight_capture_marker_state "$source") || return
+  source_mode=$(github_premidnight_capture_marker_mode "$source") || return
   release_state=$(github_premidnight_capture_marker_state "$release") || return
   [[ $release_state == "$source_state" ]] || \
     fail 'installed PostgreSQL runtime activation state differs from the release'
@@ -457,6 +521,8 @@ verify_installed_postgres_runtime_control() {
   cmp -s "$source/compose.postgres-runtime.yml" \
     "$POSTGRES_RUNTIME_CURRENT/compose.postgres-runtime.yml" || \
     fail 'installed PostgreSQL Compose overlay differs from the release'
+  verify_installed_postgres_runtime_daily_c1_readiness \
+    "$source" "$release" "$POSTGRES_RUNTIME_CURRENT"
   for launcher in "${launchers[@]}"; do
     cmp -s "$source/$launcher" "$release/$launcher" || \
       fail "versioned launcher differs from the release source: $launcher"
@@ -477,7 +543,9 @@ verify_installed_postgres_runtime_control() {
       [[ -z $(systemctl show --property=DropInPaths --value "$unit") ]] || \
         fail "systemd unit has an unreviewed drop-in: $unit"
     done
-    if [[ $source_state == active ]]; then
+    if [[ $source_mode == enable-now ]]; then
+      reconcile_github_premidnight_capture_timer
+    elif [[ $source_state == active ]]; then
       [[ $(systemctl show --property=UnitFileState --value \
         social-monitor-github-premidnight-capture-v1.timer) == disabled ]] || \
         fail 'GitHub pre-midnight timer must remain disabled'
@@ -488,7 +556,13 @@ verify_installed_postgres_runtime_control() {
         social-monitor-github-premidnight-capture-v1.service) == inactive ]] || \
         fail 'GitHub pre-midnight service must remain inactive'
     fi
-    verify_effective_postgres_daily_topology
+    containment=$(postgres_runtime_daily_c1_containment_state) || return
+    if [[ $containment != clear ]]; then
+      verify_postgres_runtime_daily_c1_contained_topology \
+        "$release" "$SYSTEMD_UNIT_DIR"
+    else
+      verify_effective_postgres_daily_topology
+    fi
     reconcile_postgres_runtime_weekly_timer
   fi
 }
@@ -496,7 +570,7 @@ verify_installed_postgres_runtime_control() {
 snapshot_postgres_runtime_control() {
   local sha=$1
   local backup=$STATE/postgres-runtime-release-rollback-${sha:0:12}.$$
-  local launcher scope target unit
+  local containment launcher scope target unit
   local -a launchers units
 
   scope=$(postgres_runtime_control_mutation_scope) || return
@@ -504,10 +578,20 @@ snapshot_postgres_runtime_control() {
   mapfile -t launchers < <(
     postgres_runtime_control_launchers_for_scope "$scope"
   )
-  install -d -m 0700 "$backup"
+  containment=$(postgres_runtime_daily_c1_containment_state) || return
+  if [[ $containment != clear && \
+        ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]] && ((EUID == 0)); then
+    enforce_postgres_runtime_daily_c1_containment \
+      "$POSTGRES_RUNTIME_CURRENT" "$SYSTEMD_UNIT_DIR"
+  fi
+  initialize_postgres_runtime_control_rollback_basis "$backup"
   printf '%s\n' "$scope" > "$backup/mutation-scope"
   if ((EUID == 0)) && [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]]; then
     snapshot_postgres_runtime_weekly_timer "$backup"
+    snapshot_postgres_runtime_daily_handoff "$backup" "$SYSTEMD_UNIT_DIR"
+    if postgres_runtime_scope_includes_github_capture "$scope"; then
+      snapshot_github_premidnight_capture_timer "$backup"
+    fi
   fi
   target=$(readlink "$POSTGRES_RUNTIME_CURRENT" 2>/dev/null || true)
   if [[ -n $target ]]; then
@@ -541,6 +625,7 @@ restore_postgres_runtime_control() {
   local -a launchers units
 
   [[ -d $backup ]] || return 1
+  require_postgres_runtime_control_rollback_allowed "$backup" || return 1
   scope=$(<"$backup/mutation-scope") || return 1
   [[ $scope =~ ^(base|capture-only|full)$ ]] || return 1
   mapfile -t units < <(
@@ -587,6 +672,9 @@ restore_postgres_runtime_control() {
       return 1
     fi
   done
+  [[ ! -f $backup/daily-timer-states ]] || \
+    restore_postgres_runtime_daily_handoff_units "$backup" "$SYSTEMD_UNIT_DIR" || \
+    return 1
   rm -f "$next_link" || return 1
   if [[ -f $backup/current-target ]]; then
     ln -s "$target" "$next_link" || return 1
@@ -599,106 +687,14 @@ restore_postgres_runtime_control() {
   if ((EUID == 0)) && [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]]; then
     systemctl daemon-reload || return 1
   fi
+  [[ ! -f $backup/daily-timer-states ]] || \
+    restore_postgres_runtime_daily_handoff_states "$backup" || return 1
   [[ ! -f $backup/weekly-timer-state ]] ||
     restore_postgres_runtime_weekly_timer "$backup" || return 1
+  [[ ! -f $backup/github-premidnight-timer-state ]] || \
+    restore_github_premidnight_capture_timer "$backup" || return 1
   rm -rf "$backup"
 }
-
-reconcile_postgres_runtime_weekly_timer() {
-  local timer=social-monitor-weekly.timer unit_state active_state next_trigger
-  unit_state=$(systemctl show --property=UnitFileState --value "$timer") ||
-    { fail 'systemd weekly timer enablement is unavailable'; return 1; }
-  case $unit_state in
-    enabled) ;;
-    disabled) systemctl enable "$timer" ||
-      { fail 'systemd weekly timer could not be enabled'; return 1; } ;;
-    *) fail "systemd weekly timer enablement is not reconcilable: $unit_state"; return 1 ;;
-  esac
-  active_state=$(systemctl show --property=ActiveState --value "$timer") ||
-    { fail 'systemd weekly timer active state is unavailable'; return 1; }
-  case $active_state in
-    active) ;;
-    inactive) systemctl start "$timer" || {
-      fail 'systemd weekly timer could not be started'; return 1; } ;;
-    *) fail "systemd weekly timer active state is not reconcilable: $active_state"; return 1 ;;
-  esac
-  unit_state=$(systemctl show --property=UnitFileState --value "$timer") ||
-    { fail 'systemd weekly timer proof is unavailable'; return 1; }
-  active_state=$(systemctl show --property=ActiveState --value "$timer") ||
-    { fail 'systemd weekly timer proof is unavailable'; return 1; }
-  next_trigger=$(systemctl show --property=NextElapseUSecRealtime --value "$timer") ||
-    { fail 'systemd weekly timer proof is unavailable'; return 1; }
-  [[ $unit_state == enabled && $active_state == active && -n $next_trigger ]] ||
-    { fail "systemd weekly timer proof is invalid: $unit_state/$active_state"; return 1; }
-}
-
-reconcile_effective_postgres_daily_timer() {
-  local timer=$1 active_state next_trigger
-  active_state=$(systemctl show --property=ActiveState --value "$timer") ||
-    { fail "systemd daily timer active state is unavailable: $timer"; return 1; }
-  case $active_state in
-    active) ;;
-    inactive) systemctl start "$timer" ||
-      { fail "systemd daily timer could not be started: $timer"; return 1; } ;;
-    *) fail "systemd daily timer active state is not reconcilable: $timer ($active_state)"
-      return 1 ;;
-  esac
-  active_state=$(systemctl show --property=ActiveState --value "$timer") ||
-    { fail "systemd daily timer active state is unavailable after reconciliation: $timer"; return 1; }
-  [[ $active_state == active ]] ||
-    { fail "systemd daily timer is not active after reconciliation: $timer"; return 1; }
-  next_trigger=$(systemctl show --property=NextElapseUSecRealtime --value "$timer") ||
-    { fail "systemd daily timer next trigger is unavailable: $timer"; return 1; }
-  [[ -n $next_trigger ]] ||
-    { fail "systemd daily timer has no next trigger: $timer"; return 1; }
-}
-
-verify_effective_postgres_daily_topology() (
-  set -euo pipefail
-  local legacy_timer=social-monitor-daily.timer
-  local legacy_service=social-monitor-daily.service
-  local v6_timer=social-monitor-reader-summary-production-day.timer
-  local v6_service=social-monitor-reader-summary-production-day.service
-  local timer service runner
-  local legacy_enabled=false v6_enabled=false
-  local effective_service=$STATE/postgres-daily-service.$$.unit
-  trap 'rm -f "$effective_service"' EXIT
-
-  systemctl is-enabled --quiet "$legacy_timer" && legacy_enabled=true
-  systemctl is-enabled --quiet "$v6_timer" && v6_enabled=true
-  if [[ $legacy_enabled == "$v6_enabled" ]]; then
-    fail 'exactly one reviewed production daily timer must be enabled'
-    return 1
-  fi
-  if [[ $v6_enabled == true ]]; then
-    timer=$v6_timer
-    service=$v6_service
-    runner=$CONTROL/run-reader-summary-production-day.sh
-  else
-    timer=$legacy_timer
-    service=$legacy_service
-    runner=$CONTROL/daily-run.sh
-  fi
-  [[ -f $runner ]] || {
-    fail 'effective production daily runner is unavailable'
-    return 1
-  }
-  [[ -z $(systemctl show --property=DropInPaths --value "$timer") ]] || {
-    fail "systemd daily timer has an unreviewed drop-in: $timer"
-    return 1
-  }
-  [[ -z $(systemctl show --property=DropInPaths --value "$service") ]] || {
-    fail "systemd daily service has an unreviewed drop-in: $service"
-    return 1
-  }
-  systemctl cat "$service" > "$effective_service" || {
-    fail 'effective production daily service is unavailable'
-    return 1
-  }
-  python3 "$REPO/ops/deploy/verify-postgres-runtime-topology.py" \
-    daily "$effective_service" "$runner" || return
-  reconcile_effective_postgres_daily_timer "$timer"
-)
 
 capture_effective_postgres_environment() {
   local output=$1

--- a/ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+++ b/ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+# Sourced by postgres-runtime-deploy-lib.sh. Owns the weekly systemd timer's
+# exact snapshot, rollback, and post-activation reconciliation contract.
+
+# This helper also owns the adjacent pre-midnight capture timer because both
+# timers need the same deployment-transaction snapshot/restore boundary.
+
+github_premidnight_capture_marker_mode() {
+  local root=$1 marker
+  marker=$root/github-premidnight-capture-v1.activation
+  if [[ ! -e $marker && ! -L $marker ]]; then
+    printf 'absent\n'
+    return
+  fi
+  [[ -f $marker && ! -L $marker ]] || {
+    fail 'GitHub pre-midnight activation marker is not a regular file'
+    return 1
+  }
+  if cmp -s "$marker" <(printf 'install-disabled-v1\n'); then
+    printf 'install-disabled\n'
+  elif cmp -s "$marker" <(printf 'enable-now-v1\n'); then
+    printf 'enable-now\n'
+  else
+    fail 'GitHub pre-midnight activation marker is invalid'
+    return 1
+  fi
+}
+
+github_premidnight_capture_marker_state() {
+  local mode
+  mode=$(github_premidnight_capture_marker_mode "$1") || return
+  [[ $mode == absent ]] && printf 'inactive\n' || printf 'active\n'
+}
+
+postgres_runtime_scope_includes_github_capture() {
+  [[ $1 == capture-only || $1 == full ]]
+}
+
+snapshot_github_premidnight_capture_timer() {
+  local backup=$1 unit_state active_state service_state
+  unit_state=$(systemctl show --property=UnitFileState --value \
+    social-monitor-github-premidnight-capture-v1.timer) || return 1
+  active_state=$(systemctl show --property=ActiveState --value \
+    social-monitor-github-premidnight-capture-v1.timer) || return 1
+  service_state=$(systemctl show --property=ActiveState --value \
+    social-monitor-github-premidnight-capture-v1.service) || return 1
+  [[ "$unit_state $active_state" =~ ^(enabled\ active|disabled\ inactive)$ ]] || {
+    fail "GitHub pre-midnight timer state is not rollback-safe: $unit_state/$active_state"
+    return 1
+  }
+  [[ $service_state == inactive ]] || {
+    fail "GitHub pre-midnight service is not rollback-safe: $service_state"
+    return 1
+  }
+  printf '%s %s\n' "$unit_state" "$active_state" > \
+    "$backup/github-premidnight-timer-state"
+}
+
+restore_github_premidnight_capture_timer() {
+  local backup=$1 unit_state active_state timer
+  timer=social-monitor-github-premidnight-capture-v1.timer
+  read -r unit_state active_state < \
+    "$backup/github-premidnight-timer-state" || return 1
+  case "$unit_state/$active_state" in
+    enabled/active) systemctl enable --now "$timer" || return 1 ;;
+    disabled/inactive) systemctl disable --now "$timer" || return 1 ;;
+    *) return 1 ;;
+  esac
+  [[ $(systemctl show --property=UnitFileState --value "$timer") == \
+      "$unit_state" && \
+     $(systemctl show --property=ActiveState --value "$timer") == \
+      "$active_state" ]]
+}
+
+reconcile_github_premidnight_capture_timer() {
+  local timer=social-monitor-github-premidnight-capture-v1.timer
+  local unit_state active_state next_trigger service_state
+  systemctl enable --now "$timer" || {
+    fail 'GitHub pre-midnight timer could not be enabled and started'
+    return 1
+  }
+  unit_state=$(systemctl show --property=UnitFileState --value "$timer") || return 1
+  active_state=$(systemctl show --property=ActiveState --value "$timer") || return 1
+  next_trigger=$(systemctl show --property=NextElapseUSecRealtime --value \
+    "$timer") || return 1
+  service_state=$(systemctl show --property=ActiveState --value \
+    social-monitor-github-premidnight-capture-v1.service) || return 1
+  [[ $unit_state == enabled && $active_state == active && \
+     -n $next_trigger && $service_state == inactive ]] || {
+    fail "GitHub pre-midnight timer activation proof is invalid: $unit_state/$active_state/$service_state"
+    return 1
+  }
+}
+
+snapshot_postgres_runtime_weekly_timer() {
+  local backup=$1 unit_state active_state
+  unit_state=$(systemctl show --property=UnitFileState --value social-monitor-weekly.timer) ||
+    { fail 'systemd weekly timer enablement is unavailable'; return 1; }
+  active_state=$(systemctl show --property=ActiveState --value social-monitor-weekly.timer) ||
+    { fail 'systemd weekly timer active state is unavailable'; return 1; }
+  [[ "$unit_state $active_state" =~ ^(enabled\ active|disabled\ inactive)$ ]] ||
+    { fail "systemd weekly timer state is not rollback-safe: $unit_state/$active_state"; return 1; }
+  printf '%s %s\n' "$unit_state" "$active_state" > "$backup/weekly-timer-state"
+}
+
+restore_postgres_runtime_weekly_timer() {
+  local backup=$1 unit_state active_state
+  read -r unit_state active_state < "$backup/weekly-timer-state" || return 1
+  [[ "$unit_state $active_state" =~ ^(enabled\ active|disabled\ inactive)$ ]] || return 1
+  case "$unit_state/$active_state" in
+    enabled/active) systemctl enable social-monitor-weekly.timer && systemctl start social-monitor-weekly.timer || return 1 ;;
+    disabled/inactive) systemctl stop social-monitor-weekly.timer && systemctl disable social-monitor-weekly.timer || return 1 ;;
+  esac
+  [[ $(systemctl show --property=UnitFileState --value social-monitor-weekly.timer) == "$unit_state" && $(systemctl show --property=ActiveState --value social-monitor-weekly.timer) == "$active_state" ]]
+}
+
+reconcile_postgres_runtime_weekly_timer() {
+  local timer=social-monitor-weekly.timer unit_state active_state next_trigger
+  unit_state=$(systemctl show --property=UnitFileState --value "$timer") ||
+    { fail 'systemd weekly timer enablement is unavailable'; return 1; }
+  case $unit_state in
+    enabled) ;;
+    disabled) systemctl enable "$timer" ||
+      { fail 'systemd weekly timer could not be enabled'; return 1; } ;;
+    *) fail "systemd weekly timer enablement is not reconcilable: $unit_state"; return 1 ;;
+  esac
+  active_state=$(systemctl show --property=ActiveState --value "$timer") ||
+    { fail 'systemd weekly timer active state is unavailable'; return 1; }
+  case $active_state in
+    active) ;;
+    inactive) systemctl start "$timer" || {
+      fail 'systemd weekly timer could not be started'; return 1; } ;;
+    *) fail "systemd weekly timer active state is not reconcilable: $active_state"; return 1 ;;
+  esac
+  unit_state=$(systemctl show --property=UnitFileState --value "$timer") ||
+    { fail 'systemd weekly timer proof is unavailable'; return 1; }
+  active_state=$(systemctl show --property=ActiveState --value "$timer") ||
+    { fail 'systemd weekly timer proof is unavailable'; return 1; }
+  next_trigger=$(systemctl show --property=NextElapseUSecRealtime --value "$timer") ||
+    { fail 'systemd weekly timer proof is unavailable'; return 1; }
+  [[ $unit_state == enabled && $active_state == active && -n $next_trigger ]] ||
+    { fail "systemd weekly timer proof is invalid: $unit_state/$active_state"; return 1; }
+}

--- a/ops/deploy/production-release-a-transition.sh
+++ b/ops/deploy/production-release-a-transition.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 INTEGRATION_BASE=bb76b205fb9ee77a016cf62b4905a1be53988ed3
 APPROVED_A=cb6790a93122d138bae61f3155133ce926a88874
 APPROVED_B=140e73127376452103bd7a5a4b8a9103a24537c0
+FIXED_E=889d50f50328c89e25b3ef898e552df631b3222f
+FIXED_A2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a
+FIXED_B2=e3b5b5d89b3586668e36f987f03672415b5a0f37
 BACKEND_BASE=4bb8f6d4969b8449726a10859202b23e2bfb4366
 CONTROL_BASE=cec570ce45a357d2f521c0513b39a5ecffb2222a
 ENTRYPOINT=ops/deploy/social-monitor-production-deploy.sh
@@ -11,6 +14,7 @@ OLD_ENTRYPOINT_BLOB=cd6c54ba92e2e55ecc7e9a55bcdec08a1c8f4551
 APPROVED_ENTRYPOINT_BLOB=25295a9d2f9265795ca46894728b25fe9d70422b
 SNAPSHOT_PATH=libs/contracts/rest/openapi.snapshot.json
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
+POST_ROLLBACK_BOOTSTRAP_SHA=e7b19bc805815af310f1e5096d3fec5789129ddb
 EXPECTED_E_PATHS=47
 EXPECTED_FRONTEND_PATHS=33
 EXPECTED_PUBLIC_PATHS=34
@@ -30,12 +34,18 @@ OWNED_PATHS=(
 )
 
 RUNTIME_CONTROL_PATHS=(
+  ops/deploy/production-runtime/daily-c1-runtime.sh
   ops/deploy/production-runtime/daily-run.sh
+  ops/deploy/production-runtime/reader-summary-daily-c1.readiness
+  ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+  ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
   ops/deploy/production-runtime/github-premidnight-capture-v1.activation
   ops/deploy/production-runtime/github-premidnight-capture-v1.sh
   ops/deploy/production-runtime/social-monitor-github-premidnight-capture-v1.service
   ops/deploy/production-runtime/social-monitor-github-premidnight-capture-v1.timer
   ops/deploy/production-runtime/social-monitor-daily.service
+  ops/deploy/production-runtime/social-monitor-daily.timer
+  ops/deploy/production-runtime/social-monitor-reader-summary-production-day.service.d-10-daily-c1-owner.conf
   ops/deploy/production-runtime/social-monitor-weekly.service
   ops/deploy/production-runtime/social-monitor-weekly.timer
 )
@@ -87,16 +97,14 @@ manifest_digest() {
 }
 
 manifest_trailer() {
-  local commit=$1 key=$2 label=$3
-  local -a values
-  mapfile -t values < <(
-    git show -s --format=%B "$commit" |
-      git interpret-trailers --parse |
-      awk -F': ' -v key="$key" '$1 == key { print $2 }'
-  )
-  ((${#values[@]} == 1)) && [[ ${values[0]} =~ ^[0-9a-f]{64}$ ]] ||
+  local commit=$1 key=$2 label=$3 values count
+  values=$(git show -s --format=%B "$commit" |
+    git interpret-trailers --parse |
+    awk -F': ' -v key="$key" '$1 == key { print $2 }')
+  count=$(awk 'NF { count += 1 } END { print count + 0 }' <<< "$values")
+  [[ $count == 1 && $values =~ ^[0-9a-f]{64}$ ]] ||
     fail "$label must contain one exact $key trailer"
-  printf '%s\n' "${values[0]}"
+  printf '%s\n' "$values"
 }
 
 verify_manifest() {
@@ -220,9 +228,10 @@ verify_three_phase_graph() {
     "$CONTROL_BASE" "$release_e" -- "${RUNTIME_CONTROL_PATHS[@]}" | LC_ALL=C sort)
   [[ $runtime_paths == "$PENDING_RUNTIME_PATH" ]] ||
     fail 'Release E pending runtime delta is not exactly daily-run.sh'
-  git diff --quiet "$release_e" "$release_a2" -- "${RUNTIME_CONTROL_PATHS[@]}" &&
-    git diff --quiet "$release_a2" "$release_b2" -- "${RUNTIME_CONTROL_PATHS[@]}" ||
+  if ! git diff --quiet "$release_e" "$release_a2" -- "${RUNTIME_CONTROL_PATHS[@]}" ||
+     ! git diff --quiet "$release_a2" "$release_b2" -- "${RUNTIME_CONTROL_PATHS[@]}"; then
     fail 'Release A2/B2 unexpectedly changes runtime-control paths'
+  fi
 
   verify_manifest "$release_e" "$release_e" \
     Recovery-E-Manifest-SHA256 'Release E'
@@ -242,9 +251,28 @@ verify_three_phase_graph() {
   RELEASE_B2=$release_b2
 }
 
+first_parent_contains() {
+  local ancestor=$1 descendant=$2 found
+  found=$(git rev-list --first-parent "$descendant" |
+    awk -v ancestor="$ancestor" '$0 == ancestor { found = 1 } END { print found + 0 }')
+  [[ $found == 1 ]]
+}
+
+verify_target() {
+  local target=$1
+  require_commit "$target" 'target commit'
+  verify_three_phase_graph "$FIXED_B2"
+  [[ $RELEASE_E == "$FIXED_E" && $RELEASE_A2 == "$FIXED_A2" ]] ||
+    fail 'fixed E/A2/B2 graph does not match the canonical anchors'
+  first_parent_contains "$FIXED_B2" "$target" ||
+    fail 'target commit does not first-parent-contain canonical Release B2'
+  TARGET=$target
+}
+
 load_plan() {
-  local plan_file=$1 key value extra required
-  declare -gA PLAN=()
+  local plan_file=$1 key value extra required seen=' '
+  PLAN_FRONTEND='' PLAN_BACKEND='' PLAN_BACKEND_BASE='' PLAN_CONTROL=''
+  PLAN_X_COLLECTOR='' PLAN_BOOTSTRAP='' PLAN_BOOTSTRAP_SHA='' PLAN_REPAIR=''
   [[ -f $plan_file && ! -L $plan_file ]] || fail 'plan input is not a regular file'
   while IFS='=' read -r key value extra; do
     [[ -n $key && -n $value && -z ${extra:-} ]] || fail 'plan has a malformed line'
@@ -252,69 +280,133 @@ load_plan() {
       frontend|backend|backend_base|control|x_collector|postgres_pool_bootstrap|postgres_pool_bootstrap_sha|postgres_pool_repair) ;;
       *) fail "plan contains unexpected key $key" ;;
     esac
-    [[ -z ${PLAN[$key]+present} ]] || fail "plan contains duplicate key $key"
-    PLAN[$key]=$value
+    case $seen in *" $key "*) fail "plan contains duplicate key $key" ;; esac
+    seen="$seen$key "
+    case $key in
+      frontend) PLAN_FRONTEND=$value ;;
+      backend) PLAN_BACKEND=$value ;;
+      backend_base) PLAN_BACKEND_BASE=$value ;;
+      control) PLAN_CONTROL=$value ;;
+      x_collector) PLAN_X_COLLECTOR=$value ;;
+      postgres_pool_bootstrap) PLAN_BOOTSTRAP=$value ;;
+      postgres_pool_bootstrap_sha) PLAN_BOOTSTRAP_SHA=$value ;;
+      postgres_pool_repair) PLAN_REPAIR=$value ;;
+    esac
   done < "$plan_file"
-  for required in frontend backend backend_base control x_collector \
-    postgres_pool_bootstrap postgres_pool_bootstrap_sha postgres_pool_repair; do
-    [[ -n ${PLAN[$required]+present} ]] || fail "plan is missing key $required"
+  for required in frontend backend backend_base control x_collector postgres_pool_bootstrap postgres_pool_bootstrap_sha postgres_pool_repair; do
+    case $seen in *" $required "*) ;; *) fail "plan is missing key $required" ;; esac
   done
   for required in frontend backend control x_collector postgres_pool_repair; do
-    [[ ${PLAN[$required]} =~ ^(true|false)$ ]] || fail "plan key $required is not boolean"
+    case $required in
+      frontend) value=$PLAN_FRONTEND ;; backend) value=$PLAN_BACKEND ;;
+      control) value=$PLAN_CONTROL ;; x_collector) value=$PLAN_X_COLLECTOR ;;
+      postgres_pool_repair) value=$PLAN_REPAIR ;;
+    esac
+    [[ $value =~ ^(true|false)$ ]] || fail "plan key $required is not boolean"
   done
-  [[ ${PLAN[backend_base]} =~ ^[0-9a-f]{40}$ ]] || fail 'plan backend_base is invalid'
-  [[ ${PLAN[postgres_pool_bootstrap_sha]} =~ ^[0-9a-f]{40}$ && \
-     ${PLAN[postgres_pool_bootstrap_sha]} != 0000000000000000000000000000000000000000 ]] ||
+  [[ $PLAN_BACKEND_BASE =~ ^[0-9a-f]{40}$ ]] || fail 'plan backend_base is invalid'
+  [[ $PLAN_BOOTSTRAP_SHA =~ ^[0-9a-f]{40}$ ]] ||
     fail 'plan bootstrap SHA is invalid'
-  [[ ${PLAN[postgres_pool_bootstrap]} == "$POSTGRES_POOL_BOOTSTRAP_VERSION" ]] ||
-    fail 'plan PostgreSQL pool bootstrap is not postgres-pool-v1'
-  [[ ${PLAN[postgres_pool_repair]} == false ]] ||
-    fail 'inspect-plan must never report a repair'
+  [[ $PLAN_BOOTSTRAP =~ ^(uninstalled|$POSTGRES_POOL_BOOTSTRAP_VERSION)$ ]] ||
+    fail 'plan PostgreSQL pool bootstrap status is invalid'
+  if [[ $PLAN_BOOTSTRAP == uninstalled ]]; then
+    [[ $PLAN_BOOTSTRAP_SHA == 0000000000000000000000000000000000000000 ]] ||
+      fail 'uninstalled bootstrap must use the zero marker'
+  fi
 }
 
 plan_flags_are() {
-  [[ ${PLAN[frontend]} == "$1" && ${PLAN[backend]} == "$2" && \
-     ${PLAN[control]} == "$3" && ${PLAN[x_collector]} == "$4" ]]
+  [[ $PLAN_FRONTEND == "$1" && $PLAN_BACKEND == "$2" && \
+     $PLAN_CONTROL == "$3" && $PLAN_X_COLLECTOR == "$4" ]]
+}
+
+repair_required() {
+  [[ $PLAN_REPAIR == true || $PLAN_BOOTSTRAP == uninstalled ||
+     $PLAN_BOOTSTRAP_SHA == 0000000000000000000000000000000000000000 ]]
+}
+
+emit_state() {
+  if repair_required; then
+    printf 'transition_state=repair-required\n'
+  else
+    printf 'transition_state=%s\n' "$1"
+  fi
 }
 
 classify_plan() {
-  local release_b2=$1 target_phase=$2 plan_file=$3
-  verify_three_phase_graph "$release_b2"
+  local target=$1 target_phase=$2 plan_file=$3
+  verify_target "$target"
   load_plan "$plan_file"
+  if require_commit "$PLAN_BACKEND_BASE" 'current backend marker' &&
+     first_parent_contains "$FIXED_B2" "$PLAN_BACKEND_BASE"; then
+    if repair_required; then
+      printf 'transition_state=repair-required\n'
+    elif plan_flags_are false false false false; then
+      printf 'transition_state=target-complete\n'
+    else
+      printf 'transition_state=target-pending\n'
+    fi
+    return
+  fi
+  if [[ $target_phase == TARGET &&
+        $PLAN_BACKEND_BASE == "$BACKEND_BASE" &&
+        $PLAN_BOOTSTRAP == uninstalled &&
+        $PLAN_BOOTSTRAP_SHA == 0000000000000000000000000000000000000000 &&
+        $PLAN_REPAIR == false &&
+        $PLAN_FRONTEND =~ ^(true|false)$ &&
+        $PLAN_BACKEND == true && $PLAN_CONTROL == true &&
+        $PLAN_X_COLLECTOR == false ]]; then
+    printf 'transition_state=repair-required\n'
+    return
+  fi
+  if [[ $target_phase == TARGET &&
+        $(git cat-file -t "$PLAN_BACKEND_BASE" 2>/dev/null || true) == commit &&
+        $(first_parent_contains "$PLAN_BACKEND_BASE" "$target" && printf true || printf false) == true &&
+        $PLAN_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" &&
+        ( $PLAN_BOOTSTRAP_SHA == "$POST_ROLLBACK_BOOTSTRAP_SHA" ||
+          ( $(git cat-file -t "$PLAN_BOOTSTRAP_SHA" 2>/dev/null || true) == commit &&
+            $(first_parent_contains "$FIXED_B2" "$PLAN_BOOTSTRAP_SHA" && printf true || printf false) == true ) ) &&
+        $PLAN_REPAIR == false && $PLAN_FRONTEND =~ ^(true|false)$ &&
+        $PLAN_BACKEND == true && $PLAN_CONTROL == true &&
+        $PLAN_X_COLLECTOR == false ]]; then
+    printf 'transition_state=target-pending\n'
+    return
+  fi
   case $target_phase in
     E)
-      if [[ ${PLAN[backend_base]} == "$BACKEND_BASE" ]] &&
+      if [[ $PLAN_BACKEND_BASE == "$BACKEND_BASE" ]] &&
          plan_flags_are false true true false; then
-        printf 'transition_state=pre-E\n'
-      elif [[ ${PLAN[backend_base]} == "$RELEASE_E" ]] &&
+        emit_state pre-E
+      elif [[ $PLAN_BACKEND_BASE == "$RELEASE_E" ]] &&
            plan_flags_are false false true false; then
-        printf 'transition_state=pre-E\n'
-      elif [[ ${PLAN[backend_base]} == "$RELEASE_E" ]] &&
+        emit_state pre-E
+      elif [[ $PLAN_BACKEND_BASE == "$RELEASE_E" ]] &&
            plan_flags_are false false false false; then
-        printf 'transition_state=E-complete\n'
+        emit_state E-complete
       else
         fail 'Release E plan is neither its exact pending, retry, nor complete state'
       fi
       ;;
     A2)
-      [[ ${PLAN[backend_base]} == "$RELEASE_E" ]] ||
+      [[ $PLAN_BACKEND_BASE == "$RELEASE_E" ]] ||
         fail 'Release A2 backend_base is not Release E'
       plan_flags_are false false true false ||
         fail 'Release A2 plan is not the exact control-only state'
-      printf 'transition_state=E-complete\n'
+      emit_state E-complete
       ;;
     B2)
-      [[ ${PLAN[backend_base]} == "$RELEASE_E" ]] ||
+      [[ $PLAN_BACKEND_BASE == "$RELEASE_E" ]] ||
         fail 'Release B2 backend_base is not Release E'
       if plan_flags_are true false false false; then
-        printf 'transition_state=A-complete\n'
+        emit_state A-complete
       elif plan_flags_are false false false false; then
-        printf 'transition_state=B-complete\n'
+        emit_state B-complete
       else
         fail 'Release B2 plan is neither pending nor complete'
       fi
       ;;
-    *) fail 'plan phase must be E, A2, or B2' ;;
+    TARGET) fail 'current target plan does not prove the fixed phases complete' ;;
+    *) fail 'plan phase must be E, A2, B2, or TARGET' ;;
   esac
 }
 
@@ -343,7 +435,7 @@ verify_worktree() {
 }
 
 for anchor in "$INTEGRATION_BASE" "$APPROVED_A" "$APPROVED_B" \
-  "$BACKEND_BASE" "$CONTROL_BASE"; do
+  "$BACKEND_BASE" "$CONTROL_BASE" "$FIXED_E" "$FIXED_A2" "$FIXED_B2"; do
   require_commit "$anchor" "fixed anchor $anchor"
 done
 git merge-base --is-ancestor "$BACKEND_BASE" "$CONTROL_BASE" ||
@@ -357,17 +449,15 @@ case ${1:-} in
     verify_worktree
     ;;
   validate)
-    [[ $# == 2 && ${2:-} =~ ^[0-9a-f]{40}$ ]] || fail 'validate requires Release B2 SHA'
-    require_commit "$2" 'Release B2'
-    verify_three_phase_graph "$2"
-    printf 'release_e=%s\nrelease_a2=%s\nrelease_b2=%s\n' \
-      "$RELEASE_E" "$RELEASE_A2" "$RELEASE_B2"
+    [[ $# == 2 && ${2:-} =~ ^[0-9a-f]{40}$ ]] || fail 'validate requires target SHA'
+    verify_target "$2"
+    printf 'release_e=%s\nrelease_a2=%s\nrelease_b2=%s\ntarget=%s\n' \
+      "$RELEASE_E" "$RELEASE_A2" "$RELEASE_B2" "$TARGET"
     ;;
   state)
     [[ $# == 4 && ${2:-} =~ ^[0-9a-f]{40}$ ]] ||
-      fail 'state requires Release B2 SHA, E|A2|B2, and plan file'
-    require_commit "$2" 'Release B2'
+      fail 'state requires target SHA, E|A2|B2|TARGET, and plan file'
     classify_plan "$2" "$3" "$4"
     ;;
-  *) fail 'usage: production-release-a-transition.sh worktree|validate B2_SHA|state B2_SHA E|A2|B2 PLAN_FILE' ;;
+  *) fail 'usage: production-release-a-transition.sh worktree|validate TARGET_SHA|state TARGET_SHA E|A2|B2|TARGET PLAN_FILE' ;;
 esac

--- a/ops/deploy/production-release-a-transition.test.sh
+++ b/ops/deploy/production-release-a-transition.test.sh
@@ -4,342 +4,261 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 TRANSITION=$SCRIPT_DIR/production-release-a-transition.sh
-INTEGRATION_BASE=bb76b205fb9ee77a016cf62b4905a1be53988ed3
-APPROVED_A=cb6790a93122d138bae61f3155133ce926a88874
-APPROVED_B=140e73127376452103bd7a5a4b8a9103a24537c0
+FIXED_E=889d50f50328c89e25b3ef898e552df631b3222f
+FIXED_A2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a
+FIXED_B2=e3b5b5d89b3586668e36f987f03672415b5a0f37
 BACKEND_BASE=4bb8f6d4969b8449726a10859202b23e2bfb4366
-ENTRYPOINT=ops/deploy/social-monitor-production-deploy.sh
-SNAPSHOT=libs/contracts/rest/openapi.snapshot.json
+ZERO_SHA=0000000000000000000000000000000000000000
 FIXTURE=$(mktemp -d /tmp/social-monitor-release-transition.XXXXXX)
 trap 'rm -rf "$FIXTURE"' EXIT
 REPO=$FIXTURE/repo
 REFUSAL_COUNT=0
 
-OWNED_PATHS=(
-  .github/workflows/production-deploy.yml
-  ops/deploy/production-release-a-transition.sh
-  ops/deploy/production-release-a-transition.test.sh
-  ops/deploy/rabbitmq-quorum-health.sh
-  ops/deploy/rabbitmq-quorum-health.test.sh
-  ops/deploy/rabbitmq-quorum-recovery.sh
-  ops/deploy/rabbitmq-quorum-recovery.test.sh
-)
-
 git clone -q --shared "$PROJECT_ROOT" "$REPO"
 git -C "$REPO" config user.name 'Release Transition Test'
 git -C "$REPO" config user.email release-transition@example.invalid
 
-manifest_digest() {
-  LC_ALL=C git -C "$REPO" diff-tree --no-commit-id -r --full-index \
-    --no-renames "$1" | sha256sum | awk '{print $1}'
-}
-
-make_e_commit() {
-  local tree=$1 parent=$2 message=$3 provisional digest
-  provisional=$(printf '%s\n' "$message" | git -C "$REPO" commit-tree "$tree" -p "$parent")
-  digest=$(manifest_digest "$provisional")
-  {
-    printf '%s\n\n' "$message"
-    printf 'Recovery-E-Manifest-SHA256: %s\n' "$digest"
-  } | git -C "$REPO" commit-tree "$tree" -p "$parent"
-}
-
-make_a_commit() {
-  local tree=$1 release_e=$2 message=$3 provisional e_digest a_digest
-  provisional=$(printf '%s\n' "$message" | git -C "$REPO" commit-tree "$tree" -p "$release_e")
-  e_digest=$(manifest_digest "$release_e")
-  a_digest=$(manifest_digest "$provisional")
-  {
-    printf '%s\n\n' "$message"
-    printf 'Recovery-E-Manifest-SHA256: %s\n' "$e_digest"
-    printf 'Recovery-A-Manifest-SHA256: %s\n' "$a_digest"
-  } | git -C "$REPO" commit-tree "$tree" -p "$release_e"
-}
-
-make_b_commit() {
-  local tree=$1 release_a=$2 message=$3 provisional release_e
-  local e_digest a_digest b_digest
-  provisional=$(printf '%s\n' "$message" | git -C "$REPO" commit-tree "$tree" -p "$release_a")
-  release_e=$(git -C "$REPO" rev-parse "$release_a^")
-  e_digest=$(manifest_digest "$release_e")
-  a_digest=$(manifest_digest "$release_a")
-  b_digest=$(manifest_digest "$provisional")
-  {
-    printf '%s\n\n' "$message"
-    printf 'Recovery-E-Manifest-SHA256: %s\n' "$e_digest"
-    printf 'Recovery-A-Manifest-SHA256: %s\n' "$a_digest"
-    printf 'Recovery-B-Manifest-SHA256: %s\n' "$b_digest"
-  } | git -C "$REPO" commit-tree "$tree" -p "$release_a"
-}
-
-write_plan() {
-  local path=$1 frontend=$2 backend=$3 backend_base=$4 control=$5 collector=$6 marker=$7
-  printf 'frontend=%s\nbackend=%s\nbackend_base=%s\ncontrol=%s\nx_collector=%s\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\npostgres_pool_repair=false\n' \
-    "$frontend" "$backend" "$backend_base" "$control" "$collector" "$marker" > "$path"
-}
-
 assert_refuses() {
-  local expected=$1
+  local expected=$1 stderr
   shift
   REFUSAL_COUNT=$((REFUSAL_COUNT + 1))
-  local stderr=$FIXTURE/refusal-$REFUSAL_COUNT.stderr
+  stderr=$FIXTURE/refusal-$REFUSAL_COUNT.stderr
   if "$@" > "$FIXTURE/refusal-$REFUSAL_COUNT.stdout" 2> "$stderr"; then
     printf 'command unexpectedly succeeded: %s\n' "$*" >&2
     exit 1
   fi
   grep -F "$expected" "$stderr" >/dev/null || {
     printf 'command failed without expected diagnostic: %s\n' "$expected" >&2
-    cat "$stderr" >&2
+    sed -n '1,120p' "$stderr" >&2
     exit 1
   }
 }
 
-derive_a_tree() {
-  local e_tree=$1
-  git -C "$REPO" read-tree --reset -u "$e_tree"
-  git -C "$REPO" checkout -q "$APPROVED_A" -- "$ENTRYPOINT"
-  git -C "$REPO" add "$ENTRYPOINT"
-  git -C "$REPO" write-tree
+write_plan() {
+  local path=$1 frontend=$2 backend=$3 backend_base=$4 control=$5 collector=$6
+  local bootstrap=${7:-postgres-pool-v1} marker=${8:-$FIXED_E} repair=${9:-false}
+  printf 'frontend=%s\nbackend=%s\nbackend_base=%s\ncontrol=%s\nx_collector=%s\npostgres_pool_bootstrap=%s\npostgres_pool_bootstrap_sha=%s\npostgres_pool_repair=%s\n' \
+    "$frontend" "$backend" "$backend_base" "$control" "$collector" \
+    "$bootstrap" "$marker" "$repair" > "$path"
 }
-
-derive_b_tree() {
-  local a_tree=$1
-  git -C "$REPO" read-tree --reset -u "$a_tree"
-  git -C "$REPO" checkout -q "$APPROVED_B" -- apps/frontend "$SNAPSHOT"
-  git -C "$REPO" add apps/frontend "$SNAPSHOT"
-  git -C "$REPO" write-tree
-}
-
-[[ $(stat -c '%a' "$TRANSITION") == 755 ]]
-[[ $(cd "$PROJECT_ROOT" && bash "$TRANSITION" worktree) == transition_state=pre-E ]]
-
-# E is the reviewed A tree with the old sealed entrypoint and fresh orchestration bytes.
-git -C "$REPO" read-tree --reset -u "$APPROVED_A"
-git -C "$REPO" checkout -q "$INTEGRATION_BASE" -- "$ENTRYPOINT"
-for path in "${OWNED_PATHS[@]}"; do
-  case $path in
-    .github/workflows/production-deploy.yml) mode=0644 ;;
-    *.sh) mode=0755 ;;
-    *) printf 'owned fixture path has no declared mode: %s\n' "$path" >&2; exit 1 ;;
-  esac
-  install -m "$mode" "$PROJECT_ROOT/$path" "$REPO/$path"
-done
-git -C "$REPO" add -A
-E_TREE=$(git -C "$REPO" write-tree)
-RELEASE_E=$(make_e_commit "$E_TREE" "$INTEGRATION_BASE" 'test: frozen Release E')
-
-# A changes only the sealed entrypoint; B changes only the reviewed public paths.
-A_TREE=$(derive_a_tree "$E_TREE")
-RELEASE_A=$(make_a_commit "$A_TREE" "$RELEASE_E" 'test: frozen Release A')
-B_TREE=$(derive_b_tree "$A_TREE")
-RELEASE_B=$(make_b_commit "$B_TREE" "$RELEASE_A" 'test: frozen Release B')
 
 cd "$REPO"
-expected_graph=$(printf 'release_e=%s\nrelease_a2=%s\nrelease_b2=%s' \
-  "$RELEASE_E" "$RELEASE_A" "$RELEASE_B")
-[[ $(bash "$TRANSITION" validate "$RELEASE_B") == "$expected_graph" ]]
+for path in \
+  ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh \
+  ops/deploy/postgres-runtime-weekly-timer-state-lib.sh \
+  ops/deploy/production-runtime/reader-summary-daily-c1.readiness \
+  ops/deploy/production-runtime/social-monitor-daily.timer; do
+  [[ $(grep -Fxc "  $path" "$TRANSITION") == 1 ]]
+  grep -F " $path" "$SCRIPT_DIR/social-monitor-production-deploy.sh" >/dev/null
+done
+TARGET=$(printf 'test: target descendant\n' |
+  git commit-tree "$(git rev-parse "$FIXED_B2^{tree}")" -p "$FIXED_B2")
+expected=$(printf 'release_e=%s\nrelease_a2=%s\nrelease_b2=%s\ntarget=%s' \
+  "$FIXED_E" "$FIXED_A2" "$FIXED_B2" "$TARGET")
+[[ $(bash "$TRANSITION" validate "$TARGET") == "$expected" ]]
 
-# The four durable states use exact phase-specific plans; B-complete is replay-safe.
-write_plan "$FIXTURE/e-pending.plan" false true "$BACKEND_BASE" true false "$RELEASE_E"
-write_plan "$FIXTURE/e-retry.plan" false false "$RELEASE_E" true false "$RELEASE_E"
-write_plan "$FIXTURE/e-complete.plan" false false "$RELEASE_E" false false "$RELEASE_E"
-write_plan "$FIXTURE/a-pending.plan" false false "$RELEASE_E" true false "$RELEASE_E"
-write_plan "$FIXTURE/b-pending.plan" true false "$RELEASE_E" false false "$RELEASE_E"
-write_plan "$FIXTURE/b-complete.plan" false false "$RELEASE_E" false false "$RELEASE_E"
-[[ $(bash "$TRANSITION" state "$RELEASE_B" E "$FIXTURE/e-pending.plan") == transition_state=pre-E ]]
-[[ $(bash "$TRANSITION" state "$RELEASE_B" E "$FIXTURE/e-retry.plan") == transition_state=pre-E ]]
-[[ $(bash "$TRANSITION" state "$RELEASE_B" E "$FIXTURE/e-complete.plan") == transition_state=E-complete ]]
-[[ $(bash "$TRANSITION" state "$RELEASE_B" A2 "$FIXTURE/a-pending.plan") == transition_state=E-complete ]]
-[[ $(bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/b-pending.plan") == transition_state=A-complete ]]
-[[ $(bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/b-complete.plan") == transition_state=B-complete ]]
-[[ $(bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/b-complete.plan") == transition_state=B-complete ]]
+# Exact fixed phases remain restart-safe while a current backend marker on the
+# canonical first-parent chain supersedes all three fixed recovery phases.
+write_plan "$FIXTURE/e-pending.plan" false true "$BACKEND_BASE" true false
+write_plan "$FIXTURE/e-complete.plan" false false "$FIXED_E" false false
+write_plan "$FIXTURE/a-pending.plan" false false "$FIXED_E" true false
+write_plan "$FIXTURE/b-pending.plan" true false "$FIXED_E" false false
+write_plan "$FIXTURE/b-complete.plan" false false "$FIXED_E" false false
+write_plan "$FIXTURE/target-pending.plan" true true "$FIXED_B2" true false
+write_plan "$FIXTURE/target-complete.plan" false false "$TARGET" false false
+write_plan "$FIXTURE/post-rollback-target.plan" false true "$BACKEND_BASE" true false \
+  postgres-pool-v1 e7b19bc805815af310f1e5096d3fec5789129ddb
+write_plan "$FIXTURE/post-rollback-uninstalled-target.plan" true true \
+  "$BACKEND_BASE" true false uninstalled "$ZERO_SHA"
+[[ $(bash "$TRANSITION" state "$TARGET" E "$FIXTURE/e-pending.plan") == transition_state=pre-E ]]
+[[ $(bash "$TRANSITION" state "$TARGET" E "$FIXTURE/e-complete.plan") == transition_state=E-complete ]]
+[[ $(bash "$TRANSITION" state "$TARGET" A2 "$FIXTURE/a-pending.plan") == transition_state=E-complete ]]
+[[ $(bash "$TRANSITION" state "$TARGET" B2 "$FIXTURE/b-pending.plan") == transition_state=A-complete ]]
+[[ $(bash "$TRANSITION" state "$TARGET" B2 "$FIXTURE/b-complete.plan") == transition_state=B-complete ]]
+[[ $(bash "$TRANSITION" state "$TARGET" TARGET "$FIXTURE/target-pending.plan") == transition_state=target-pending ]]
+[[ $(bash "$TRANSITION" state "$TARGET" TARGET "$FIXTURE/target-complete.plan") == transition_state=target-complete ]]
+[[ $(bash "$TRANSITION" state "$TARGET" TARGET "$FIXTURE/post-rollback-target.plan") == transition_state=target-pending ]]
+[[ $(bash "$TRANSITION" state "$TARGET" TARGET \
+  "$FIXTURE/post-rollback-uninstalled-target.plan") == transition_state=repair-required ]]
+write_plan "$FIXTURE/post-rollback-descendant-bootstrap.plan" false true \
+  "$BACKEND_BASE" true false postgres-pool-v1 "$TARGET"
+[[ $(bash "$TRANSITION" state "$TARGET" TARGET \
+  "$FIXTURE/post-rollback-descendant-bootstrap.plan") == transition_state=target-pending ]]
+write_plan "$FIXTURE/post-rollback-descendant-backend.plan" false true \
+  "$FIXED_A2" true false postgres-pool-v1 "$TARGET"
+[[ $(bash "$TRANSITION" state "$TARGET" TARGET \
+  "$FIXTURE/post-rollback-descendant-backend.plan") == transition_state=target-pending ]]
+write_plan "$FIXTURE/post-rollback-frontend-target.plan" true true "$BACKEND_BASE" true false \
+  postgres-pool-v1 e7b19bc805815af310f1e5096d3fec5789129ddb
+[[ $(bash "$TRANSITION" state "$TARGET" TARGET "$FIXTURE/post-rollback-frontend-target.plan") == transition_state=target-pending ]]
 
-# Nearby or all-false A plans cannot masquerade as the required control-only phase.
-assert_refuses 'Release A2 plan is not the exact control-only state' \
-  bash "$TRANSITION" state "$RELEASE_B" A2 "$FIXTURE/b-complete.plan"
-write_plan "$FIXTURE/wrong-e.plan" true true "$BACKEND_BASE" true false "$RELEASE_E"
-assert_refuses 'Release E plan is neither its exact pending, retry, nor complete state' \
-  bash "$TRANSITION" state "$RELEASE_B" E "$FIXTURE/wrong-e.plan"
-write_plan "$FIXTURE/wrong-b.plan" true false "$RELEASE_E" true false "$RELEASE_E"
+# Bootstrap absence and an already reported repair are explicit A2 states.
+write_plan "$FIXTURE/uninstalled.plan" false false "$FIXED_E" true false uninstalled "$ZERO_SHA"
+write_plan "$FIXTURE/repair.plan" false false "$FIXED_E" true false postgres-pool-v1 "$FIXED_A2" true
+[[ $(bash "$TRANSITION" state "$TARGET" A2 "$FIXTURE/uninstalled.plan") == transition_state=repair-required ]]
+[[ $(bash "$TRANSITION" state "$TARGET" A2 "$FIXTURE/repair.plan") == transition_state=repair-required ]]
+
+# Execute the confirmed kill window: integration is A2, control remains pending,
+# and the bootstrap marker is absent. The bounded client may report failure
+# after its one reconciliation attempt; only the fresh plan is authoritative.
+HOST_BOOTSTRAP=uninstalled
+DEPLOY_CALLS=0
+DEPLOY_LOG=$FIXTURE/deploy.log
+inspect_a2() {
+  if [[ $HOST_BOOTSTRAP == uninstalled ]]; then
+    write_plan "$1" false false "$FIXED_E" true false uninstalled "$ZERO_SHA"
+  else
+    write_plan "$1" false false "$FIXED_E" true false postgres-pool-v1 "$FIXED_A2"
+  fi
+}
+bounded_client_deploy() {
+  local requested=$1
+  DEPLOY_CALLS=$((DEPLOY_CALLS + 1))
+  printf '%s\n' "$requested" >> "$DEPLOY_LOG"
+  [[ $requested == "$FIXED_A2" ]] || return 70
+  HOST_BOOTSTRAP=installed
+  return 1
+}
+inspect_a2 "$FIXTURE/interrupted.plan"
+write_plan "$FIXTURE/interrupted-b2.plan" true false "$FIXED_E" true false uninstalled "$ZERO_SHA"
 assert_refuses 'Release B2 plan is neither pending nor complete' \
-  bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/wrong-b.plan"
-write_plan "$FIXTURE/wrong-base.plan" false false "$BACKEND_BASE" true false "$RELEASE_E"
+  bash "$TRANSITION" state "$TARGET" B2 "$FIXTURE/interrupted-b2.plan"
+[[ $(bash "$TRANSITION" state "$TARGET" A2 "$FIXTURE/interrupted.plan") == transition_state=repair-required ]]
+repair_status=0
+bounded_client_deploy "$FIXED_A2" || repair_status=$?
+[[ $repair_status == 1 && $HOST_BOOTSTRAP == installed ]]
+inspect_a2 "$FIXTURE/post-repair.plan"
+[[ $(bash "$TRANSITION" state "$TARGET" A2 "$FIXTURE/post-repair.plan") == transition_state=E-complete ]]
+# The older E probe now sees the newer A2 marker as absent. The next workflow
+# proof must therefore use A2 again rather than treating this stale view as a
+# second repair request.
+write_plan "$FIXTURE/stale-e-after-a2-repair.plan" false false "$FIXED_E" false false uninstalled "$ZERO_SHA"
+[[ $(bash "$TRANSITION" state "$TARGET" E "$FIXTURE/stale-e-after-a2-repair.plan") == transition_state=repair-required ]]
+# Replay and the next A2 handoff proof do not loop or broad-deploy TARGET.
+[[ $(bash "$TRANSITION" state "$TARGET" A2 "$FIXTURE/post-repair.plan") == transition_state=E-complete ]]
+[[ $DEPLOY_CALLS == 1 && $(< "$DEPLOY_LOG") == "$FIXED_A2" ]]
+
+# Compact parser and phase classifiers fail closed on malformed or nearby data.
+sed 's/^frontend=.*/frontend=maybe/' "$FIXTURE/target-pending.plan" > "$FIXTURE/bad-boolean.plan"
+assert_refuses 'plan key frontend is not boolean' \
+  bash "$TRANSITION" state "$TARGET" TARGET "$FIXTURE/bad-boolean.plan"
+printf 'frontend=true\nfrontend=false\n' > "$FIXTURE/duplicate.plan"
+assert_refuses 'plan contains duplicate key frontend' \
+  bash "$TRANSITION" state "$TARGET" TARGET "$FIXTURE/duplicate.plan"
+write_plan "$FIXTURE/wrong-a.plan" false false "$BACKEND_BASE" true false
 assert_refuses 'Release A2 backend_base is not Release E' \
-  bash "$TRANSITION" state "$RELEASE_B" A2 "$FIXTURE/wrong-base.plan"
-write_plan "$FIXTURE/wrong-b-base.plan" true false "$BACKEND_BASE" false false "$RELEASE_E"
-assert_refuses 'Release B2 backend_base is not Release E' \
-  bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/wrong-b-base.plan"
-write_plan "$FIXTURE/wrong-x.plan" true false "$RELEASE_E" false true "$RELEASE_E"
+  bash "$TRANSITION" state "$TARGET" A2 "$FIXTURE/wrong-a.plan"
+write_plan "$FIXTURE/post-rollback-wrong-bootstrap.plan" false true "$BACKEND_BASE" true false \
+  postgres-pool-v1 "$FIXED_E"
+assert_refuses 'current target plan does not prove the fixed phases complete' \
+  bash "$TRANSITION" state "$TARGET" TARGET "$FIXTURE/post-rollback-wrong-bootstrap.plan"
+write_plan "$FIXTURE/post-rollback-uninstalled-control-complete.plan" true true \
+  "$BACKEND_BASE" false false uninstalled "$ZERO_SHA"
+assert_refuses 'current target plan does not prove the fixed phases complete' \
+  bash "$TRANSITION" state "$TARGET" TARGET \
+    "$FIXTURE/post-rollback-uninstalled-control-complete.plan"
+write_plan "$FIXTURE/post-rollback-uninstalled-wrong-base.plan" true true \
+  "$FIXED_A2" true false uninstalled "$ZERO_SHA"
+assert_refuses 'current target plan does not prove the fixed phases complete' \
+  bash "$TRANSITION" state "$TARGET" TARGET \
+    "$FIXTURE/post-rollback-uninstalled-wrong-base.plan"
+write_plan "$FIXTURE/wrong-b.plan" true false "$FIXED_E" true false
 assert_refuses 'Release B2 plan is neither pending nor complete' \
-  bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/wrong-x.plan"
-sed 's/postgres-pool-v1/uninstalled/' "$FIXTURE/b-pending.plan" > "$FIXTURE/no-bootstrap.plan"
-assert_refuses 'plan PostgreSQL pool bootstrap is not postgres-pool-v1' \
-  bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/no-bootstrap.plan"
-sed 's/^postgres_pool_bootstrap_sha=.*/postgres_pool_bootstrap_sha=0000000000000000000000000000000000000000/' \
-  "$FIXTURE/b-pending.plan" > "$FIXTURE/zero-bootstrap.plan"
-assert_refuses 'plan bootstrap SHA is invalid' \
-  bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/zero-bootstrap.plan"
-sed 's/postgres_pool_repair=false/postgres_pool_repair=true/' \
-  "$FIXTURE/b-pending.plan" > "$FIXTURE/repair.plan"
-assert_refuses 'inspect-plan must never report a repair' \
-  bash "$TRANSITION" state "$RELEASE_B" B2 "$FIXTURE/repair.plan"
+  bash "$TRANSITION" state "$TARGET" B2 "$FIXTURE/wrong-b.plan"
+write_plan "$FIXTURE/bad-bootstrap.plan" false false "$FIXED_E" false false uninstalled "$FIXED_E"
+assert_refuses 'uninstalled bootstrap must use the zero marker' \
+  bash "$TRANSITION" state "$TARGET" B2 "$FIXTURE/bad-bootstrap.plan"
 
-# A graph with the right trees but the wrong E parent is rejected.
-WRONG_PARENT=$(git rev-parse "$INTEGRATION_BASE^")
-WRONG_PARENT_E=$(make_e_commit "$E_TREE" "$WRONG_PARENT" 'test: wrong-parent E')
-WRONG_PARENT_A=$(make_a_commit "$A_TREE" "$WRONG_PARENT_E" 'test: wrong-parent A')
-WRONG_PARENT_B=$(make_b_commit "$B_TREE" "$WRONG_PARENT_A" 'test: wrong-parent B')
-assert_refuses 'Release E is not a direct child of the fixed integration base' \
-  bash "$TRANSITION" validate "$WRONG_PARENT_B"
+# Sibling ancestry and B2 appearing only through a merge's second parent are
+# both rejected, even when their trees match the canonical release.
+SIBLING=$(printf 'test: sibling\n' |
+  git commit-tree "$(git rev-parse "$FIXED_B2^{tree}")" -p "$FIXED_A2")
+SECOND_PARENT_ONLY=$(printf 'test: second-parent only\n' |
+  git commit-tree "$(git rev-parse "$FIXED_B2^{tree}")" -p "$SIBLING" -p "$FIXED_B2")
+assert_refuses 'target commit does not first-parent-contain canonical Release B2' \
+  bash "$TRANSITION" validate "$SIBLING"
+assert_refuses 'target commit does not first-parent-contain canonical Release B2' \
+  bash "$TRANSITION" validate "$SECOND_PARENT_ONLY"
 
-# E cannot install the new entrypoint early.
-git read-tree --reset -u "$E_TREE"
-git checkout -q "$APPROVED_A" -- "$ENTRYPOINT"
-git add "$ENTRYPOINT"
-EARLY_ENTRYPOINT_TREE=$(git write-tree)
-EARLY_ENTRYPOINT_E=$(make_e_commit "$EARLY_ENTRYPOINT_TREE" "$INTEGRATION_BASE" 'test: early entrypoint E')
-EARLY_ENTRYPOINT_A=$(make_a_commit "$A_TREE" "$EARLY_ENTRYPOINT_E" 'test: early entrypoint A')
-EARLY_ENTRYPOINT_B=$(make_b_commit "$B_TREE" "$EARLY_ENTRYPOINT_A" 'test: early entrypoint B')
-assert_refuses 'Release E entrypoint is not the sealed old bridge' \
-  bash "$TRANSITION" validate "$EARLY_ENTRYPOINT_B"
+# Tampering with the fixed B2 object through a replacement ref must trip its
+# immutable manifest before any target state can be accepted.
+FORGED_B2=$(printf 'test: forged B2 manifest\n\nRecovery-E-Manifest-SHA256: %064d\nRecovery-A-Manifest-SHA256: %064d\nRecovery-B-Manifest-SHA256: %064d\n' 0 0 0 |
+  git commit-tree "$(git rev-parse "$FIXED_B2^{tree}")" -p "$FIXED_A2")
+git replace "$FIXED_B2" "$FORGED_B2"
+assert_refuses 'Release B2 Recovery-E-Manifest-SHA256 path/hash manifest does not match' \
+  bash "$TRANSITION" validate "$TARGET"
+git replace -d "$FIXED_B2" >/dev/null
 
-# A must change exactly the approved entrypoint and must use its approved blob.
-git read-tree --reset -u "$E_TREE"
-printf 'wrong-entrypoint\n' > "$ENTRYPOINT"
-git add "$ENTRYPOINT"
-WRONG_A_TREE=$(git write-tree)
-WRONG_A=$(make_a_commit "$WRONG_A_TREE" "$RELEASE_E" 'test: wrong entrypoint A')
-WRONG_A_B_TREE=$(derive_b_tree "$WRONG_A_TREE")
-WRONG_A_B=$(make_b_commit "$WRONG_A_B_TREE" "$WRONG_A" 'test: wrong entrypoint B')
-assert_refuses 'Release A2/B2 entrypoint is not the approved controller' \
-  bash "$TRANSITION" validate "$WRONG_A_B"
-
-git read-tree --reset -u "$A_TREE"
-printf 'extra-a-path\n' > extra-a-path.txt
-git add extra-a-path.txt
-EXTRA_A_TREE=$(git write-tree)
-EXTRA_A=$(make_a_commit "$EXTRA_A_TREE" "$RELEASE_E" 'test: extra-path A')
-EXTRA_A_B_TREE=$(derive_b_tree "$EXTRA_A_TREE")
-EXTRA_A_B=$(make_b_commit "$EXTRA_A_B_TREE" "$EXTRA_A" 'test: extra-path A B')
-assert_refuses 'Release A2 does not change exactly the sealed entrypoint' \
-  bash "$TRANSITION" validate "$EXTRA_A_B"
-
-# Reviewed bytes and exact public path sets are immutable.
-git read-tree --reset -u "$E_TREE"
-printf '\nwrong-reviewed-byte\n' >> ops/deploy/README.md
-git add ops/deploy/README.md
-WRONG_E_TREE=$(git write-tree)
-WRONG_E=$(make_e_commit "$WRONG_E_TREE" "$INTEGRATION_BASE" 'test: wrong-byte E')
-WRONG_E_A_TREE=$(derive_a_tree "$WRONG_E_TREE")
-WRONG_E_A=$(make_a_commit "$WRONG_E_A_TREE" "$WRONG_E" 'test: wrong-byte A')
-WRONG_E_B_TREE=$(derive_b_tree "$WRONG_E_A_TREE")
-WRONG_E_B=$(make_b_commit "$WRONG_E_B_TREE" "$WRONG_E_A" 'test: wrong-byte B')
-assert_refuses 'Release E does not match its approved tree outside reviewed exclusions' \
-  bash "$TRANSITION" validate "$WRONG_E_B"
-
-git read-tree --reset -u "$B_TREE"
-printf 'extra-public-path\n' > extra-public-path.txt
-git add extra-public-path.txt
-EXTRA_B_TREE=$(git write-tree)
-EXTRA_B=$(make_b_commit "$EXTRA_B_TREE" "$RELEASE_A" 'test: extra-path B')
-assert_refuses 'Release B2 does not change exactly the 34 reviewed public paths' \
-  bash "$TRANSITION" validate "$EXTRA_B"
-
-# Mode drift in the executable transition source fails the immutable tree guard.
-git read-tree --reset -u "$E_TREE"
-chmod 0644 ops/deploy/production-release-a-transition.sh
-git add ops/deploy/production-release-a-transition.sh
-MODE_E_TREE=$(git write-tree)
-MODE_E=$(make_e_commit "$MODE_E_TREE" "$INTEGRATION_BASE" 'test: mode-drift E')
-MODE_A_TREE=$(derive_a_tree "$MODE_E_TREE")
-MODE_A=$(make_a_commit "$MODE_A_TREE" "$MODE_E" 'test: mode-drift A')
-MODE_B_TREE=$(derive_b_tree "$MODE_A_TREE")
-MODE_B=$(make_b_commit "$MODE_B_TREE" "$MODE_A" 'test: mode-drift B')
-assert_refuses 'Release E owned path has an invalid mode or type: ops/deploy/production-release-a-transition.sh' \
-  bash "$TRANSITION" validate "$MODE_B"
-
-# Stable E/A/B manifest trailers fail closed independently at every phase.
-{
-  printf 'test: forged E manifest\n\n'
-  printf 'Recovery-E-Manifest-SHA256: %064d\n' 0
-} | git commit-tree "$E_TREE" -p "$INTEGRATION_BASE" > "$FIXTURE/forged-e.sha"
-FORGED_E=$(< "$FIXTURE/forged-e.sha")
-FORGED_E_A=$(make_a_commit "$A_TREE" "$FORGED_E" 'test: forged-E A')
-FORGED_E_B=$(make_b_commit "$B_TREE" "$FORGED_E_A" 'test: forged-E B')
-assert_refuses 'Release E Recovery-E-Manifest-SHA256 path/hash manifest does not match' \
-  bash "$TRANSITION" validate "$FORGED_E_B"
-
-{
-  printf 'test: forged A manifest\n\n'
-  printf 'Recovery-E-Manifest-SHA256: %s\n' "$(manifest_digest "$RELEASE_E")"
-  printf 'Recovery-A-Manifest-SHA256: %064d\n' 0
-} | git commit-tree "$A_TREE" -p "$RELEASE_E" > "$FIXTURE/forged-a.sha"
-FORGED_A=$(< "$FIXTURE/forged-a.sha")
-FORGED_A_B=$(make_b_commit "$B_TREE" "$FORGED_A" 'test: forged-A B')
-assert_refuses 'Release A2 Recovery-A-Manifest-SHA256 path/hash manifest does not match' \
-  bash "$TRANSITION" validate "$FORGED_A_B"
-
-{
-  printf 'test: forged B manifest\n\n'
-  printf 'Recovery-E-Manifest-SHA256: %s\n' "$(manifest_digest "$RELEASE_E")"
-  printf 'Recovery-A-Manifest-SHA256: %s\n' "$(manifest_digest "$RELEASE_A")"
-  printf 'Recovery-B-Manifest-SHA256: %064d\n' 0
-} | git commit-tree "$B_TREE" -p "$RELEASE_A" > "$FIXTURE/forged-b.sha"
-FORGED_B=$(< "$FIXTURE/forged-b.sha")
-assert_refuses 'Recovery-B-Manifest-SHA256 path/hash manifest does not match' \
-  bash "$TRANSITION" validate "$FORGED_B"
-
-# Workflow order is local validation -> E -> fresh proof -> A -> fresh proof -> B -> acceptance.
+# Workflow preserves job-scoped dependencies, repair ordering, a fresh proof,
+# fixed anchors and deployment of the current target.
 python3 - "$PROJECT_ROOT/.github/workflows/production-deploy.yml" <<'PY'
-import pathlib
-import sys
-
-workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
-ordered = [
-    "Validate frozen three-phase graph before production SSH",
-    "Freshly inspect B then A then E before mutation",
-    "Deploy and reconcile Release E through the installed wrapper",
-    "Open fresh SSH after Release E",
-    "Prove E-complete through the Release A plan",
-    "Deploy and reconcile Release A through the installed wrapper",
-    "Open fresh SSH after Release A",
-    "Prove A-complete through the Release B plan",
-    "Freshly require A-complete or B-complete",
-    "Upload immutable frontend release",
-    "Deploy changed components",
-    "Accept only B-complete durable state",
-]
-positions = [workflow.index(marker) for marker in ordered]
-if positions != sorted(positions):
-    raise SystemExit("three-phase workflow order is not E -> A -> B -> acceptance")
-release_job = workflow[workflow.index("  release_a:"):workflow.index("  deploy:")]
-deploy_job = workflow[workflow.index("  deploy:"):workflow.index("  acceptance:")]
-acceptance_job = workflow[workflow.index("  acceptance:"):]
+import pathlib, sys
+w = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+for anchor in (
+    "889d50f50328c89e25b3ef898e552df631b3222f",
+    "c64c3b46b6b6ba5c7ac7b04028932e09dae2116a",
+    "e3b5b5d89b3586668e36f987f03672415b5a0f37",
+):
+    if anchor not in w:
+        raise SystemExit(f"workflow omits canonical anchor {anchor}")
+release = w[w.index("  release_a:"):w.index("  deploy:")]
+deploy = w[w.index("  deploy:"):w.index("  acceptance:")]
+acceptance = w[w.index("  acceptance:"):]
+plan = w[w.index("  plan:"):w.index("  verify_reader_summary_publication:")]
 for dependency in ("plan", "verify_reader_summary_publication", "verify_backend", "build_frontend"):
-    if f"      - {dependency}\n" not in release_job:
+    if f"      - {dependency}\n" not in release:
         raise SystemExit(f"transition mutation is not gated by {dependency}")
-if "      - release_a\n" not in deploy_job:
-    raise SystemExit("Release B deployment does not depend on E/A reconciliation")
-if "      - deploy\n" not in acceptance_job:
-    raise SystemExit("acceptance does not depend on Release B deployment")
-post_e = release_job[
-    release_job.index("Open fresh SSH after Release E"):
-    release_job.index("Deploy and reconcile Release A through the installed wrapper")
+ordered = ["Repair PostgreSQL bootstrap after verification", "Freshly inspect after bounded repair"]
+if [release.index(x) for x in ordered] != sorted(release.index(x) for x in ordered):
+    raise SystemExit("repair is not followed by a fresh inspection")
+e_proof = release[
+    release.index("Prove E-complete through the Release A plan"):
+    release.index("Deploy and reconcile Release A through the installed wrapper")
 ]
-for proof in ('inspect-plan "$release_e"', 'state "$GITHUB_SHA" E "$plan"',
-              '[[ $state == transition_state=E-complete ]]'):
-    if proof not in post_e:
-        raise SystemExit(f"fresh post-E session omits convergence proof: {proof}")
-for phase in ('E "$e_plan"', 'A2 "$a_plan"', 'B2 "$b_plan"'):
-    if phase not in workflow:
-        raise SystemExit(f"missing host fallback phase {phase}")
-for state in ("pre-E", "E-complete", "A-complete", "B-complete"):
-    if state not in workflow:
-        raise SystemExit(f"workflow omits transition state {state}")
-if "A2" + "-complete" in workflow or "B2" + "-complete" in workflow:
-    raise SystemExit("workflow changed public A/B state names")
-if 'github-production-deploy-client.sh plan "$GITHUB_SHA"' in workflow:
-    raise SystemExit("recovery preflight must remain read-only")
+if 'inspect-plan "$release_e"' in e_proof or ' state "$GITHUB_SHA" E ' in e_proof:
+    raise SystemExit("post-repair E-complete proof still probes stale fixed E")
+for fragment in ('inspect-plan "$release_a2"', 'state "$GITHUB_SHA" A2 "$plan"'):
+    if fragment not in e_proof:
+        raise SystemExit(f"post-repair E-complete proof omits exact A2 evidence: {fragment}")
+for fragment in (
+    "if: needs.plan.outputs.transition_state == 'repair-required'",
+    'DEPLOY_RECONCILE_ATTEMPTS: 1',
+    'github-production-deploy-client.sh deploy "$REPAIR_ANCHOR"',
+):
+    if fragment not in release:
+        raise SystemExit(f"bounded repair contract omits {fragment}")
+for forbidden in (' plan "$GITHUB_SHA"', ' deploy "$GITHUB_SHA"'):
+    if forbidden in plan:
+        raise SystemExit("read-only plan job performs a mutation")
+if 'repair_anchor: ${{ steps.plan.outputs.repair_anchor }}' not in plan:
+    raise SystemExit("plan job does not publish the fixed repair anchor")
+for fragment in (
+    "target_atomic_repair_plan()",
+    "== 4bb8f6d4969b8449726a10859202b23e2bfb4366",
+    "[[ $transition_state != repair-required ]] ||",
+    "repair_anchor=$daily_c1_atomic_repair",
+):
+    if fragment not in plan:
+        raise SystemExit(f"TARGET repair admission omits {fragment}")
+if "[[ $target_state != transition_state=repair-required ]]" in plan:
+    raise SystemExit("TARGET repair still falls through to stale fixed-phase probes")
+for fragment in (
+    "TRANSITION_STATE: ${{ needs.plan.outputs.transition_state }}",
+    "$TRANSITION_STATE == repair-required",
+    "REPAIR_ANCHOR: ${{ needs.plan.outputs.repair_anchor }}",
+    "$REPAIR_ANCHOR == 61018b1d376ba6695c29f9ccee1b53b1b344d4dc",
+    "repairable uninstalled bootstrap has a nonzero durable release SHA",
+):
+    if fragment not in w:
+        raise SystemExit(f"backend gate omits bounded TARGET repair contract: {fragment}")
+if 'deploy "$GITHUB_SHA"' not in deploy:
+    raise SystemExit("deploy job does not deploy the current target")
+if "      - release_a\n" not in deploy:
+    raise SystemExit("target deploy does not depend on fixed-phase reconciliation")
+if "      - deploy\n" not in acceptance:
+    raise SystemExit("acceptance does not depend on target deployment")
+if "postgres_pool_repair != 'true'" in deploy:
+    raise SystemExit("post-repair target deploy is still incorrectly suppressed")
 PY
 
-echo 'Frozen E/A/B three-phase transition tests passed'
+echo 'Canonical E/A2/B2 target transition tests passed'

--- a/ops/deploy/reader-summary-publication-deploy-lib.sh
+++ b/ops/deploy/reader-summary-publication-deploy-lib.sh
@@ -15,82 +15,44 @@ READER_SUMMARY_PUBLICATION_DATABASE_HOST=dbaas-db-8050451-do-user-39622063-0.e.d
 READER_SUMMARY_PUBLICATION_DATABASE_PORT=25060
 READER_SUMMARY_PUBLICATION_VALIDATION_ATTEMPTS=3
 READER_SUMMARY_PUBLICATION_VALIDATION_RETRY_SECONDS=2
-# shellcheck source=ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/reader-summary-publication-system-dsn-bootstrap-lib.sh"
-if [[ -f $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/reader-summary-original-cutoff-correction-lib.sh ]]; then
-  # shellcheck source=ops/deploy/reader-summary-original-cutoff-correction-lib.sh
-  source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/reader-summary-original-cutoff-correction-lib.sh"
+if declare -F source_reviewed_deploy_library >/dev/null && \
+   [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} != 1 ]]; then
+  reader_summary_publication_support_sha=$(git -C "$REPO" rev-parse HEAD) || \
+    fail 'publication support commit cannot be resolved'
+  source_reviewed_deploy_library "$reader_summary_publication_support_sha" \
+    ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh \
+    'reader summary publication system DSN bootstrap library'
+  source_reviewed_deploy_library "$reader_summary_publication_support_sha" \
+    ops/deploy/reader-summary-publication-prebootstrap-lib.sh \
+    'reader summary publication prebootstrap library'
+  if git -C "$REPO" cat-file -e \
+      "$reader_summary_publication_support_sha:ops/deploy/reader-summary-original-cutoff-correction-lib.sh" \
+      2>/dev/null; then
+    source_reviewed_deploy_library "$reader_summary_publication_support_sha" \
+      ops/deploy/reader-summary-original-cutoff-correction-lib.sh \
+      'reader summary original cutoff correction library'
+  fi
+  unset reader_summary_publication_support_sha
+else
+  reader_summary_publication_support_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  # shellcheck source=ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh
+  source "$reader_summary_publication_support_dir/reader-summary-publication-system-dsn-bootstrap-lib.sh"
+  # shellcheck source=ops/deploy/reader-summary-publication-prebootstrap-lib.sh
+  source "$reader_summary_publication_support_dir/reader-summary-publication-prebootstrap-lib.sh"
+  if [[ -f $reader_summary_publication_support_dir/reader-summary-original-cutoff-correction-lib.sh ]]; then
+    # shellcheck source=ops/deploy/reader-summary-original-cutoff-correction-lib.sh
+    source "$reader_summary_publication_support_dir/reader-summary-original-cutoff-correction-lib.sh"
+  fi
+  unset reader_summary_publication_support_dir
 fi
 
 # This file is the authenticated target-publication wrapper loaded by the
 # installed c59 deploy-control bridge. The bridge's local target SHA remains
 # Bash-dynamically scoped while this file is sourced, so validate the adjacent
 # target-only backup implementation here before returning to installed code.
+# The adjacent prebootstrap also seals the inactive daily systemd handoff.
 ! declare -F create_pre_migration_database_backup >/dev/null || \
   fail 'PostgreSQL backup entrypoint was loaded before target validation'
-
-reader_summary_publication_prebootstrap_target_daily_runner() {
-  if [[ ! ${publication_library+x} && ! ${reviewed_digest+x} &&
-        ! ${actual_digest+x} ]]; then
-    return 0
-  fi
-  [[ ${publication_library+x} && ${reviewed_digest+x} &&
-     ${actual_digest+x} ]] || \
-    fail 'incomplete target publication loader context'
-
-  local expected_publication_library=$REPO/ops/deploy/reader-summary-publication-deploy-lib.sh
-  local integration_head process_id deploy_lock_fd expected_deploy_lock
-  local admission_lock_fd expected_admission_lock previous_sha services service
-
-  [[ $publication_library == "$expected_publication_library" ]] || \
-    fail 'target publication loader path is invalid'
-  [[ -n ${reviewed_digest:-} && \
-     ${actual_digest:-} == "$reviewed_digest" ]] || \
-    fail 'target publication loader digest does not match its review'
-  [[ ${sha:-} =~ ^[0-9a-f]{40}$ ]] || \
-    fail 'target publication loader SHA is invalid'
-  integration_head=$(git -C "$REPO" rev-parse HEAD) || \
-    fail 'target publication loader integration HEAD cannot be read'
-  [[ $integration_head == "$sha" ]] || \
-    fail 'target publication loader integration HEAD does not match its SHA'
-  [[ ${backend:-} == true ]] || \
-    fail 'target publication prebootstrap backend context is invalid'
-
-  [[ -n ${DEPLOY_LOCK:-} && -n ${POSTGRES_ADMISSION_LOCK:-} ]] || \
-    fail 'target publication prebootstrap lock paths are missing'
-  process_id=$BASHPID
-  deploy_lock_fd=$(readlink -f -- "/proc/$process_id/fd/9") || \
-    fail 'target publication prebootstrap deployment lock descriptor is unavailable'
-  expected_deploy_lock=$(readlink -f -- "$DEPLOY_LOCK") || \
-    fail 'target publication prebootstrap deployment lock path is unavailable'
-  admission_lock_fd=$(readlink -f -- "/proc/$process_id/fd/8") || \
-    fail 'target publication prebootstrap PostgreSQL admission descriptor is unavailable'
-  expected_admission_lock=$(readlink -f -- "$POSTGRES_ADMISSION_LOCK") || \
-    fail 'target publication prebootstrap PostgreSQL admission lock path is unavailable'
-  [[ $deploy_lock_fd == "$expected_deploy_lock" && \
-     $admission_lock_fd == "$expected_admission_lock" ]] || \
-    fail 'target publication prebootstrap lock descriptor is invalid'
-
-  declare -F marker_value >/dev/null || \
-    fail 'target publication prebootstrap backend marker helper is missing'
-  declare -F backend_services >/dev/null || \
-    fail 'target publication prebootstrap backend service helper is missing'
-  declare -F daily_runner_image_bootstrap_before_rescue >/dev/null || \
-    fail 'target publication prebootstrap daily-runner bootstrap helper is missing'
-  previous_sha=$(marker_value backend) || \
-    fail 'target publication prebootstrap backend marker cannot be read'
-  [[ $previous_sha =~ ^[0-9a-f]{40}$ ]] || \
-    fail 'target publication prebootstrap backend marker is invalid'
-  [[ $previous_sha == "$sha" ]] && return 0
-  services=$(backend_services "$previous_sha" "$sha") || \
-    fail 'target publication prebootstrap backend service discovery failed'
-  while IFS= read -r service; do
-    [[ $service == daily-runner ]] || continue
-    daily_runner_image_bootstrap_before_rescue "$previous_sha" "$sha" || return 1
-    return 0
-  done <<< "$services"
-  return 0
-}
 
 load_target_postgres_backup_deploy_library() {
   local target_sha=$1

--- a/ops/deploy/reader-summary-recovery-maintenance-lib.sh
+++ b/ops/deploy/reader-summary-recovery-maintenance-lib.sh
@@ -4,6 +4,10 @@
 # and fail are defined. The installed V4A4 entrypoint retains its one-argument
 # ABI; the SSH wrapper carries the exact retry-set authorization on stdin.
 
+DAILY_DELIVERY_C1_DEPLOY_LOCK_WAIT_SECONDS=600
+READER_SUMMARY_PRODUCTION_TENANT_ID=00000000-0000-7000-8000-000000006101
+READER_SUMMARY_PRODUCTION_WORKSPACE_ID=00000000-0000-7000-8000-000000006102
+
 verify_daily_runner_maintenance_runtime() {
   local runtime_release backend_release control_release integration_release
   runtime_release=$(cat "$POSTGRES_RUNTIME_CURRENT/READY" 2>/dev/null || true)
@@ -177,8 +181,7 @@ assert_reader_summary_daily_bounded_maintenance_authorization() {
 }
 
 refresh_daily_runner_maintenance_auth() {
-  "$CONTROL/refresh-codex-auth.sh" \
-    --broker-pool-job-id social-monitor-production-account-pool-terra-v25-20260804 || return
+  "$CONTROL/refresh-codex-auth.sh" || return
   if [[ -f $ROOT/runtime/auth-account-changed ]]; then
     local stamp
     stamp=$(date -u +%Y%m%dT%H%M%SZ)
@@ -234,12 +237,545 @@ run_reader_summary_daily_bounded_maintenance() {
     'set -eu; node scripts/run-with-timeout.mjs --timeout-ms 19800000 --node-options --max-old-space-size=768 -- ./node_modules/.bin/ts-node -r tsconfig-paths/register scripts/run-reader-summary-daily-bounded-maintenance.ts'
 }
 
+# This entrypoint intentionally rejects arguments.
+# shellcheck disable=SC2120
 run_reader_summary_daily_terminal_set_receipt() {
   [[ $# == 0 ]] || fail 'reader-summary daily terminal-set receipt accepts no input'
   "${COMPOSE[@]}" --profile daily run --rm --no-deps \
     daily-runner sh -lc \
-    'set -eu; node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=768 -- ./node_modules/.bin/ts-node -r tsconfig-paths/register scripts/read-reader-summary-daily-terminal-set-receipt.ts'
+    'set -eu; node scripts/run-with-timeout.mjs --timeout-ms 300000 --node-options --max-old-space-size=768 -- ./node_modules/.bin/ts-node -r tsconfig-paths/register scripts/read-reader-summary-daily-terminal-set-receipt.ts'
 }
+
+run_reader_summary_daily_scan_terminal_preimage_c1() {
+  "${COMPOSE[@]}" --profile daily run --rm --no-deps \
+    daily-runner sh -lc \
+    'set -eu; node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=768 -- ./node_modules/.bin/ts-node -r tsconfig-paths/register scripts/run-reader-summary-daily-canonical-recovery.ts --scan-terminal-preimage-c1'
+}
+
+run_reader_summary_production_history() (
+  local sha=${1:-} through=${2:-} yesterday
+  [[ $# == 2 && $sha =~ ^[0-9a-f]{40}$ && \
+     $through =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ && \
+     $through > 2026-07-22 && \
+     ($through < 2026-08-12 || $through == 2026-08-12) ]] || \
+    fail 'historical reader-summary recovery-through date is outside the reviewed bound'
+  yesterday=$(node -e 'process.stdout.write(new Date(Date.now()-86400000).toISOString().slice(0,10))')
+  [[ $through < $yesterday || $through == "$yesterday" ]] || \
+    fail 'historical reader-summary recovery-through date must not exceed UTC yesterday'
+  exec 7>"$DEPLOY_LOCK"
+  flock -w "$DAILY_DELIVERY_C1_DEPLOY_LOCK_WAIT_SECONDS" 7 || \
+    fail 'timed out waiting for deployment exclusion lock'
+  verify_daily_delivery_c1_release_identity "$sha"
+  [[ -x $REPO/ops/deploy/run-reader-summary-production-history.sh && \
+     ! -L $REPO/ops/deploy/run-reader-summary-production-history.sh ]] || \
+    fail 'reviewed historical reader-summary wrapper is unavailable'
+  "$REPO/ops/deploy/run-reader-summary-production-history.sh" "$through"
+)
+
+run_reader_summary_production_history_from_stdin() {
+  local sha=${1:-${sha:-}} through='' extra=''
+  IFS= read -r through || fail 'historical reader-summary recovery-through date is missing'
+  if IFS= read -r extra || [[ -n $extra ]]; then
+    fail 'historical reader-summary authorization must be exactly one line'
+  fi
+  run_reader_summary_production_history "$sha" "$through"
+}
+
+assert_reader_summary_daily_scan_repair_quiescence_c1() {
+  local service running rabbit_id queue_rows listener_rows
+  for service in api ingestion-worker event-relay; do
+    running=$(docker ps --no-trunc \
+      --filter "label=com.docker.compose.project=$PROJECT" \
+      --filter "label=com.docker.compose.service=$service" \
+      --format '{{.ID}}') || \
+      fail "cannot prove $service quiescence for daily scan terminal repair"
+    [[ -z $running ]] || \
+      fail "$service must be fully quiescent for daily scan terminal repair"
+  done
+  if ! declare -F rabbitmq_quorum_health_require_steady_state >/dev/null; then
+    source_deploy_library rabbitmq-quorum-health.sh 'RabbitMQ quorum health library'
+  fi
+  # Consumed by the dynamically sourced health library.
+  # shellcheck disable=SC2034
+  RABBITMQ_QUORUM_HEALTH_VHOST=/
+  # Consumed by the dynamically sourced health library.
+  # shellcheck disable=SC2034
+  RABBITMQ_QUORUM_HEALTH_QUEUES='jobs.freshness.scan,jobs.summary.execute,jobs.reader-summary.execute,jobs.delivery.attempt.send,events.delivery.summary.ready'
+  rabbitmq_quorum_health_require_steady_state || \
+    fail 'RabbitMQ exact required queues are not steady-state healthy'
+  rabbit_id=${RABBITMQ_QUORUM_TARGET_CONTAINER_ID:-}
+  [[ $rabbit_id =~ ^[0-9a-f]{64}$ ]] || \
+    fail 'RabbitMQ target identity is unavailable after health proof'
+  listener_rows=$(docker exec "$rabbit_id" rabbitmq-diagnostics listeners --formatter json) || \
+    fail 'RabbitMQ listener inventory is unavailable'
+  printf '%s' "$listener_rows" | python3 -c '
+import json, sys
+rows=json.load(sys.stdin)
+ports={row.get("port") for row in rows if isinstance(row,dict)}
+if not {5672,15672}.issubset(ports): raise SystemExit(1)
+' || fail 'RabbitMQ required AMQP/management listeners are not healthy'
+  queue_rows=$(docker exec "$rabbit_id" rabbitmqctl -q list_queues \
+    --vhost / name messages_ready messages_unacknowledged consumers \
+    --formatter json) || fail 'RabbitMQ queue counters are unavailable'
+  printf '%s' "$queue_rows" | python3 -c '
+import json, sys
+rows=json.load(sys.stdin)
+required={"jobs.freshness.scan","jobs.summary.execute","jobs.reader-summary.execute","jobs.delivery.attempt.send","events.delivery.summary.ready"}
+by_name={row.get("name"):row for row in rows if isinstance(row,dict)}
+if set(by_name).intersection(required) != required: raise SystemExit(1)
+scan=by_name["jobs.freshness.scan"]
+if any(scan.get(key) != 0 for key in ("messages_ready","messages_unacknowledged","consumers")):
+    raise SystemExit(1)
+' || fail 'jobs.freshness.scan must have ready=0 unacked=0 consumers=0'
+}
+
+run_reader_summary_daily_scan_terminal_repair_c1() (
+  local confirmation=${1:-} reviewed_preimage_sha256=${2:-}
+  local service running restore_status
+  local -a previously_running=()
+  [[ $# == 2 && \
+     $confirmation == reader-summary-daily-scan-terminal-repair-c1 && \
+    $reviewed_preimage_sha256 =~ ^[0-9a-f]{64}$ ]] || \
+    fail 'daily scan terminal repair requires exact confirmation and reviewed preimage SHA-256'
+  exec 7>"$DEPLOY_LOCK"
+  flock -w 3600 7 || fail 'timed out waiting for deployment exclusion lock'
+  acquire_daily_runner_maintenance_locks
+  verify_daily_runner_maintenance_runtime
+  if ! declare -F rabbitmq_quorum_health_require_steady_state >/dev/null; then
+    source_deploy_library rabbitmq-quorum-health.sh 'RabbitMQ quorum health library'
+  fi
+  for service in api ingestion-worker event-relay; do
+    running=$(docker ps --no-trunc \
+      --filter "label=com.docker.compose.project=$PROJECT" \
+      --filter "label=com.docker.compose.service=$service" \
+      --format '{{.ID}}') || \
+      fail "cannot record $service state for daily scan terminal repair"
+    [[ -z $running ]] || previously_running+=("$service")
+  done
+  # Invoked indirectly by the EXIT trap below.
+  # shellcheck disable=SC2329
+  restore_reader_summary_daily_scan_repair_services_c1() {
+    restore_status=$?
+    trap - EXIT
+    if [[ ${#previously_running[@]} -gt 0 ]]; then
+      if ! "${COMPOSE[@]}" --profile app up -d --no-deps \
+        "${previously_running[@]}"; then
+        echo 'daily scan terminal repair could not restore prior services' >&2
+        restore_status=1
+      fi
+      for service in "${previously_running[@]}"; do
+        running=$(docker ps --no-trunc \
+          --filter "label=com.docker.compose.project=$PROJECT" \
+          --filter "label=com.docker.compose.service=$service" \
+          --format '{{.ID}}' 2>/dev/null || true)
+        if [[ -z $running ]]; then
+          echo "daily scan terminal repair did not restore $service" >&2
+          restore_status=1
+        fi
+      done
+      if ! rabbitmq_quorum_health_require_steady_state; then
+        echo 'RabbitMQ is not healthy after daily scan terminal repair restore' >&2
+        restore_status=1
+      fi
+      printf 'reader-summary-daily-scan-terminal-repair-c1 restored=%s\n' \
+        "${previously_running[*]}" >&2
+    fi
+    exit "$restore_status"
+  }
+  trap restore_reader_summary_daily_scan_repair_services_c1 EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  if [[ ${#previously_running[@]} -gt 0 ]]; then
+    "${COMPOSE[@]}" stop -t 60 api ingestion-worker event-relay || \
+      fail 'daily scan terminal repair could not quiesce application services'
+  fi
+  assert_reader_summary_daily_scan_repair_quiescence_c1
+  "${COMPOSE[@]}" --profile daily run --rm --no-deps \
+    -e READER_SUMMARY_DAILY_REPAIR_RECEIPT_DIRECTORY=/var/lib/social-monitor/artifacts/reader-summary-recovery-private \
+    daily-runner sh -lc \
+    "set -eu; node scripts/run-with-timeout.mjs --timeout-ms 19800000 --node-options --max-old-space-size=768 -- ./node_modules/.bin/ts-node -r tsconfig-paths/register scripts/run-reader-summary-daily-canonical-recovery.ts --scan-terminal-repair-c1 $confirmation $reviewed_preimage_sha256"
+  assert_reader_summary_daily_scan_repair_quiescence_c1
+)
+
+run_reader_summary_daily_scan_terminal_repair_c1_from_stdin() {
+  local record='' extra='' confirmation reviewed_preimage_sha256
+  IFS= read -r record || \
+    fail 'daily scan terminal repair authorization is missing'
+  if IFS= read -r extra || [[ -n $extra ]]; then
+    fail 'daily scan terminal repair authorization must be exactly one line'
+  fi
+  IFS=' ' read -r confirmation reviewed_preimage_sha256 extra <<< "$record"
+  [[ -z ${extra:-} && \
+     $record == "$confirmation $reviewed_preimage_sha256" ]] || \
+    fail 'daily scan terminal repair authorization has unexpected fields'
+  run_reader_summary_daily_scan_terminal_repair_c1 \
+    "$confirmation" "$reviewed_preimage_sha256"
+}
+
+daily_delivery_c1_current_utc_yesterday() {
+  date -u -d yesterday +%F
+}
+
+daily_delivery_c1_systemctl() {
+  systemctl "$@"
+}
+
+daily_delivery_c1_sleep() {
+  sleep "$1"
+}
+
+daily_delivery_c1_boot_id() {
+  cat /proc/sys/kernel/random/boot_id
+}
+
+daily_delivery_c1_runtime() {
+  "$CONTROL/daily-c1-runtime.sh" "$@"
+}
+
+parse_daily_delivery_c1_journal_record() {
+  local sha=$1 expected_date=$2 raw=$3 normalized sentinel
+  [[ $raw != *$'\n'* && $raw != *$'\r'* ]] || \
+    fail 'daily C1 invocation journal inspection was not one line'
+  normalized=${raw//$'\t'/|}
+  IFS='|' read -r DAILY_C1_JOURNAL_STATE DAILY_C1_JOURNAL_RELEASE_SHA \
+    DAILY_C1_JOURNAL_DATE DAILY_C1_JOURNAL_BOOT_ID \
+    DAILY_C1_JOURNAL_INVOCATION_ID DAILY_C1_JOURNAL_BASELINE_SHA256 \
+    DAILY_C1_JOURNAL_ORIGIN DAILY_C1_JOURNAL_STARTED_AT \
+    DAILY_C1_JOURNAL_SERVICE_RESULT DAILY_C1_JOURNAL_EXIT_CODE \
+    DAILY_C1_JOURNAL_EXIT_STATUS DAILY_C1_JOURNAL_RECEIPT_SHA256 sentinel \
+    <<< "$normalized|end"
+  [[ $sentinel == end && \
+     $DAILY_C1_JOURNAL_STATE =~ ^(STARTED|SUCCESS|FAILED)$ && \
+     $DAILY_C1_JOURNAL_RELEASE_SHA == "$sha" && \
+     $DAILY_C1_JOURNAL_DATE =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ && \
+     (-z $expected_date || $DAILY_C1_JOURNAL_DATE == "$expected_date") && \
+     $DAILY_C1_JOURNAL_BOOT_ID =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ && \
+     $DAILY_C1_JOURNAL_INVOCATION_ID =~ ^[0-9a-f]{32}$ && \
+     $DAILY_C1_JOURNAL_BASELINE_SHA256 =~ ^[0-9a-f]{64}$ && \
+     $DAILY_C1_JOURNAL_ORIGIN =~ ^(automatic|manual-reconcile)$ && \
+     $DAILY_C1_JOURNAL_STARTED_AT =~ ^[1-9][0-9]*$ ]] || \
+    fail 'daily C1 invocation journal inspection fields are invalid'
+  if [[ $DAILY_C1_JOURNAL_STATE == STARTED ]]; then
+    [[ -z $DAILY_C1_JOURNAL_SERVICE_RESULT && \
+       -z $DAILY_C1_JOURNAL_EXIT_CODE && -z $DAILY_C1_JOURNAL_EXIT_STATUS && \
+       -z $DAILY_C1_JOURNAL_RECEIPT_SHA256 ]] || \
+      fail 'daily C1 STARTED journal has terminal fields'
+  fi
+}
+
+inspect_daily_delivery_c1_journal() {
+  local sha=$1 requested_date=$2 raw
+  raw=$(daily_delivery_c1_runtime --inspect "$sha" "$requested_date") || \
+    fail 'daily C1 invocation journal inspection failed'
+  if [[ $raw == $'NONE\t'"$sha"$'\t'"$requested_date" ]]; then
+    DAILY_C1_JOURNAL_STATE=NONE
+    return
+  fi
+  parse_daily_delivery_c1_journal_record "$sha" "$requested_date" "$raw"
+}
+
+inspect_daily_delivery_c1_unresolved() {
+  local sha=$1 raw
+  raw=$(daily_delivery_c1_runtime --inspect-unresolved "$sha") || \
+    fail 'daily C1 unresolved journal inspection failed'
+  if [[ $raw == $'NONE\t'"$sha" ]]; then
+    DAILY_C1_JOURNAL_STATE=NONE
+    return
+  fi
+  parse_daily_delivery_c1_journal_record "$sha" '' "$raw"
+  [[ $DAILY_C1_JOURNAL_STATE == STARTED || \
+     $DAILY_C1_JOURNAL_STATE == FAILED ]] || \
+    fail 'daily C1 unresolved journal state is invalid'
+}
+
+inspect_daily_delivery_c1_owner() {
+  local raw normalized sentinel
+  raw=$(daily_delivery_c1_runtime --inspect-owner) || \
+    fail 'daily C1 owner inspection failed'
+  [[ $raw != *$'\n'* && $raw != *$'\r'* ]] || \
+    fail 'daily C1 owner inspection was not one line'
+  normalized=${raw//$'\t'/|}
+  IFS='|' read -r DAILY_C1_OWNER_LABEL DAILY_C1_OWNER \
+    DAILY_C1_OWNER_RELEASE_SHA DAILY_C1_CURRENT_RELEASE_SHA sentinel \
+    <<< "$normalized|end"
+  [[ $sentinel == end && $DAILY_C1_OWNER_LABEL == OWNER && \
+     $DAILY_C1_OWNER =~ ^(V6|LEGACY)$ && \
+     $DAILY_C1_OWNER_RELEASE_SHA =~ ^[0-9a-f]{40}$ && \
+     $DAILY_C1_CURRENT_RELEASE_SHA =~ ^[0-9a-f]{40}$ ]] || \
+    fail 'daily C1 owner inspection fields are invalid'
+}
+
+consume_daily_delivery_c1_authorization() {
+  local required_confirmation=$1 record='' extra='' confirmation value
+  IFS= read -r record || fail 'daily delivery C1 authorization is missing'
+  if IFS= read -r extra || [[ -n $extra ]]; then
+    fail 'daily delivery C1 authorization must be exactly one line'
+  fi
+  IFS=' ' read -r confirmation value extra <<< "$record"
+  [[ -z ${extra:-} && $record == "$confirmation $value" && \
+     $confirmation == "$required_confirmation" ]] || \
+    fail 'daily delivery C1 authorization is invalid'
+  DAILY_DELIVERY_C1_AUTHORIZATION_VALUE=$value
+}
+
+verify_daily_delivery_c1_release_identity() {
+  local sha=$1 integration_release runtime_source_sha
+  integration_release=$(git -C "$REPO" rev-parse --verify 'HEAD^{commit}' \
+    2>/dev/null || true)
+  runtime_source_sha=$(cat "$POSTGRES_RUNTIME_CURRENT/SOURCE_SHA" \
+    2>/dev/null || true)
+  [[ $integration_release == "$sha" ]] || \
+    fail 'daily delivery C1 requires exact integration HEAD activation SHA'
+  [[ $runtime_source_sha == "$sha" ]] || \
+    fail 'daily delivery C1 requires exact immutable runtime SOURCE_SHA'
+  verify_daily_runner_maintenance_runtime
+}
+
+verify_daily_delivery_c1_activation() {
+  local sha=$1
+  verify_daily_delivery_c1_release_identity "$sha"
+  verify_postgres_runtime_daily_c1_ready_topology "$sha"
+}
+
+verify_daily_delivery_c1_containment_activation() {
+  local sha=$1
+  verify_daily_delivery_c1_release_identity "$sha"
+  verify_postgres_runtime_daily_c1_ready_static "$sha"
+}
+
+emit_daily_delivery_c1_run_artifact() {
+  local sha=$1 eligible_through=$2 invocation_id=$3 boot_id=$4 baseline_sha=$5
+  local origin=$6 started_at=$7 journal_receipt_sha=$8 owner_release_sha=$9
+  local legacy_unit=${10} legacy_active=${11} legacy_next=${12}
+  local v6_unit=${13} v6_active=${14} reports=$ROOT/artifacts/reports
+  local receipt=$reports/reader-summary-daily-delivery-caught-up-c1-$eligible_through.json
+  local pointer=$reports/reader-summary-daily-delivery-caught-up-c1-latest.json
+  [[ -f $receipt && ! -L $receipt && $(stat -c '%a' "$receipt") == 444 ]] || \
+    fail 'daily delivery C1 dated caught-up receipt is not immutable'
+  [[ -f $pointer && ! -L $pointer && $(stat -c '%a' "$pointer") == 444 ]] || \
+    fail 'daily delivery C1 latest pointer is not immutable'
+  python3 - "$sha" "$eligible_through" "$receipt" "$pointer" \
+    "$invocation_id" "$boot_id" "$baseline_sha" "$origin" "$started_at" \
+    "$journal_receipt_sha" "$owner_release_sha" "$legacy_unit" \
+    "$legacy_active" "$legacy_next" "$v6_unit" "$v6_active" <<'PY' || \
+    fail 'daily delivery C1 caught-up receipt is invalid'
+import datetime, hashlib, json, re, sys
+sha, through, receipt_path, pointer_path, invocation_id, boot_id, baseline_sha, origin, started_at, journal_receipt_sha, owner_release_sha, legacy_unit, legacy_active, legacy_next, v6_unit, v6_active = sys.argv[1:]
+def load(path):
+    raw = open(path, "rb").read()
+    if len(raw) > 1024 * 1024 or not raw.endswith(b"\n") or b"\n" in raw[:-1] or b"\r" in raw:
+        raise SystemExit(1)
+    value = json.loads(raw[:-1])
+    if (json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode() + b"\n") != raw:
+        raise SystemExit(1)
+    return value, raw
+receipt, receipt_bytes = load(receipt_path)
+pointer, _ = load(pointer_path)
+receipt_keys = ["schemaVersion", "firstRequiredUtcDate", "eligibleThrough", "publishedDates", "publications", "publicationSetSha256"]
+pointer_keys = ["schemaVersion", "eligibleThrough", "receiptSha256"]
+publication_keys = ["requestedUtcDate", "readerSummaryJobId", "readerSummaryArtifactId", "publicationId", "reportSha256", "proofSha256", "weeklyEvidenceSha256", "publicEvidenceSha256", "publicFrontendSha256"]
+first = datetime.date(2026, 7, 23)
+last = datetime.date.fromisoformat(through)
+dates = [(first + datetime.timedelta(days=i)).isoformat() for i in range((last-first).days+1)]
+hex64 = re.compile(r"[0-9a-f]{64}\Z")
+uuid = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z")
+publications = receipt.get("publications")
+valid_publications = isinstance(publications, list) and len(publications) == len(dates)
+if valid_publications:
+    for index, publication in enumerate(publications):
+        if (not isinstance(publication, dict) or list(publication) != publication_keys or
+            publication["requestedUtcDate"] != dates[index] or
+            not all(uuid.fullmatch(publication[key]) for key in ("readerSummaryJobId", "readerSummaryArtifactId", "publicationId")) or
+            not all(hex64.fullmatch(publication[key]) for key in publication_keys[4:])):
+            valid_publications = False
+            break
+publication_bytes = json.dumps(publications, separators=(",", ":")).encode()
+receipt_sha = hashlib.sha256(receipt_bytes).hexdigest()
+if (list(receipt) != receipt_keys or receipt.get("schemaVersion") != "reader_summary.daily_delivery_caught_up.c1" or
+    receipt.get("firstRequiredUtcDate") != dates[0] or receipt.get("eligibleThrough") != through or
+    receipt.get("publishedDates") != dates or not valid_publications or
+    receipt.get("publicationSetSha256") != hashlib.sha256(publication_bytes).hexdigest() or
+    list(pointer) != pointer_keys or pointer.get("schemaVersion") != "reader_summary.daily_delivery_caught_up_pointer.c1" or
+    pointer.get("eligibleThrough") != through or pointer.get("receiptSha256") != receipt_sha or
+    journal_receipt_sha != receipt_sha):
+    raise SystemExit(1)
+next_date = (last + datetime.timedelta(days=1)).isoformat()
+result = {"schemaVersion":"reader_summary.daily_delivery_c1_run.v2","confirmation":"reader-summary-daily-delivery-c1-run","releaseSha":sha,"requestedUtcDate":through,"eligibleThrough":through,"nextUnresolvedUtcDate":next_date,"publicationCount":len(publications),"publicationSetSha256":receipt["publicationSetSha256"],"receiptSha256":receipt_sha,"journalState":"SUCCESS","serviceInvocationId":invocation_id,"serviceBootId":boot_id,"baselineSha256":baseline_sha,"invocationOrigin":origin,"startedAtRealtimeUsec":started_at,"serviceResult":"success","exitCode":"exited","exitStatus":"0","owner":"LEGACY","ownerReleaseSha":owner_release_sha,"legacyTimerUnitFileState":legacy_unit,"legacyTimerActiveState":legacy_active,"legacyTimerNextElapseUSecRealtime":legacy_next,"v6TimerUnitFileState":v6_unit,"v6TimerActiveState":v6_active}
+print(json.dumps(result, separators=(",", ":")))
+PY
+}
+
+fail_daily_delivery_c1_with_containment() {
+  local sha=$1 message=$2
+  printf '%s %s\n' reader-summary-daily-delivery-c1-contain "$sha" | \
+    run_reader_summary_daily_delivery_c1_containment "$sha" >&2 || \
+    fail 'daily C1 failed invocation containment could not be completed'
+  fail "$message"
+}
+
+run_reader_summary_daily_delivery_c1() (
+  local sha=$1 confirmation=reader-summary-daily-delivery-c1-run requested_date
+  local attempt active_state live_invocation request_result
+  local legacy_unit legacy_active legacy_next
+  local v6_unit v6_active
+  consume_daily_delivery_c1_authorization "$confirmation"
+  requested_date=$DAILY_DELIVERY_C1_AUTHORIZATION_VALUE
+  [[ $requested_date =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || \
+    fail 'daily delivery C1 requested UTC date is invalid'
+  exec 7>"$DEPLOY_LOCK"
+  flock -w "$DAILY_DELIVERY_C1_DEPLOY_LOCK_WAIT_SECONDS" 7 || \
+    fail 'timed out waiting for deployment exclusion lock'
+  verify_daily_delivery_c1_activation "$sha" >/dev/null
+  flock -u 7 || fail 'daily C1 deployment lock could not be released for invocation reconciliation'
+  for ((attempt=0; attempt<660; attempt++)); do
+    inspect_daily_delivery_c1_unresolved "$sha"
+    if [[ $DAILY_C1_JOURNAL_STATE == NONE ]]; then
+      inspect_daily_delivery_c1_journal "$sha" "$requested_date"
+    fi
+    case $DAILY_C1_JOURNAL_STATE in
+      SUCCESS) break ;;
+      FAILED)
+        fail_daily_delivery_c1_with_containment "$sha" \
+          'daily C1 first matching invocation failed'
+        ;;
+      STARTED)
+        active_state=$(daily_delivery_c1_systemctl show --property=ActiveState \
+          --value social-monitor-daily.service)
+        live_invocation=$(daily_delivery_c1_systemctl show --property=InvocationID \
+          --value social-monitor-daily.service)
+        if [[ ($active_state == activating || $active_state == active) && \
+              $live_invocation == "$DAILY_C1_JOURNAL_INVOCATION_ID" ]]; then
+          daily_delivery_c1_sleep 30
+          continue
+        fi
+        fail_daily_delivery_c1_with_containment "$sha" \
+          'daily C1 invocation journal is orphaned'
+        ;;
+      NONE)
+        active_state=$(daily_delivery_c1_systemctl show --property=ActiveState \
+          --value social-monitor-daily.service)
+        if [[ $active_state == activating || $active_state == active ]]; then
+          daily_delivery_c1_sleep 1
+          continue
+        fi
+        [[ $active_state == inactive ]] || \
+          fail_daily_delivery_c1_with_containment "$sha" \
+            'daily C1 service failed before its invocation journal'
+        [[ $requested_date == "$(daily_delivery_c1_current_utc_yesterday)" ]] || \
+          fail 'daily C1 historical date has no matching invocation journal'
+        request_result=$(daily_delivery_c1_runtime \
+          --request-manual-start "$sha" "$requested_date") || \
+          fail 'daily C1 manual start decision failed'
+        case $request_result in
+          CREATED|RESUBMITTED|COALESCED|EXISTING_JOURNAL) ;;
+          *) fail 'daily C1 manual start decision output is invalid' ;;
+        esac
+        daily_delivery_c1_sleep 1
+        ;;
+    esac
+  done
+  inspect_daily_delivery_c1_unresolved "$sha"
+  if [[ $DAILY_C1_JOURNAL_STATE == NONE ]]; then
+    inspect_daily_delivery_c1_journal "$sha" "$requested_date"
+  fi
+  [[ ${DAILY_C1_JOURNAL_STATE:-} == SUCCESS && \
+     $DAILY_C1_JOURNAL_DATE == "$requested_date" ]] || \
+    fail_daily_delivery_c1_with_containment "$sha" \
+      'daily C1 invocation reconciliation timed out'
+  flock -w "$DAILY_DELIVERY_C1_DEPLOY_LOCK_WAIT_SECONDS" 7 || \
+    fail 'timed out waiting for final daily C1 deployment exclusion proof'
+  verify_daily_delivery_c1_activation "$sha" >/dev/null
+  inspect_daily_delivery_c1_unresolved "$sha"
+  [[ $DAILY_C1_JOURNAL_STATE == NONE ]] || \
+    fail 'daily C1 unresolved journal appeared before final exclusion proof'
+  inspect_daily_delivery_c1_journal "$sha" "$requested_date"
+  [[ $DAILY_C1_JOURNAL_STATE == SUCCESS ]] || \
+    fail 'daily C1 terminal journal changed before final exclusion proof'
+  [[ $DAILY_C1_JOURNAL_SERVICE_RESULT == success && \
+     $DAILY_C1_JOURNAL_EXIT_CODE == exited && \
+     $DAILY_C1_JOURNAL_EXIT_STATUS == 0 && \
+     $DAILY_C1_JOURNAL_RECEIPT_SHA256 =~ ^[0-9a-f]{64}$ ]] || \
+    fail 'daily C1 SUCCESS journal terminal proof is invalid'
+  active_state=$(daily_delivery_c1_systemctl show --property=ActiveState --value \
+    social-monitor-daily.service)
+  [[ $active_state == inactive ]] || \
+    fail 'daily C1 service is not inactive for final SUCCESS proof'
+  inspect_daily_delivery_c1_owner
+  [[ $DAILY_C1_OWNER == LEGACY && $DAILY_C1_CURRENT_RELEASE_SHA == "$sha" ]] || \
+    fail 'daily C1 final live owner proof is invalid'
+  legacy_unit=$(daily_delivery_c1_systemctl show --property=UnitFileState \
+    --value social-monitor-daily.timer)
+  legacy_active=$(daily_delivery_c1_systemctl show --property=ActiveState \
+    --value social-monitor-daily.timer)
+  legacy_next=$(daily_delivery_c1_systemctl show \
+    --property=NextElapseUSecRealtime --value social-monitor-daily.timer)
+  v6_unit=$(daily_delivery_c1_systemctl show --property=UnitFileState --value \
+    social-monitor-reader-summary-production-day.timer)
+  v6_active=$(daily_delivery_c1_systemctl show --property=ActiveState --value \
+    social-monitor-reader-summary-production-day.timer)
+  [[ $legacy_unit == enabled && $legacy_active == active && \
+     -n $legacy_next && $legacy_next != n/a && $v6_unit == disabled && \
+     $v6_active == inactive ]] || fail 'daily C1 final live timer proof is invalid'
+  inspect_daily_delivery_c1_journal "$sha" "$requested_date"
+  [[ $DAILY_C1_JOURNAL_STATE == SUCCESS ]] || \
+    fail 'daily C1 terminal journal changed before artifact emission'
+  emit_daily_delivery_c1_run_artifact "$sha" "$requested_date" \
+    "$DAILY_C1_JOURNAL_INVOCATION_ID" "$DAILY_C1_JOURNAL_BOOT_ID" \
+    "$DAILY_C1_JOURNAL_BASELINE_SHA256" "$DAILY_C1_JOURNAL_ORIGIN" \
+    "$DAILY_C1_JOURNAL_STARTED_AT" "$DAILY_C1_JOURNAL_RECEIPT_SHA256" \
+    "$DAILY_C1_OWNER_RELEASE_SHA" "$legacy_unit" "$legacy_active" \
+    "$legacy_next" "$v6_unit" "$v6_active"
+)
+
+run_reader_summary_daily_delivery_c1_containment() (
+  local sha=$1 confirmation=reader-summary-daily-delivery-c1-contain ready_sha
+  local legacy_unit legacy_active v6_unit v6_active legacy_service v6_service
+  local containment_state timer
+  consume_daily_delivery_c1_authorization "$confirmation"
+  ready_sha=$DAILY_DELIVERY_C1_AUTHORIZATION_VALUE
+  [[ $ready_sha == "$sha" ]] || fail 'daily C1 containment READY SHA is invalid'
+  exec 7>"$DEPLOY_LOCK"
+  flock -w 3600 7 || fail 'timed out waiting for deployment exclusion lock'
+  verify_daily_delivery_c1_containment_activation "$sha" >/dev/null
+  persist_postgres_runtime_daily_c1_containment_requested "$sha" >/dev/null
+  containment_state=$(postgres_runtime_daily_c1_containment_state)
+  if [[ $containment_state == requested ]]; then
+    verify_postgres_runtime_daily_c1_containment "$sha" REQUESTED >/dev/null
+    for timer in social-monitor-daily.timer \
+      social-monitor-reader-summary-production-day.timer; do
+      daily_delivery_c1_systemctl stop "$timer" >&2 || \
+        fail "daily C1 containment could not stop timer: $timer"
+      daily_delivery_c1_systemctl disable "$timer" >&2 || \
+        fail "daily C1 containment could not disable timer: $timer"
+    done
+    # No service is killed; after maintenance admission both must be idle.
+    acquire_daily_runner_maintenance_locks >/dev/null
+    enforce_postgres_runtime_daily_c1_containment \
+      "$POSTGRES_RUNTIME_RELEASES/$sha" "$SYSTEMD_UNIT_DIR" >&2
+  else
+    [[ $containment_state == contained ]] || \
+      fail 'daily C1 containment marker state is invalid'
+    verify_postgres_runtime_daily_c1_containment "$sha" CONTAINED >/dev/null
+    verify_postgres_runtime_daily_c1_contained_topology \
+      "$POSTGRES_RUNTIME_RELEASES/$sha" "$SYSTEMD_UNIT_DIR" >/dev/null
+  fi
+  legacy_unit=$(daily_delivery_c1_systemctl show --property=UnitFileState --value social-monitor-daily.timer)
+  legacy_active=$(daily_delivery_c1_systemctl show --property=ActiveState --value social-monitor-daily.timer)
+  v6_unit=$(daily_delivery_c1_systemctl show --property=UnitFileState --value social-monitor-reader-summary-production-day.timer)
+  v6_active=$(daily_delivery_c1_systemctl show --property=ActiveState --value social-monitor-reader-summary-production-day.timer)
+  legacy_service=$(daily_delivery_c1_systemctl show --property=ActiveState --value social-monitor-daily.service)
+  v6_service=$(daily_delivery_c1_systemctl show --property=ActiveState --value social-monitor-reader-summary-production-day.service)
+  [[ $legacy_unit == disabled && $legacy_active == inactive && \
+     $v6_unit == disabled && $v6_active == inactive && \
+     $legacy_service == inactive && $v6_service == inactive ]] || \
+    fail 'daily C1 containment did not reach the exact disabled inactive topology'
+  promote_postgres_runtime_daily_c1_containment_contained "$sha" >/dev/null
+  verify_postgres_runtime_daily_c1_containment "$sha" CONTAINED >/dev/null
+  printf '{"schemaVersion":"reader_summary.daily_delivery_c1_containment.v1","confirmation":"%s","releaseSha":"%s","state":"CONTAINED","scheduleResumePolicy":"separate-reviewed-clearance-required","legacyTimerUnitFileState":"%s","legacyTimerActiveState":"%s","v6TimerUnitFileState":"%s","v6TimerActiveState":"%s","legacyServiceActiveState":"%s","v6ServiceActiveState":"%s"}\n' \
+    "$confirmation" "$sha" "$legacy_unit" "$legacy_active" "$v6_unit" \
+    "$v6_active" "$legacy_service" "$v6_service"
+)
 
 run_reader_summary_daily_runner_maintenance() (
   local maintenance_action=$1
@@ -247,7 +783,7 @@ run_reader_summary_daily_runner_maintenance() (
   local run_invalid_product_retry_set=false
   [[ $# == 1 ]] || fail 'reader-summary daily-runner maintenance accepts exactly one action'
   case $maintenance_action in
-    reader-summary-recover-missing-days|reader-summary-weekly-run|reader-summary-daily-terminal-set-receipt-v1) ;;
+    reader-summary-recover-missing-days|reader-summary-weekly-run|reader-summary-daily-terminal-set-receipt-v1|reader-summary-daily-scan-terminal-preimage-c1|reader-summary-daily-scan-terminal-repair-c1) ;;
     *) fail 'unknown reader-summary daily-runner maintenance action' ;;
   esac
   unset READER_SUMMARY_DAILY_MAINTENANCE_AUTHORIZED_UTC_DATE READER_SUMMARY_DAILY_MAINTENANCE_MODEL_JOB_IDENTITY READER_SUMMARY_DAILY_MAINTENANCE_AUTHORITY_SHA256 READER_SUMMARY_DAILY_MAINTENANCE_RETRY_SET_TOKEN READER_SUMMARY_DAILY_MAINTENANCE_TERMINAL_SET_SHA256
@@ -265,8 +801,17 @@ run_reader_summary_daily_runner_maintenance() (
   acquire_daily_runner_maintenance_locks
   verify_daily_runner_maintenance_runtime
   if [[ $maintenance_action == reader-summary-daily-terminal-set-receipt-v1 ]]; then
+    # The no-argument contract is deliberate.
+    # shellcheck disable=SC2119
     run_reader_summary_daily_terminal_set_receipt
     return
+  fi
+  if [[ $maintenance_action == reader-summary-daily-scan-terminal-preimage-c1 ]]; then
+    run_reader_summary_daily_scan_terminal_preimage_c1
+    return
+  fi
+  if [[ $maintenance_action == reader-summary-daily-scan-terminal-repair-c1 ]]; then
+    fail 'daily scan terminal repair authorization must use its dedicated entrypoint'
   fi
   append_final_agent_runtime_model_overlay
   refresh_daily_runner_maintenance_auth || return
@@ -281,6 +826,7 @@ run_reader_summary_daily_runner_maintenance() (
         run_reader_summary_daily_canonical_recovery || return
         local bounded_run
         for bounded_run in 1 2 3 4; do
+          : "$bounded_run"
           run_reader_summary_daily_bounded_maintenance \
             "$READER_SUMMARY_DAILY_MAINTENANCE_MODEL_JOB_IDENTITY" \
             "$READER_SUMMARY_DAILY_MAINTENANCE_AUTHORITY_SHA256" || return
@@ -291,13 +837,13 @@ run_reader_summary_daily_runner_maintenance() (
       ;;
     reader-summary-weekly-run)
       "${COMPOSE[@]}" --profile daily run --rm --no-deps \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_TENANT_ID=00000000-0000-7000-8000-000000000901 \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_WORKSPACE_ID=00000000-0000-7000-8000-000000000902 \
+        -e "READER_SUMMARY_WEEKLY_PRODUCTION_TENANT_ID=$READER_SUMMARY_PRODUCTION_TENANT_ID" \
+        -e "READER_SUMMARY_WEEKLY_PRODUCTION_WORKSPACE_ID=$READER_SUMMARY_PRODUCTION_WORKSPACE_ID" \
         -e READER_SUMMARY_WEEKLY_PRODUCTION_FIRST_WEEK_START=2026-07-27 \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_CATCH_UP_LIMIT=1 \
+        -e READER_SUMMARY_WEEKLY_PRODUCTION_CATCH_UP_LIMIT=4 \
         -e "READER_SUMMARY_WEEKLY_PRODUCTION_ARTIFACT_DIR=$READER_SUMMARY_WEEKLY_PRODUCTION_ARTIFACT_DIR" \
         daily-runner sh -lc \
-        'set -eu; npm run run:reader-summary-weekly-production -- --week-start 2026-07-27; npm run run:reader-summary-weekly-production -- --replay --week-start 2026-07-27' || return
+        'set -eu; npm run run:reader-summary-weekly-production; npm run run:reader-summary-weekly-production -- --replay' || return
       ;;
     *) fail 'unknown reader-summary daily-runner maintenance action' ;;
   esac

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 
 if [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} == 1 ]]; then
@@ -93,25 +92,28 @@ BACKEND_PATHS=(
   ops/deploy/backend-runtime-health-lib.sh
   ops/deploy/rabbitmq-quorum-health.sh
   ops/deploy/rabbitmq-quorum-recovery.sh
-  ops/deploy/reader-summary-publication-deploy-lib.sh ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh
+  ops/deploy/reader-summary-publication-deploy-lib.sh ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh ops/deploy/reader-summary-publication-system-runtime-deploy-lib.sh
   ops/deploy/reader-summary-publication-pre-migration.sql
   ops/deploy/reader-summary-publication-post-migration.sql
   test
 )
-
 CONTROL_PATHS=(
   .github/workflows/production-deploy.yml
   ops/deploy
   ops/recovery/backup-restore-contract.json
 )
-
 RUNTIME_CONTROL_PATHS=(
+  ops/deploy/production-runtime/daily-c1-runtime.sh
   ops/deploy/production-runtime/daily-run.sh
+  ops/deploy/production-runtime/compose.daily-artifacts.yml
+  ops/deploy/production-runtime/reader-summary-daily-c1.readiness
+  ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh ops/deploy/postgres-runtime-weekly-timer-state-lib.sh ops/deploy/postgres-runtime-activation-boundary-lib.sh
   ops/deploy/production-runtime/github-premidnight-capture-v1.activation
   ops/deploy/production-runtime/github-premidnight-capture-v1.sh
   ops/deploy/production-runtime/social-monitor-github-premidnight-capture-v1.service
   ops/deploy/production-runtime/social-monitor-github-premidnight-capture-v1.timer
-  ops/deploy/production-runtime/social-monitor-daily.service
+  ops/deploy/production-runtime/social-monitor-daily.service ops/deploy/production-runtime/social-monitor-daily.timer
+  ops/deploy/production-runtime/social-monitor-reader-summary-production-day.service.d-10-daily-c1-owner.conf
   ops/deploy/production-runtime/social-monitor-weekly.service ops/deploy/production-runtime/social-monitor-weekly.timer
 )
 COMPOSE=(
@@ -184,9 +186,6 @@ validate_main_commit() {
 }
 
 : "$POSTGRES_RUNTIME_RELEASES" "$SYSTEMD_UNIT_DIR" "$DAILY_SINGLETON_LOCK"
-# The installed entrypoint intentionally loads the current integration
-# libraries before advance_integration. A bridge release must install these
-# control functions before a later release changes runtime-control assets.
 DEPLOY_CONTROL_LIBRARY_AVAILABLE=false
 if [[ -f $REPO/ops/deploy/deploy-control-lib.sh ]]; then
   # shellcheck source=ops/deploy/deploy-control-lib.sh
@@ -228,14 +227,16 @@ source "$REPO/ops/deploy/backend-runtime-health-lib.sh"
 # shellcheck source=ops/deploy/backend-image-rescue-lib.sh
 source "$REPO/ops/deploy/backend-image-rescue-lib.sh"
 source_deploy_library() {
-  local library=$1 label=$2 path
-  path=$REPO/ops/deploy/$library
-  if [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} == 1 && ! -f $path ]]; then
-    path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$library
+  local library=$1 label=$2 path=$REPO/ops/deploy/$1 reviewed_sha
+  if [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} == 1 ]]; then
+    [[ -f $path && ! -L $path ]] || path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$library
+    [[ -f $path && ! -L $path ]] || fail "$label is not a regular file"
+    # shellcheck source=/dev/null
+    source "$path"
+    return
   fi
-  [[ -f $path && ! -L $path ]] || fail "$label is not a regular file"
-  # shellcheck source=/dev/null
-  source "$path"
+  reviewed_sha=$(git -C "$REPO" rev-parse --verify 'HEAD^{commit}') || fail "$label reviewed integration commit is unavailable"
+  source_reviewed_deploy_library "$reviewed_sha" "ops/deploy/$library" "$label"
 }
 source_deploy_library docker-maintenance-lib.sh 'docker maintenance library'
 # Ordering marker for legacy fixture checks: source "$daily_runner_bootstrap_library".
@@ -889,7 +890,7 @@ deploy_release_runtime_transaction() {
   set +e
   (
     set -euo pipefail
-    activate_postgres_runtime_control "$sha" "$compatible_backend_sha"
+    activate_postgres_runtime_control "$sha" "$compatible_backend_sha" "$runtime_control_backup"
     verify_compose_scope
     if [[ $backend == true ]]; then
       deploy_backend "$sha"
@@ -902,7 +903,7 @@ deploy_release_runtime_transaction() {
   fi
   trap - HUP INT TERM
   if ((activation_status != 0)); then
-    rollback_backend_and_runtime_control \
+    rollback_backend_and_runtime_control_forward_only_safe \
       "$backend" "$previous_images" "$runtime_control_backup" || rollback_status=$?
     if ((rollback_status != 0)); then
       fail 'release failed; rollback is incomplete and rescue tags were preserved'
@@ -988,8 +989,12 @@ case ${action:-} in
   deploy) deploy_release "$sha" ;;
   disk-report) print_docker_disk_report ;;
   project-disk-cleanup) cleanup_project_docker_storage ;;
-  reader-summary-recover-missing-days|reader-summary-weekly-run|reader-summary-daily-terminal-set-receipt-v1)
+  reader-summary-recover-missing-days|reader-summary-weekly-run|reader-summary-daily-terminal-set-receipt-v1|reader-summary-daily-scan-terminal-preimage-c1)
     run_reader_summary_daily_runner_maintenance "$action"
     ;;
-  *) fail 'allowed commands: plan, upload, deploy, disk-report, project-disk-cleanup, reader-summary-recover-missing-days, reader-summary-weekly-run, reader-summary-daily-terminal-set-receipt-v1' ;;
+  reader-summary-daily-scan-terminal-repair-c1) run_reader_summary_daily_scan_terminal_repair_c1_from_stdin ;;
+  reader-summary-production-history) run_reader_summary_production_history_from_stdin ;;
+  reader-summary-daily-delivery-c1-run) run_reader_summary_daily_delivery_c1 "$sha" ;;
+  reader-summary-daily-delivery-c1-contain) run_reader_summary_daily_delivery_c1_containment "$sha" ;;
+  *) fail 'command is not in the reviewed production allowlist' ;;
 esac

--- a/ops/deploy/x-collector-image-deploy-lib.test.sh
+++ b/ops/deploy/x-collector-image-deploy-lib.test.sh
@@ -219,6 +219,9 @@ CURRENT_ENTRYPOINT_SOURCE_CLOSURE=(
   ops/deploy/deploy-control-lib.sh
   ops/deploy/deploy-control-bridge-lib.sh
   ops/deploy/postgres-runtime-deploy-lib.sh
+  ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+  ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+  ops/deploy/postgres-runtime-activation-boundary-lib.sh
   ops/deploy/backend-runtime-health-lib.sh
   ops/deploy/backend-image-rescue-lib.sh
   ops/deploy/docker-maintenance-lib.sh
@@ -382,6 +385,9 @@ A_CONTROLLER="$TRANSITION_CONTROL/github-production-deploy.sh" \
       ops/deploy/deploy-control-lib.sh
       ops/deploy/deploy-control-bridge-lib.sh
       ops/deploy/postgres-runtime-deploy-lib.sh
+      ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+      ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+      ops/deploy/postgres-runtime-activation-boundary-lib.sh
       ops/deploy/backend-runtime-health-lib.sh
       ops/deploy/backend-image-rescue-lib.sh
       ops/deploy/docker-maintenance-lib.sh


### PR DESCRIPTION
Register the exact reviewed Daily C1 control-only bridge on main ancestry so the production deploy client can install the new controller before the unchanged final runtime release. The bridge contains only the workflow-sealed 20 control paths; those blobs already match current main.