### PR TITLE
fix(summary): align history collection recovery bound

### DIFF
--- a/scripts/lib/reader-summary-clean-real-day-collection-cli.spec.ts
+++ b/scripts/lib/reader-summary-clean-real-day-collection-cli.spec.ts
@@ -65,12 +65,12 @@ describe("clean real-day collection CLI", () => {
     ).toThrow("outside the daily maintenance upper bound");
   });
 
-  it("binds production history to 6101/6102 and an exact Aug12 artifact", () => {
+  it("binds production history to 6101/6102 through the exact Aug20 artifact", () => {
     const cli = withArgs(
       [
         "--update",
         "--date",
-        "2026-08-12",
+        "2026-08-20",
         "--provider-catch-up",
         "--allow-historical-provider-collection",
         "--allow-unproven-existing-window",
@@ -83,7 +83,7 @@ describe("clean real-day collection CLI", () => {
 
     expect(cli.maintenanceScope).toEqual(readerSummaryProductionHistoryScope);
     expect(cli.outputPath).toBe(
-      "/durable/production-history/reader-summary-clean-real-day-collection.2026-08-12.v1.json",
+      "/durable/production-history/reader-summary-clean-real-day-collection.2026-08-20.v1.json",
     );
     expect(cli.targetDiscoveryScopeValues).toEqual([
       readerSummaryProductionHistoryScope.tenantId,
@@ -91,13 +91,13 @@ describe("clean real-day collection CLI", () => {
     ]);
   });
 
-  it("rejects production history outside Jul23-Aug12", () => {
+  it("rejects production history outside Jul23-Aug20", () => {
     expect(() =>
       withArgs(
         [
           "--update",
           "--date",
-          "2026-08-13",
+          "2026-08-21",
           "--provider-catch-up",
           "--allow-historical-provider-collection",
           "--allow-unproven-existing-window",

--- a/scripts/lib/reader-summary-daily-maintenance-bounds.ts
+++ b/scripts/lib/reader-summary-daily-maintenance-bounds.ts
@@ -12,7 +12,7 @@ export const readerSummaryDailyJul31Aug3MaintenanceBounds: ReaderSummaryDailyMai
 export const readerSummaryProductionHistoryMaintenanceBounds: ReaderSummaryDailyMaintenanceBounds =
   Object.freeze({
     lowerInclusive: "2026-07-23",
-    upperInclusive: "2026-08-12",
+    upperInclusive: "2026-08-20",
   });
 
 export const assertReaderSummaryDailyMaintenanceBounds = (


### PR DESCRIPTION
## Summary
- align the production-history provider collection bound with the already reviewed daily catch-up window through 2026-08-20
- keep 2026-08-21 and later rejected
- cover the exact upper bound and first rejected date

## Production evidence
The 2026-08-15 catch-up reached the collection CLI and failed closed because this inner bound still ended on 2026-08-12. Existing data, RLS scope, and all three X accounts were visible; AI summary did not start.

## Verification
- focused Jest spec: 6/6 passed
- git diff --check passed