### PR TITLE
fix(summary): extend reviewed daily catch-up window

### DIFF
--- a/ops/deploy/production-runtime/daily-run.sh
+++ b/ops/deploy/production-runtime/daily-run.sh
@@ -49,7 +49,7 @@ MAINTENANCE_DATE=${2:-}
 case "$DATE_FLAG" in
   --check-readiness|--today|--yesterday) ;;
   --maintenance-date)
-    [[ $# -eq 2 && $MAINTENANCE_DATE =~ ^2026-(07-(2[3-9]|3[01])|08-(0[1-9]|1[0-2]))$ ]] || {
+    [[ $# -eq 2 && $MAINTENANCE_DATE =~ ^2026-(07-(2[3-9]|3[01])|08-(0[1-9]|1[0-9]|20))$ ]] || {
       echo "historical daily production-day date is outside the reviewed recovery bound" >&2
       exit 64
     }

--- a/ops/deploy/production-runtime/daily-run.test.sh
+++ b/ops/deploy/production-runtime/daily-run.test.sh
@@ -111,7 +111,7 @@ grep -Fx -- '-n 9' "$fake_flock.calls" >/dev/null
 [[ $(wc -l <"$fake_flock.calls") -eq 1 ]]
 [[ ! -e "$work_marker" ]]
 
-for invalid in 2026-07-22 2026-08-13 not-a-date; do
+for invalid in 2026-07-22 2026-08-21 not-a-date; do
   set +e
   SOCIAL_MONITOR_DAILY_RUN_TEST_MODE=1 \
   SOCIAL_MONITOR_DAILY_RUN_TEST_ROOT="$test_root" \
@@ -124,5 +124,18 @@ for invalid in 2026-07-22 2026-08-13 not-a-date; do
   grep -Fx 'historical daily production-day date is outside the reviewed recovery bound' \
     "$test_root/invalid" >/dev/null
 done
+
+set +e
+SOCIAL_MONITOR_DAILY_RUN_TEST_MODE=1 \
+SOCIAL_MONITOR_DAILY_RUN_TEST_ROOT="$test_root" \
+SOCIAL_MONITOR_DAILY_RUN_TEST_FLOCK="$fake_flock" \
+SOCIAL_MONITOR_DAILY_RUN_TEST_DOCKER="$fake_docker" \
+  bash "$DAILY_RUN" --maintenance-date 2026-08-20 \
+    >"$test_root/valid-bound-stdout" 2>"$test_root/valid-bound-stderr"
+status=$?
+set -e
+[[ $status -eq 75 ]]
+grep -Fx 'daily production-day run already active' \
+  "$test_root/valid-bound-stderr" >/dev/null
 
 printf 'daily V6 reader-summary schedule wiring test passed\n'

--- a/ops/deploy/run-reader-summary-production-history.sh
+++ b/ops/deploy/run-reader-summary-production-history.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 readonly FIRST_RECOVERY_DATE=2026-07-23
-readonly LAST_REVIEWED_DATE=2026-08-12
+readonly LAST_REVIEWED_DATE=2026-08-20
 readonly DAILY_RUN=/var/data/social-monitor/control/daily-run.sh
 
 through=${1:-}

--- a/ops/deploy/run-reader-summary-production-history.test.sh
+++ b/ops/deploy/run-reader-summary-production-history.test.sh
@@ -18,7 +18,7 @@ export HISTORY_LOG=$FIXTURE/history.log
 bash "$FIXTURE/wrapper.sh" 2026-07-25
 [[ $(cat "$HISTORY_LOG") == $'--maintenance-date 2026-07-23\n--maintenance-date 2026-07-24\n--maintenance-date 2026-07-25' ]]
 
-for invalid in 2026-07-22 2026-08-13 garbage; do
+for invalid in 2026-07-22 2026-08-21 garbage; do
   if bash "$FIXTURE/wrapper.sh" "$invalid" >/dev/null 2>&1; then
     echo "invalid historical bound was accepted: $invalid" >&2
     exit 1


### PR DESCRIPTION
Production daily cursor is terminal at 2026-08-14, while the next scheduled target is 2026-08-20. The consecutive transition guard correctly blocks skipping the gap.

This change extends the existing reviewed maintenance recovery window through 2026-08-20 and keeps the normal live daily timer unchanged. Recovery still runs one date at a time through the existing quality, summary, and publication gates.

Checks:
- daily-run.test.sh
- run-reader-summary-production-history.test.sh
- daily-runtime-contract.test.sh
- check:source-line-cap
- bash syntax and ShellCheck for changed production scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended supported historical maintenance dates through August 20, 2026.
  * Updated recovery processing to include the newly reviewed date range.
  * Preserved existing validation rules, including rejecting dates after the approved boundary and dates later than yesterday.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->