### PR TITLE
fix(summary): initialize recovery CLI safely

### DIFF
--- a/scripts/reader-summary-historical-degraded-recovery.spec.ts
+++ b/scripts/reader-summary-historical-degraded-recovery.spec.ts
@@ -1,9 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
 import {
   assertHistoricalDegradedRecoveryCliArguments,
   recoveryHelpText,
 } from "./reader-summary-historical-degraded-recovery";
 
 describe("historical degraded recovery CLI evidence contract", () => {
+  it("initializes every CLI helper before the executable entrypoint runs", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-r",
+        "ts-node/register",
+        "-r",
+        "tsconfig-paths/register",
+        resolve(__dirname, "reader-summary-historical-degraded-recovery.ts"),
+        "invalid-command",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, NODE_ENV: "test" },
+        timeout: 30_000,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Command must be install-input, prepare, run, or verify",
+    );
+    expect(result.stderr).not.toContain("before initialization");
+  });
+
   it.each([
     ["prepare", ["prepare", "--date", "2026-08-18"]],
     ["run", ["run", "--date", "2026-08-18", "--authority-sha256", "a".repeat(64)]],

--- a/scripts/reader-summary-historical-degraded-recovery.ts
+++ b/scripts/reader-summary-historical-degraded-recovery.ts
@@ -44,13 +44,6 @@ type RecoveryInputArtifact = Exclude<
   "authority"
 >;
 
-if (require.main === module) {
-  void main().catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-  });
-}
-
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   if (args.includes("--help") || args.length === 0) {
@@ -469,4 +462,11 @@ Verify (read-only; rechecks live truth/files/source and public receipt):
   npm run reader-summary:historical-degraded-recovery -- verify --date DATE --authority-sha256 SHA
 
 DATE is restricted to 2026-08-18 or 2026-08-19 and the production workspace/UTC daily scope is compiled in. This command is not scheduled.`;
+}
+
+if (require.main === module) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
 }


### PR DESCRIPTION
## What

- move the historical recovery executable entrypoint after all `const` helpers are initialized
- add a subprocess regression that executes the real TypeScript CLI and rejects TDZ failures

## Evidence

- production reproduced the prior failure before any recovery evidence or database mutation
- focused CLI suite: 9/9 passed
- the rolling schedule does not call this bounded historical CLI

## Production

After merge and exact-SHA deploy, replay the unchanged bounded Aug 18-19 recovery script under the daily locks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line startup reliability by ensuring invalid commands return the expected validation message and exit status.
  * Prevented an initialization-order error during CLI execution.

* **Tests**
  * Added regression coverage for CLI behavior when all required startup helpers are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->