### PR TITLE
test(agent-runtime): prove auth pool failover end to end

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -411,6 +411,7 @@ jobs:
           npm run check:dependencies
           npm run check:container
           npm run check:runtime-compose
+          npm run check:subscription-runtime-auth-pool-e2e
           npm run check:runtime-profile-guards
           npm run check:migrations
           npm run check:tenant-db-guards

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Run backend unit tests
         run: npm test
 
+      - name: Prove subscription runtime auth-pool failover
+        run: npm run check:subscription-runtime-auth-pool-e2e
+
   backend_e2e:
     name: Backend end-to-end tests
     runs-on: ubuntu-latest

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 777genius
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,9 @@
 Social Monitor
 Copyright 2026 777genius
 
-This product is licensed under the Apache License, Version 2.0.
+Original Social Monitor material is licensed under the Apache License,
+Version 2.0.
+
+Third-party and vendored components are excluded from that license unless
+their own licensing materials state otherwise. In particular, artifacts under
+vendor/*.tgz remain subject to the terms of their respective owners.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Social Monitor
+Copyright 2026 777genius
+
+This product is licensed under the Apache License, Version 2.0.

--- a/README.md
+++ b/README.md
@@ -434,4 +434,4 @@ Use this project only with data sources you are allowed to access and monitor. S
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -434,4 +434,7 @@ Use this project only with data sources you are allowed to access and monitor. S
 
 ## License
 
-Apache License 2.0. See [LICENSE](LICENSE).
+Original Social Monitor material is licensed under Apache License 2.0. See
+[LICENSE](LICENSE) and [NOTICE](NOTICE). Third-party and vendored components,
+including `vendor/*.tgz`, remain subject to their respective owners' terms and
+are not relicensed by this repository.

--- a/apps/agent-runtime/README.md
+++ b/apps/agent-runtime/README.md
@@ -47,6 +47,8 @@ Important env:
 - `AGENT_RUNTIME_REASONING_EFFORT`, required production effort (`xhigh`)
 - `AGENT_RUNTIME_TIMEOUT_MS`, generic Social Monitor task timeout fallback
 - `AGENT_RUNTIME_CODEX_AUTH_JSON_PATH`
+- `AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT`, immutable pool snapshot root
+- `AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST`, manifest path inside the pool root
 - `AGENT_RUNTIME_CLAUDE_TOKEN_ENV`, default `CLAUDE_CODE_OAUTH_TOKEN`
 
 Operational invariant: production summary launchers append
@@ -62,6 +64,45 @@ allowlist above from the repository `.env`; unrelated application credentials
 are not copied into the child process. It also uses the standard local durable
 state root under `XDG_STATE_HOME` (or `~/.local/state`) and the current
 `~/.codex/auth.json` when no explicit Codex auth path is configured.
+
+## Production Codex Auth Pool
+
+Production uses the reviewed
+`ops/deploy/production-runtime/compose.agent-runtime-model.yml` overlay. It
+clears the legacy single-account auth path, mounts
+`/var/data/social-monitor/auth-pool` read-only and points the bridge at the
+immutable current manifest. `ops/deploy/host/refresh-codex-auth.sh` owns
+atomic snapshot and manifest creation.
+
+The manifest contract is:
+
+```json
+{
+  "schemaVersion": 1,
+  "snapshotId": "<immutable-generation>",
+  "accounts": [
+    {
+      "id": "account-a",
+      "relativePath": "snapshots/<immutable-generation>/account-a/auth.json"
+    }
+  ]
+}
+```
+
+Both pool environment values must be configured together. When neither is
+present, the bridge preserves the legacy single-account behavior. Local
+startup does not auto-select `~/.codex/auth.json` when a pool is configured.
+
+Run the deterministic bridge gate with:
+
+```sh
+npm run check:subscription-runtime-auth-pool-e2e
+```
+
+The gate creates a temporary sandbox project and fake auth snapshots, sends
+one exact read-only task through the native subscription-runtime safe
+executor, simulates quota on the first account and proves completion on the
+second. It never reads host Codex auth or starts a real agent task.
 
 ## Local Codex Compose
 

--- a/apps/agent-runtime/README.md
+++ b/apps/agent-runtime/README.md
@@ -102,7 +102,15 @@ npm run check:subscription-runtime-auth-pool-e2e
 The gate creates a temporary sandbox project and fake auth snapshots, sends
 one exact read-only task through the native subscription-runtime safe
 executor, simulates quota on the first account and proves completion on the
-second. It never reads host Codex auth or starts a real agent task.
+second. It also verifies native workspace, sandbox, approval, tool-disable,
+model and effort controls, and simulates refreshed materialized auth without
+allowing writeback to the immutable pool snapshots. It never reads host Codex
+auth or starts a real agent task.
+
+The vendored runtime currently uses `outputSchemaName` to select structured
+result parsing but sends `outputSchema: null` to native `turn/start`. This gate
+does not claim native JSON-schema enforcement; that requires a reviewed
+subscription-runtime artifact upgrade.
 
 ## Local Codex Compose
 

--- a/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { orderCodexAuthAccountsForTask } from "./codex-auth-pool-routing.mjs";
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+const runtimeBridgePath = join(
+  repositoryRoot,
+  "apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs",
+);
+
+test(
+  "fails over one exact sandbox task through the native Codex auth pool",
+  { timeout: 30_000 },
+  async () => {
+    const fixture = await createFixture();
+    try {
+      const beforeAuth = await Promise.all(
+        fixture.authPaths.map((path) => readFile(path, "utf8")),
+      );
+      const execution = await execFileAsync(
+        process.execPath,
+        [
+          runtimeBridgePath,
+          "--provider",
+          "codex",
+          "--input",
+          fixture.requestPath,
+          "--format",
+          "result-json",
+          "--state-root",
+          fixture.stateRoot,
+          "--codex-binary",
+          fixture.codexBinaryPath,
+          "--model",
+          "gpt-5.6-sol",
+          "--timeout-ms",
+          "15000",
+        ],
+        {
+          cwd: fixture.sandboxProject,
+          env: {
+            PATH: process.env.PATH,
+            LANG: "C.UTF-8",
+            AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT: fixture.poolRoot,
+            AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST: "current.json",
+            AGENT_RUNTIME_REASONING_EFFORT: "xhigh",
+            SUBSCRIPTION_RUNTIME_LOCAL_ENCRYPTION_KEY:
+              Buffer.alloc(32, 7).toString("base64"),
+          },
+          maxBuffer: 1024 * 1024,
+        },
+      ).then(
+        ({ stdout, stderr }) => ({ exitCode: 0, stdout, stderr }),
+        (error) => ({
+          exitCode: error.code,
+          stdout: error.stdout ?? "",
+          stderr: error.stderr ?? "",
+        }),
+      );
+
+      const attempts = (await readFile(fixture.attemptLogPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const result = JSON.parse(execution.stdout);
+      assert.equal(
+        execution.exitCode,
+        0,
+        JSON.stringify({ result, attempts, stderr: execution.stderr }),
+      );
+      assert.equal(result.status, "completed");
+      assert.deepEqual(result.structuredOutput, {
+        ok: true,
+        account: "account-b",
+      });
+      assert.deepEqual(
+        attempts.map(({ account, command }) => ({ account, command })),
+        [
+          { account: "account-a", command: "turn" },
+          { account: "account-b", command: "turn" },
+        ],
+      );
+      const appServerAttempts = attempts.filter(
+        ({ command }) => command === "turn",
+      );
+      assert.equal(appServerAttempts.length, 2);
+      assert.equal(
+        appServerAttempts[0].promptSha256,
+        appServerAttempts[1].promptSha256,
+      );
+
+      const canonicalRequest = JSON.parse(
+        await readFile(fixture.requestPath, "utf8"),
+      );
+      assert.equal(canonicalRequest.task.controls.model, "gpt-5.6-sol");
+      assert.equal(canonicalRequest.task.controls.reasoningEffort, "xhigh");
+      assert.equal(canonicalRequest.task.controls.responseFormat, "json");
+      assert.equal(
+        canonicalRequest.task.metadata.runtimeOutput,
+        "structured_output",
+      );
+
+      const afterAuth = await Promise.all(
+        fixture.authPaths.map((path) => readFile(path, "utf8")),
+      );
+      assert.deepEqual(afterAuth, beforeAuth);
+    } finally {
+      await fixture.cleanup();
+    }
+  },
+);
+
+async function createFixture() {
+  const root = await mkdtemp(
+    join(tmpdir(), "social-monitor-subscription-runtime-e2e-"),
+  );
+  const sandboxProject = join(root, "sandbox-project");
+  const stateRoot = join(root, "state");
+  const poolRoot = join(root, "auth-pool");
+  const snapshotId = "sandbox-snapshot-1";
+  const snapshotRoot = join(poolRoot, "snapshots", snapshotId);
+  const attemptLogPath = join(root, "codex-attempts.ndjson");
+  await Promise.all([
+    mkdir(sandboxProject, { recursive: true, mode: 0o700 }),
+    mkdir(stateRoot, { recursive: true, mode: 0o700 }),
+    mkdir(snapshotRoot, { recursive: true, mode: 0o700 }),
+  ]);
+
+  const accountIds = ["account-a", "account-b"];
+  const authPaths = [];
+  const accountRoots = [];
+  for (const accountId of accountIds) {
+    const accountRoot = join(snapshotRoot, accountId);
+    const authPath = join(accountRoot, "auth.json");
+    await mkdir(accountRoot, { mode: 0o700 });
+    await writeFile(
+      authPath,
+      `${JSON.stringify(fakeCodexAuth(accountId))}\n`,
+      { mode: 0o400 },
+    );
+    accountRoots.push(accountRoot);
+    authPaths.push(authPath);
+  }
+
+  const manifestPath = join(poolRoot, "current.json");
+  await writeFile(
+    manifestPath,
+    `${JSON.stringify({
+      schemaVersion: 1,
+      snapshotId,
+      accounts: accountIds.map((id) => ({
+        id,
+        relativePath: `snapshots/${snapshotId}/${id}/auth.json`,
+      })),
+    })}\n`,
+    { mode: 0o400 },
+  );
+  const poolDirectories = [
+    ...accountRoots,
+    snapshotRoot,
+    join(poolRoot, "snapshots"),
+    poolRoot,
+  ];
+  await Promise.all(poolDirectories.map((path) => chmod(path, 0o500)));
+
+  const codexBinaryPath = join(root, "fake-codex.mjs");
+  await writeFile(
+    codexBinaryPath,
+    fakeCodexBinarySource(attemptLogPath),
+    "utf8",
+  );
+  await chmod(codexBinaryPath, 0o755);
+
+  const requestPath = join(root, "request.json");
+  await writeFile(
+    requestPath,
+    `${JSON.stringify(agentTaskRequest(taskIdStartingWith(accountIds, "account-a")))}\n`,
+    "utf8",
+  );
+
+  return {
+    attemptLogPath,
+    authPaths,
+    codexBinaryPath,
+    poolRoot,
+    requestPath,
+    sandboxProject,
+    stateRoot,
+    cleanup: async () => {
+      await Promise.all(
+        poolDirectories.map((path) => chmod(path, 0o700).catch(() => {})),
+      );
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function taskIdStartingWith(accountIds, expectedAccountId) {
+  for (let index = 0; index < 1000; index += 1) {
+    const taskId = `sandbox-auth-pool-e2e-${index}`;
+    if (
+      orderCodexAuthAccountsForTask(accountIds, taskId)[0] ===
+      expectedAccountId
+    ) {
+      return taskId;
+    }
+  }
+  throw new Error("Unable to select a deterministic first sandbox account");
+}
+
+function agentTaskRequest(runId) {
+  return {
+    protocolVersion: 1,
+    runId,
+    cwd: ".",
+    timeoutMs: 15_000,
+    task: {
+      kind: "structured-prompt",
+      systemPrompt: "Return JSON only.",
+      prompt: "Return the sandbox auth-pool result.",
+      outputSchemaName: "auth-pool-e2e",
+      controls: {
+        outputSchema: {
+          type: "object",
+          required: ["ok", "account"],
+          properties: {
+            ok: { type: "boolean" },
+            account: { type: "string" },
+          },
+        },
+      },
+      metadata: {},
+    },
+    context: {
+      application: "social-monitor",
+      purpose: "social_monitor.summary.generate",
+      correlationId: "sandbox-auth-pool-e2e",
+    },
+  };
+}
+
+function fakeCodexAuth(accountId) {
+  return {
+    auth_mode: "chatgpt",
+    last_refresh: new Date().toISOString(),
+    tokens: {
+      access_token: `sandbox-access-${accountId}`,
+      account_id: accountId,
+      id_token: `sandbox-id-${accountId}`,
+      refresh_token: `sandbox-refresh-${accountId}`,
+      expiry: "2099-01-01T00:00:00.000Z",
+    },
+  };
+}
+
+function fakeCodexBinarySource(attemptLogPath) {
+  return `#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { appendFile, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+const args = process.argv.slice(2);
+const command = args[0] ?? "";
+const auth = JSON.parse(
+  await readFile(join(process.env.CODEX_HOME, "auth.json"), "utf8"),
+);
+const account = auth.tokens.account_id;
+
+if (command === "app-server") {
+  const input = createInterface({ input: process.stdin });
+  for await (const line of input) {
+    const request = JSON.parse(line);
+    if (request.method === "initialize") {
+      send({ id: request.id, result: {} });
+      continue;
+    }
+    if (request.method === "thread/start") {
+      send({
+        id: request.id,
+        result: { thread: { id: "thread-" + account } },
+      });
+      continue;
+    }
+    if (request.method === "turn/start") {
+      const turnId = "turn-" + account;
+      const prompt = request.params.input[0].text;
+      await recordAttempt("turn", prompt);
+      send({ id: request.id, result: { turn: { id: turnId } } });
+      if (account === "account-a") {
+        send({
+          method: "turn/completed",
+          params: {
+            turn: {
+              id: turnId,
+              status: { type: "failed" },
+              error: { message: "You've hit your usage limit" },
+            },
+          },
+        });
+      } else {
+        send({
+          method: "item/completed",
+          params: {
+            turnId,
+            item: {
+              type: "agentMessage",
+              text: JSON.stringify({ ok: true, account }),
+            },
+          },
+        });
+        send({
+          method: "turn/completed",
+          params: {
+            turn: { id: turnId, status: { type: "completed" } },
+          },
+        });
+      }
+      continue;
+    }
+    send({
+      id: request.id,
+      error: { code: -32601, message: "unsupported sandbox method" },
+    });
+  }
+} else if (command === "exec") {
+  const prompt = await readFile(0, "utf8");
+  await recordAttempt("exec", prompt);
+  if (account === "account-a") {
+    process.stderr.write("You've hit your usage limit\\n");
+    process.exit(1);
+  }
+  process.stdout.write(
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: JSON.stringify({ ok: true, account }),
+      },
+    }) + "\\n",
+  );
+} else {
+  process.stderr.write("sandbox fake Codex received an unsupported command\\n");
+  process.exit(87);
+}
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+async function recordAttempt(commandName, prompt) {
+  const promptSha256 = createHash("sha256").update(prompt).digest("hex");
+  await appendFile(
+    ${JSON.stringify(attemptLogPath)},
+    JSON.stringify({ account, command: commandName, promptSha256 }) + "\\n",
+    "utf8",
+  );
+}
+`;
+}

--- a/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
@@ -130,6 +130,9 @@ test(
         assert.equal(threadAttempt.modelReasoningEffort, "xhigh");
         assert.equal(threadAttempt.sandboxMode, "read-only");
         assert.equal(threadAttempt.webSearch, "disabled");
+        assert.deepEqual(threadAttempt.environments, []);
+        assert.deepEqual(threadAttempt.dynamicTools, []);
+        assert.equal(threadAttempt.experimentalRawEvents, false);
         assert.deepEqual(threadAttempt.features, {
           apps: false,
           hooks: false,
@@ -346,6 +349,9 @@ if (command === "app-server") {
         modelReasoningEffort: request.params.config?.model_reasoning_effort,
         sandboxMode: request.params.config?.sandbox_mode,
         webSearch: request.params.config?.web_search,
+        environments: request.params.environments,
+        dynamicTools: request.params.dynamicTools,
+        experimentalRawEvents: request.params.experimentalRawEvents,
         features: request.params.config?.features,
       });
       send({

--- a/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
@@ -6,6 +6,7 @@ import {
   mkdir,
   readFile,
   rm,
+  stat,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -34,6 +35,9 @@ test(
     try {
       const beforeAuth = await Promise.all(
         fixture.authPaths.map((path) => readFile(path, "utf8")),
+      );
+      const beforeAuthModes = await Promise.all(
+        fixture.authPaths.map(async (path) => (await stat(path)).mode & 0o777),
       );
       const execution = await execFileAsync(
         process.execPath,
@@ -91,21 +95,50 @@ test(
         ok: true,
         account: "account-b",
       });
+      const turnAttempts = attempts.filter(({ command }) => command === "turn");
       assert.deepEqual(
-        attempts.map(({ account, command }) => ({ account, command })),
+        turnAttempts.map(({ account, command }) => ({ account, command })),
         [
           { account: "account-a", command: "turn" },
           { account: "account-b", command: "turn" },
         ],
       );
-      const appServerAttempts = attempts.filter(
-        ({ command }) => command === "turn",
-      );
-      assert.equal(appServerAttempts.length, 2);
       assert.equal(
-        appServerAttempts[0].promptSha256,
-        appServerAttempts[1].promptSha256,
+        turnAttempts[0].promptSha256,
+        turnAttempts[1].promptSha256,
       );
+      for (const turnAttempt of turnAttempts) {
+        assert.equal(turnAttempt.model, "gpt-5.6-sol");
+        assert.equal(turnAttempt.effort, "xhigh");
+        assert.equal(turnAttempt.approvalPolicy, "never");
+        assert.deepEqual(turnAttempt.environments, []);
+        assert.equal(turnAttempt.materializedAuthChanged, true);
+        const threadAttempt = attempts.find(
+          ({ account, command, threadId }) =>
+            account === turnAttempt.account &&
+            command === "thread" &&
+            threadId === turnAttempt.threadId,
+        );
+        assert.ok(
+          threadAttempt,
+          `missing thread/start for ${turnAttempt.account}`,
+        );
+        assert.equal(threadAttempt.model, "gpt-5.6-sol");
+        assert.equal(threadAttempt.approvalPolicy, "never");
+        assert.equal(threadAttempt.sandbox, "read-only");
+        assert.equal(threadAttempt.runtimeWorkspaceIsIsolated, true);
+        assert.equal(threadAttempt.modelReasoningEffort, "xhigh");
+        assert.equal(threadAttempt.sandboxMode, "read-only");
+        assert.equal(threadAttempt.webSearch, "disabled");
+        assert.deepEqual(threadAttempt.features, {
+          apps: false,
+          hooks: false,
+          memories: false,
+          multi_agent: false,
+          shell_snapshot: false,
+          skill_mcp_dependency_install: false,
+        });
+      }
 
       const canonicalRequest = JSON.parse(
         await readFile(fixture.requestPath, "utf8"),
@@ -121,7 +154,12 @@ test(
       const afterAuth = await Promise.all(
         fixture.authPaths.map((path) => readFile(path, "utf8")),
       );
+      const afterAuthModes = await Promise.all(
+        fixture.authPaths.map(async (path) => (await stat(path)).mode & 0o777),
+      );
       assert.deepEqual(afterAuth, beforeAuth);
+      assert.deepEqual(beforeAuthModes, [0o400, 0o400]);
+      assert.deepEqual(afterAuthModes, beforeAuthModes);
     } finally {
       await fixture.cleanup();
     }
@@ -184,7 +222,7 @@ async function createFixture() {
   const codexBinaryPath = join(root, "fake-codex.mjs");
   await writeFile(
     codexBinaryPath,
-    fakeCodexBinarySource(attemptLogPath),
+    fakeCodexBinarySource(attemptLogPath, stateRoot),
     "utf8",
   );
   await chmod(codexBinaryPath, 0o755);
@@ -271,18 +309,17 @@ function fakeCodexAuth(accountId) {
   };
 }
 
-function fakeCodexBinarySource(attemptLogPath) {
+function fakeCodexBinarySource(attemptLogPath, stateRoot) {
   return `#!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { appendFile, readFile } from "node:fs/promises";
+import { appendFile, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 
 const args = process.argv.slice(2);
 const command = args[0] ?? "";
-const auth = JSON.parse(
-  await readFile(join(process.env.CODEX_HOME, "auth.json"), "utf8"),
-);
+const materializedAuthPath = join(process.env.CODEX_HOME, "auth.json");
+const auth = JSON.parse(await readFile(materializedAuthPath, "utf8"));
 const account = auth.tokens.account_id;
 
 if (command === "app-server") {
@@ -294,16 +331,45 @@ if (command === "app-server") {
       continue;
     }
     if (request.method === "thread/start") {
+      const threadId = "thread-" + account;
+      await recordAttempt({
+        account,
+        command: "thread",
+        threadId,
+        model: request.params.model,
+        approvalPolicy: request.params.approvalPolicy,
+        sandbox: request.params.sandbox,
+        runtimeWorkspaceIsIsolated:
+          request.params.cwd.startsWith(${JSON.stringify(`${stateRoot}/task-workspaces/`)}) &&
+          request.params.runtimeWorkspaceRoots?.length === 1 &&
+          request.params.runtimeWorkspaceRoots[0] === request.params.cwd,
+        modelReasoningEffort: request.params.config?.model_reasoning_effort,
+        sandboxMode: request.params.config?.sandbox_mode,
+        webSearch: request.params.config?.web_search,
+        features: request.params.config?.features,
+      });
       send({
         id: request.id,
-        result: { thread: { id: "thread-" + account } },
+        result: { thread: { id: threadId } },
       });
       continue;
     }
     if (request.method === "turn/start") {
       const turnId = "turn-" + account;
       const prompt = request.params.input[0].text;
-      await recordAttempt("turn", prompt);
+      const materializedAuthChanged = await refreshMaterializedAuth();
+      await recordAttempt({
+        account,
+        command: "turn",
+        threadId: request.params.threadId,
+        promptSha256: createHash("sha256").update(prompt).digest("hex"),
+        model: request.params.model,
+        effort: request.params.effort,
+        approvalPolicy: request.params.approvalPolicy,
+        environments: request.params.environments,
+        outputSchema: request.params.outputSchema,
+        materializedAuthChanged,
+      });
       send({ id: request.id, result: { turn: { id: turnId } } });
       if (account === "account-a") {
         send({
@@ -343,7 +409,11 @@ if (command === "app-server") {
   }
 } else if (command === "exec") {
   const prompt = await readFile(0, "utf8");
-  await recordAttempt("exec", prompt);
+  await recordAttempt({
+    account,
+    command: "exec",
+    promptSha256: createHash("sha256").update(prompt).digest("hex"),
+  });
   if (account === "account-a") {
     process.stderr.write("You've hit your usage limit\\n");
     process.exit(1);
@@ -366,11 +436,25 @@ function send(message) {
   process.stdout.write(JSON.stringify(message) + "\\n");
 }
 
-async function recordAttempt(commandName, prompt) {
-  const promptSha256 = createHash("sha256").update(prompt).digest("hex");
+async function refreshMaterializedAuth() {
+  const before = await readFile(materializedAuthPath, "utf8");
+  const refreshed = {
+    ...auth,
+    last_refresh: new Date().toISOString(),
+    tokens: {
+      ...auth.tokens,
+      access_token: "sandbox-refreshed-access-" + account,
+    },
+  };
+  const after = JSON.stringify(refreshed) + "\\n";
+  await writeFile(materializedAuthPath, after, "utf8");
+  return before !== after;
+}
+
+async function recordAttempt(attempt) {
   await appendFile(
     ${JSON.stringify(attemptLogPath)},
-    JSON.stringify({ account, command: commandName, promptSha256 }) + "\\n",
+    JSON.stringify(attempt) + "\\n",
     "utf8",
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "social-monitor",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.1",
         "@google-cloud/bigquery": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "check:retention": "node scripts/check-retention.mjs",
     "check:retention-plan": "ts-node -r tsconfig-paths/register scripts/check-retention-plan.ts",
     "check:runtime-compose": "node scripts/check-runtime-compose.mjs",
+    "check:subscription-runtime-auth-pool-e2e": "node --test apps/agent-runtime/bin/*.test.mjs",
     "check:runtime-profile-guards": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=512 -- ts-node -r tsconfig-paths/register scripts/check-runtime-profile-guards.ts",
     "check:security-final-sweep": "node scripts/check-security-final-sweep.mjs",
     "check:staging-reliability-evidence": "node scripts/check-staging-reliability-evidence.mjs && node scripts/check-postgres-restore-evidence.mjs",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "check:retention": "node scripts/check-retention.mjs",
     "check:retention-plan": "ts-node -r tsconfig-paths/register scripts/check-retention-plan.ts",
     "check:runtime-compose": "node scripts/check-runtime-compose.mjs",
-    "check:subscription-runtime-auth-pool-e2e": "node --test apps/agent-runtime/bin/*.test.mjs",
+    "check:subscription-runtime-auth-pool-e2e": "node --test apps/agent-runtime/bin/codex-auth-pool-manifest.test.mjs apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.test.mjs",
     "check:runtime-profile-guards": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=512 -- ts-node -r tsconfig-paths/register scripts/check-runtime-profile-guards.ts",
     "check:security-final-sweep": "node scripts/check-security-final-sweep.mjs",
     "check:staging-reliability-evidence": "node scripts/check-staging-reliability-evidence.mjs && node scripts/check-postgres-restore-evidence.mjs",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Backend/API-first social monitoring MVP platform.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "check:agent-quality-rules": "node scripts/check-agent-quality-rules.mjs",

--- a/scripts/check-review-ci.mjs
+++ b/scripts/check-review-ci.mjs
@@ -5,7 +5,19 @@ const workflowPath = ".github/workflows/pull-request.yml";
 const workflow = readFileSync(workflowPath, "utf8");
 const productionWorkflowPath = ".github/workflows/production-deploy.yml";
 const productionWorkflow = readFileSync(productionWorkflowPath, "utf8");
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const violations = [];
+const subscriptionRuntimeAuthPoolE2eCommand =
+  "node --test apps/agent-runtime/bin/codex-auth-pool-manifest.test.mjs apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.test.mjs";
+
+if (
+  packageJson.scripts?.["check:subscription-runtime-auth-pool-e2e"] !==
+  subscriptionRuntimeAuthPoolE2eCommand
+) {
+  violations.push(
+    "package.json: subscription runtime auth-pool e2e must enumerate only the reviewed deterministic sandbox tests",
+  );
+}
 
 const findJob = (source, jobId) => source.match(
   new RegExp(

--- a/scripts/check-review-ci.mjs
+++ b/scripts/check-review-ci.mjs
@@ -35,6 +35,7 @@ const requiredFragments = [
   "npm run check:reader-summary-weekly-review-manifest-postgres18",
   "npm run check:container",
   "npm run check:runtime-compose",
+  "npm run check:subscription-runtime-auth-pool-e2e",
   "npm run check:production-deploy-lifecycle",
   "npm run test:e2e",
   "flutter test app",
@@ -98,6 +99,16 @@ if (
 ) {
   violations.push(
     `${productionWorkflowPath}: verify_reader_summary_publication must run the weekly review manifest PostgreSQL 18 contract`,
+  );
+}
+
+if (
+  !productionWorkflow.includes(
+    "npm run check:subscription-runtime-auth-pool-e2e",
+  )
+) {
+  violations.push(
+    `${productionWorkflowPath}: production deploy must run the sandbox subscription-runtime auth-pool e2e`,
   );
 }
 

--- a/scripts/check-runtime-compose.mjs
+++ b/scripts/check-runtime-compose.mjs
@@ -8,6 +8,14 @@ const codexAuthCompose = readFileSync(
   "docker-compose.agent-runtime-codex.yml",
   "utf8",
 ).replaceAll("\r\n", "\n");
+const productionAgentRuntimeCompose = readFileSync(
+  "ops/deploy/production-runtime/compose.agent-runtime-model.yml",
+  "utf8",
+).replaceAll("\r\n", "\n");
+const startAgentRuntime = readFileSync(
+  "scripts/start-agent-runtime.mjs",
+  "utf8",
+).replaceAll("\r\n", "\n");
 const envExample = readFileSync(".env.example", "utf8").replaceAll(
   "\r\n",
   "\n",
@@ -177,6 +185,31 @@ if (
   violations.push(
     "docker-compose.agent-runtime-codex.yml must not contain raw auth tokens",
   );
+}
+
+for (const marker of [
+  'AGENT_RUNTIME_CODEX_AUTH_JSON_PATH: ""',
+  'CODEX_AUTH_JSON_PATH: ""',
+  "AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT: /run/social-monitor-codex-auth-pool",
+  "AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST: /run/social-monitor-codex-auth-pool/current.json",
+  "/var/data/social-monitor/auth-pool:/run/social-monitor-codex-auth-pool:ro",
+]) {
+  if (!productionAgentRuntimeCompose.includes(marker)) {
+    violations.push(
+      `production agent-runtime overlay missing marker "${marker}"`,
+    );
+  }
+}
+
+for (const marker of [
+  '"AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT"',
+  '"AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST"',
+  "env.AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT === undefined",
+  "env.AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST === undefined",
+]) {
+  if (!startAgentRuntime.includes(marker)) {
+    violations.push(`start-agent-runtime missing auth-pool marker "${marker}"`);
+  }
 }
 
 if (violations.length > 0) {

--- a/scripts/start-agent-runtime.mjs
+++ b/scripts/start-agent-runtime.mjs
@@ -19,6 +19,8 @@ const allowedEnvKeys = [
   "SUBSCRIPTION_RUNTIME_LOCAL_ENCRYPTION_KEY_FILE",
   "AGENT_RUNTIME_CODEX_AUTH_JSON_PATH",
   "CODEX_AUTH_JSON_PATH",
+  "AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT",
+  "AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST",
   "AGENT_RUNTIME_CLAUDE_TOKEN_ENV",
   "AGENT_RUNTIME_MODEL",
   "AGENT_RUNTIME_REASONING_EFFORT",
@@ -36,6 +38,8 @@ const defaultCodexAuthPath = join(homedir(), ".codex", "auth.json");
 if (
   env.AGENT_RUNTIME_CODEX_AUTH_JSON_PATH === undefined &&
   env.CODEX_AUTH_JSON_PATH === undefined &&
+  env.AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT === undefined &&
+  env.AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST === undefined &&
   existsSync(defaultCodexAuthPath)
 ) {
   env.AGENT_RUNTIME_CODEX_AUTH_JSON_PATH = defaultCodexAuthPath;


### PR DESCRIPTION
## Summary

- Add a deterministic subprocess E2E for the native subscription-runtime Codex auth pool.
- Prove immutable manifest loading, quota failover from account-a to account-b, exact prompt reuse and read-only auth snapshots.
- Wire the gate into pull request and production deploy validation.
- Pass auth-pool configuration through the local runtime launcher without falling back to host auth.
- Replace the MIT license with Apache License 2.0 and add NOTICE.

## Safety

- Uses a temporary sandbox project, fake auth snapshots and a fake Codex app-server.
- Does not read host Codex auth.
- Does not launch a real agent task or touch a real user project.

## Verification

- npm run check:subscription-runtime-auth-pool-e2e - 10 passed
- targeted agent-runtime Jest suites - 21 passed
- npm run check:runtime-compose
- npm run check:runtime-profile-guards
- npm run check:review-ci
- npm run check:container
- npm run check:source-line-cap
- npm run check:dependencies
- npm run check:secrets
- git diff --check

Repository-wide pinned TypeScript typecheck still reports existing errors in unrelated weekly-summary and social-collection test files. No changed TypeScript file is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex subscription authentication-pool support with configurable pool and manifest settings.
  * Added automatic failover between authentication accounts when usage limits are reached.
  * Preserved read-only authentication files during runtime operations.

* **Documentation**
  * Documented authentication-pool configuration, fallback behavior, local startup, and validation procedures.
  * Updated project licensing information to Apache License 2.0 and added required notices.

* **Quality Improvements**
  * Added automated end-to-end validation for authentication-pool failover in pull-request and production checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->