### PR TITLE
fix(ops): route midnight schedule through rolling e2e

### DIFF
--- a/ops/deploy/production-runtime/daily-run.sh
+++ b/ops/deploy/production-runtime/daily-run.sh
@@ -5,7 +5,8 @@ PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 # Canonical daily stages are owned by run-reader-summary-production-day.ts:
 # collection -> collection quality -> AI summary -> publication gates.
 
-if [[ ${SOCIAL_MONITOR_DAILY_RUN_TEST_MODE:-} == 1 ]]; then
+DAILY_TEST_MODE=${SOCIAL_MONITOR_DAILY_RUN_TEST_MODE:-0}
+if [[ $DAILY_TEST_MODE == 1 ]]; then
   ROOT=${SOCIAL_MONITOR_DAILY_RUN_TEST_ROOT:?daily-run test root is required}
   [[ $ROOT == /tmp/* ]] || {
     echo 'daily production-day test root must be below /tmp' >&2
@@ -61,6 +62,13 @@ case "$DATE_FLAG" in
     ;;
   *) echo "usage: $0 [--check-readiness|--today|--yesterday|--maintenance-date YYYY-MM-DD]" >&2; exit 64 ;;
 esac
+
+# The rolling pipeline is the production owner for scheduled collection,
+# summary generation and publication. Keep the reviewed midnight timer as its
+# sixth four-hour trigger while retaining explicit maintenance modes below.
+if [[ $DATE_FLAG == --yesterday && $DAILY_TEST_MODE != 1 ]]; then
+  exec "$ROOT/control/rolling-run.sh"
+fi
 
 [[ $POSTGRES_ADMISSION_WAIT_SECONDS =~ \
    ^([0-9]+([.][0-9]+)?|[.][0-9]+)$ ]] || {

--- a/ops/deploy/production-runtime/daily-run.test.sh
+++ b/ops/deploy/production-runtime/daily-run.test.sh
@@ -48,6 +48,9 @@ grep -F 'historicalMode === "true" && expected < previous' "$DAILY_RUN" >/dev/nu
 grep -F 'if [ "$transition" = historical ]; then' "$DAILY_RUN" >/dev/null
 grep -F -- '--dated-state "$requested_state"' "$DAILY_RUN" >/dev/null
 grep -F 'DATE_FLAG=${1:---yesterday}' "$DAILY_RUN" >/dev/null
+grep -F 'if [[ $DATE_FLAG == --yesterday && $DAILY_TEST_MODE != 1 ]]; then' \
+  "$DAILY_RUN" >/dev/null
+grep -F 'exec "$ROOT/control/rolling-run.sh"' "$DAILY_RUN" >/dev/null
 ! grep -Eq 'READER_SUMMARY.*(MAINTENANCE|HISTORICAL).*DATE_FLAG' "$DAILY_RUN"
 
 if grep -Eq \

--- a/ops/deploy/production-runtime/daily-runtime-contract.test.sh
+++ b/ops/deploy/production-runtime/daily-runtime-contract.test.sh
@@ -17,6 +17,9 @@ grep -F '"$FLOCK_COMMAND" -w "$POSTGRES_ADMISSION_WAIT_SECONDS" 8' \
   "$DAILY_RUN" >/dev/null
 grep -Fx 'ExecStart=/var/data/social-monitor/control/daily-run.sh --yesterday' \
   "$DAILY_SERVICE" >/dev/null
+grep -F 'if [[ $DATE_FLAG == --yesterday && $DAILY_TEST_MODE != 1 ]]; then' \
+  "$DAILY_RUN" >/dev/null
+grep -F 'exec "$ROOT/control/rolling-run.sh"' "$DAILY_RUN" >/dev/null
 grep -Fx 'Unit=social-monitor-daily.service' "$DAILY_TIMER" >/dev/null
 grep -Fx 'Restart=no' "$DAILY_SERVICE" >/dev/null
 


### PR DESCRIPTION
## Summary
- make the reviewed midnight timer invoke the same rolling collection -> summary -> publication pipeline
- keep explicit maintenance modes unchanged
- preserve the six-per-day four-hour schedule without the stale daily cursor path

## Evidence
- daily V6 schedule wiring test
- daily runtime contract test
- rolling-run tests
- PostgreSQL topology verifier tests
- daily C1 readiness helper tests

## Production intent
The 04/08/12/16/20 UTC rolling timer remains authoritative. The 00:15 UTC legacy timer becomes the sixth trigger for that same E2E runner.