### PR TITLE
fix(summaries): publish rolling updates with partial providers

### DIFF
--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -126,7 +126,9 @@ export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
     export DURABLE_READER_SUMMARY_PERIOD_ENDED_AT="$(node -e '\''const day = new Date(`${process.argv[1]}T00:00:00.000Z`); day.setUTCDate(day.getUTCDate() + 1); process.stdout.write(day.toISOString());'\'' "$ROLLING_COLLECTION_DATE")"
     export DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF="$rolling_observation_cutoff"
     export DURABLE_READER_SUMMARY_MODEL=agent-runtime
-    export DURABLE_READER_SUMMARY_TOPIC_LABELER=agent-runtime
+    # Keep rolling publication available when one provider is partial. The
+    # canonical daily pipeline uses the same deterministic topic-map path.
+    export DURABLE_READER_SUMMARY_TOPIC_LABELER=deterministic
     export DURABLE_READER_SUMMARY_MAX_EVIDENCE_ITEMS=120
     export DURABLE_READER_SUMMARY_EVIDENCE_PATH="$evidence_path"
     export DURABLE_READER_SUMMARY_FRONTEND_FIXTURE_PATH="$frontend_path"

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -36,6 +36,8 @@ grep -F -- '-e ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev
 grep -F -- 'daily-runner sh -lc' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- "--providers \"\$required_providers\"" "$RUNNER" >/dev/null
 grep -F -- 'npm run capture:durable-reader-summary' "$RUNNER" >/dev/null
+grep -F -- 'DURABLE_READER_SUMMARY_MODEL=agent-runtime' "$RUNNER" >/dev/null
+grep -F -- 'DURABLE_READER_SUMMARY_TOPIC_LABELER=deterministic' "$RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_MAX_EVIDENCE_ITEMS=120' "$RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_PERIOD_ENDED_AT' "$RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF' "$RUNNER" >/dev/null


### PR DESCRIPTION
## What changed
- keep the agent-runtime model for rolling summary content
- use the canonical deterministic topic-map path so an optional grouping miss cannot block publication
- preserve partial-provider warnings and collection receipts

## Production evidence
- the 20:15 UTC run persisted 54 fresh rows and 604 total day rows
- X persisted 8 fresh rows and reached 80 total rows before one rate-limit event
- publication then failed only on agent-runtime topic-map grouped coverage below 0.5

## Verification
- bash -n ops/deploy/production-runtime/rolling-run.sh
- bash ops/deploy/production-runtime/rolling-run.test.sh
- node ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
- npm run check:source-line-cap
- full deploy checks defer to Linux CI because macOS Bash 3 lacks required GNU features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Rolling summary deployments now use consistent, deterministic topic labels.
  - Summaries continue to be published when a provider is only partially available.
  - Durable reader summaries use the configured runtime model for improved consistency.

- **Tests**
  - Added coverage to verify labeling and runtime configuration during rolling deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->