### PR TITLE
fix(summary): evaluate rolling freshness through observation time

### DIFF
--- a/scripts/lib/clean-real-day-provider-acquisition.ts
+++ b/scripts/lib/clean-real-day-provider-acquisition.ts
@@ -49,6 +49,7 @@ import { CleanRealDaySourceConfigReader } from "./clean-real-day-source-config-r
 import {
   configuredProviderCollectionTargetItemCount,
   durableSnapshotReuseProviderCollectionObservation,
+  providerCollectionFreshnessReferenceAt,
   successfulProviderCollectionObservation,
   unavailableProviderCollectionObservation,
 } from "./provider-collection-observability";
@@ -160,6 +161,10 @@ export const executeCleanRealDayProviderAcquisition = async (params: {
     params.runStartedAt,
     params.targetWindowEndedAt,
   );
+  const freshnessReferenceAt = providerCollectionFreshnessReferenceAt({
+    observedAt: params.runStartedAt,
+    targetWindowEndedAt: params.targetWindowEndedAt,
+  });
   const liveTargets = params.targets.filter(
     (target) => !shouldReuseDurableSnapshot(target, closedRequestedUtcDay),
   );
@@ -185,7 +190,7 @@ export const executeCleanRealDayProviderAcquisition = async (params: {
           target,
           liveRuntime.executeScan,
           liveRuntime.scanJobReporter,
-          params.targetWindowEndedAt,
+          freshnessReferenceAt,
         ),
       );
     },

--- a/scripts/lib/provider-collection-observability.spec.ts
+++ b/scripts/lib/provider-collection-observability.spec.ts
@@ -1,6 +1,7 @@
 import {
   configuredProviderCollectionTargetItemCount,
   durableSnapshotReuseProviderCollectionObservation,
+  providerCollectionFreshnessReferenceAt,
   successfulProviderCollectionObservation,
   unavailableProviderCollectionObservation,
   withProviderCollectionWindowProof,
@@ -128,6 +129,28 @@ describe("provider collection observability", () => {
       targetItemCount: 100,
       evaluatedItemCount: 100,
     });
+    expect(final.freshness).toEqual({
+      newestAcceptedPublishedAt: "2026-07-09T23:00:00.000Z",
+      lagToWindowEndSeconds: 3600,
+    });
+  });
+
+  it("caps current-day freshness at the observed part of the window", () => {
+    expect(
+      providerCollectionFreshnessReferenceAt({
+        observedAt: new Date("2026-07-09T12:00:00.000Z"),
+        targetWindowEndedAt: new Date("2026-07-10T00:00:00.000Z"),
+      }),
+    ).toEqual(new Date("2026-07-09T12:00:00.000Z"));
+  });
+
+  it("keeps the full window boundary once the requested day is closed", () => {
+    expect(
+      providerCollectionFreshnessReferenceAt({
+        observedAt: new Date("2026-07-10T00:05:00.000Z"),
+        targetWindowEndedAt: new Date("2026-07-10T00:00:00.000Z"),
+      }),
+    ).toEqual(new Date("2026-07-10T00:00:00.000Z"));
   });
 
   it("labels durable reuse without claiming a fetch, page, insert, or retry", () => {

--- a/scripts/lib/provider-collection-observability.ts
+++ b/scripts/lib/provider-collection-observability.ts
@@ -235,7 +235,36 @@ export const withProviderCollectionWindowProof = (params: {
       params.observation.rateLimitEventCount,
     ),
     slo,
+    freshness: {
+      ...params.observation.freshness,
+      ...(params.newestPublishedAt === undefined
+        ? {}
+        : {
+            newestAcceptedPublishedAt: params.newestPublishedAt.toISOString(),
+            lagToWindowEndSeconds: Math.max(
+              0,
+              Math.round(
+                (params.targetWindowEndedAt.getTime() -
+                  params.newestPublishedAt.getTime()) /
+                  1000,
+              ),
+            ),
+          }),
+    },
   };
+};
+
+export const providerCollectionFreshnessReferenceAt = (params: {
+  readonly observedAt: Date;
+  readonly targetWindowEndedAt: Date;
+}): Date => {
+  const observedAt = params.observedAt.getTime();
+  const targetWindowEndedAt = params.targetWindowEndedAt.getTime();
+  if (!Number.isFinite(observedAt) || !Number.isFinite(targetWindowEndedAt)) {
+    throw new Error("Provider collection freshness boundary must be valid");
+  }
+
+  return new Date(Math.min(observedAt, targetWindowEndedAt));
 };
 
 export const configuredProviderCollectionTargetItemCount = (

--- a/scripts/run-reader-summary-clean-real-day-collection.ts
+++ b/scripts/run-reader-summary-clean-real-day-collection.ts
@@ -59,7 +59,10 @@ import {
   type CleanRealDaySourceBindingTarget as SourceBindingTarget,
 } from "./lib/clean-real-day-provider-acquisition";
 import { requireScanPolicyTargets } from "./lib/clean-real-day-scan-policy-targets";
-import { withProviderCollectionWindowProof } from "./lib/provider-collection-observability";
+import {
+  providerCollectionFreshnessReferenceAt,
+  withProviderCollectionWindowProof,
+} from "./lib/provider-collection-observability";
 import {
   explicitGitHubUnavailableIsTransparentPartialDailyInput,
   providerMeetsProductionBlockingPolicy,
@@ -631,6 +634,10 @@ function buildReport(params: {
   readonly targetWindow: CleanRealDayCollectionReport["freshWindow"];
 }): CleanRealDayCollectionReport {
   const targetWindowEndedAt = new Date(targetPublishedWindow.endExclusive);
+  const freshnessReferenceAt = providerCollectionFreshnessReferenceAt({
+    observedAt: params.completedAt,
+    targetWindowEndedAt,
+  });
   const collectedScanResults = params.scanResults.map((scan) => {
     if (scan.acquisitionMode === "durable_snapshot_reuse") {
       return scan;
@@ -647,7 +654,7 @@ function buildReport(params: {
         ...(newestItemAt === undefined
           ? {}
           : { newestPublishedAt: new Date(newestItemAt) }),
-        targetWindowEndedAt,
+        targetWindowEndedAt: freshnessReferenceAt,
       }),
     };
   });


### PR DESCRIPTION
## What changed
- cap current-day collection freshness at the observed portion of the UTC window
- keep closed-day freshness anchored to the exact day boundary
- refresh authoritative window freshness metadata together with SLO evaluation

## Why
Rolling runs were comparing fresh posts with the future end of the current UTC day. Near the six-hour threshold this incorrectly marked every provider stale and produced noisy blocking-provider output even when collection was fresh.

## Evidence
- 35 focused Jest tests passed
- affected TypeScript files passed ESLint
- source line-cap gate passed
- full repository typecheck/code-quality remain red on pre-existing unrelated weekly summary, OTel dependency, generated Prisma, and >500 LOC baseline findings