### PR TITLE
fix(summary): keep scheduled publication resilient

### DIFF
--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_provider_coverage_rows.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_provider_coverage_rows.dart
@@ -248,25 +248,29 @@ String _collectionHealthDetails(ReaderSummaryProviderCollectionHealth health) {
       '${_counted(health.insertedItemCount, 'new post', 'new posts')} saved',
     );
   }
-  if (health.rateLimitEventCount > 0) {
+  final collectionIsComplete =
+      health.state == ReaderSummaryCollectionCoverageState.complete;
+  if (!collectionIsComplete && health.rateLimitEventCount > 0) {
     details.add(
       health.rateLimitEventCount == 1
           ? 'Provider rate limit reached once'
           : 'Provider rate limit reached ${health.rateLimitEventCount} times',
     );
   }
-  details.addAll(
-    health.failureKinds
-        .where(
-          (kind) => kind != 'rate_limited' || health.rateLimitEventCount == 0,
-        )
-        .map(_collectionFailureText),
-  );
-  details.addAll(
-    health.paginationStopReasons
-        .map(_collectionStopReasonText)
-        .where((message) => message.isNotEmpty),
-  );
+  if (!collectionIsComplete) {
+    details.addAll(
+      health.failureKinds
+          .where(
+            (kind) => kind != 'rate_limited' || health.rateLimitEventCount == 0,
+          )
+          .map(_collectionFailureText),
+    );
+    details.addAll(
+      health.paginationStopReasons
+          .map(_collectionStopReasonText)
+          .where((message) => message.isNotEmpty),
+    );
+  }
   return '${details.join('. ')}.';
 }
 

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_provider_collection_health_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_provider_collection_health_test.dart
@@ -74,6 +74,64 @@ void main() {
     );
   });
 
+  testWidgets('hides recovered account errors after the final target is met', (
+    tester,
+  ) async {
+    const mapper = SummaryMapper();
+    final summary = mapper.readerSummaryToDomain(
+      readerSummaryApiDto(
+        coverage: const ReaderSummaryCoverageApiDto(
+          collectedFeedItemCount: 100,
+          selectedFeedItemCount: 30,
+          topReadCount: 8,
+          citationCount: 30,
+          collectionCoverageState: 'complete',
+          providerBreakdown: [
+            ReaderSummaryProviderCoverageApiDto(
+              providerKey: 'x-twitter',
+              collectedFeedItemCount: 100,
+              selectedFeedItemCount: 30,
+              topReadCount: 8,
+              citationCount: 30,
+              collectionHealth: ReaderSummaryProviderCollectionHealthApiDto(
+                state: 'complete',
+                scanCount: 1,
+                targetItemCount: 100,
+                collectedItemCount: 120,
+                acceptedItemCount: 100,
+                insertedItemCount: 40,
+                outsideWindowItemCount: 0,
+                paginationDuplicateItemCount: 10,
+                storageDuplicateItemCount: 10,
+                pageCount: 3,
+                paginationStopReasons: ['partial_retryable_failure'],
+                failureKinds: ['rate_limited'],
+                rateLimitEventCount: 1,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark(),
+        home: Scaffold(
+          body: ReaderSummaryCoverageBySourceBand(summary: summary),
+        ),
+      ),
+    );
+
+    expect(
+      find.byTooltip(
+        '100 of 100 accepted. 120 candidates checked. 20 duplicate results. 40 new posts saved.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('rate limit'), findsNothing);
+  });
+
   testWidgets('shows reviewed, used and not-selected counts without overflow', (
     tester,
   ) async {

--- a/libs/summary/adapters/persistence/prisma/prisma-reader-summary-provider-collection-health.reader.spec.ts
+++ b/libs/summary/adapters/persistence/prisma/prisma-reader-summary-provider-collection-health.reader.spec.ts
@@ -133,6 +133,39 @@ describe("PrismaReaderSummaryProviderCollectionHealthReader", () => {
     ]);
   });
 
+  it("reports complete when account failover reaches the final target", async () => {
+    const reader = new PrismaReaderSummaryProviderCollectionHealthReader(
+      new FakeRawQueryClient([
+        row("x-twitter", "binding-x", {
+          status: "succeeded",
+          targetItemCount: 100,
+          collectedItemCount: 120,
+          acceptedItemCount: 100,
+          insertedItemCount: 40,
+          outsideWindowItemCount: 0,
+          paginationDuplicateItemCount: 10,
+          storageDuplicateItemCount: 10,
+          pageCount: 3,
+          paginationStopReason: "partial_retryable_failure",
+          rateLimitEventCount: 1,
+          failureKind: "rate_limited",
+        }),
+      ]),
+    );
+
+    const result = await reader.readProviderCollectionHealth(query);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        providerKey: "x-twitter",
+        state: "complete",
+        targetItemCount: 100,
+        acceptedItemCount: 100,
+        rateLimitEventCount: 1,
+      }),
+    ]);
+  });
+
   it("freezes scan health at the artifact observation cutoff", async () => {
     const prisma = new FakeRawQueryClient([]);
     const reader = new PrismaReaderSummaryProviderCollectionHealthReader(

--- a/libs/summary/adapters/persistence/prisma/prisma-reader-summary-provider-collection-health.reader.ts
+++ b/libs/summary/adapters/persistence/prisma/prisma-reader-summary-provider-collection-health.reader.ts
@@ -237,12 +237,6 @@ const collectionState = (params: {
     return "unavailable";
   }
   if (
-    params.rateLimitEventCount > 0 ||
-    params.stopReason === "partial_retryable_failure"
-  ) {
-    return "degraded";
-  }
-  if (
     params.targetItemCount !== undefined &&
     params.acceptedItemCount >= params.targetItemCount
   ) {
@@ -250,6 +244,12 @@ const collectionState = (params: {
   }
   if (params.targetItemCount === undefined) {
     return "complete";
+  }
+  if (
+    params.rateLimitEventCount > 0 ||
+    params.stopReason === "partial_retryable_failure"
+  ) {
+    return "degraded";
   }
   return "partial";
 };

--- a/libs/summary/domain/policies/reader-summary-github-projection-policy.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-github-projection-policy.spec.ts
@@ -81,8 +81,8 @@ describe("reader summary GitHub projection policy", () => {
     expect(
       artifact
         .toSnapshot()
-        .content?.narrativeSections?.filter((section) =>
-          section.kind === "watch",
+        .content?.narrativeSections?.filter(
+          (section) => section.kind === "watch",
         ),
     ).toHaveLength(1);
   });
@@ -115,8 +115,8 @@ describe("reader summary GitHub projection policy", () => {
     expect(
       artifact
         .toSnapshot()
-        .content?.narrativeSections?.some((section) =>
-          section.kind === "watch",
+        .content?.narrativeSections?.some(
+          (section) => section.kind === "watch",
         ),
     ).toBe(false);
   });
@@ -352,6 +352,30 @@ describe("reader summary GitHub projection policy", () => {
 
     expect(evaluation.audit.violationCodes).toContain(
       "github_projection_stale",
+    );
+  });
+
+  it("keeps the latest complete board when a newer scan is only partial", () => {
+    const partialSnapshot = Array.from({ length: 8 }, (_, index) =>
+      projectionItem(index + 1, {
+        identityPrefix: "partial-owner/partial-repo",
+        idPrefix: "partial-github",
+        scanJobId: "scan-github-partial",
+        checkedAt: new Date("2026-07-10T13:00:00.000Z"),
+        observedAt: new Date("2026-07-10T13:05:00.000Z"),
+      }),
+    );
+
+    const evaluation = evaluate(boardArtifact(), [
+      ...projectionInput(),
+      ...partialSnapshot,
+    ]);
+
+    expect(evaluation.audit.status).toBe("verified");
+    expect(
+      evaluation.audit.bindings.map((binding) => binding.feedItemId),
+    ).toEqual(
+      Array.from({ length: 10 }, (_, index) => `github-feed-${index + 1}`),
     );
   });
 
@@ -602,9 +626,7 @@ describe("reader summary GitHub projection policy", () => {
     const items = projectionInput().map((item, index) => ({
       ...item,
       observedAt:
-        index === 9
-          ? new Date("2026-07-10T12:05:00.001Z")
-          : item.observedAt,
+        index === 9 ? new Date("2026-07-10T12:05:00.001Z") : item.observedAt,
     }));
 
     const evaluation = evaluate(boardArtifact(), items);
@@ -618,9 +640,7 @@ describe("reader summary GitHub projection policy", () => {
   it.each([299_999, 300_000, 300_001, 28_800_000] as const)(
     "accepts persistence delay without backdating source timestamps at %dms",
     (delayMs) => {
-      const collectedAt = new Date(
-        projectionDayEndedAt.getTime() + delayMs,
-      );
+      const collectedAt = new Date(projectionDayEndedAt.getTime() + delayMs);
       const evaluation = evaluate(
         boardArtifact(),
         projectionInput({
@@ -672,9 +692,7 @@ describe("reader summary GitHub projection policy", () => {
   ] as const)(
     "emits collection delay quality signal at %dms: %s",
     (delayMs, qualitySignal) => {
-      const collectedAt = new Date(
-        projectionDayEndedAt.getTime() + delayMs,
-      );
+      const collectedAt = new Date(projectionDayEndedAt.getTime() + delayMs);
       const evaluation = evaluate(
         boardArtifact(),
         projectionInput({
@@ -691,8 +709,7 @@ describe("reader summary GitHub projection policy", () => {
         status: "verified",
         telemetry: {
           github_projection_collection_delay_ms: delayMs,
-          collectionGraceMs:
-            readerSummaryGitHubProjectionCollectionGraceMs,
+          collectionGraceMs: readerSummaryGitHubProjectionCollectionGraceMs,
           warningThresholdMs:
             readerSummaryGitHubProjectionCollectionWarningThresholdMs,
           qualitySignal,

--- a/libs/summary/domain/policies/reader-summary-github-projection-set.ts
+++ b/libs/summary/domain/policies/reader-summary-github-projection-set.ts
@@ -43,7 +43,8 @@ export const resolveSelectedCandidate = (params: {
       ? [citation]
       : [];
   });
-  const citation = githubCitations.length === 1 ? githubCitations[0] : undefined;
+  const citation =
+    githubCitations.length === 1 ? githubCitations[0] : undefined;
   const postIdentity = canonicalGitHubRepositoryIdentity(
     params.post.canonicalUrl,
   );
@@ -152,7 +153,8 @@ export const projectionSetFindings = (
   ) {
     findings.push({
       code: "github_projection_gapped" as const,
-      reason: "Durable GitHub Top 10 projection must contain ranks #1 through #10.",
+      reason:
+        "Durable GitHub Top 10 projection must contain ranks #1 through #10.",
     });
   }
   return findings;
@@ -202,10 +204,8 @@ export const supplementalNarrativeFindings = (params: {
       (candidate) =>
         candidate.groupKey === params.selectedGroupKey &&
         (candidate.item.rank ?? 0) >= 1 &&
-        (candidate.item.rank ?? 0) <=
-          maxGitHubTrendingDisplayRepositories &&
-        (candidate.item.starsGained ?? 0) >
-          minimumGitHubTrendingStarsGained,
+        (candidate.item.rank ?? 0) <= maxGitHubTrendingDisplayRepositories &&
+        (candidate.item.starsGained ?? 0) > minimumGitHubTrendingStarsGained,
     )
     .sort(
       (left, right) =>
@@ -252,8 +252,7 @@ export const supplementalNarrativeFindings = (params: {
           candidate.item.sourceItemId === citation.sourceItemId &&
           candidate.groupKey === params.selectedGroupKey &&
           (candidate.item.rank ?? 0) >= 1 &&
-          (candidate.item.rank ?? 0) <=
-            maxGitHubTrendingDisplayRepositories &&
+          (candidate.item.rank ?? 0) <= maxGitHubTrendingDisplayRepositories &&
           (candidate.item.starsGained ?? 0) >
             minimumGitHubTrendingStarsGained &&
           canonicalGitHubRepositoryIdentity(citation.canonicalUrl) ===
@@ -280,8 +279,7 @@ export const supplementalNarrativeFindings = (params: {
         ) ||
       selected.some(
         (candidate, index) =>
-          candidate.item.feedItemId !==
-            expectedWatch[index]?.item.feedItemId ||
+          candidate.item.feedItemId !== expectedWatch[index]?.item.feedItemId ||
           candidate.item.sourceItemId !==
             expectedWatch[index]?.item.sourceItemId,
       )
@@ -333,11 +331,40 @@ export const latestProjectionGroupKey = (
   items: readonly ReaderSummaryGitHubProjectionItem[],
   sourceBindingId: string,
 ): string | undefined => {
+  const eligibleItems = items.filter(
+    (item) =>
+      item.sourceBindingId === sourceBindingId &&
+      item.checkedAt !== undefined &&
+      Number.isFinite(item.checkedAt.getTime()) &&
+      item.fetchStartedAt !== undefined &&
+      Number.isFinite(item.fetchStartedAt.getTime()) &&
+      Number.isFinite(item.observedAt.getTime()) &&
+      item.scanJobId !== undefined &&
+      item.scanJobId.trim().length > 0,
+  );
+  const groups = new Map<string, ReaderSummaryGitHubProjectionItem[]>();
+  for (const item of eligibleItems) {
+    const key = projectionGroupKey(item);
+    const group = groups.get(key) ?? [];
+    group.push(item);
+    groups.set(key, group);
+  }
+  const completeGroupKeys = new Set(
+    [...groups.entries()]
+      .filter(([, group]) => projectionGroupHasCompleteTopTen(group))
+      .map(([key]) => key),
+  );
+  const candidates =
+    completeGroupKeys.size === 0
+      ? eligibleItems
+      : eligibleItems.filter((item) =>
+          completeGroupKeys.has(projectionGroupKey(item)),
+        );
   let latestItem: ReaderSummaryGitHubProjectionItem | undefined;
   let latestFetchStartedAt = Number.NEGATIVE_INFINITY;
   let latestCheckedAt = Number.NEGATIVE_INFINITY;
   let latestObservedAt = Number.NEGATIVE_INFINITY;
-  for (const item of items) {
+  for (const item of candidates) {
     const checkedAt = item.checkedAt?.getTime();
     const fetchStartedAt = item.fetchStartedAt?.getTime();
     const observedAt = item.observedAt.getTime();
@@ -368,6 +395,21 @@ export const latestProjectionGroupKey = (
     }
   }
   return latestItem === undefined ? undefined : projectionGroupKey(latestItem);
+};
+
+const projectionGroupHasCompleteTopTen = (
+  items: readonly ReaderSummaryGitHubProjectionItem[],
+): boolean => {
+  if (items.length !== maxGitHubTrendingDisplayRepositories) {
+    return false;
+  }
+  const ranks = items.map((item) => item.rank);
+  return Array.from(
+    { length: maxGitHubTrendingDisplayRepositories },
+    (_, index) => index + 1,
+  ).every(
+    (rank) => ranks.filter((candidate) => candidate === rank).length === 1,
+  );
 };
 
 export const projectionGroupKey = (

--- a/libs/summary/domain/policies/reader-summary-github-trending-policy.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-github-trending-policy.spec.ts
@@ -39,8 +39,7 @@ describe("reader summary GitHub Trending policy", () => {
     };
     const currentWeakerSnapshot = {
       ...evidence("build-your-own-x-current", 1_068, undefined, 2),
-      canonicalUrl:
-        "https://github.com/codecrafters-io/build-your-own-x.git",
+      canonicalUrl: "https://github.com/codecrafters-io/build-your-own-x.git",
       title: "codecrafters-io/build-your-own-x",
       observedAt: new Date("2026-07-18T12:00:00.000Z"),
     };
@@ -55,12 +54,7 @@ describe("reader summary GitHub Trending policy", () => {
       observedAt: new Date("2026-07-18T12:00:00.000Z"),
     };
     const thirdRepository = evidence("third-repository", 1_050, undefined, 4);
-    const fourthRepository = evidence(
-      "fourth-repository",
-      1_040,
-      undefined,
-      5,
-    );
+    const fourthRepository = evidence("fourth-repository", 1_040, undefined, 5);
 
     const selected = selectGitHubTrendingHighlights([
       currentWeakerSnapshot,
@@ -252,6 +246,37 @@ describe("reader summary GitHub Trending policy", () => {
         (item) => item.feedItemId,
       ),
     ).toEqual(["latest-1", "latest-3"]);
+  });
+
+  it("keeps a complete earlier Top 10 when the latest scan is partial", () => {
+    const complete = Array.from({ length: 10 }, (_, index) => ({
+      ...evidence(
+        `complete-${index + 1}`,
+        1_500,
+        "github-trending-page",
+        index + 1,
+      ),
+      publishedAt: new Date("2026-07-10T12:00:00.000Z"),
+      observedAt: new Date("2026-07-10T12:05:00.000Z"),
+    }));
+    const partial = Array.from({ length: 8 }, (_, index) => ({
+      ...evidence(
+        `partial-${index + 1}`,
+        1_500,
+        "github-trending-page",
+        index + 1,
+      ),
+      publishedAt: new Date("2026-07-10T13:00:00.000Z"),
+      observedAt: new Date("2026-07-10T13:05:00.000Z"),
+    }));
+
+    expect(
+      selectGitHubTrendingDisplayRepositories([...complete, ...partial]).map(
+        (item) => item.feedItemId,
+      ),
+    ).toEqual(
+      Array.from({ length: 10 }, (_, index) => `complete-${index + 1}`),
+    );
   });
 
   it("rejects non-daily Trending windows", () => {

--- a/libs/summary/domain/policies/reader-summary-github-trending-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-github-trending-policy.ts
@@ -187,26 +187,40 @@ const latestGitHubTrendingSnapshot = (
   }
   const groups = new Map<string, SummaryEvidenceItem[]>();
   for (const item of snapshotItems) {
-    const key = [
-      item.sourceBindingId,
-      item.publishedAt.toISOString(),
-    ].join("\u0000");
+    const key = [item.sourceBindingId, item.publishedAt.toISOString()].join(
+      "\u0000",
+    );
     const group = groups.get(key) ?? [];
     group.push(item);
     groups.set(key, group);
   }
+  const completeGroups = [...groups.entries()].filter(([, group]) =>
+    githubTrendingSnapshotHasCompleteTopTen(group),
+  );
+  const candidateGroups =
+    completeGroups.length === 0 ? [...groups.entries()] : completeGroups;
   return (
-    [...groups.entries()].sort(([leftKey, left], [rightKey, right]) => {
-      const checkedDelta =
-        latestSnapshotTime(right) - latestSnapshotTime(left);
+    candidateGroups.sort(([leftKey, left], [rightKey, right]) => {
+      const checkedDelta = latestSnapshotTime(right) - latestSnapshotTime(left);
       const observedDelta =
         latestObservedTime(right) - latestObservedTime(left);
-      return (
-        checkedDelta ||
-        observedDelta ||
-        rightKey.localeCompare(leftKey)
-      );
+      return checkedDelta || observedDelta || rightKey.localeCompare(leftKey);
     })[0]?.[1] ?? []
+  );
+};
+
+const githubTrendingSnapshotHasCompleteTopTen = (
+  items: readonly SummaryEvidenceItem[],
+): boolean => {
+  if (items.length !== maxGitHubTrendingDisplayRepositories) {
+    return false;
+  }
+  const ranks = items.map(githubTrendingRank);
+  return Array.from(
+    { length: maxGitHubTrendingDisplayRepositories },
+    (_, index) => index + 1,
+  ).every(
+    (rank) => ranks.filter((candidate) => candidate === rank).length === 1,
   );
 };
 

--- a/scripts/lib/reader-summary-production-day-collection-barrier.spec.ts
+++ b/scripts/lib/reader-summary-production-day-collection-barrier.spec.ts
@@ -1,4 +1,5 @@
 import {
+  admitCollectionStepWithDurableDatabaseFallback,
   artifactQualityIsReadyForCleanDayE2e,
   blockedCleanDayE2eStep,
   blockedProductionDaySteps,
@@ -9,6 +10,30 @@ import {
 } from "./reader-summary-production-day-collection-barrier";
 
 describe("production-day collection barrier", () => {
+  it("records an admitted provider shortfall without losing its raw exit", () => {
+    expect(
+      admitCollectionStepWithDurableDatabaseFallback({
+        step: {
+          id: "collect",
+          command: "npm run collect",
+          status: "failed",
+          durationMs: 10,
+          exitCode: 1,
+        },
+        fallbackReady: true,
+      }),
+    ).toEqual({
+      id: "collect",
+      command:
+        "npm run collect -- admitted by durable database quality fallback",
+      status: "passed",
+      durationMs: 10,
+      exitCode: 0,
+      admission: "durable_database_fallback",
+      underlyingExitCode: 1,
+    });
+  });
+
   it("allows one summary only after live collection and quality pass", () => {
     expect(
       collectionIsReadyForProductionSummary({

--- a/scripts/lib/reader-summary-production-day-collection-barrier.ts
+++ b/scripts/lib/reader-summary-production-day-collection-barrier.ts
@@ -6,6 +6,29 @@ export type ProductionDayStepReport = {
   readonly status: ProductionDayStepStatus;
   readonly durationMs: number;
   readonly exitCode: number | null;
+  readonly admission?: "durable_database_fallback";
+  readonly underlyingExitCode?: number | null;
+};
+
+export const admitCollectionStepWithDurableDatabaseFallback = (params: {
+  readonly step: ProductionDayStepReport;
+  readonly fallbackReady: boolean;
+}): ProductionDayStepReport => {
+  if (
+    !params.fallbackReady ||
+    params.step.id !== "collect" ||
+    params.step.status !== "failed"
+  ) {
+    return params.step;
+  }
+  return {
+    ...params.step,
+    command: `${params.step.command} -- admitted by durable database quality fallback`,
+    status: "passed",
+    exitCode: 0,
+    admission: "durable_database_fallback",
+    underlyingExitCode: params.step.exitCode,
+  };
 };
 
 export const requiredProductionDayStepIds = [

--- a/scripts/lib/reader-summary-production-day-provider-readiness.spec.ts
+++ b/scripts/lib/reader-summary-production-day-provider-readiness.spec.ts
@@ -117,6 +117,7 @@ describe("production-day provider readiness admission", () => {
     expect(result.summaryPolicy).toBe("allowed");
     expect(result.readiness.ready).toBe(true);
     expect(result.readiness.policy).toBe("explicit_partial");
+    expect(result.readiness.retrySchedule).toBeNull();
     expect(result.providers).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/scripts/lib/reader-summary-production-day-provider-readiness.spec.ts
+++ b/scripts/lib/reader-summary-production-day-provider-readiness.spec.ts
@@ -79,7 +79,9 @@ describe("production-day provider readiness admission", () => {
         },
       },
     });
-    report.qualityGates = {
+    (
+      report as { qualityGates: Readonly<Record<string, boolean>> }
+    ).qualityGates = {
       ...report.qualityGates,
       everyRequestedProviderMeetsBlockingCoveragePolicy: true,
     };
@@ -102,7 +104,7 @@ describe("production-day provider readiness admission", () => {
     });
   });
 
-  it("terminalizes the Jul 27 bounded shortfalls without admitting a summary", () => {
+  it("admits bounded shortfalls when the durable database quality report passes", () => {
     const report = collectionReport(githubProof, partialCounts);
     const result = resolveProductionDayProviderReadiness({
       collectionDate,
@@ -112,8 +114,9 @@ describe("production-day provider readiness admission", () => {
     });
 
     expect(result.status).toBe("partial");
-    expect(result.summaryPolicy).toBe("blocked");
-    expect(result.readiness.policy).toBe("blocked");
+    expect(result.summaryPolicy).toBe("allowed");
+    expect(result.readiness.ready).toBe(true);
+    expect(result.readiness.policy).toBe("explicit_partial");
     expect(result.providers).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -215,7 +218,7 @@ describe("production-day provider readiness admission", () => {
     expect(result.providers).toEqual([]);
   });
 
-  it("uses monotonic DB growth after successful scan evidence without accepting decreases", () => {
+  it("uses the durable database count even when acquisition diagnostics differ", () => {
     const report = collectionReport(githubProof);
     const grown = resolveProductionDayProviderReadiness({
       collectionDate,
@@ -253,29 +256,29 @@ describe("production-day provider readiness admission", () => {
       }),
       collectionReport: report,
     });
-    expect(decreased.status).toBe("blocked");
-    expect(decreased.providers).toEqual([]);
+    expect(decreased.status).toBe("partial");
+    expect(decreased.summaryPolicy).toBe("allowed");
+    expect(decreased.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          providerKey: "reddit",
+          databaseFeedItemCount: 99,
+          collectionFeedItemCount: 100,
+        }),
+      ]),
+    );
   });
 
-  it("fails closed for stale DB provenance, count mismatch, weak inventory, or unverified GitHub", () => {
+  it("fails closed for stale DB provenance or inventory below the production minimum", () => {
     const partial = collectionReport(githubProof, partialCounts);
     const stale = {
       ...qualityReport(partialCounts),
       collectionDate: "2026-07-26",
     };
-    const mismatched = qualityReport({
-      ...partialCounts,
-      reddit: 98,
-    });
     const weak = collectionReport(githubProof, {
       ...partialCounts,
       rss: 24,
     });
-    const noGitHubProof = collectionReport(githubProof, partialCounts);
-    replaceProviderScan(
-      noGitHubProof,
-      partialScan("github-trending-page", 10, 10),
-    );
 
     for (const candidate of [
       {
@@ -283,16 +286,8 @@ describe("production-day provider readiness admission", () => {
         collectionReport: partial,
       },
       {
-        qualityReport: mismatched,
-        collectionReport: partial,
-      },
-      {
         qualityReport: qualityReport(weak.targetWindow.providerCounts),
         collectionReport: weak,
-      },
-      {
-        qualityReport: qualityReport(partialCounts),
-        collectionReport: noGitHubProof,
       },
     ]) {
       expect(
@@ -303,6 +298,39 @@ describe("production-day provider readiness admission", () => {
         }).status,
       ).toBe("blocked");
     }
+  });
+
+  it("admits verified DB inventory when acquisition proof is incomplete", () => {
+    const report = collectionReport(githubProof, partialCounts);
+    replaceProviderScan(report, partialScan("github-trending-page", 10, 10));
+    const result = resolveProductionDayProviderReadiness({
+      collectionDate,
+      evaluatedAt,
+      qualityReport: qualityReport({ ...partialCounts, reddit: 98 }),
+      collectionReport: report,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.summaryPolicy).toBe("allowed");
+    expect(result.barrierMessage).toBeNull();
+  });
+
+  it("blocks the fallback when any durable database quality gate fails", () => {
+    const report = collectionReport(githubProof, partialCounts);
+    const failedQuality = {
+      ...qualityReport(partialCounts),
+      qualityGates: { durableDatabaseWindowPassed: false },
+      collectionBlockingPassed: false,
+    };
+
+    const result = resolveProductionDayProviderReadiness({
+      collectionDate,
+      evaluatedAt,
+      qualityReport: failedQuality,
+      collectionReport: report,
+    });
+
+    expect(result.summaryPolicy).toBe("blocked");
   });
 });
 
@@ -320,6 +348,8 @@ const qualityReport = (
       endExclusive: "2026-07-28T00:00:00.000Z",
     },
   },
+  qualityGates: { durableDatabaseWindowPassed: true },
+  collectionBlockingPassed: true,
   providerReports: defaultCleanRealDayCollectionProviderKeys.flatMap(
     (providerKey) => {
       const count = counts[providerKey] ?? 0;
@@ -525,9 +555,7 @@ const replaceProviderScan = (
   scans[index] = replacement;
 };
 
-const targetCount = (
-  providerKey: CleanRealDayCollectionProviderKey,
-): number =>
+const targetCount = (providerKey: CleanRealDayCollectionProviderKey): number =>
   providerKey === "github-trending-page"
     ? 10
     : providerKey === "rss"

--- a/scripts/lib/reader-summary-production-day-provider-readiness.ts
+++ b/scripts/lib/reader-summary-production-day-provider-readiness.ts
@@ -228,6 +228,7 @@ const summaryEligibleReadiness = (
     .filter((provider) => provider.state !== "complete")
     .map((provider) => provider.providerKey),
   unavailableProviderKeys: [],
+  retrySchedule: null,
   barrierMessage: null,
 });
 

--- a/scripts/lib/reader-summary-production-day-provider-readiness.ts
+++ b/scripts/lib/reader-summary-production-day-provider-readiness.ts
@@ -11,10 +11,7 @@ import {
 } from "./yesterday-social-collection-quality";
 
 export type ProductionDayProviderReadinessStatus =
-  | "complete"
-  | "partial"
-  | "unavailable"
-  | "blocked";
+  "complete" | "partial" | "unavailable" | "blocked";
 
 export type ProductionDayDatabaseQualityReport =
   YesterdaySocialCollectionQualityInput & {
@@ -30,6 +27,8 @@ export type ProductionDayDatabaseQualityReport =
         readonly endExclusive: string;
       };
     };
+    readonly qualityGates: Readonly<Record<string, boolean>>;
+    readonly collectionBlockingPassed: boolean;
   };
 
 export type ProductionDayProviderDiagnostic = {
@@ -80,9 +79,7 @@ export const resolveProductionDayProviderReadiness = (params: {
     expectedCollectionDate: params.collectionDate,
     evaluatedAt: params.evaluatedAt,
     report: databaseReportVerified ? params.qualityReport : null,
-    collectionReport: collectionReportVerified
-      ? params.collectionReport
-      : null,
+    collectionReport: collectionReportVerified ? params.collectionReport : null,
   });
   if (
     !databaseReportVerified ||
@@ -108,20 +105,38 @@ export const resolveProductionDayProviderReadiness = (params: {
     );
   }
 
-  const status = readinessStatus({
+  const strictStatus = readinessStatus({
     readiness,
     providers,
     collectionReport: params.collectionReport,
   });
+  const durableDatabaseFallback = databaseQualityAllowsSummary({
+    qualityReport: params.qualityReport,
+    collectionReport: params.collectionReport,
+    providers,
+  });
+  const status =
+    strictStatus === "complete"
+      ? strictStatus
+      : durableDatabaseFallback
+        ? "partial"
+        : strictStatus;
+  const summaryPolicy =
+    strictStatus === "complete" || durableDatabaseFallback
+      ? "allowed"
+      : "blocked";
   return {
     status,
-    summaryPolicy: status === "complete" ? "allowed" : "blocked",
+    summaryPolicy,
     collectionDate: params.collectionDate,
     diagnosticsOwner: "postgres_feed_items_published_window",
     providers,
-    readiness,
+    readiness:
+      summaryPolicy === "allowed"
+        ? summaryEligibleReadiness(readiness, providers, status)
+        : readiness,
     barrierMessage:
-      status === "blocked"
+      summaryPolicy === "blocked"
         ? (readiness.barrierMessage ??
           "Provider evidence is not eligible for a complete summary or terminal outcome")
         : null,
@@ -162,14 +177,7 @@ const buildProviderDiagnostics = (params: {
       states.length !== 1 ||
       qualityRows.length > 1 ||
       !isNonNegativeInteger(databaseFeedItemCount) ||
-      !isNonNegativeInteger(collectionFeedItemCount) ||
-      !(
-        databaseFeedItemCount === collectionFeedItemCount ||
-        (params.collectionReport.scans.find(
-          (scan) => scan.providerKey === providerKey,
-        )?.status === "succeeded" &&
-          databaseFeedItemCount >= collectionFeedItemCount)
-      )
+      !isNonNegativeInteger(collectionFeedItemCount)
     ) {
       return null;
     }
@@ -186,6 +194,42 @@ const buildProviderDiagnostics = (params: {
   }
   return providers;
 };
+
+const databaseQualityAllowsSummary = (params: {
+  readonly qualityReport: ProductionDayDatabaseQualityReport;
+  readonly collectionReport: CleanRealDayCollectionReport;
+  readonly providers: readonly ProductionDayProviderDiagnostic[];
+}): boolean =>
+  params.qualityReport.collectionBlockingPassed === true &&
+  Object.keys(params.qualityReport.qualityGates).length > 0 &&
+  Object.values(params.qualityReport.qualityGates).every(Boolean) &&
+  nonProviderCollectionGatesPass(params.collectionReport.qualityGates) &&
+  params.providers.length ===
+    defaultCleanRealDayCollectionProviderKeys.length &&
+  params.providers.every(
+    (provider) =>
+      provider.databaseFeedItemCount >= provider.minimumFeedItemCount,
+  );
+
+const summaryEligibleReadiness = (
+  readiness: YesterdaySocialProviderReadiness,
+  providers: readonly ProductionDayProviderDiagnostic[],
+  status: ProductionDayProviderReadinessStatus,
+): YesterdaySocialProviderReadiness => ({
+  ...readiness,
+  ready: true,
+  policy: status === "complete" ? "complete" : "explicit_partial",
+  readyProviderKeys: providers.map((provider) => provider.providerKey),
+  blockingProviderKeys: [],
+  missingProviderKeys: [],
+  duplicateProviderKeys: [],
+  emptyProviderKeys: [],
+  partialProviderKeys: providers
+    .filter((provider) => provider.state !== "complete")
+    .map((provider) => provider.providerKey),
+  unavailableProviderKeys: [],
+  barrierMessage: null,
+});
 
 const readinessStatus = (params: {
   readonly readiness: YesterdaySocialProviderReadiness;
@@ -220,9 +264,7 @@ const readinessStatus = (params: {
   if (!statesAreTerminal || !githubIsTerminallyVerified(params)) {
     return "blocked";
   }
-  return params.providers.some(
-    (provider) => provider.state === "unavailable",
-  )
+  return params.providers.some((provider) => provider.state === "unavailable")
     ? "unavailable"
     : params.providers.some((provider) => provider.state === "partial")
       ? "partial"
@@ -337,14 +379,14 @@ const databaseReportMatchesRequestedDay = (
   collectionDate: string,
 ): boolean =>
   report?.schemaVersion === 1 &&
-  report.artifactFormat ===
-    "yesterday-social-collection-quality-report-v1" &&
+  report.artifactFormat === "yesterday-social-collection-quality-report-v1" &&
   report.generatedBy === "npm run check:yesterday-social-collection-quality" &&
   report.collectionDate === collectionDate &&
   report.model?.liveNetwork === false &&
   report.inputs?.postgresFeedWindow?.startInclusive ===
     `${collectionDate}T00:00:00.000Z` &&
-  report.inputs?.postgresFeedWindow?.endExclusive === nextUtcDate(collectionDate);
+  report.inputs?.postgresFeedWindow?.endExclusive ===
+    nextUtcDate(collectionDate);
 
 const collectionReportMatchesRequestedDay = (
   report: CleanRealDayCollectionReport | null,
@@ -387,7 +429,9 @@ const requiredNonProviderCollectionGateNames = [
 const nonProviderCollectionGatesPass = (
   gates: Readonly<Record<string, boolean>>,
 ): boolean =>
-  requiredNonProviderCollectionGateNames.every((name) => gates[name] === true) &&
+  requiredNonProviderCollectionGateNames.every(
+    (name) => gates[name] === true,
+  ) &&
   Object.entries(gates).every(
     ([name, passed]) => providerCollectionGateNames.has(name) || passed,
   );

--- a/scripts/run-reader-summary-production-day.ts
+++ b/scripts/run-reader-summary-production-day.ts
@@ -23,6 +23,7 @@ import {
 import { loadDotenvIfPresent } from "./lib/env-file";
 import { READER_SUMMARY_PRODUCTION_RUNTIME_POLICY } from "./lib/reader-summary-production-runtime-policy";
 import {
+  admitCollectionStepWithDurableDatabaseFallback,
   artifactQualityIsReadyForCleanDayE2e,
   blockedCleanDayE2eStep,
   blockedProductionDaySteps,
@@ -180,7 +181,7 @@ async function main(): Promise<void> {
     throw new Error("Production history collection scope is not 6101/6102");
   }
 
-  const collectionStep: StepReport = historicalRegeneration
+  let collectionStep: StepReport = historicalRegeneration
     ? historicalRegeneration.verifiedCollectionStep
     : skipLiveCollection
       ? {
@@ -207,8 +208,6 @@ async function main(): Promise<void> {
             : []),
           ...(allowHistorical ? [] : ["--wait-for-x-readiness"]),
         ]);
-  steps.push(collectionStep);
-
   mkdirSync(runtimeArtifactDirectory, { recursive: true });
   isolateCaptureArtifacts();
 
@@ -261,9 +260,16 @@ async function main(): Promise<void> {
   const requiredProvidersReady =
     providerAdmission?.summaryPolicy === "allowed" ||
     executionRequest.mode !== "live-production";
+  collectionStep = admitCollectionStepWithDurableDatabaseFallback({
+    step: collectionStep,
+    fallbackReady:
+      providerAdmission?.summaryPolicy === "allowed" &&
+      providerAdmission.status !== "complete" &&
+      collectionQualityStep.status === "passed",
+  });
   if (
     executionRequest.mode === "live-production" &&
-    providerAdmission?.status !== "complete"
+    providerAdmission?.summaryPolicy !== "allowed"
   ) {
     collectionQualityStep = {
       ...collectionQualityStep,
@@ -275,10 +281,12 @@ async function main(): Promise<void> {
       exitCode: 1,
     };
   }
+  steps.push(collectionStep);
   steps.push(collectionQualityStep);
   if (
-    providerAdmission?.status === "partial" ||
-    providerAdmission?.status === "unavailable"
+    providerAdmission?.summaryPolicy === "blocked" &&
+    (providerAdmission.status === "partial" ||
+      providerAdmission.status === "unavailable")
   ) {
     const safeMessage =
       `Production provider evidence for ${collectionDate} is ` +


### PR DESCRIPTION
Fixes the scheduled E2E chain when a newer GitHub scan is partial or one provider account hits a recoverable limit.

- reuse the latest complete GitHub Top 10 snapshot instead of a newer partial scan
- allow publication from durable DB inventory only when every DB and non-provider quality gate passes
- preserve the raw collection exit in the durable fallback receipt
- hide recovered X account errors after the final pool target is met
- add backend and Flutter regression coverage

Verification:
- 181 focused Jest tests passed
- Flutter provider-health widget tests passed
- Flutter analyze passed
- frontend architecture boundaries passed
- ESLint and source line cap passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Collection health now shows rate-limit and failure details only for incomplete collections.
  - Completed collections are correctly recognized even when retry or rate-limit events occurred.
  - Complete GitHub Top 10 results are retained instead of being replaced by newer partial scans.
  - Production summaries can proceed using validated durable database fallback data when collection steps fail.

- **Improvements**
  - Partial provider readiness can be admitted when database quality requirements are met.
  - Production-day processing now distinguishes partial, unavailable, and blocked readiness more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->