### PR TITLE
feat(summaries): add web find-in-page search

### DIFF
--- a/apps/frontend/features/summaries/lib/src/presentation/pages/published_summary_page.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/pages/published_summary_page.dart
@@ -28,7 +28,7 @@ class _PublishedSummaryPageState extends State<PublishedSummaryPage> {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
+    final page = AnimatedBuilder(
       animation: widget.store,
       builder: (context, _) {
         final state = widget.store.state;
@@ -83,6 +83,7 @@ class _PublishedSummaryPageState extends State<PublishedSummaryPage> {
         );
       },
     );
+    return AppWebFindInPage(child: page);
   }
 }
 

--- a/apps/frontend/features/summaries/lib/src/presentation/pages/summaries_feature_page.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/pages/summaries_feature_page.dart
@@ -39,7 +39,7 @@ class _SummariesFeaturePageState extends State<SummariesFeaturePage> {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
+    final page = AnimatedBuilder(
       animation: widget.store,
       builder: (context, child) {
         return MediaQuery.removePadding(
@@ -52,6 +52,7 @@ class _SummariesFeaturePageState extends State<SummariesFeaturePage> {
         );
       },
     );
+    return AppWebFindInPage(child: page);
   }
 }
 

--- a/apps/frontend/features/summaries/test/presentation/pages/published_summary_page_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/published_summary_page_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:social_monitor_design_system/social_monitor_design_system.dart';
 import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
@@ -49,6 +51,18 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.byType(AppWebFindInPage), findsOneWidget);
+    if (kIsWeb) {
+      await _sendFindShortcut(tester);
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'GitHub daily radar');
+      await tester.pump();
+
+      expect(find.text('1/1'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+    }
     expect(
       find.byKey(const ValueKey('published-reader-summary-view')),
       findsOneWidget,
@@ -80,6 +94,17 @@ void main() {
       findsNothing,
     );
   });
+}
+
+Future<void> _sendFindShortcut(WidgetTester tester) async {
+  final modifier =
+      defaultTargetPlatform == TargetPlatform.macOS ||
+          defaultTargetPlatform == TargetPlatform.iOS
+      ? LogicalKeyboardKey.metaLeft
+      : LogicalKeyboardKey.controlLeft;
+  await tester.sendKeyDownEvent(modifier);
+  await tester.sendKeyEvent(LogicalKeyboardKey.keyF);
+  await tester.sendKeyUpEvent(modifier);
 }
 
 final class _SourceLauncher implements ReaderSourceLauncher {

--- a/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_layout_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_layout_test.dart
@@ -35,6 +35,7 @@ void main() {
     await _pumpSizedFeature(tester, store: store);
     await tester.pumpAndSettle();
 
+    expect(find.byType(AppWebFindInPage), findsOneWidget);
     final header = find.byKey(const ValueKey('workspace-summary-header-band'));
 
     expect(header, findsOneWidget);

--- a/apps/frontend/packages/design_system/lib/social_monitor_design_system.dart
+++ b/apps/frontend/packages/design_system/lib/social_monitor_design_system.dart
@@ -17,6 +17,7 @@ export 'src/components/app_provider_logo.dart';
 export 'src/components/app_responsive_split_view.dart';
 export 'src/components/app_section_header.dart';
 export 'src/components/app_status_badge.dart';
+export 'src/components/app_web_find_in_page.dart';
 export 'src/components/app_workspace_switcher.dart';
 export 'src/responsive/app_breakpoints.dart';
 export 'src/theme/app_theme.dart';

--- a/apps/frontend/packages/design_system/lib/src/components/app_web_find_in_page.dart
+++ b/apps/frontend/packages/design_system/lib/src/components/app_web_find_in_page.dart
@@ -1,0 +1,21 @@
+import 'package:find_in_page/find_in_page.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// Adds browser-style find-in-page behavior to a Flutter web subtree.
+///
+/// Other platforms receive [child] unchanged so their native find and
+/// keyboard behavior is not affected.
+final class AppWebFindInPage extends StatelessWidget {
+  const AppWebFindInPage({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kIsWeb) {
+      return child;
+    }
+    return FindInPageScope(child: child);
+  }
+}

--- a/apps/frontend/packages/design_system/pubspec.yaml
+++ b/apps/frontend/packages/design_system/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.11.5
 
 dependencies:
+  find_in_page: 2.2.3
   flutter:
     sdk: flutter
   flutter_svg: ^2.3.0

--- a/apps/frontend/packages/design_system/test/app_web_find_in_page_test.dart
+++ b/apps/frontend/packages/design_system/test/app_web_find_in_page_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_monitor_design_system/social_monitor_design_system.dart';
+
+void main() {
+  testWidgets('enables browser-style find only on web', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AppWebFindInPage(
+          child: Scaffold(body: Text('Release notes Needle')),
+        ),
+      ),
+    );
+
+    expect(find.text('Release notes Needle'), findsOneWidget);
+
+    await _sendFindShortcut(tester);
+    await tester.pumpAndSettle();
+
+    if (!kIsWeb) {
+      expect(find.byType(TextField), findsNothing);
+      return;
+    }
+
+    expect(find.byType(TextField), findsOneWidget);
+    await tester.enterText(find.byType(TextField), 'Needle');
+    await tester.pump();
+
+    expect(find.text('1/1'), findsOneWidget);
+  });
+}
+
+Future<void> _sendFindShortcut(WidgetTester tester) async {
+  final modifier =
+      defaultTargetPlatform == TargetPlatform.macOS ||
+          defaultTargetPlatform == TargetPlatform.iOS
+      ? LogicalKeyboardKey.metaLeft
+      : LogicalKeyboardKey.controlLeft;
+  await tester.sendKeyDownEvent(modifier);
+  await tester.sendKeyEvent(LogicalKeyboardKey.keyF);
+  await tester.sendKeyUpEvent(modifier);
+}

--- a/apps/frontend/pubspec.lock
+++ b/apps/frontend/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  find_in_page:
+    dependency: transitive
+    description:
+      name: find_in_page
+      sha256: "6ff9118347ed2fcc66aa2ea0c7c917a26bda21e88e4636514fc756615847e9a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   fixnum:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- pin find_in_page 2.2.3 behind the design-system AppWebFindInPage boundary
- enable browser-style Cmd/Ctrl+F search on authenticated and published Summary pages
- keep non-web behavior unchanged through the kIsWeb guard

## Verification

- Flutter 3.41.9 / Dart 3.11.5 analyze: passed
- Summary feature suite: 222 tests passed
- design-system suite: 14 tests passed
- Chrome widget tests: Cmd/Ctrl+F opens the bar and finds Summary text
- app suite: 44 tests passed
- architecture boundary suite: 21 tests passed
- shared-kernel suite: 16 tests passed
- generated-api suite: 13 tests passed
- dependency contract and source line-cap checks: passed

## Notes

- The package searches rendered Flutter text automatically. Rows that a lazy sliver has never built remain subject to the package's documented lazy-list limitation.
- npm audit --audit-level=moderate still reports the repository's existing 9 npm vulnerabilities. This PR does not change npm dependencies or package-lock.json.
