### PR TITLE
fix(ops): recover scheduled collection via containerd

### DIFF
--- a/ops/deploy/production-runtime/rolling-containerd-fallback.sh
+++ b/ops/deploy/production-runtime/rolling-containerd-fallback.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+ROOT=${SOCIAL_MONITOR_ROOT:-/var/data/social-monitor}
+CTR=${SOCIAL_MONITOR_CTR_COMMAND:-ctr}
+DOCKER=${SOCIAL_MONITOR_DOCKER_COMMAND:-docker}
+SYSTEMCTL=${SOCIAL_MONITOR_SYSTEMCTL_COMMAND:-systemctl}
+X_TASK_ID=social-monitor-x-host-fallback
+
+# The normal systemd timer remains authoritative whenever its manager answers.
+# This makes the cron fallback self-disabling after a host recovery or reboot.
+if timeout 5 "$SYSTEMCTL" show --property=ActiveState --value \
+  social-monitor-rolling.timer 2>/dev/null | grep -Fx active >/dev/null; then
+  exit 0
+fi
+
+x_task_running() {
+  "$CTR" -n moby tasks ls 2>/dev/null |
+    awk -v id="$X_TASK_ID" '$1 == id && $3 == "RUNNING" { found = 1 } END { exit !found }'
+}
+
+start_host_network_x_collector() {
+  local runtime_env
+  runtime_env=$(mktemp "$ROOT/runtime/x-host-fallback-env.XXXXXX")
+  cleanup_x_env() {
+    rm -f -- "$runtime_env"
+  }
+  trap cleanup_x_env RETURN
+  chmod 0600 "$runtime_env"
+
+  if "$CTR" -n moby tasks ls 2>/dev/null | awk -v id="$X_TASK_ID" \
+    '$1 == id { found = 1 } END { exit !found }'; then
+    "$CTR" -n moby tasks rm -f "$X_TASK_ID"
+  fi
+  if "$CTR" -n moby containers info "$X_TASK_ID" >/dev/null 2>&1; then
+    "$CTR" -n moby containers rm "$X_TASK_ID"
+  fi
+
+  "$DOCKER" inspect social-monitor-prod-x-collector-1 |
+    jq -r '.[0].Config.Env[]' |
+    grep -v '^X_COLLECTOR_GRPC_BIND=' > "$runtime_env"
+  printf '%s\n' 'X_COLLECTOR_GRPC_BIND=0.0.0.0:50051' >> "$runtime_env"
+
+  "$CTR" -n moby run -d --null-io --net-host --user 1000:1000 \
+    --cwd /app/apps/x-collector \
+    --env-file "$runtime_env" \
+    --mount type=bind,src="$ROOT/runtime/x-collector",dst=/var/lib/social-monitor-x,options=rbind:rw \
+    --mount type=bind,src="$ROOT/secrets/x-collector",dst=/run/social-monitor-x,options=rbind:ro \
+    --label social-monitor.project=social-monitor \
+    --label social-monitor.purpose=x-collector-host-network-fallback \
+    docker.io/library/social-monitor-prod-x-collector:latest "$X_TASK_ID"
+}
+
+if ! x_task_running; then
+  start_host_network_x_collector
+fi
+
+for _ in {1..15}; do
+  if x_task_running && ss -lnt | grep -Eq ':50051\b'; then
+    break
+  fi
+  sleep 1
+done
+if ! x_task_running || ! ss -lnt | grep -Eq ':50051\b'; then
+  echo 'rolling fallback could not start the host-network X collector' >&2
+  exit 75
+fi
+
+export SOCIAL_MONITOR_ROLLING_RUNTIME=containerd
+export SOCIAL_MONITOR_ROLLING_X_ADDRESS=127.0.0.1:50051
+exec "$ROOT/control/rolling-run.sh"

--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -10,20 +10,32 @@ if [[ ${SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE:-} == 1 ]]; then
     exit 64
   }
   DOCKER_COMMAND=${SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER:?test docker command is required}
+  CTR_COMMAND=${SOCIAL_MONITOR_ROLLING_RUN_TEST_CTR:-ctr}
   FLOCK_COMMAND=${SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK:-flock}
   NOW=${SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW:-2026-08-15T08:15:00.000Z}
 else
   ROOT=/var/data/social-monitor
   DOCKER_COMMAND=docker
+  CTR_COMMAND=ctr
   FLOCK_COMMAND=flock
   NOW=
   unset SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE \
     SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT \
     SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER \
+    SOCIAL_MONITOR_ROLLING_RUN_TEST_CTR \
     SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK \
     SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW
 fi
 unset DATABASE_URL
+
+ROLLING_RUNTIME=${SOCIAL_MONITOR_ROLLING_RUNTIME:-docker}
+case "$ROLLING_RUNTIME" in
+  docker | containerd) ;;
+  *)
+    echo "unsupported rolling runtime: $ROLLING_RUNTIME" >&2
+    exit 64
+    ;;
+esac
 
 COMPOSE=(
   "$DOCKER_COMMAND" compose -p social-monitor-prod
@@ -69,11 +81,20 @@ if "$ROOT/control/refresh-codex-auth.sh"; then
     fi
     install -d -m 0700 -o 1000 -g 1000 \
       "$ROOT/runtime/subscription-runtime/sessions"
-    "${COMPOSE[@]}" restart agent-runtime
-    rm -f "$ROOT/runtime/auth-account-changed"
-    sleep 3
+    if [[ $ROLLING_RUNTIME == docker ]]; then
+      "${COMPOSE[@]}" restart agent-runtime
+      rm -f "$ROOT/runtime/auth-account-changed"
+      sleep 3
+    else
+      # The host-network fallback cannot safely restart a Docker-managed
+      # runtime while the Docker task API is unavailable. Collection remains
+      # available, while publication waits for the normal runtime to recover.
+      auth_ready=false
+    fi
   fi
-  "${COMPOSE[@]}" --profile app up -d --no-deps agent-runtime
+  if [[ $ROLLING_RUNTIME == docker ]]; then
+    "${COMPOSE[@]}" --profile app up -d --no-deps agent-runtime
+  fi
 fi
 
 collection_date=${NOW:0:10}
@@ -90,15 +111,9 @@ fi
 export SOCIAL_MONITOR_ROLLING_RUN_ID=$run_id
 export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
 
-# The quoted body expands only inside the daily runner container.
+# The quoted heredoc expands only inside the daily runner container.
 # shellcheck disable=SC2016
-"${COMPOSE[@]}" --profile daily run --rm --no-deps \
-  -e "ROLLING_RUN_ID=$run_id" \
-  -e "ROLLING_COLLECTION_DATE=$collection_date" \
-  -e "ROLLING_PERIOD_ENDED_AT=$NOW" \
-  -e "ROLLING_RECEIPT_PATH=$receipt_container_path" \
-  -e "ROLLING_AUTH_READY=$auth_ready" \
-  daily-runner sh -lc '
+container_body=$(cat <<'ROLLING_CONTAINER_BODY'
     set -eu
 
     artifact_root=/var/lib/social-monitor/artifacts/rolling-summary
@@ -132,7 +147,7 @@ export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
     export DURABLE_READER_SUMMARY_WORKSPACE_ID=00000000-0000-7000-8000-000000006102
     export DURABLE_READER_SUMMARY_CADENCE=daily
     export DURABLE_READER_SUMMARY_PERIOD_STARTED_AT="$period_started_at"
-    export DURABLE_READER_SUMMARY_PERIOD_ENDED_AT="$(node -e '\''const day = new Date(`${process.argv[1]}T00:00:00.000Z`); day.setUTCDate(day.getUTCDate() + 1); process.stdout.write(day.toISOString());'\'' "$ROLLING_COLLECTION_DATE")"
+    export DURABLE_READER_SUMMARY_PERIOD_ENDED_AT="$(node -e 'const day = new Date(`${process.argv[1]}T00:00:00.000Z`); day.setUTCDate(day.getUTCDate() + 1); process.stdout.write(day.toISOString());' "$ROLLING_COLLECTION_DATE")"
     export DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF="$rolling_observation_cutoff"
     export DURABLE_READER_SUMMARY_MODEL=agent-runtime
     # Keep rolling publication available when one provider is partial. The
@@ -147,7 +162,77 @@ export SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH=$receipt_host_path
       write-receipt "$ROLLING_RECEIPT_PATH" "$evidence_path" "$collection_artifact" \
       "$ROLLING_RUN_ID" "$ROLLING_COLLECTION_DATE" "$rolling_observation_cutoff" \
       "$collection_exit"
-  '
+ROLLING_CONTAINER_BODY
+)
+
+if [[ $ROLLING_RUNTIME == docker ]]; then
+  "${COMPOSE[@]}" --profile daily run --rm --no-deps \
+    -e "ROLLING_RUN_ID=$run_id" \
+    -e "ROLLING_COLLECTION_DATE=$collection_date" \
+    -e "ROLLING_PERIOD_ENDED_AT=$NOW" \
+    -e "ROLLING_RECEIPT_PATH=$receipt_container_path" \
+    -e "ROLLING_AUTH_READY=$auth_ready" \
+    daily-runner sh -lc "$container_body"
+else
+  runtime_env=$(mktemp "$ROOT/runtime/rolling-containerd-env.XXXXXX")
+  rendered_env=$(mktemp "$ROOT/runtime/rolling-containerd-rendered-env.XXXXXX")
+  cleanup_containerd_env() {
+    rm -f -- "$runtime_env" "$rendered_env"
+  }
+  trap cleanup_containerd_env EXIT
+  chmod 0600 "$runtime_env" "$rendered_env"
+
+  "${COMPOSE[@]}" --profile app --profile daily config --format json |
+    jq -r '.services["daily-runner"].environment | to_entries[] | "\(.key)=\(.value)"' > "$rendered_env"
+
+  agent_ip=${SOCIAL_MONITOR_ROLLING_AGENT_RUNTIME_IP:-$(
+    "$DOCKER_COMMAND" inspect --format \
+      '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+      social-monitor-prod-agent-runtime-1
+  )}
+  redis_ip=${SOCIAL_MONITOR_ROLLING_REDIS_IP:-$(
+    "$DOCKER_COMMAND" inspect --format \
+      '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+      social-monitor-prod-redis-1
+  )}
+  rabbitmq_ip=${SOCIAL_MONITOR_ROLLING_RABBITMQ_IP:-$(
+    "$DOCKER_COMMAND" inspect --format \
+      '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+      social-monitor-prod-rabbitmq-1
+  )}
+  x_address=${SOCIAL_MONITOR_ROLLING_X_ADDRESS:-127.0.0.1:50051}
+  [[ $agent_ip =~ ^[0-9.]+$ && $redis_ip =~ ^[0-9.]+$ &&
+    $rabbitmq_ip =~ ^[0-9.]+$ && $x_address =~ ^[A-Za-z0-9.:-]+$ ]] || {
+    echo 'rolling containerd fallback resolved an invalid service address' >&2
+    exit 75
+  }
+
+  while IFS='=' read -r key value; do
+    case "$key" in
+      AGENT_RUNTIME_GRPC_ADDRESS) value="$agent_ip:50052" ;;
+      X_COLLECTOR_GRPC_ADDRESS) value=$x_address ;;
+      REDIS_URL) value=${value//redis:6379/$redis_ip:6379} ;;
+      RABBITMQ_URL)
+        value=${value/rabbitmq:/$rabbitmq_ip:}
+        ;;
+    esac
+    printf '%s=%s\n' "$key" "$value" >> "$runtime_env"
+  done < "$rendered_env"
+
+  "$CTR_COMMAND" -n moby run --rm --net-host \
+    --env-file "$runtime_env" \
+    --env "ROLLING_RUN_ID=$run_id" \
+    --env "ROLLING_COLLECTION_DATE=$collection_date" \
+    --env "ROLLING_PERIOD_ENDED_AT=$NOW" \
+    --env "ROLLING_RECEIPT_PATH=$receipt_container_path" \
+    --env "ROLLING_AUTH_READY=$auth_ready" \
+    --mount type=bind,src="$ROOT/artifacts",dst=/var/lib/social-monitor/artifacts,options=rbind:rw \
+    --mount type=bind,src="$ROOT/artifacts/evals",dst=/app/ops/evals,options=rbind:rw \
+    --mount type=bind,src="$ROOT/runtime/x-collector",dst=/app/apps/x-collector/var/x-collector,options=rbind:rw \
+    --mount type=bind,src="$ROOT/secrets/db/ca-certificate.crt",dst=/run/social-monitor-db/ca-certificate.crt,options=rbind:ro \
+    docker.io/library/social-monitor-prod-daily-runner:latest \
+    "social-monitor-rolling-$run_id" sh -lc "$container_body"
+fi
 
 node "$ROOT/integration/ops/deploy/production-runtime/rolling-summary-receipt.mjs" \
   validate-receipt "$receipt_host_path" "$run_id" "$collection_date"

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -9,16 +9,20 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 mkdir -p \
   "$TEST_ROOT/control/postgres-runtime-current" \
   "$TEST_ROOT/control/deploy-state" \
+  "$TEST_ROOT/runtime/x-collector" \
   "$TEST_ROOT/secrets" \
+  "$TEST_ROOT/secrets/db" \
   "$TEST_ROOT/artifacts/rolling-summary"
 sha=1111111111111111111111111111111111111111
 printf '%s\n' "$sha" > "$TEST_ROOT/control/postgres-runtime-current/READY"
 printf '%s\n' "$sha" > "$TEST_ROOT/control/deploy-state/backend.sha"
 touch "$TEST_ROOT/secrets/production.env"
+touch "$TEST_ROOT/secrets/db/ca-certificate.crt"
 ln -s "$REPO" "$TEST_ROOT/integration"
 
 fake_flock=/usr/bin/true
 fake_docker=$REPO/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
+fake_ctr=$REPO/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
 refresh=$TEST_ROOT/control/refresh-codex-auth.sh
 ln -s /usr/bin/true "$refresh"
 export SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG=$TEST_ROOT/docker.log
@@ -75,5 +79,31 @@ ROLLING_AUTH_READY=false sh -ec \
 auth_guard_status=$?
 set -e
 ((auth_guard_status == 75))
+
+ln -sfn /usr/bin/true "$refresh"
+SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_CTR=$fake_ctr \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T16:15:00.000Z \
+SOCIAL_MONITOR_ROLLING_RUNTIME=containerd \
+  bash "$RUNNER"
+grep -F -- '-n moby run --rm --net-host' "$TEST_ROOT/docker.log" >/dev/null
+grep -F -- '--env ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
+grep -F -- '--env ROLLING_AUTH_READY=true' "$TEST_ROOT/docker.log" >/dev/null
+grep -F -- 'docker.io/library/social-monitor-prod-daily-runner:latest' \
+  "$TEST_ROOT/docker.log" >/dev/null
+grep -Fx 'AGENT_RUNTIME_GRPC_ADDRESS=172.19.0.6:50052' \
+  "$TEST_ROOT/docker.log" >/dev/null
+grep -Fx 'X_COLLECTOR_GRPC_ADDRESS=127.0.0.1:50051' \
+  "$TEST_ROOT/docker.log" >/dev/null
+grep -Fx 'REDIS_URL=redis://172.19.0.3:6379' "$TEST_ROOT/docker.log" >/dev/null
+grep -Fx 'RABBITMQ_URL=amqp://user:password@172.19.0.2:5672' \
+  "$TEST_ROOT/docker.log" >/dev/null
+if compgen -G "$TEST_ROOT/runtime/rolling-containerd-*-env.*" >/dev/null; then
+  echo 'rolling containerd secret environment was not cleaned up' >&2
+  exit 1
+fi
 
 echo 'rolling-run tests passed'

--- a/ops/deploy/production-runtime/social-monitor-rolling-fallback.cron
+++ b/ops/deploy/production-runtime/social-monitor-rolling-fallback.cron
@@ -1,0 +1,4 @@
+SHELL=/bin/bash
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
+15 4,8,12,16,20 * * * root timeout 7500 /var/data/social-monitor/control/rolling-containerd-fallback.sh >> /var/data/social-monitor/artifacts/rolling-summary/cron-fallback.log 2>&1

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG:?test log is required}"
+args=("$@")
+for ((index = 0; index < ${#args[@]}; index += 1)); do
+  if [[ ${args[$index]} == --env-file ]]; then
+    grep -E '^(AGENT_RUNTIME_GRPC_ADDRESS|X_COLLECTOR_GRPC_ADDRESS|REDIS_URL|RABBITMQ_URL)=' \
+      "${args[$((index + 1))]}" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+  fi
+done
+[[ $* != *'--env ROLLING_AUTH_READY=false'* ]] || exit 75
+printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS","publication":{"readerSummaryJobId":"test-job","readerSummaryId":"test-summary","status":"completed"}}\n' \
+  "$SOCIAL_MONITOR_ROLLING_RUN_ID" > \
+  "$SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH"

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
@@ -2,6 +2,26 @@
 set -euo pipefail
 
 printf '%s\n' "$*" >> "${SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG:?test log is required}"
+if [[ $1 == inspect ]]; then
+  case "${*: -1}" in
+    social-monitor-prod-agent-runtime-1) printf '%s\n' 172.19.0.6 ;;
+    social-monitor-prod-redis-1) printf '%s\n' 172.19.0.3 ;;
+    social-monitor-prod-rabbitmq-1) printf '%s\n' 172.19.0.2 ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+if [[ $* == *' config --format json'* ]]; then
+  printf '%s\n' \
+    '{"services":{"daily-runner":{"environment":{' \
+    '"AGENT_RUNTIME_GRPC_ADDRESS":"agent-runtime:50052",' \
+    '"X_COLLECTOR_GRPC_ADDRESS":"x-collector:50051",' \
+    '"REDIS_URL":"redis://redis:6379",' \
+    '"RABBITMQ_URL":"amqp://user:password@rabbitmq:5672",' \
+    '"DATABASE_URL":"postgres://example"' \
+    '}}}}'
+  exit 0
+fi
 if [[ $* == *' daily-runner sh -lc '* ]]; then
   [[ $* != *'-e ROLLING_AUTH_READY=false'* ]] || exit 75
   printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS","publication":{"readerSummaryJobId":"test-job","readerSummaryId":"test-summary","status":"completed"}}\n' \


### PR DESCRIPTION
## What changed

- add a containerd host-network fallback for rolling collection when systemd and Docker task creation are unavailable
- keep the normal systemd timer authoritative after host recovery
- run X collection through the working host network and preserve the existing collection-to-summary pipeline
- add focused coverage for Docker and containerd execution

## Evidence

- rolling-run shell test passes for Docker, unavailable-auth, and containerd paths
- rolling receipt contract test passes
- source line cap passes
- production X recovery collected 54 new unique posts after the broken bridge returned zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a containerd-based fallback for production rolling deployments.
  * Added configurable Docker or containerd runtime support.
  * Added scheduled fallback execution every four hours.
  * Added runtime checks, service readiness validation, authentication handling, and cleanup of temporary secrets.

* **Bug Fixes**
  * Improved recovery from stale container state and unavailable rolling authentication.

* **Tests**
  * Added coverage for containerd execution, service configuration, environment handling, and secret cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->