### PR TITLE
fix(summary): make selector migration replay-safe

### DIFF
--- a/prisma/migrations/20260814055000_reader_summary_weekly_selector_citation_proof/migration.sql
+++ b/prisma/migrations/20260814055000_reader_summary_weekly_selector_citation_proof/migration.sql
@@ -49,7 +49,10 @@ BEGIN
   );
   IF v_occurrences = 1 AND v_selector_occurrences = 0 THEN
     EXECUTE replace(v_definition, v_needle, v_replacement);
-  ELSIF v_occurrences = 0 AND v_selector_occurrences = 1 THEN
+  -- The selector expression intentionally retains one provider citationId
+  -- reference inside its canonical hash input. A replay therefore observes
+  -- one legacy-shaped substring together with the installed selector.
+  ELSIF v_occurrences = 1 AND v_selector_occurrences = 1 THEN
     NULL;
   ELSE
     RAISE EXCEPTION


### PR DESCRIPTION
Production deploy exposed a replay bug after the selector function body had already been installed but Prisma had not finalized the migration record. The generated selector intentionally retains one nested provider citationId expression, so the installed state is legacy=1 and selector=1, not legacy=0 and selector=1.\n\nThis makes that exact state an idempotent no-op. Verified against production with the privileged migration role and a forced transaction rollback: the complete migration reached ROLLBACK successfully.