### PR TITLE
fix(deploy): accept terminal failed services as idle

### DIFF
--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
@@ -653,7 +653,7 @@ wait_postgres_runtime_daily_c1_services_idle() {
     for service in \
       "$POSTGRES_RUNTIME_DAILY_SERVICE" "$POSTGRES_RUNTIME_DAILY_V6_SERVICE"; do
       state=$(systemctl show --property=ActiveState --value "$service") || return
-      [[ $state == inactive ]] || all_idle=false
+      [[ $state =~ ^(inactive|failed)$ ]] || all_idle=false
     done
     [[ $all_idle == true ]] && return 0
     sleep 1

--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
@@ -327,6 +327,9 @@ if prove_postgres_runtime_daily_c1_flip_idle >/dev/null 2>&1; then
   echo 'daily C1 handoff accepted an active v6 service' >&2
   exit 1
 fi
+reset_v6_topology
+LEGACY_SERVICE_STATE=failed V6_SERVICE_STATE=failed
+prove_postgres_runtime_daily_c1_flip_idle
 
 # A failure before the durable owner flip remains rollback-safe: legacy is only
 # enabled, never started, and V6 remains the effective owner.


### PR DESCRIPTION
## Summary
- treat failed oneshot services as terminal during the daily owner handoff
- keep active services blocked
- add regression coverage for stale failed service states

## Verification
- bash ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
- bash -n changed scripts
- git diff --check

Full deploy test requires Linux Bash and runs in CI.