### PR TITLE
fix(summary): preserve rolling collection without model auth

### DIFF
--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -58,20 +58,23 @@ if [[ -z $NOW ]]; then
   NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
 fi
 
-"$ROOT/control/refresh-codex-auth.sh"
-if [[ -f "$ROOT/runtime/auth-account-changed" ]]; then
-  stamp=$(date -u +%Y%m%dT%H%M%SZ)
-  if [[ -d "$ROOT/runtime/subscription-runtime/sessions" ]]; then
-    mv "$ROOT/runtime/subscription-runtime/sessions" \
-      "$ROOT/backups/subscription-runtime-sessions.$stamp"
+auth_ready=false
+if "$ROOT/control/refresh-codex-auth.sh"; then
+  auth_ready=true
+  if [[ -f "$ROOT/runtime/auth-account-changed" ]]; then
+    stamp=$(date -u +%Y%m%dT%H%M%SZ)
+    if [[ -d "$ROOT/runtime/subscription-runtime/sessions" ]]; then
+      mv "$ROOT/runtime/subscription-runtime/sessions" \
+        "$ROOT/backups/subscription-runtime-sessions.$stamp"
+    fi
+    install -d -m 0700 -o 1000 -g 1000 \
+      "$ROOT/runtime/subscription-runtime/sessions"
+    "${COMPOSE[@]}" restart agent-runtime
+    rm -f "$ROOT/runtime/auth-account-changed"
+    sleep 3
   fi
-  install -d -m 0700 -o 1000 -g 1000 \
-    "$ROOT/runtime/subscription-runtime/sessions"
-  "${COMPOSE[@]}" restart agent-runtime
-  rm -f "$ROOT/runtime/auth-account-changed"
-  sleep 3
+  "${COMPOSE[@]}" --profile app up -d --no-deps agent-runtime
 fi
-"${COMPOSE[@]}" --profile app up -d --no-deps agent-runtime
 
 collection_date=${NOW:0:10}
 run_id=$(printf '%s' "$NOW" | tr -d ':.-')
@@ -94,6 +97,7 @@ export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
   -e "ROLLING_COLLECTION_DATE=$collection_date" \
   -e "ROLLING_PERIOD_ENDED_AT=$NOW" \
   -e "ROLLING_RECEIPT_PATH=$receipt_container_path" \
+  -e "ROLLING_AUTH_READY=$auth_ready" \
   daily-runner sh -lc '
     set -eu
 
@@ -118,6 +122,11 @@ export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
     chmod 0444 "$collection_artifact.next"
     mv "$collection_artifact.next" "$collection_artifact"
     rolling_observation_cutoff=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+    if [[ "$ROLLING_AUTH_READY" != true ]]; then
+      echo "rolling collection saved; AI summary is pending an available subscription account" >&2
+      exit 75
+    fi
 
     export DURABLE_READER_SUMMARY_TENANT_ID=00000000-0000-7000-8000-000000006101
     export DURABLE_READER_SUMMARY_WORKSPACE_ID=00000000-0000-7000-8000-000000006102

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -33,6 +33,7 @@ SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T08:15:00.000Z \
 grep -F -- '--profile app up -d --no-deps agent-runtime' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '--profile daily run --rm --no-deps' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '-e ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
+grep -F -- '-e ROLLING_AUTH_READY=true' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- 'daily-runner sh -lc' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- "--providers \"\$required_providers\"" "$RUNNER" >/dev/null
 grep -F -- 'npm run capture:durable-reader-summary' "$RUNNER" >/dev/null
@@ -47,5 +48,24 @@ grep -Fx 'OnCalendar=*-*-* 04,08,12,16,20:15:00 UTC' \
   "$REPO/ops/deploy/production-runtime/social-monitor-rolling.timer" >/dev/null
 grep -Fx 'Persistent=true' \
   "$REPO/ops/deploy/production-runtime/social-monitor-rolling.timer" >/dev/null
+
+ln -sfn /usr/bin/false "$refresh"
+if SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T12:15:00.000Z \
+    bash "$RUNNER"; then
+  echo 'rolling run accepted unavailable summary auth' >&2
+  exit 1
+fi
+grep -F -- '-e ROLLING_AUTH_READY=false' "$TEST_ROOT/docker.log" >/dev/null
+[[ $(grep -Fc -- '--profile app up -d --no-deps agent-runtime' \
+  "$TEST_ROOT/docker.log") == 1 ]]
+
+collection_line=$(grep -n 'npm run run:reader-summary-clean-real-day-collection' \
+  "$RUNNER" | cut -d: -f1)
+auth_guard_line=$(grep -n 'ROLLING_AUTH_READY.*!= true' "$RUNNER" | cut -d: -f1)
+((collection_line < auth_guard_line))
 
 echo 'rolling-run tests passed'

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "${SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG:?test log is required}"
 if [[ $* == *' daily-runner sh -lc '* ]]; then
+  [[ $* != *'-e ROLLING_AUTH_READY=false'* ]] || exit 75
   printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS","publication":{"readerSummaryJobId":"test-job","readerSummaryId":"test-summary","status":"completed"}}\n' \
     "$SOCIAL_MONITOR_ROLLING_RUN_ID" > \
     "$SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH"


### PR DESCRIPTION
## Summary
- collect and persist rolling provider data even when every subscription account is quota-blocked
- skip agent runtime startup and summary generation until auth is available
- keep the run non-successful so a missing summary is never reported as published
- add a regression case proving collection is admitted before the auth guard

## Verification
- bash ops/deploy/production-runtime/rolling-run.test.sh
- bash -n changed runtime scripts
- git diff --check