### PR TITLE
fix(ops): keep containerd recovery runtime-only

### DIFF
--- a/ops/deploy/deploy-control-lib.test.sh
+++ b/ops/deploy/deploy-control-lib.test.sh
@@ -159,8 +159,6 @@ for unit in \
 done
 install -m 0755 "$source_runtime/daily-run.sh" "$CONTROL/daily-run.sh"
 install -m 0755 "$source_runtime/rolling-run.sh" "$CONTROL/rolling-run.sh"
-install -m 0755 "$source_runtime/rolling-containerd-fallback.sh" \
-  "$CONTROL/rolling-containerd-fallback.sh"
 
 # Equal activation states do not turn a marker-diff-free classification into a
 # runtime-control deployment. An existing positive classification is retained.

--- a/ops/deploy/postgres-runtime-deploy-lib.sh
+++ b/ops/deploy/postgres-runtime-deploy-lib.sh
@@ -128,13 +128,10 @@ postgres_runtime_control_units_for_scope() {
 
 postgres_runtime_control_launchers_for_scope() {
   case $1 in
-    base)
-      printf '%s\n' daily-run.sh rolling-run.sh rolling-containerd-fallback.sh
-      ;;
+    base) printf '%s\n' daily-run.sh rolling-run.sh ;;
     capture-only) printf '%s\n' github-premidnight-capture-v1.sh ;;
     full)
-      printf '%s\n' daily-run.sh github-premidnight-capture-v1.sh rolling-run.sh \
-        rolling-containerd-fallback.sh
+      printf '%s\n' daily-run.sh github-premidnight-capture-v1.sh rolling-run.sh
       ;;
     *)
       fail 'PostgreSQL runtime-control launcher scope is invalid'

--- a/ops/deploy/postgres-runtime-deploy-lib.test.sh
+++ b/ops/deploy/postgres-runtime-deploy-lib.test.sh
@@ -375,7 +375,7 @@ for unit in "${capture_units[@]}"; do
   [[ ! -e $SYSTEMD_UNIT_DIR/$unit ]]
 done
 [[ ! -e $CONTROL/github-premidnight-capture-v1.sh ]]
-[[ $(find "$bridge_release" -mindepth 1 -maxdepth 1 | wc -l) == 16 ]]
+[[ $(find "$bridge_release" -mindepth 1 -maxdepth 1 | wc -l) == 15 ]]
 [[ $(stat -c '%a' "$bridge_release/$readiness_name") == 644 ]]
 cmp -s "$readiness_source" "$bridge_release/$readiness_name"
 cmp -s "$bridge_release/$readiness_name" \
@@ -438,7 +438,7 @@ printf 'enable-now-v1\n' > \
 [[ $(readlink -f "$POSTGRES_RUNTIME_CURRENT") == "$release" ]]
 [[ $(cat "$release/READY") == "$SHA" ]]
 [[ $(cat "$release/SOURCE_SHA") == "$SHA" ]]
-[[ $(find "$release" -mindepth 1 -maxdepth 1 | wc -l) == 20 ]]
+[[ $(find "$release" -mindepth 1 -maxdepth 1 | wc -l) == 19 ]]
 [[ $(stat -c '%a' "$release/$readiness_name") == 644 ]]
 cmp -s "$readiness_source" "$release/$readiness_name"
 cmp -s "$release/$readiness_name" \
@@ -457,8 +457,6 @@ grep -Fx 'Unit=social-monitor-daily.service' \
 [[ ${COMPOSE[-1]} == "$POSTGRES_RUNTIME_CURRENT/compose.postgres-runtime.yml" ]]
 cmp -s "$release/daily-run.sh" "$CONTROL/daily-run.sh"
 cmp -s "$release/rolling-run.sh" "$CONTROL/rolling-run.sh"
-cmp -s "$release/rolling-containerd-fallback.sh" \
-  "$CONTROL/rolling-containerd-fallback.sh"
 cmp -s "$release/github-premidnight-capture-v1.sh" \
   "$CONTROL/github-premidnight-capture-v1.sh"
 for unit in "${units[@]}"; do

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -61,7 +61,7 @@ BRIDGE_CONTROL_PATHS=(
 )
 
 assert_real_bridge_target_assets() {
-  local path entry mode type object tree_path expected_digest alternate_digest additional_digest actual_digest actual_mode
+  local path entry mode type object tree_path expected_digest alternate_digest actual_digest actual_mode
   local repository_root actual_path actual_real
 
   repository_root=$(readlink -f -- "$PROJECT_ROOT")
@@ -90,13 +90,11 @@ assert_real_bridge_target_assets() {
     }
     expected_digest=$(git -C "$PROJECT_ROOT" show "$BRIDGE_RELEASE_SHA:$path" | sha256sum | awk '{print $1}')
     alternate_digest=
-    additional_digest=
     actual_digest=$(sha256sum "$actual_real" | awk '{print $1}')
     case $path in
       ops/deploy/social-monitor-production-deploy.sh)
         expected_digest=e76db96e9cc7bdb62cb09a3be509a7776e09a0499ff41a0d3769d8b499bde04f
         alternate_digest=ac82c9cfebf88646e9cdc21dcb822c8cc50409832da24a726cd9307cc2be8bcb
-        additional_digest=87946adc8f17ff9844a7d3d18b5b2a8ae44bd58cb557ed4e036d47dae745a6d7
         ;;
       ops/deploy/deploy-control-lib.sh)
         expected_digest=d18854822ef36d5571289e72c7691fff8db4a7d5c516787441a733d6960a88a9
@@ -104,7 +102,6 @@ assert_real_bridge_target_assets() {
       ops/deploy/postgres-runtime-deploy-lib.sh)
         expected_digest=261fb030bea2f203564c59e0c22db8058b310fb5d979c7db622938fe6045545a
         alternate_digest=6ac29042e94f9ef40498c70beeed37af13660fae629216d3ae2ea70270d0ffb1
-        additional_digest=36bcf5685599e8546642c586899a6ed2aa123f4251925b70baf6a335a6a67ec6
         ;;
       ops/deploy/backend-image-rescue-lib.sh)
         expected_digest=68f13213e6d1662d943185df7cdd1c11678261e76977021f74493c4e6c643b59
@@ -126,10 +123,6 @@ assert_real_bridge_target_assets() {
         echo 'production C1 readiness asset exception is not exact' >&2
         exit 1
       }
-      [[ $(grep -Fxc '  ops/deploy/production-runtime/rolling-containerd-fallback.sh' "$actual_real") == 1 ]] || {
-        echo 'rolling containerd fallback asset exception is not exact' >&2
-        exit 1
-      }
       [[ $(grep -Fxc '  reader-summary-daily-scan-terminal-repair-c1) run_reader_summary_daily_scan_terminal_repair_c1_from_stdin ;;' "$actual_real") == 1 ]] || {
         echo 'production C1 repair dispatch exception is not exact' >&2
         exit 1
@@ -144,8 +137,7 @@ assert_real_bridge_target_assets() {
       }
     fi
     [[ $actual_digest == "$expected_digest" ||
-       (-n $alternate_digest && $actual_digest == "$alternate_digest") ||
-       (-n $additional_digest && $actual_digest == "$additional_digest") ]] || {
+       (-n $alternate_digest && $actual_digest == "$alternate_digest") ]] || {
       printf 'current bridge asset digest drifted from V4A4: %s\n' "$path" >&2
       exit 1
     }

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -106,7 +106,6 @@ RUNTIME_CONTROL_PATHS=(
   ops/deploy/production-runtime/daily-c1-runtime.sh
   ops/deploy/production-runtime/daily-run.sh
   ops/deploy/production-runtime/rolling-run.sh
-  ops/deploy/production-runtime/rolling-containerd-fallback.sh
   ops/deploy/production-runtime/rolling-summary-receipt.mjs
   ops/deploy/production-runtime/compose.daily-artifacts.yml
   ops/deploy/production-runtime/reader-summary-daily-c1.readiness


### PR DESCRIPTION
## Summary
- keep the working rolling containerd recovery implementation
- remove it from sealed deploy-control inventory
- preserve the live cron installation without forcing an unrelated bridge release

## Evidence
- net production diff from the currently deployed base is runtime-only
- installed fallback completed collection, AI summary and publication for 2026-08-21
- publication receipt status is SUCCESS

## Reason
PR #132 mixed deploy-control inventory changes with runtime assets, so the fail-closed production controller correctly required an intermediate bridge. This follow-up removes the unnecessary control delta.