### PR TITLE
fix(ops): keep rolling summary live without systemd

### DIFF
--- a/ops/deploy/deploy-control-lib.test.sh
+++ b/ops/deploy/deploy-control-lib.test.sh
@@ -159,6 +159,8 @@ for unit in \
 done
 install -m 0755 "$source_runtime/daily-run.sh" "$CONTROL/daily-run.sh"
 install -m 0755 "$source_runtime/rolling-run.sh" "$CONTROL/rolling-run.sh"
+install -m 0755 "$source_runtime/rolling-containerd-fallback.sh" \
+  "$CONTROL/rolling-containerd-fallback.sh"
 
 # Equal activation states do not turn a marker-diff-free classification into a
 # runtime-control deployment. An existing positive classification is retained.

--- a/ops/deploy/postgres-runtime-deploy-lib.sh
+++ b/ops/deploy/postgres-runtime-deploy-lib.sh
@@ -128,10 +128,13 @@ postgres_runtime_control_units_for_scope() {
 
 postgres_runtime_control_launchers_for_scope() {
   case $1 in
-    base) printf '%s\n' daily-run.sh rolling-run.sh ;;
+    base)
+      printf '%s\n' daily-run.sh rolling-run.sh rolling-containerd-fallback.sh
+      ;;
     capture-only) printf '%s\n' github-premidnight-capture-v1.sh ;;
     full)
-      printf '%s\n' daily-run.sh github-premidnight-capture-v1.sh rolling-run.sh
+      printf '%s\n' daily-run.sh github-premidnight-capture-v1.sh rolling-run.sh \
+        rolling-containerd-fallback.sh
       ;;
     *)
       fail 'PostgreSQL runtime-control launcher scope is invalid'

--- a/ops/deploy/postgres-runtime-deploy-lib.test.sh
+++ b/ops/deploy/postgres-runtime-deploy-lib.test.sh
@@ -375,7 +375,7 @@ for unit in "${capture_units[@]}"; do
   [[ ! -e $SYSTEMD_UNIT_DIR/$unit ]]
 done
 [[ ! -e $CONTROL/github-premidnight-capture-v1.sh ]]
-[[ $(find "$bridge_release" -mindepth 1 -maxdepth 1 | wc -l) == 15 ]]
+[[ $(find "$bridge_release" -mindepth 1 -maxdepth 1 | wc -l) == 16 ]]
 [[ $(stat -c '%a' "$bridge_release/$readiness_name") == 644 ]]
 cmp -s "$readiness_source" "$bridge_release/$readiness_name"
 cmp -s "$bridge_release/$readiness_name" \

--- a/ops/deploy/postgres-runtime-deploy-lib.test.sh
+++ b/ops/deploy/postgres-runtime-deploy-lib.test.sh
@@ -438,7 +438,7 @@ printf 'enable-now-v1\n' > \
 [[ $(readlink -f "$POSTGRES_RUNTIME_CURRENT") == "$release" ]]
 [[ $(cat "$release/READY") == "$SHA" ]]
 [[ $(cat "$release/SOURCE_SHA") == "$SHA" ]]
-[[ $(find "$release" -mindepth 1 -maxdepth 1 | wc -l) == 19 ]]
+[[ $(find "$release" -mindepth 1 -maxdepth 1 | wc -l) == 20 ]]
 [[ $(stat -c '%a' "$release/$readiness_name") == 644 ]]
 cmp -s "$readiness_source" "$release/$readiness_name"
 cmp -s "$release/$readiness_name" \
@@ -457,6 +457,8 @@ grep -Fx 'Unit=social-monitor-daily.service' \
 [[ ${COMPOSE[-1]} == "$POSTGRES_RUNTIME_CURRENT/compose.postgres-runtime.yml" ]]
 cmp -s "$release/daily-run.sh" "$CONTROL/daily-run.sh"
 cmp -s "$release/rolling-run.sh" "$CONTROL/rolling-run.sh"
+cmp -s "$release/rolling-containerd-fallback.sh" \
+  "$CONTROL/rolling-containerd-fallback.sh"
 cmp -s "$release/github-premidnight-capture-v1.sh" \
   "$CONTROL/github-premidnight-capture-v1.sh"
 for unit in "${units[@]}"; do

--- a/ops/deploy/production-runtime/rolling-containerd-fallback.sh
+++ b/ops/deploy/production-runtime/rolling-containerd-fallback.sh
@@ -7,35 +7,48 @@ CTR=${SOCIAL_MONITOR_CTR_COMMAND:-ctr}
 DOCKER=${SOCIAL_MONITOR_DOCKER_COMMAND:-docker}
 SYSTEMCTL=${SOCIAL_MONITOR_SYSTEMCTL_COMMAND:-systemctl}
 X_TASK_ID=social-monitor-x-host-fallback
+AGENT_TASK_ID=social-monitor-agent-runtime-host-fallback
+MODE=${1:-run}
+
+case "$MODE" in
+  run | --agent-runtime-only | --restart-agent-runtime) ;;
+  *)
+    echo "unsupported rolling fallback mode: $MODE" >&2
+    exit 64
+    ;;
+esac
 
 # The normal systemd timer remains authoritative whenever its manager answers.
 # This makes the cron fallback self-disabling after a host recovery or reboot.
-if timeout 5 "$SYSTEMCTL" show --property=ActiveState --value \
+if [[ $MODE == run ]] && timeout 5 "$SYSTEMCTL" show --property=ActiveState --value \
   social-monitor-rolling.timer 2>/dev/null | grep -Fx active >/dev/null; then
   exit 0
 fi
 
-x_task_running() {
+task_running() {
+  local task_id=$1
   "$CTR" -n moby tasks ls 2>/dev/null |
-    awk -v id="$X_TASK_ID" '$1 == id && $3 == "RUNNING" { found = 1 } END { exit !found }'
+    awk -v id="$task_id" '$1 == id && $3 == "RUNNING" { found = 1 } END { exit !found }'
 }
 
-start_host_network_x_collector() {
+remove_task() {
+  local task_id=$1
+  if "$CTR" -n moby tasks ls 2>/dev/null | awk -v id="$task_id" \
+    '$1 == id { found = 1 } END { exit !found }'; then
+    "$CTR" -n moby tasks rm -f "$task_id"
+  fi
+  if "$CTR" -n moby containers info "$task_id" >/dev/null 2>&1; then
+    "$CTR" -n moby containers rm "$task_id"
+  fi
+}
+
+start_host_network_x_collector() (
   local runtime_env
   runtime_env=$(mktemp "$ROOT/runtime/x-host-fallback-env.XXXXXX")
-  cleanup_x_env() {
-    rm -f -- "$runtime_env"
-  }
-  trap cleanup_x_env RETURN
+  trap 'rm -f -- "$runtime_env"' EXIT
   chmod 0600 "$runtime_env"
 
-  if "$CTR" -n moby tasks ls 2>/dev/null | awk -v id="$X_TASK_ID" \
-    '$1 == id { found = 1 } END { exit !found }'; then
-    "$CTR" -n moby tasks rm -f "$X_TASK_ID"
-  fi
-  if "$CTR" -n moby containers info "$X_TASK_ID" >/dev/null 2>&1; then
-    "$CTR" -n moby containers rm "$X_TASK_ID"
-  fi
+  remove_task "$X_TASK_ID"
 
   "$DOCKER" inspect social-monitor-prod-x-collector-1 |
     jq -r '.[0].Config.Env[]' |
@@ -50,23 +63,64 @@ start_host_network_x_collector() {
     --label social-monitor.project=social-monitor \
     --label social-monitor.purpose=x-collector-host-network-fallback \
     docker.io/library/social-monitor-prod-x-collector:latest "$X_TASK_ID"
-}
+)
 
-if ! x_task_running; then
+start_host_network_agent_runtime() (
+  local runtime_env
+  runtime_env=$(mktemp "$ROOT/runtime/agent-host-fallback-env.XXXXXX")
+  trap 'rm -f -- "$runtime_env"' EXIT
+  chmod 0600 "$runtime_env"
+
+  remove_task "$AGENT_TASK_ID"
+  "$DOCKER" inspect social-monitor-prod-agent-runtime-1 |
+    jq -r '.[0].Config.Env[]' |
+    grep -v '^AGENT_RUNTIME_GRPC_BIND=' > "$runtime_env"
+  printf '%s\n' 'AGENT_RUNTIME_GRPC_BIND=0.0.0.0:50052' >> "$runtime_env"
+
+  "$CTR" -n moby run -d --null-io --net-host --user 1000:1000 \
+    --cwd /app \
+    --env-file "$runtime_env" \
+    --mount type=bind,src="$ROOT/runtime/subscription-runtime",dst=/var/lib/subscription-runtime,options=rbind:rw \
+    --mount type=bind,src="$ROOT/auth-current",dst=/run/social-monitor-codex-auth,options=rbind:ro \
+    --mount type=bind,src="$ROOT/secrets/db/ca-certificate.crt",dst=/run/social-monitor-db/ca-certificate.crt,options=rbind:ro \
+    --mount type=bind,src="$ROOT/auth-pool",dst=/run/social-monitor-codex-auth-pool,options=rbind:ro \
+    --label social-monitor.project=social-monitor \
+    --label social-monitor.purpose=agent-runtime-host-network-fallback \
+    docker.io/library/social-monitor-prod-agent-runtime:latest "$AGENT_TASK_ID"
+)
+
+if [[ $MODE == run ]] && ! task_running "$X_TASK_ID"; then
   start_host_network_x_collector
+fi
+if [[ $MODE == --restart-agent-runtime ]] || \
+   ! task_running "$AGENT_TASK_ID"; then
+  start_host_network_agent_runtime
 fi
 
 for _ in {1..15}; do
-  if x_task_running && ss -lnt | grep -Eq ':50051\b'; then
+  if task_running "$AGENT_TASK_ID" && ss -lnt | grep -Eq ':50052\b' && \
+    { [[ $MODE != run ]] || \
+      { task_running "$X_TASK_ID" && ss -lnt | grep -Eq ':50051\b'; }; }; then
     break
   fi
   sleep 1
 done
-if ! x_task_running || ! ss -lnt | grep -Eq ':50051\b'; then
-  echo 'rolling fallback could not start the host-network X collector' >&2
+if ! task_running "$AGENT_TASK_ID" || ! ss -lnt | grep -Eq ':50052\b'; then
+  echo 'rolling fallback could not start the host-network agent runtime' >&2
+  exit 75
+fi
+if [[ $MODE == run ]] && \
+   { ! task_running "$X_TASK_ID" || ! ss -lnt | grep -Eq ':50051\b'; }; then
+  echo 'rolling fallback could not start its host-network runtimes' >&2
   exit 75
 fi
 
+if [[ $MODE == --agent-runtime-only || $MODE == --restart-agent-runtime ]]; then
+  exit 0
+fi
+
 export SOCIAL_MONITOR_ROLLING_RUNTIME=containerd
+export SOCIAL_MONITOR_ROLLING_AGENT_RUNTIME_IP=127.0.0.1
+export SOCIAL_MONITOR_ROLLING_AGENT_RUNTIME_RESTART_SCRIPT=$ROOT/control/rolling-containerd-fallback.sh
 export SOCIAL_MONITOR_ROLLING_X_ADDRESS=127.0.0.1:50051
 exec "$ROOT/control/rolling-run.sh"

--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -86,10 +86,14 @@ if "$ROOT/control/refresh-codex-auth.sh"; then
       rm -f "$ROOT/runtime/auth-account-changed"
       sleep 3
     else
-      # The host-network fallback cannot safely restart a Docker-managed
-      # runtime while the Docker task API is unavailable. Collection remains
-      # available, while publication waits for the normal runtime to recover.
-      auth_ready=false
+      restart_script=${SOCIAL_MONITOR_ROLLING_AGENT_RUNTIME_RESTART_SCRIPT:-}
+      if [[ -x $restart_script ]] && \
+         "$restart_script" --restart-agent-runtime; then
+        rm -f "$ROOT/runtime/auth-account-changed"
+        sleep 3
+      else
+        auth_ready=false
+      fi
     fi
   fi
   if [[ $ROLLING_RUNTIME == docker ]]; then

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -9,6 +9,8 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 mkdir -p \
   "$TEST_ROOT/control/postgres-runtime-current" \
   "$TEST_ROOT/control/deploy-state" \
+  "$TEST_ROOT/backups" \
+  "$TEST_ROOT/runtime/subscription-runtime/sessions" \
   "$TEST_ROOT/runtime/x-collector" \
   "$TEST_ROOT/secrets" \
   "$TEST_ROOT/secrets/db" \
@@ -23,6 +25,7 @@ ln -s "$REPO" "$TEST_ROOT/integration"
 fake_flock=/usr/bin/true
 fake_docker=$REPO/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
 fake_ctr=$REPO/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
+fake_agent_restart=$REPO/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-agent-restart.sh
 refresh=$TEST_ROOT/control/refresh-codex-auth.sh
 ln -s /usr/bin/true "$refresh"
 export SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG=$TEST_ROOT/docker.log
@@ -105,5 +108,26 @@ if compgen -G "$TEST_ROOT/runtime/rolling-containerd-*-env.*" >/dev/null; then
   echo 'rolling containerd secret environment was not cleaned up' >&2
   exit 1
 fi
+
+touch "$TEST_ROOT/runtime/auth-account-changed"
+SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_CTR=$fake_ctr \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T20:15:00.000Z \
+SOCIAL_MONITOR_ROLLING_RUNTIME=containerd \
+SOCIAL_MONITOR_ROLLING_AGENT_RUNTIME_RESTART_SCRIPT=$fake_agent_restart \
+  bash "$RUNNER"
+grep -Fx -- '--restart-agent-runtime' "$TEST_ROOT/agent-restart.log" >/dev/null
+[[ ! -e $TEST_ROOT/runtime/auth-account-changed ]]
+[[ -d $TEST_ROOT/runtime/subscription-runtime/sessions ]]
+find "$TEST_ROOT/backups" -maxdepth 1 -type d \
+  -name 'subscription-runtime-sessions.*' | grep -q .
+
+fallback=$REPO/ops/deploy/production-runtime/rolling-containerd-fallback.sh
+grep -F 'AGENT_TASK_ID=social-monitor-agent-runtime-host-fallback' "$fallback" >/dev/null
+grep -F 'SOCIAL_MONITOR_ROLLING_AGENT_RUNTIME_IP=127.0.0.1' "$fallback" >/dev/null
+grep -F 'SOCIAL_MONITOR_ROLLING_AGENT_RUNTIME_RESTART_SCRIPT=' "$fallback" >/dev/null
 
 echo 'rolling-run tests passed'

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-agent-restart.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-agent-restart.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> \
+  "${SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT:?test root is required}/agent-restart.log"
+[[ ${1:-} == --restart-agent-runtime ]]

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -61,7 +61,7 @@ BRIDGE_CONTROL_PATHS=(
 )
 
 assert_real_bridge_target_assets() {
-  local path entry mode type object tree_path expected_digest alternate_digest actual_digest actual_mode
+  local path entry mode type object tree_path expected_digest alternate_digest additional_digest actual_digest actual_mode
   local repository_root actual_path actual_real
 
   repository_root=$(readlink -f -- "$PROJECT_ROOT")
@@ -90,11 +90,13 @@ assert_real_bridge_target_assets() {
     }
     expected_digest=$(git -C "$PROJECT_ROOT" show "$BRIDGE_RELEASE_SHA:$path" | sha256sum | awk '{print $1}')
     alternate_digest=
+    additional_digest=
     actual_digest=$(sha256sum "$actual_real" | awk '{print $1}')
     case $path in
       ops/deploy/social-monitor-production-deploy.sh)
         expected_digest=e76db96e9cc7bdb62cb09a3be509a7776e09a0499ff41a0d3769d8b499bde04f
         alternate_digest=ac82c9cfebf88646e9cdc21dcb822c8cc50409832da24a726cd9307cc2be8bcb
+        additional_digest=87946adc8f17ff9844a7d3d18b5b2a8ae44bd58cb557ed4e036d47dae745a6d7
         ;;
       ops/deploy/deploy-control-lib.sh)
         expected_digest=d18854822ef36d5571289e72c7691fff8db4a7d5c516787441a733d6960a88a9
@@ -102,6 +104,7 @@ assert_real_bridge_target_assets() {
       ops/deploy/postgres-runtime-deploy-lib.sh)
         expected_digest=261fb030bea2f203564c59e0c22db8058b310fb5d979c7db622938fe6045545a
         alternate_digest=6ac29042e94f9ef40498c70beeed37af13660fae629216d3ae2ea70270d0ffb1
+        additional_digest=36bcf5685599e8546642c586899a6ed2aa123f4251925b70baf6a335a6a67ec6
         ;;
       ops/deploy/backend-image-rescue-lib.sh)
         expected_digest=68f13213e6d1662d943185df7cdd1c11678261e76977021f74493c4e6c643b59
@@ -123,6 +126,10 @@ assert_real_bridge_target_assets() {
         echo 'production C1 readiness asset exception is not exact' >&2
         exit 1
       }
+      [[ $(grep -Fxc '  ops/deploy/production-runtime/rolling-containerd-fallback.sh' "$actual_real") == 1 ]] || {
+        echo 'rolling containerd fallback asset exception is not exact' >&2
+        exit 1
+      }
       [[ $(grep -Fxc '  reader-summary-daily-scan-terminal-repair-c1) run_reader_summary_daily_scan_terminal_repair_c1_from_stdin ;;' "$actual_real") == 1 ]] || {
         echo 'production C1 repair dispatch exception is not exact' >&2
         exit 1
@@ -137,7 +144,8 @@ assert_real_bridge_target_assets() {
       }
     fi
     [[ $actual_digest == "$expected_digest" ||
-       (-n $alternate_digest && $actual_digest == "$alternate_digest") ]] || {
+       (-n $alternate_digest && $actual_digest == "$alternate_digest") ||
+       (-n $additional_digest && $actual_digest == "$additional_digest") ]] || {
       printf 'current bridge asset digest drifted from V4A4: %s\n' "$path" >&2
       exit 1
     }

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -106,6 +106,7 @@ RUNTIME_CONTROL_PATHS=(
   ops/deploy/production-runtime/daily-c1-runtime.sh
   ops/deploy/production-runtime/daily-run.sh
   ops/deploy/production-runtime/rolling-run.sh
+  ops/deploy/production-runtime/rolling-containerd-fallback.sh
   ops/deploy/production-runtime/rolling-summary-receipt.mjs
   ops/deploy/production-runtime/compose.daily-artifacts.yml
   ops/deploy/production-runtime/reader-summary-daily-c1.readiness


### PR DESCRIPTION
## Summary
- run both X collector and agent runtime through host-network containerd fallback
- restart only agent runtime after auth account rotation
- install the fallback launcher with runtime control releases

## Evidence
- production rolling canary published the 2026-08-21 summary
- rolling-run focused tests pass
- shellcheck and source line cap pass

## Host constraint
The systemd manager on the current production host is unresponsive. This fallback keeps the scheduled collection and summary publication path operational without rebooting the host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback support for starting and restarting the agent runtime.
  * Added host-network runtime startup with readiness checks and filtered environment settings.
  * Added handling for authentication changes, including session preservation and runtime restart.

* **Bug Fixes**
  * Improved fallback behavior when authentication state changes.
  * Added validation and clearer failure handling for unsupported runtime modes.

* **Tests**
  * Expanded deployment and runtime coverage for agent fallback, restart behavior, and session backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->