### PR TITLE
fix(deploy): keep runtime release on installed control

### DIFF
--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
@@ -653,7 +653,7 @@ wait_postgres_runtime_daily_c1_services_idle() {
     for service in \
       "$POSTGRES_RUNTIME_DAILY_SERVICE" "$POSTGRES_RUNTIME_DAILY_V6_SERVICE"; do
       state=$(systemctl show --property=ActiveState --value "$service") || return
-      [[ $state =~ ^(inactive|failed)$ ]] || all_idle=false
+      [[ $state == inactive ]] || all_idle=false
     done
     [[ $all_idle == true ]] && return 0
     sleep 1

--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
@@ -327,9 +327,6 @@ if prove_postgres_runtime_daily_c1_flip_idle >/dev/null 2>&1; then
   echo 'daily C1 handoff accepted an active v6 service' >&2
   exit 1
 fi
-reset_v6_topology
-LEGACY_SERVICE_STATE=failed V6_SERVICE_STATE=failed
-prove_postgres_runtime_daily_c1_flip_idle
 
 # A failure before the durable owner flip remains rollback-safe: legacy is only
 # enabled, never started, and V6 remains the effective owner.


### PR DESCRIPTION
## Summary
- restore the sealed daily handoff helper to the exact currently installed blob
- keep product/runtime fixes deployable without an additional control bridge release
- use a bounded systemd reset-failed operation for the stale terminal unit state

## Verification
- helper blob matches deployed baseline 119726c2f2aff06798cade4dc3a127f24a2d2cc9
- bash ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
- bash ops/deploy/production-runtime/rolling-run.test.sh
- git diff --check