### PR TITLE
fix(ops): accept complete terminal provider evidence

### DIFF
--- a/scripts/verify-reader-summary-production-day-state.mjs
+++ b/scripts/verify-reader-summary-production-day-state.mjs
@@ -380,7 +380,7 @@ function validateProvider(value) {
       value.minimumFeedItemCount,
     ].every((count) => Number.isInteger(count) && count >= 0) ||
     !Array.isArray(value.reasonCodes) ||
-    value.reasonCodes.length === 0 ||
+    (value.state !== "complete" && value.reasonCodes.length === 0) ||
     value.reasonCodes.some(
       (reason) => typeof reason !== "string" || reason.length === 0,
     )

--- a/scripts/verify-reader-summary-production-day-state.test.mjs
+++ b/scripts/verify-reader-summary-production-day-state.test.mjs
@@ -184,6 +184,23 @@ test("terminal outcome must prove no model, publication, or recollection", () =>
   });
 });
 
+test("terminal incomplete providers require a diagnostic reason", () => {
+  withFixture((directory) => {
+    const outcomePath = writeOutcome(directory, collectionDate, "partial");
+    const outcome = JSON.parse(readFileSync(outcomePath, "utf8"));
+    outcome.providerReadiness.providers[1].reasonCodes = [];
+    writeFileSync(outcomePath, `${JSON.stringify(outcome)}\n`);
+    assertFailure([
+      "--expected-date",
+      collectionDate,
+      "--terminal-outcome",
+      outcomePath,
+      "--state-out",
+      join(directory, "state.json"),
+    ]);
+  });
+});
+
 function writeLegacyPublication(directory, date) {
   const period = utcPeriod(date);
   const captureExecution = {
@@ -318,19 +335,30 @@ function writeOutcome(directory, date, outcome) {
       },
       providerReadiness: {
         diagnosticsOwner: "postgres_feed_items_published_window",
-        providers: [{
-          providerKey: "reddit",
-          state: outcome,
-          evidence:
-            outcome === "partial" ? "live_collection" : "explicit_unavailable",
-          databaseFeedItemCount: outcome === "partial" ? 45 : 0,
-          collectionFeedItemCount: outcome === "partial" ? 45 : 0,
-          minimumFeedItemCount: 50,
-          reasonCodes:
-            outcome === "partial"
-              ? ["target_shortfall"]
-              : ["provider_unavailable"],
-        }],
+        providers: [
+          {
+            providerKey: "hacker-news",
+            state: "complete",
+            evidence: "live_collection",
+            databaseFeedItemCount: 100,
+            collectionFeedItemCount: 100,
+            minimumFeedItemCount: 70,
+            reasonCodes: [],
+          },
+          {
+            providerKey: "reddit",
+            state: outcome,
+            evidence:
+              outcome === "partial" ? "live_collection" : "explicit_unavailable",
+            databaseFeedItemCount: outcome === "partial" ? 45 : 0,
+            collectionFeedItemCount: outcome === "partial" ? 45 : 0,
+            minimumFeedItemCount: 50,
+            reasonCodes:
+              outcome === "partial"
+                ? ["target_shortfall"]
+                : ["provider_unavailable"],
+          },
+        ],
       },
     }, null, 2)}\n`,
   );


### PR DESCRIPTION
Fixes the production historical daily runner rejecting a valid terminal provider set when complete providers have no reason codes. Incomplete providers still require explicit non-empty diagnostic reasons.\n\nVerified with the focused state verifier test suite and source line cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed terminal providers can now be accepted without diagnostic reason codes.
  * Incomplete providers continue to require at least one reason code for validation.

* **Tests**
  * Added regression coverage for provider validation and completed provider states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->