### PR TITLE
feat(frontend): clarify summary collection funnel

### DIFF
--- a/apps/frontend/features/summaries/docs/ubiquitous_language.md
+++ b/apps/frontend/features/summaries/docs/ubiquitous_language.md
@@ -30,6 +30,13 @@ language.
 - Provider Metric: readable native provider metric such as Reddit score, HN
   points, GitHub stars, X likes, comments or upvote ratio.
 - Source Mix: provider coverage summary for the workspace summary.
+- Reviewed Post: a unique collected feed item that was available to Summary
+  selection for the covered period. It is not a raw provider response or a
+  repeated sighting of the same post.
+- Used in Summary: a Reviewed Post selected as Summary evidence.
+- Not Selected: a Reviewed Post that was available but was not used in the
+  Summary. This does not by itself mean that the post was spam, irrelevant or
+  low quality.
 - Trust & evidence: compact reader-facing summary of confidence, monitored
   source-group diversity, citations and reliability risks for a Summary. It
   opens the cited evidence details, hides raw internal scores from users and

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_coverage_by_source_band.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_coverage_by_source_band.dart
@@ -153,14 +153,24 @@ class _ProviderCoverageRow extends StatelessWidget {
             ],
           ),
           const SizedBox(height: AppSpacing.xs),
-          Text(
-            row.detailText,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: textTheme.labelSmall?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0,
+          Tooltip(
+            message: row.detailTooltipText,
+            child: Semantics(
+              label: row.detailTooltipText,
+              excludeSemantics: true,
+              child: Text(
+                key: ValueKey(
+                  'reader-summary-provider-funnel-${row.providerKey}',
+                ),
+                row.detailText,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: textTheme.labelSmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0,
+                ),
+              ),
             ),
           ),
           const SizedBox(height: AppSpacing.xs),
@@ -183,10 +193,6 @@ class _ProviderCollectionHealthIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (health.state == ReaderSummaryCollectionCoverageState.complete) {
-      return const SizedBox.shrink();
-    }
-
     final colorScheme = Theme.of(context).colorScheme;
     final (icon, color) = switch (health.state) {
       ReaderSummaryCollectionCoverageState.partial => (
@@ -223,21 +229,7 @@ class _ProviderCollectionHealthIndicator extends StatelessWidget {
 
 String _providerCollectionHealthTooltip(
   ReaderSummaryProviderCollectionHealth health,
-) {
-  final details = <String>[_collectionHealthText(health)];
-  if (health.rateLimitEventCount > 0) {
-    details.add(
-      '${health.rateLimitEventCount} rate-limit ${health.rateLimitEventCount == 1 ? 'event' : 'events'}',
-    );
-  }
-  if (health.failureKinds.isNotEmpty) {
-    details.add('Failure: ${health.failureKinds.join(', ')}');
-  }
-  if (health.paginationStopReasons.isNotEmpty) {
-    details.add('Stopped: ${health.paginationStopReasons.join(', ')}');
-  }
-  return details.join('. ');
-}
+) => _collectionHealthDetails(health);
 
 class _ProviderCoverageBar extends StatelessWidget {
   const _ProviderCoverageBar({

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_filtered_evidence.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_filtered_evidence.dart
@@ -103,8 +103,8 @@ class _SourceFilterStats extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     return Tooltip(
       message: collectedCount == null
-          ? 'Selected evidence and read-first posts used by this summary'
-          : 'Posts collected and selected for this summary',
+          ? 'Posts used by this summary; total reviewed count is unavailable'
+          : 'Unique posts reviewed, used and not selected by this summary',
       child: Text(
         _summaryStatsLabel(
           collectedCount: collectedCount,
@@ -150,10 +150,13 @@ String _summaryStatsLabel({
 }) {
   final parts = <String>[];
   if (collectedCount != null && collectedCount > 0) {
-    parts.add('${_formatCount(collectedCount)} collected');
+    parts.add('${_formatCount(collectedCount)} reviewed');
   }
   if (selectedCount > 0) {
-    parts.add('${_formatCount(selectedCount)} selected for summary');
+    parts.add('${_formatCount(selectedCount)} used');
+  }
+  if (collectedCount != null && collectedCount > selectedCount) {
+    parts.add('${_formatCount(collectedCount - selectedCount)} not selected');
   }
   if (topReadCount > 0) {
     parts.add('${_formatCount(topReadCount)} top reads');

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_provider_coverage_rows.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_provider_coverage_rows.dart
@@ -33,51 +33,81 @@ final class _ProviderCoverageRowData {
     return baseline > 0 ? baseline : topReadCount;
   }
 
+  int? get reviewedCount {
+    final collected = collectedFeedItemCount;
+    if (collected == null) {
+      return null;
+    }
+    return math.max(collected, selectedFeedItemCount);
+  }
+
+  int get notSelectedCount => math.max(
+    (reviewedCount ?? selectedFeedItemCount) - selectedFeedItemCount,
+    0,
+  );
+
   String get primaryCountText {
+    final reviewed = reviewedCount;
     if (collectionHealth?.state ==
-        ReaderSummaryCollectionCoverageState.unavailable) {
+            ReaderSummaryCollectionCoverageState.unavailable &&
+        (reviewed ?? 0) == 0) {
       return 'Unavailable';
     }
-    final collected = collectedFeedItemCount;
-    if (collected != null) {
-      return '${formatCompactCount(collected)} collected';
+    if (reviewed != null) {
+      return '${formatCompactCount(reviewed)} reviewed';
     }
-    return '${formatCompactCount(selectedFeedItemCount)} selected';
+    return '${formatCompactCount(selectedFeedItemCount)} used';
   }
 
   String get detailText {
-    final parts = <String>[];
-    final health = collectionHealth;
-    if (health != null &&
-        health.state != ReaderSummaryCollectionCoverageState.complete) {
-      parts.add(_collectionHealthText(health));
+    final reviewed = reviewedCount;
+    if (reviewed == null) {
+      return selectedFeedItemCount == 0
+          ? 'No posts used in summary'
+          : '${formatCompactCount(selectedFeedItemCount)} used in summary';
     }
-    if (collectedFeedItemCount != null) {
-      parts.add(_selectedCoverageText());
+    if (reviewed == 0) {
+      return 'No posts reviewed';
     }
-    if (topReadCount > 0) {
-      parts.add(_topReadsText(topReadCount));
-    }
-    if (citationCount > 0) {
-      parts.add('${formatCompactCount(citationCount)} citations');
-    }
-    if (lowRelevanceFeedItemCount > 0) {
-      parts.add('${formatCompactCount(lowRelevanceFeedItemCount)} low rel.');
-    }
-    if (mutedFeedItemCount > 0) {
-      parts.add('${formatCompactCount(mutedFeedItemCount)} muted');
-    }
-    return parts.isEmpty ? 'No selected evidence' : parts.join(' · ');
+    final percent = ((selectedFeedItemCount / reviewed) * 100).round();
+    return '${formatCompactCount(selectedFeedItemCount)} used ($percent%)'
+        ' · ${formatCompactCount(notSelectedCount)} not selected';
   }
 
-  String _selectedCoverageText() {
-    final selected = '${formatCompactCount(selectedFeedItemCount)} selected';
-    final collected = collectedFeedItemCount;
-    if (collected == null || collected <= 0 || selectedFeedItemCount <= 0) {
-      return selected;
+  String get detailTooltipText {
+    final reviewed = reviewedCount;
+    if (reviewed == null) {
+      return '${formatCompactCount(selectedFeedItemCount)} posts were used in '
+          'this summary. The total reviewed count is unavailable.';
     }
-    final percent = ((selectedFeedItemCount / collected) * 100).round();
-    return '$selected ($percent%)';
+    if (reviewed == 0) {
+      return 'No posts were available for this summary.';
+    }
+    final details = <String>[
+      '${_counted(reviewed, 'unique post', 'unique posts')} ${reviewed == 1 ? 'was' : 'were'} reviewed',
+      '${_counted(selectedFeedItemCount, 'post', 'posts')} ${selectedFeedItemCount == 1 ? 'was' : 'were'} used in this summary',
+      '${_counted(notSelectedCount, 'post', 'posts')} ${notSelectedCount == 1 ? 'was' : 'were'} not selected',
+    ];
+    if (topReadCount > 0) {
+      details.add(_topReadsText(topReadCount));
+    }
+    if (citationCount > 0) {
+      details.add(_counted(citationCount, 'citation', 'citations'));
+    }
+    if (lowRelevanceFeedItemCount > 0) {
+      details.add(
+        '${_counted(lowRelevanceFeedItemCount, 'post', 'posts')} marked low relevance',
+      );
+    }
+    if (mutedFeedItemCount > 0) {
+      details.add('${_counted(mutedFeedItemCount, 'post', 'posts')} muted');
+    }
+    if (userRatedFeedItemCount > 0) {
+      details.add(
+        '${_counted(userRatedFeedItemCount, 'post', 'posts')} rated by readers',
+      );
+    }
+    return '${details.join('. ')}.';
   }
 
   bool get hasEvidence {
@@ -196,6 +226,77 @@ String _collectionHealthText(ReaderSummaryProviderCollectionHealth health) {
   };
 }
 
+String _collectionHealthDetails(ReaderSummaryProviderCollectionHealth health) {
+  final details = <String>[
+    _collectionHealthText(health),
+    '${_counted(health.collectedItemCount, 'candidate', 'candidates')} checked',
+  ];
+  if (health.outsideWindowItemCount > 0) {
+    details.add(
+      '${_counted(health.outsideWindowItemCount, 'post', 'posts')} outside the summary date',
+    );
+  }
+  final duplicateCount =
+      health.paginationDuplicateItemCount + health.storageDuplicateItemCount;
+  if (duplicateCount > 0) {
+    details.add(
+      _counted(duplicateCount, 'duplicate result', 'duplicate results'),
+    );
+  }
+  if (health.insertedItemCount > 0) {
+    details.add(
+      '${_counted(health.insertedItemCount, 'new post', 'new posts')} saved',
+    );
+  }
+  if (health.rateLimitEventCount > 0) {
+    details.add(
+      health.rateLimitEventCount == 1
+          ? 'Provider rate limit reached once'
+          : 'Provider rate limit reached ${health.rateLimitEventCount} times',
+    );
+  }
+  details.addAll(
+    health.failureKinds
+        .where(
+          (kind) => kind != 'rate_limited' || health.rateLimitEventCount == 0,
+        )
+        .map(_collectionFailureText),
+  );
+  details.addAll(
+    health.paginationStopReasons
+        .map(_collectionStopReasonText)
+        .where((message) => message.isNotEmpty),
+  );
+  return '${details.join('. ')}.';
+}
+
+String _collectionFailureText(String failureKind) {
+  return switch (failureKind) {
+    'rate_limited' => 'Provider rate limit reached',
+    'auth_failed' => 'Provider sign-in failed',
+    'unavailable' => 'Provider was unavailable',
+    'invalid_query' => 'Collection query was invalid',
+    _ => 'Provider reported a collection error',
+  };
+}
+
+String _collectionStopReasonText(String stopReason) {
+  return switch (stopReason) {
+    'partial_retryable_failure' =>
+      'Collection stopped early after a temporary provider error',
+    'high_duplicate_rate' =>
+      'Collection stopped after results became mostly duplicates',
+    'low_new_item_yield' =>
+      'Collection stopped after it stopped finding new posts',
+    'max_pages' => 'Collection reached its page limit',
+    'no_next_cursor' => 'Provider had no more result pages',
+    'cursor_not_advanced' => 'Provider did not advance to a new result page',
+    'failed' => 'Collection did not complete',
+    'target_items' || 'single_page' => '',
+    _ => 'Collection stopped before the configured target',
+  };
+}
+
 List<_ProviderCoverageRowData> _sortProviderCoverageRows(
   List<_ProviderCoverageRowData> rows,
 ) {
@@ -236,6 +337,9 @@ String _topReadsText(int count) {
   final noun = count == 1 ? 'top read' : 'top reads';
   return '${formatCompactCount(count)} $noun';
 }
+
+String _counted(int count, String singular, String plural) =>
+    '${formatCompactCount(count)} ${count == 1 ? singular : plural}';
 
 Color _providerCoverageColor(String providerKey) {
   return switch (providerKey.trim().toLowerCase()) {

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_brief_surface_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_brief_surface_test.dart
@@ -263,10 +263,10 @@ void main() {
       );
 
       expect(
-        find.text('255 collected · 80 selected for summary · 9 top reads'),
+        find.text('255 reviewed · 80 used · 175 not selected · 9 top reads'),
         findsOneWidget,
       );
-      expect(find.text('80 collected · 80 selected'), findsNothing);
+      expect(find.text('80 reviewed · 80 used'), findsNothing);
     },
   );
 

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_provider_collection_health_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_provider_collection_health_test.dart
@@ -58,15 +58,62 @@ void main() {
       ),
     );
 
+    expect(find.text('12 reviewed'), findsOneWidget);
+    expect(find.text('8 used (67%) · 4 not selected'), findsOneWidget);
     expect(
-      find.textContaining('Degraded collection: 12 of 80 accepted'),
+      find.byTooltip(
+        '12 unique posts were reviewed. 8 posts were used in this summary. 4 posts were not selected. 2 top reads. 8 citations.',
+      ),
       findsOneWidget,
     );
     expect(
       find.byTooltip(
-        'Degraded collection: 12 of 80 accepted. 1 rate-limit event. Failure: rate_limited. Stopped: partial_retryable_failure',
+        'Degraded collection: 12 of 80 accepted. 16 candidates checked. 4 posts outside the summary date. 4 duplicate results. 10 new posts saved. Provider rate limit reached once. Collection stopped early after a temporary provider error.',
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('shows reviewed, used and not-selected counts without overflow', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final summary = const SummaryMapper().readerSummaryToDomain(
+      readerSummaryApiDto(
+        coverage: const ReaderSummaryCoverageApiDto(
+          collectedFeedItemCount: 66,
+          selectedFeedItemCount: 30,
+          topReadCount: 8,
+          citationCount: 30,
+          providerBreakdown: [
+            ReaderSummaryProviderCoverageApiDto(
+              providerKey: 'rss',
+              collectedFeedItemCount: 66,
+              selectedFeedItemCount: 30,
+              topReadCount: 8,
+              citationCount: 30,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark(),
+        home: Scaffold(
+          body: ReaderSummaryCoverageBySourceBand(summary: summary),
+        ),
+      ),
+    );
+
+    expect(find.text('66 reviewed'), findsOneWidget);
+    expect(find.text('30 used (45%) · 36 not selected'), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 }

--- a/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
@@ -179,12 +179,9 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(find.text('180 collected', skipOffstage: false), findsOneWidget);
+      expect(find.text('180 reviewed', skipOffstage: false), findsOneWidget);
       expect(
-        find.text(
-          '28 selected (30%) · 1 top read · 2 citations',
-          skipOffstage: false,
-        ),
+        find.text('28 used (30%) · 64 not selected', skipOffstage: false),
         findsOneWidget,
       );
       await tester.scrollUntilVisible(


### PR DESCRIPTION
## What changed
- show reviewed, used, and not-selected counts per provider
- keep collector health details in a readable tooltip
- align overall summary stats with the same terminology
- document that not selected does not mean spam or low quality

## Verification
- 213 Summary feature tests passed
- full npm run check:frontend passed
- frontend architecture boundary test passed
- compact 320 px widget test passes without overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated summary statistics to clearly distinguish reviewed posts, posts used in the summary, and reviewed posts not selected.
  * Provider coverage details now include clearer counts, reader ratings, collection health information, duplicate and rate-limit details, failures, and stop reasons.
  * Added accessible tooltips and labels for provider details and collection health indicators.
  * Collection health indicators remain visible even when coverage is complete.
  * Improved layout behavior on narrow screens to prevent content overflow.
* **Documentation**
  * Clarified terminology describing reviewed, used, and not-selected posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->