### PR TITLE
fix(summaries): preserve rolling receipt permissions

### DIFF
--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -78,7 +78,11 @@ run_id=$(printf '%s' "$NOW" | tr -d ':.-')
 artifact_root="$ROOT/artifacts/rolling-summary"
 receipt_host_path="$artifact_root/rolling-summary.$run_id.receipt.v1.json"
 receipt_container_path="/var/lib/social-monitor/artifacts/rolling-summary/rolling-summary.$run_id.receipt.v1.json"
-mkdir -p "$artifact_root"
+if [[ ${SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE:-} == 1 ]]; then
+  install -d -m 0750 "$artifact_root"
+else
+  install -d -m 0750 -o 1000 -g 1000 "$artifact_root"
+fi
 
 export SOCIAL_MONITOR_ROLLING_RUN_ID=$run_id
 export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
@@ -113,22 +117,24 @@ export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
     cp "$collection_source" "$collection_artifact.next"
     chmod 0444 "$collection_artifact.next"
     mv "$collection_artifact.next" "$collection_artifact"
+    rolling_observation_cutoff=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
 
     export DURABLE_READER_SUMMARY_TENANT_ID=00000000-0000-7000-8000-000000006101
     export DURABLE_READER_SUMMARY_WORKSPACE_ID=00000000-0000-7000-8000-000000006102
     export DURABLE_READER_SUMMARY_CADENCE=daily
     export DURABLE_READER_SUMMARY_PERIOD_STARTED_AT="$period_started_at"
-    export DURABLE_READER_SUMMARY_PERIOD_ENDED_AT="$ROLLING_PERIOD_ENDED_AT"
+    export DURABLE_READER_SUMMARY_PERIOD_ENDED_AT="$(node -e '\''const day = new Date(`${process.argv[1]}T00:00:00.000Z`); day.setUTCDate(day.getUTCDate() + 1); process.stdout.write(day.toISOString());'\'' "$ROLLING_COLLECTION_DATE")"
+    export DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF="$rolling_observation_cutoff"
     export DURABLE_READER_SUMMARY_MODEL=agent-runtime
     export DURABLE_READER_SUMMARY_TOPIC_LABELER=agent-runtime
-    export DURABLE_READER_SUMMARY_MAX_EVIDENCE_ITEMS=200
+    export DURABLE_READER_SUMMARY_MAX_EVIDENCE_ITEMS=120
     export DURABLE_READER_SUMMARY_EVIDENCE_PATH="$evidence_path"
     export DURABLE_READER_SUMMARY_FRONTEND_FIXTURE_PATH="$frontend_path"
     npm run capture:durable-reader-summary
 
     node ops/deploy/production-runtime/rolling-summary-receipt.mjs \
       write-receipt "$ROLLING_RECEIPT_PATH" "$evidence_path" "$collection_artifact" \
-      "$ROLLING_RUN_ID" "$ROLLING_COLLECTION_DATE" "$ROLLING_PERIOD_ENDED_AT" \
+      "$ROLLING_RUN_ID" "$ROLLING_COLLECTION_DATE" "$rolling_observation_cutoff" \
       "$collection_exit"
   '
 

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -36,7 +36,9 @@ grep -F -- '-e ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev
 grep -F -- 'daily-runner sh -lc' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- "--providers \"\$required_providers\"" "$RUNNER" >/dev/null
 grep -F -- 'npm run capture:durable-reader-summary' "$RUNNER" >/dev/null
+grep -F -- 'DURABLE_READER_SUMMARY_MAX_EVIDENCE_ITEMS=120' "$RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_PERIOD_ENDED_AT' "$RUNNER" >/dev/null
+grep -F -- 'DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF' "$RUNNER" >/dev/null
 grep -Fx 'ExecStart=/var/data/social-monitor/control/rolling-run.sh' \
   "$REPO/ops/deploy/production-runtime/social-monitor-rolling.service" >/dev/null
 grep -Fx 'OnCalendar=*-*-* 04,08,12,16,20:15:00 UTC' \

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "${SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG:?test log is required}"
 if [[ $* == *' daily-runner sh -lc '* ]]; then
-  printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS"}\n' \
+  printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS","publication":{"readerSummaryJobId":"test-job","readerSummaryId":"test-summary","status":"completed"}}\n' \
     "$SOCIAL_MONITOR_ROLLING_RUN_ID" > \
     "$SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH"
 fi

--- a/scripts/capture-durable-reader-summary-from-postgres.ts
+++ b/scripts/capture-durable-reader-summary-from-postgres.ts
@@ -99,6 +99,8 @@ const defaultTenantId = "11111111-1111-4111-8111-111111111111";
 const defaultWorkspaceId = "22222222-2222-4222-8222-222222222222";
 const periodStartedAtEnv = "DURABLE_READER_SUMMARY_PERIOD_STARTED_AT";
 const periodEndedAtEnv = "DURABLE_READER_SUMMARY_PERIOD_ENDED_AT";
+const liveObservationCutoffEnv =
+  "DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF";
 const cadenceEnv = "DURABLE_READER_SUMMARY_CADENCE";
 const historicalGitHubOmissionReasonEnv =
   "DURABLE_READER_SUMMARY_HISTORICAL_GITHUB_OMISSION_REASON";
@@ -180,6 +182,16 @@ async function main(): Promise<void> {
       "Historical GitHub omission requires explicit historical recovery mode",
     );
   }
+  const liveObservationCutoff = resolveLiveObservationCutoff({
+    value: readDateEnv(liveObservationCutoffEnv),
+    dailyReplayActive: dailyReplay !== null,
+    recoveryActive: recoveryTimestampPolicy.active,
+    cadence,
+    timezone,
+    periodStartedAt,
+    periodEndedAt,
+    now,
+  });
   const sourceProvenance: ReaderSummaryProductionDayAttemptIdentityInput["sourceProvenance"] =
     dailyReplay !== null
       ? {
@@ -205,7 +217,12 @@ async function main(): Promise<void> {
                     historicalGitHubOmission.reason,
                 }),
           }
-        : { kind: "live-production" };
+        : {
+            kind: "live-production",
+            ...(liveObservationCutoff === undefined
+              ? {}
+              : { observationCutoff: liveObservationCutoff.toISOString() }),
+          };
   const maxEvidenceItems = readIntegerEnv(
     "DURABLE_READER_SUMMARY_MAX_EVIDENCE_ITEMS",
     200,
@@ -902,6 +919,38 @@ const readDateEnv = (name: string): Date | undefined => {
   }
 
   return date;
+};
+
+const resolveLiveObservationCutoff = (params: {
+  readonly value: Date | undefined;
+  readonly dailyReplayActive: boolean;
+  readonly recoveryActive: boolean;
+  readonly cadence: DurableReaderSummaryCadence;
+  readonly timezone: string;
+  readonly periodStartedAt: Date;
+  readonly periodEndedAt: Date;
+  readonly now: Date;
+}): Date | undefined => {
+  if (params.value === undefined) {
+    return undefined;
+  }
+  if (
+    params.dailyReplayActive ||
+    params.recoveryActive ||
+    params.cadence !== "daily" ||
+    params.timezone !== "UTC" ||
+    params.periodEndedAt.getTime() - params.periodStartedAt.getTime() !==
+      86_400_000 ||
+    params.value.getTime() < params.periodStartedAt.getTime() ||
+    params.value.getTime() >= params.periodEndedAt.getTime() ||
+    params.value.getTime() > params.now.getTime()
+  ) {
+    throw new Error(
+      `${liveObservationCutoffEnv} requires a current exact UTC daily period`,
+    );
+  }
+
+  return params.value;
 };
 
 const readModelMode = (): DurableReaderSummaryModelMode => {

--- a/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
@@ -69,6 +69,37 @@ describe("reader summary production-day attempt identity", () => {
     );
   });
 
+  it("isolates rolling live snapshots by observation cutoff", () => {
+    const first = {
+      ...liveIdentity,
+      sourceProvenance: {
+        kind: "live-production",
+        observationCutoff: "2026-08-13T08:15:00.000Z",
+      },
+    } satisfies ReaderSummaryProductionDayAttemptIdentityInput;
+    const second = {
+      ...first,
+      sourceProvenance: {
+        ...first.sourceProvenance,
+        observationCutoff: "2026-08-13T12:15:00.000Z",
+      },
+    } satisfies ReaderSummaryProductionDayAttemptIdentityInput;
+
+    expect(readerSummaryProductionDayAttemptIdentity(first)).not.toBe(
+      readerSummaryProductionDayAttemptIdentity(second),
+    );
+  });
+
+  it("rejects a non-canonical rolling observation cutoff", () => {
+    expect(() => readerSummaryProductionDayAttemptIdentity({
+      ...liveIdentity,
+      sourceProvenance: {
+        kind: "live-production",
+        observationCutoff: "2026-08-13T08:15:00Z",
+      },
+    })).toThrow("observation cutoff is invalid");
+  });
+
   it("produces the same regeneration identity for identical authority", () => {
     expect(
       readerSummaryProductionDayAttemptIdentity(regenerationIdentity),

--- a/scripts/lib/reader-summary-production-day-attempt-identity.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.ts
@@ -8,7 +8,10 @@ export type ReaderSummaryProductionDayAttemptIdentityInput = Readonly<{
   periodKey: string;
   servingAuthority: ReaderSummaryServingAuthority;
   sourceProvenance:
-    | Readonly<{ kind: "live-production" }>
+    | Readonly<{
+        kind: "live-production";
+        observationCutoff?: string;
+      }>
     | Readonly<{
         kind: "historical-regeneration";
         sourceReportSha256: string;
@@ -37,7 +40,16 @@ export const readerSummaryProductionDayAttemptIdentity = (
     servingAuthority: servingAuthority(input.servingAuthority),
     sourceProvenance:
       input.sourceProvenance.kind === "live-production"
-        ? { kind: input.sourceProvenance.kind }
+        ? {
+            kind: input.sourceProvenance.kind,
+            ...(input.sourceProvenance.observationCutoff === undefined
+              ? {}
+              : {
+                  observationCutoff: requiredIsoTimestamp(
+                    input.sourceProvenance.observationCutoff,
+                  ),
+                }),
+          }
         : input.sourceProvenance.kind === "persisted-daily-replay"
           ? {
               kind: input.sourceProvenance.kind,
@@ -132,6 +144,17 @@ const requiredSha256 = (value: string): string => {
   if (!/^[0-9a-f]{64}$/u.test(value)) {
     throw new Error("Reader summary production-day SHA-256 is invalid");
   }
+  return value;
+};
+
+const requiredIsoTimestamp = (value: string): string => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
+    throw new Error(
+      "Reader summary production-day observation cutoff is invalid",
+    );
+  }
+
   return value;
 };
 


### PR DESCRIPTION
Fix the production rolling E2E blockers found by the real production run:

- create the immutable receipt directory for the non-root daily runner
- keep model input within the established top-120 evidence budget while preserving all collected posts in storage and counters
- publish Today so far against the canonical UTC day required by the GitHub projection gate
- isolate each rolling snapshot with its own observation-cutoff identity so later four-hour runs regenerate instead of reusing an older job
- update the fake Docker receipt to the current validator contract

Verified locally:
- rolling-run.test.sh
- rolling-summary-receipt.test.mjs
- bash syntax checks

Production evidence before the final fix:
- receipt Permission denied reproduced and repaired
- 371 unique posts collected for 2026-08-15
- model budget preflight reproduced at 200 evidence items and passed at 120
- gpt-5.6-sol generation completed, then the old partial-day GitHub projection rule rejected publication

The final change preserves that quality rule by using the canonical full-day summary period while binding every rolling attempt to its actual observation cutoff.