### PR TITLE
refactor(summaries): split capture period policy

### DIFF
--- a/scripts/capture-durable-reader-summary-from-postgres.ts
+++ b/scripts/capture-durable-reader-summary-from-postgres.ts
@@ -86,6 +86,13 @@ import {
   resolveReaderSummaryServingAuthority,
 } from "./lib/reader-summary-serving-authority";
 import {
+  addUtcDays,
+  liveObservationCutoffEnv,
+  resolveLiveObservationCutoff,
+  resolveRecoveryTimestampPolicy,
+  startOfUtcDay,
+} from "./lib/reader-summary-capture-period-policy";
+import {
   assertReaderSummaryDbPublicationFailpointInactive,
   createRecoverableReaderSummaryPublication,
 } from "./lib/reader-summary-db-publication-reconciliation";
@@ -99,8 +106,6 @@ const defaultTenantId = "11111111-1111-4111-8111-111111111111";
 const defaultWorkspaceId = "22222222-2222-4222-8222-222222222222";
 const periodStartedAtEnv = "DURABLE_READER_SUMMARY_PERIOD_STARTED_AT";
 const periodEndedAtEnv = "DURABLE_READER_SUMMARY_PERIOD_ENDED_AT";
-const liveObservationCutoffEnv =
-  "DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF";
 const cadenceEnv = "DURABLE_READER_SUMMARY_CADENCE";
 const historicalGitHubOmissionReasonEnv =
   "DURABLE_READER_SUMMARY_HISTORICAL_GITHUB_OMISSION_REASON";
@@ -841,14 +846,6 @@ const writeOptionalJsonArtifact = (envName: string, value: unknown): void => {
   );
 };
 
-const startOfUtcDay = (date: Date): Date =>
-  new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-  );
-
-const addUtcDays = (date: Date, days: number): Date =>
-  new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
-
 const readCadence = (): DurableReaderSummaryCadence => {
   const value = readEnv(cadenceEnv) ?? "custom";
   if (
@@ -863,51 +860,6 @@ const readCadence = (): DurableReaderSummaryCadence => {
   throw new Error(`${cadenceEnv} must be daily, weekly, monthly or custom`);
 };
 
-const resolveRecoveryTimestampPolicy = (params: {
-  readonly argv: readonly string[];
-  readonly envValue?: string;
-  readonly cadence: DurableReaderSummaryCadence;
-  readonly timezone: string;
-  readonly periodStartedAt: Date;
-  readonly periodEndedAt: Date;
-  readonly now: Date;
-}): {
-  readonly active: boolean;
-  readonly policy: ReaderSummaryTimestampPolicy;
-} => {
-  const explicitlyHistorical = params.argv.includes("--historical-recovery");
-  if (!explicitlyHistorical && params.envValue === undefined) {
-    return { active: false, policy: "published_at" };
-  }
-  if (!explicitlyHistorical || params.envValue === undefined) {
-    throw new Error(
-      `Historical recovery requires both --historical-recovery and ${recoveryTimestampPolicyEnv}`,
-    );
-  }
-  if (
-    params.envValue !== "published_at" &&
-    params.envValue !== "observed_at"
-  ) {
-    throw new Error(
-      `${recoveryTimestampPolicyEnv} must be published_at or observed_at`,
-    );
-  }
-  if (
-    params.cadence !== "daily" ||
-    params.timezone !== "UTC" ||
-    params.periodStartedAt.toISOString() !==
-      `${params.periodStartedAt.toISOString().slice(0, 10)}T00:00:00.000Z` ||
-    params.periodEndedAt.getTime() - params.periodStartedAt.getTime() !==
-      86_400_000 ||
-    params.periodEndedAt.getTime() > params.now.getTime()
-  ) {
-    throw new Error(
-      "Historical recovery timestamp policy is restricted to one completed exact UTC day",
-    );
-  }
-  return { active: true, policy: params.envValue };
-};
-
 const readDateEnv = (name: string): Date | undefined => {
   const value = readEnv(name);
   if (value === undefined) {
@@ -919,38 +871,6 @@ const readDateEnv = (name: string): Date | undefined => {
   }
 
   return date;
-};
-
-const resolveLiveObservationCutoff = (params: {
-  readonly value: Date | undefined;
-  readonly dailyReplayActive: boolean;
-  readonly recoveryActive: boolean;
-  readonly cadence: DurableReaderSummaryCadence;
-  readonly timezone: string;
-  readonly periodStartedAt: Date;
-  readonly periodEndedAt: Date;
-  readonly now: Date;
-}): Date | undefined => {
-  if (params.value === undefined) {
-    return undefined;
-  }
-  if (
-    params.dailyReplayActive ||
-    params.recoveryActive ||
-    params.cadence !== "daily" ||
-    params.timezone !== "UTC" ||
-    params.periodEndedAt.getTime() - params.periodStartedAt.getTime() !==
-      86_400_000 ||
-    params.value.getTime() < params.periodStartedAt.getTime() ||
-    params.value.getTime() >= params.periodEndedAt.getTime() ||
-    params.value.getTime() > params.now.getTime()
-  ) {
-    throw new Error(
-      `${liveObservationCutoffEnv} requires a current exact UTC daily period`,
-    );
-  }
-
-  return params.value;
 };
 
 const readModelMode = (): DurableReaderSummaryModelMode => {

--- a/scripts/lib/reader-summary-capture-period-policy.spec.ts
+++ b/scripts/lib/reader-summary-capture-period-policy.spec.ts
@@ -1,0 +1,74 @@
+import {
+  addUtcDays,
+  resolveLiveObservationCutoff,
+  resolveRecoveryTimestampPolicy,
+  startOfUtcDay,
+} from "./reader-summary-capture-period-policy";
+
+const startedAt = new Date("2026-08-15T00:00:00.000Z");
+const endedAt = new Date("2026-08-16T00:00:00.000Z");
+const now = new Date("2026-08-15T16:15:00.000Z");
+
+describe("reader summary capture period policy", () => {
+  it("accepts a rolling observation cutoff inside the current UTC day", () => {
+    const cutoff = new Date("2026-08-15T16:14:59.000Z");
+
+    expect(resolveLiveObservationCutoff({
+      value: cutoff,
+      dailyReplayActive: false,
+      recoveryActive: false,
+      cadence: "daily",
+      timezone: "UTC",
+      periodStartedAt: startedAt,
+      periodEndedAt: endedAt,
+      now,
+    })).toEqual(cutoff);
+  });
+
+  it.each([
+    { dailyReplayActive: true, recoveryActive: false },
+    { dailyReplayActive: false, recoveryActive: true },
+  ])("rejects rolling cutoff for replay or recovery", (mode) => {
+    expect(() => resolveLiveObservationCutoff({
+      value: new Date("2026-08-15T12:00:00.000Z"),
+      ...mode,
+      cadence: "daily",
+      timezone: "UTC",
+      periodStartedAt: startedAt,
+      periodEndedAt: endedAt,
+      now,
+    })).toThrow("requires a current exact UTC daily period");
+  });
+
+  it("rejects a future rolling cutoff", () => {
+    expect(() => resolveLiveObservationCutoff({
+      value: new Date("2026-08-15T16:15:01.000Z"),
+      dailyReplayActive: false,
+      recoveryActive: false,
+      cadence: "daily",
+      timezone: "UTC",
+      periodStartedAt: startedAt,
+      periodEndedAt: endedAt,
+      now,
+    })).toThrow("requires a current exact UTC daily period");
+  });
+
+  it("keeps historical recovery restricted to a completed UTC day", () => {
+    expect(resolveRecoveryTimestampPolicy({
+      argv: ["--historical-recovery"],
+      envValue: "published_at",
+      cadence: "daily",
+      timezone: "UTC",
+      periodStartedAt: startedAt,
+      periodEndedAt: endedAt,
+      now: new Date("2026-08-17T00:00:00.000Z"),
+    })).toEqual({ active: true, policy: "published_at" });
+  });
+
+  it("provides UTC day helpers without local-time drift", () => {
+    expect(startOfUtcDay(new Date("2026-08-15T21:30:00.000Z"))).toEqual(
+      startedAt,
+    );
+    expect(addUtcDays(startedAt, 1)).toEqual(endedAt);
+  });
+});

--- a/scripts/lib/reader-summary-capture-period-policy.ts
+++ b/scripts/lib/reader-summary-capture-period-policy.ts
@@ -1,0 +1,97 @@
+import type { ReaderSummaryTimestampPolicy } from "@social-monitor/summary/ports";
+
+export const liveObservationCutoffEnv =
+  "DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF";
+const recoveryTimestampPolicyEnv =
+  "DURABLE_READER_SUMMARY_RECOVERY_TIMESTAMP_POLICY";
+
+type ReaderSummaryCaptureCadence =
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "custom";
+
+export const startOfUtcDay = (date: Date): Date =>
+  new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+
+export const addUtcDays = (date: Date, days: number): Date =>
+  new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+
+export const resolveRecoveryTimestampPolicy = (params: {
+  readonly argv: readonly string[];
+  readonly envValue?: string;
+  readonly cadence: ReaderSummaryCaptureCadence;
+  readonly timezone: string;
+  readonly periodStartedAt: Date;
+  readonly periodEndedAt: Date;
+  readonly now: Date;
+}): {
+  readonly active: boolean;
+  readonly policy: ReaderSummaryTimestampPolicy;
+} => {
+  const explicitlyHistorical = params.argv.includes("--historical-recovery");
+  if (!explicitlyHistorical && params.envValue === undefined) {
+    return { active: false, policy: "published_at" };
+  }
+  if (!explicitlyHistorical || params.envValue === undefined) {
+    throw new Error(
+      `Historical recovery requires both --historical-recovery and ${recoveryTimestampPolicyEnv}`,
+    );
+  }
+  if (
+    params.envValue !== "published_at" &&
+    params.envValue !== "observed_at"
+  ) {
+    throw new Error(
+      `${recoveryTimestampPolicyEnv} must be published_at or observed_at`,
+    );
+  }
+  if (
+    params.cadence !== "daily" ||
+    params.timezone !== "UTC" ||
+    params.periodStartedAt.toISOString() !==
+      `${params.periodStartedAt.toISOString().slice(0, 10)}T00:00:00.000Z` ||
+    params.periodEndedAt.getTime() - params.periodStartedAt.getTime() !==
+      86_400_000 ||
+    params.periodEndedAt.getTime() > params.now.getTime()
+  ) {
+    throw new Error(
+      "Historical recovery timestamp policy is restricted to one completed exact UTC day",
+    );
+  }
+  return { active: true, policy: params.envValue };
+};
+
+export const resolveLiveObservationCutoff = (params: {
+  readonly value: Date | undefined;
+  readonly dailyReplayActive: boolean;
+  readonly recoveryActive: boolean;
+  readonly cadence: ReaderSummaryCaptureCadence;
+  readonly timezone: string;
+  readonly periodStartedAt: Date;
+  readonly periodEndedAt: Date;
+  readonly now: Date;
+}): Date | undefined => {
+  if (params.value === undefined) {
+    return undefined;
+  }
+  if (
+    params.dailyReplayActive ||
+    params.recoveryActive ||
+    params.cadence !== "daily" ||
+    params.timezone !== "UTC" ||
+    params.periodEndedAt.getTime() - params.periodStartedAt.getTime() !==
+      86_400_000 ||
+    params.value.getTime() < params.periodStartedAt.getTime() ||
+    params.value.getTime() >= params.periodEndedAt.getTime() ||
+    params.value.getTime() > params.now.getTime()
+  ) {
+    throw new Error(
+      `${liveObservationCutoffEnv} requires a current exact UTC daily period`,
+    );
+  }
+
+  return params.value;
+};


### PR DESCRIPTION
Fixes the production deploy gate after rolling summary support pushed the capture entrypoint over the 1000 LOC hard cap.

- extracts UTC period and recovery/rolling cutoff policy into a focused module
- keeps the capture entrypoint at 959 LOC
- adds focused tests for rolling cutoff, replay/recovery isolation, and UTC day helpers
- preserves runtime behavior

Verified: build, targeted ESLint, 28 focused tests, architecture gate, source-line-cap gate, and rolling-run contract.