### PR TITLE
fix(deploy): preserve rolling bridge tests

### DIFF
--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -18,6 +18,8 @@ DEPLOY_CONTROL_DAILY_FINAL_BASE=d494c143c242873bfac53f54c15b0f24df0ab33d
 DEPLOY_CONTROL_DAILY_FINAL_HELPER_BLOB=119726c2f2aff06798cade4dc3a127f24a2d2cc9
 DEPLOY_CONTROL_SCHEDULED_SUMMARY_CATCH_UP_BASE=e377453d5b440aacc8077e8af1345eb5a74aae7b
 DEPLOY_CONTROL_ROLLING_SUMMARY_FINAL_TREE=6a68fd8f88477811e220c042d5176e452241389f
+DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH=ops/deploy/deploy-control-bridge-runtime-helper.test.sh
+DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH=ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -190,7 +192,7 @@ deploy_control_is_reviewed_scheduled_summary_catch_up_transition() {
 
 deploy_control_is_reviewed_rolling_summary_transition() {
   local bridge=$1 target=$2 repository=${REPO:-.}
-  local target_parent final_delta
+  local target_parent expected final_delta path
   local -a target_ancestry=()
 
   git -C "$repository" cat-file -e \
@@ -207,12 +209,19 @@ deploy_control_is_reviewed_rolling_summary_transition() {
     return 1
   final_delta=$(git -C "$repository" diff --name-only --no-renames \
     "$DEPLOY_CONTROL_ROLLING_SUMMARY_FINAL_TREE" "$target" -- \
-    2>/dev/null) || return 1
-  [[ $final_delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" && \
-     $(git -C "$repository" rev-parse \
-       "$bridge:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) == \
+    2>/dev/null | LC_ALL=C sort) || return 1
+  expected=$(printf '%s\n' \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" \
+    "$DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH" \
+    "$DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH" | \
+    LC_ALL=C sort)
+  [[ $final_delta == "$expected" ]] || return 1
+  while IFS= read -r path; do
+    [[ $(git -C "$repository" rev-parse \
+         "$bridge:$path" 2>/dev/null) == \
        $(git -C "$repository" rev-parse \
-       "$target:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) ]]
+         "$target:$path" 2>/dev/null) ]] || return 1
+  done <<< "$expected"
 }
 
 deploy_control_reviewed_transition_matches() {

--- a/ops/deploy/deploy-control-bridge-runtime-helper.test.sh
+++ b/ops/deploy/deploy-control-bridge-runtime-helper.test.sh
@@ -173,19 +173,36 @@ if declare -F deploy_control_is_reviewed_daily_c1_bridge_transition >/dev/null; 
   verify_deploy_control_bridge_target_compatibility "$reviewed_bridge_sha"
 fi
 
-rolling_final_tree=$(git -C "$REPO" rev-parse HEAD)
+printf 'pinned helper test\n' > \
+  "$REPO/$DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH"
+printf 'pinned RabbitMQ test\n' > \
+  "$REPO/$DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH"
+rolling_final_tree=$(commit_target_state 'test: seed rolling final test assets')
 DEPLOY_CONTROL_ROLLING_SUMMARY_FINAL_TREE=$rolling_final_tree
 printf '# reviewed rolling admission bridge\n' >> \
   "$REPO/$DEPLOY_CONTROL_BRIDGE_SELF_PATH"
+printf 'reviewed helper test\n' > \
+  "$REPO/$DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH"
+printf 'reviewed RabbitMQ test\n' > \
+  "$REPO/$DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH"
 rolling_bridge_sha=$(commit_target_state 'test: rolling admission bridge')
 git -C "$REPO" commit --allow-empty -qm 'test: rolling final tree'
 rolling_target_sha=$(git -C "$REPO" rev-parse HEAD)
 deploy_control_is_reviewed_rolling_summary_transition \
   "$rolling_bridge_sha" "$rolling_target_sha"
+git -C "$REPO" checkout -q "$rolling_bridge_sha"
+printf 'mutated helper test\n' > \
+  "$REPO/$DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH"
+rolling_mutated_sha=$(commit_target_state 'test: reject changed admitted asset')
+if deploy_control_is_reviewed_rolling_summary_transition \
+    "$rolling_bridge_sha" "$rolling_mutated_sha"; then
+  fail 'rolling transition accepted a target-mutated admitted asset'
+fi
+git -C "$REPO" checkout -q "$rolling_bridge_sha"
 printf 'unreviewed\n' > "$REPO/unreviewed-target-file"
 rolling_invalid_sha=$(commit_target_state 'test: reject rolling target drift')
 if deploy_control_is_reviewed_rolling_summary_transition \
-    "$rolling_target_sha" "$rolling_invalid_sha"; then
+    "$rolling_bridge_sha" "$rolling_invalid_sha"; then
   fail 'rolling transition accepted target drift outside the pinned final tree'
 fi
 printf 'deploy control bridge runtime helper tests passed\n'

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -104,7 +104,7 @@ assert_real_bridge_target_assets() {
         expected_digest=68f13213e6d1662d943185df7cdd1c11678261e76977021f74493c4e6c643b59
         ;;
       ops/deploy/deploy-control-bridge-lib.sh)
-        expected_digest=0b98516598ec1bfdebf298444f0370da6fead91483c62aa1e874a3cc29c5330e
+        expected_digest=e6f958555966b77d02b85da8d0b9195e13a200dcb2b19c8afc010fab6d28b65d
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then


### PR DESCRIPTION
Control-only bridge hardening for the rolling summary release.\n\n- admits exactly the bridge library and its two verification tests\n- requires all three blobs to remain identical in the final release\n- keeps frontend, backend and runtime assets unchanged\n\nFocused helper and Linux bridge-transition contracts pass.