### PR TITLE
chore(deploy): bridge summary recovery control

### DIFF
--- a/ops/deploy/reader-summary-recovery-maintenance-lib.sh
+++ b/ops/deploy/reader-summary-recovery-maintenance-lib.sh
@@ -5,6 +5,8 @@
 # ABI; the SSH wrapper carries the exact retry-set authorization on stdin.
 
 DAILY_DELIVERY_C1_DEPLOY_LOCK_WAIT_SECONDS=600
+READER_SUMMARY_PRODUCTION_TENANT_ID=00000000-0000-7000-8000-000000006101
+READER_SUMMARY_PRODUCTION_WORKSPACE_ID=00000000-0000-7000-8000-000000006102
 
 verify_daily_runner_maintenance_runtime() {
   local runtime_release backend_release control_release integration_release
@@ -835,13 +837,13 @@ run_reader_summary_daily_runner_maintenance() (
       ;;
     reader-summary-weekly-run)
       "${COMPOSE[@]}" --profile daily run --rm --no-deps \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_TENANT_ID=00000000-0000-7000-8000-000000000901 \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_WORKSPACE_ID=00000000-0000-7000-8000-000000000902 \
+        -e "READER_SUMMARY_WEEKLY_PRODUCTION_TENANT_ID=$READER_SUMMARY_PRODUCTION_TENANT_ID" \
+        -e "READER_SUMMARY_WEEKLY_PRODUCTION_WORKSPACE_ID=$READER_SUMMARY_PRODUCTION_WORKSPACE_ID" \
         -e READER_SUMMARY_WEEKLY_PRODUCTION_FIRST_WEEK_START=2026-07-27 \
-        -e READER_SUMMARY_WEEKLY_PRODUCTION_CATCH_UP_LIMIT=1 \
+        -e READER_SUMMARY_WEEKLY_PRODUCTION_CATCH_UP_LIMIT=4 \
         -e "READER_SUMMARY_WEEKLY_PRODUCTION_ARTIFACT_DIR=$READER_SUMMARY_WEEKLY_PRODUCTION_ARTIFACT_DIR" \
         daily-runner sh -lc \
-        'set -eu; npm run run:reader-summary-weekly-production -- --week-start 2026-07-27; npm run run:reader-summary-weekly-production -- --replay --week-start 2026-07-27' || return
+        'set -eu; npm run run:reader-summary-weekly-production; npm run run:reader-summary-weekly-production -- --replay' || return
       ;;
     *) fail 'unknown reader-summary daily-runner maintenance action' ;;
   esac


### PR DESCRIPTION
Minimal control-only bridge from the current production integration marker. It updates the one sealed recovery-control file needed before deploying PR #98, without changing backend, frontend, or runtime assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weekly reader-summary maintenance by targeting the correct production tenant and workspace.
  * Increased catch-up processing from one run to four.
  * Updated weekly processing to include both standard and replay jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->