### PR TITLE
fix(summaries): match displayed rolling schedule

### DIFF
--- a/apps/frontend/features/summaries/lib/src/domain/value_objects/summary_refresh_schedule.dart
+++ b/apps/frontend/features/summaries/lib/src/domain/value_objects/summary_refresh_schedule.dart
@@ -1,28 +1,28 @@
 final class SummaryRefreshSchedule {
   const SummaryRefreshSchedule._();
 
-  static const refreshInterval = Duration(hours: 4);
+  static const _scheduledHoursUtc = [4, 8, 12, 16, 20];
   static const scheduledMinuteUtc = 15;
 
   static DateTime nextScheduledAt(DateTime now) {
     final utc = now.toUtc();
-    final currentSlotHour =
-        (utc.hour ~/ refreshInterval.inHours) * refreshInterval.inHours;
-    var candidate = DateTime.utc(
-      utc.year,
-      utc.month,
-      utc.day,
-      currentSlotHour,
-      scheduledMinuteUtc,
-    );
-    if (!candidate.isAfter(utc)) {
-      candidate = candidate.add(refreshInterval);
+    for (final hour in _scheduledHoursUtc) {
+      final candidate = _slot(utc, hour);
+      if (candidate.isAfter(utc)) return candidate;
     }
-    return candidate;
+    final tomorrow = utc.add(const Duration(days: 1));
+    return _slot(tomorrow, _scheduledHoursUtc.first);
   }
 
-  static DateTime latestScheduledAt(DateTime now) =>
-      nextScheduledAt(now).subtract(refreshInterval);
+  static DateTime latestScheduledAt(DateTime now) {
+    final utc = now.toUtc();
+    for (final hour in _scheduledHoursUtc.reversed) {
+      final candidate = _slot(utc, hour);
+      if (!candidate.isAfter(utc)) return candidate;
+    }
+    final yesterday = utc.subtract(const Duration(days: 1));
+    return _slot(yesterday, _scheduledHoursUtc.last);
+  }
 
   static bool isUpdateDue({
     required DateTime now,
@@ -33,4 +33,7 @@ final class SummaryRefreshSchedule {
     final value = next.toUtc().difference(now.toUtc());
     return value.isNegative ? Duration.zero : value;
   }
+
+  static DateTime _slot(DateTime day, int hour) =>
+      DateTime.utc(day.year, day.month, day.day, hour, scheduledMinuteUtc);
 }

--- a/apps/frontend/features/summaries/test/domain/value_objects/summary_refresh_schedule_test.dart
+++ b/apps/frontend/features/summaries/test/domain/value_objects/summary_refresh_schedule_test.dart
@@ -12,12 +12,21 @@ void main() {
       );
     });
 
-    test('moves to the next slot after the scheduled minute', () {
+    test('moves to the first rolling slot after the nightly finalizer', () {
       expect(
         SummaryRefreshSchedule.nextScheduledAt(
           DateTime.parse('2026-08-15T20:15:00.000Z'),
         ),
-        DateTime.parse('2026-08-16T00:15:00.000Z'),
+        DateTime.parse('2026-08-16T04:15:00.000Z'),
+      );
+    });
+
+    test('uses the previous evening slot before the first daily run', () {
+      expect(
+        SummaryRefreshSchedule.latestScheduledAt(
+          DateTime.parse('2026-08-16T02:00:00.000Z'),
+        ),
+        DateTime.parse('2026-08-15T20:15:00.000Z'),
       );
     });
 


### PR DESCRIPTION
## Summary
- align the UI countdown with the production rolling timer slots
- skip the nightly 00:15 UTC finalizer when calculating the next current-day refresh
- cover the overnight next/latest slot behavior

## Verification
- focused summary refresh schedule and widget tests
- flutter analyze
- frontend architecture boundary tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated summary refresh scheduling to use fixed UTC run times: 04:00, 08:00, 12:00, 16:00, and 20:00.
  * Improved handling of schedules that cross into the next or previous day.
  * Corrected selection of the latest completed scheduled run before the first daily refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->