### PR TITLE
fix(summary): enforce rolling auth guard in POSIX shell

### DIFF
--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -123,7 +123,7 @@ export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
     mv "$collection_artifact.next" "$collection_artifact"
     rolling_observation_cutoff=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
 
-    if [[ "$ROLLING_AUTH_READY" != true ]]; then
+    if [ "$ROLLING_AUTH_READY" != true ]; then
       echo "rolling collection saved; AI summary is pending an available subscription account" >&2
       exit 75
     fi

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -67,5 +67,13 @@ collection_line=$(grep -n 'npm run run:reader-summary-clean-real-day-collection'
   "$RUNNER" | cut -d: -f1)
 auth_guard_line=$(grep -n 'ROLLING_AUTH_READY.*!= true' "$RUNNER" | cut -d: -f1)
 ((collection_line < auth_guard_line))
+grep -F 'if [ "$ROLLING_AUTH_READY" != true ]; then' "$RUNNER" >/dev/null
+! grep -F 'if [[ "$ROLLING_AUTH_READY"' "$RUNNER" >/dev/null
+set +e
+ROLLING_AUTH_READY=false sh -ec \
+  'if [ "$ROLLING_AUTH_READY" != true ]; then exit 75; fi'
+auth_guard_status=$?
+set -e
+((auth_guard_status == 75))
 
 echo 'rolling-run tests passed'


### PR DESCRIPTION
## Summary
- use POSIX test syntax inside the daily-runner sh boundary
- prevent summary execution when subscription auth is unavailable
- add a sh-level regression proving exit status 75

## Verification
- bash ops/deploy/production-runtime/rolling-run.test.sh
- bash -n changed scripts
- git diff --check
- production E2E exposed the previous [[ incompatibility after collection persisted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment script compatibility with POSIX-compliant shell environments.
  * Preserved the existing behavior of stopping with status 75 when subscription authentication is unavailable.

* **Tests**
  * Added coverage confirming authentication checks work correctly across supported shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->