### PR TITLE
fix(summaries): show refresh schedule on latest page

### DIFF
--- a/apps/frontend/features/summaries/lib/src/presentation/components/workspace_summary_period_shell.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/workspace_summary_period_shell.dart
@@ -77,7 +77,10 @@ class WorkspaceSummaryPeriodShell extends StatelessWidget {
               if (showRefreshSchedule && summary != null) ...[
                 const SizedBox(height: AppSpacing.xs),
                 WorkspaceSummaryRefreshStatus(
-                  collectedAt: summary.generatedAt ?? summary.period.endedAt,
+                  collectedAt:
+                      summary.summaryWindow.endsAt ??
+                      summary.generatedAt ??
+                      summary.period.endedAt,
                   onRefreshDue: onRefreshDue,
                 ),
               ],

--- a/apps/frontend/features/summaries/lib/src/presentation/pages/published_summary_page.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/pages/published_summary_page.dart
@@ -132,6 +132,8 @@ class _PublishedSummaryArticle extends StatelessWidget {
                 unawaited(store.selectCalendarDate(date)),
             isGenerating: false,
             exportSummary: summary,
+            showRefreshSchedule: store.isViewingLatestDailySummary,
+            onRefreshDue: () => unawaited(store.load()),
             contentPadding: articlePadding,
             child: ReaderSummaryView.readOnly(
               key: const ValueKey('published-reader-summary-view'),

--- a/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
@@ -69,6 +69,13 @@ final class PublishedSummaryStore extends ChangeNotifier {
         sameSummaryPeriodWindow(selectedPeriod, periods.last);
   }
 
+  bool get isViewingLatestDailySummary {
+    final requestedId = summaryId?.trim();
+    return (requestedId == null || requestedId.isEmpty) &&
+        selectedPeriodPreset == SummaryPeriodPreset.daily &&
+        isCurrentPeriod;
+  }
+
   Future<void> load() async {
     final generation = _generationGuard.markOperationStarted();
     final previous = switch (state) {

--- a/apps/frontend/features/summaries/test/presentation/pages/published_summary_page_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/published_summary_page_test.dart
@@ -34,7 +34,6 @@ void main() {
       loadHistory: LoadWorkspaceSummaryHistoryUseCase(catalog),
       loadPublished: LoadPublishedSummaryUseCase(catalog),
       openReaderSource: const OpenReaderSourceUseCase(_SourceLauncher()),
-      summaryId: summary.id,
     );
     addTearDown(store.dispose);
     final theme = AppTheme.light();
@@ -59,6 +58,11 @@ void main() {
       findsOneWidget,
     );
     expect(find.byType(ReaderSummaryView), findsOneWidget);
+    expect(
+      find.textContaining('Collected through 2026-06-26 18:58 UTC'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('next update in'), findsOneWidget);
     expect(find.byKey(const ValueKey('open-weekly-summary')), findsNothing);
     expect(find.text('Week'), findsOneWidget);
 

--- a/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
@@ -46,6 +46,7 @@ void main() {
     expect(readyPeriods, isNotEmpty);
     expect(_samePeriod(readyPeriods.last, summary.period), isTrue);
     expect(_samePeriod(store.selectedPeriod, summary.period), isTrue);
+    expect(store.isViewingLatestDailySummary, isFalse);
 
     history.complete(
       const Result.failure(


### PR DESCRIPTION
## What changed
- show the rolling collection timestamp and live next-run countdown on the public Latest summary page
- refresh the latest summary when a scheduled slot becomes due
- use the evidence-window end as the truthful collection cutoff
- keep the schedule hidden for direct historical summary links

## Verification
- fvm flutter test focused summary page, refresh status and navigation tests
- fvm flutter analyze
- fvm flutter test app/test/architecture/frontend_architecture_boundaries_test.dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refresh-scheduling controls to the latest daily summary.
  * Summaries now reload automatically when a scheduled refresh is due.
  * Displayed the summary collection timestamp and countdown until the next update.

* **Bug Fixes**
  * Improved refresh timestamp selection for more accurate update information.
  * Explicitly selected historical daily periods no longer show latest-summary refresh controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->