### PR TITLE
fix(summary): bind historical quality exception

### DIFF
--- a/scripts/lib/reader-summary-historical-degraded-recovery-live.spec.ts
+++ b/scripts/lib/reader-summary-historical-degraded-recovery-live.spec.ts
@@ -149,19 +149,75 @@ describe("historical degraded recovery live GitHub zero", () => {
       },
       blockingPassed: true,
     }));
-    const quality = (datasetSha256: string) => Buffer.from(JSON.stringify({
-      artifactFormat: "yesterday-social-collection-quality-report-v1",
-      collectionDate: "2026-08-18",
-      collectionBlockingPassed: true,
-      inputs: {
-        historicalRegenerationFreshness: {
-          mode: "historical_regeneration_current_snapshot",
-          generalAllowHistorical: false,
-          manifestFileSha256: sha256(manifest),
-          datasetSha256,
+    const qualityGates = {
+      globalXCollectionSucceeded: true,
+      postgresFeedItemsAvailable: true,
+      allExpectedPrimarySourcesPresent: true,
+      redditVisibleFeedItemsAtLeast50: true,
+      xTwitterVisibleFeedItemsMeetProductionMinimum: true,
+      everyPrimaryItemHasText: true,
+      everyPrimaryItemHasCanonicalUrl: true,
+      primaryDuplicateRateBelowFivePercent: true,
+      primaryEngagementMetadataCoverageAtLeast90Percent: true,
+      primaryFreshnessP90Below48Hours: true,
+      xCollectorLedgerAvailable: true,
+      xCollectorRunCountAtLeast20: true,
+      xCollectorCompletedRunRateMeetsProductionMinimum: true,
+      xCollectorUsableRunRateMeetsProductionMinimum: true,
+      xCollectorNoNonTerminalOrUnknownRuns: true,
+      xCollectorLedgerJsonValid: true,
+      xCollectorReturnedAtLeast500Tweets: true,
+      xCollectorHasTopAndLatest: true,
+      xCollectorHasStrictAndDiscoveryLanes: true,
+      xCollectorDistinctQueryHashesAtLeast4: true,
+      xAccountPoolStateAvailable: true,
+      xAccountPoolTracksPerAccount: true,
+      dayWindowAuditAvailable: true,
+      observedWindowFilterIsStrict: true,
+      duplicateAndLowRelevanceCountsReported: true,
+      summaryArtifactAbsenceIsExplicit: true,
+      noOrphanFeedInterestReferences: true,
+      noOrphanFeedSourceItemReferences: true,
+      noOrphanFeedSourceBindingReferences: true,
+      collectionIntegrityCleanForEval: true,
+      noRawSecretFragments: true,
+    };
+    const quality = (
+      datasetSha256: string,
+      options: Readonly<{
+        blockingPassed?: boolean;
+        gateOverrides?: Readonly<Record<string, boolean>>;
+        omitGate?: string;
+      }> = {},
+    ) => {
+      const gates: Record<string, boolean> = {
+        ...qualityGates,
+        ...options.gateOverrides,
+      };
+      if (options.omitGate !== undefined) delete gates[options.omitGate];
+      return Buffer.from(JSON.stringify({
+        schemaVersion: 1,
+        artifactFormat: "yesterday-social-collection-quality-report-v1",
+        collectionDate: "2026-08-18",
+        generatedBy: "npm run check:yesterday-social-collection-quality",
+        collectionBlockingPassed: options.blockingPassed ?? true,
+        summaryQualityVerified: false,
+        completionStatus:
+          "collection_quality_verified_summary_artifact_missing",
+        summaryArtifactCoverage: {
+          verificationStatus: "not_verified_missing_summary_artifact",
         },
-      },
-    }));
+        qualityGates: gates,
+        inputs: {
+          historicalRegenerationFreshness: {
+            mode: "historical_regeneration_current_snapshot",
+            generalAllowHistorical: false,
+            manifestFileSha256: sha256(manifest),
+            datasetSha256,
+          },
+        },
+      }));
+    };
     const params = {
       requestedUtcDate: "2026-08-18",
       files: {
@@ -176,6 +232,40 @@ describe("historical degraded recovery live GitHub zero", () => {
 
     expect(() => verifyHistoricalDegradedRecoveryInputArtifacts(params))
       .not.toThrow();
+    expect(() => verifyHistoricalDegradedRecoveryInputArtifacts({
+      ...params,
+      files: {
+        ...params.files,
+        collectionQualityReportBytes: quality(dataset.aggregateSha256, {
+          blockingPassed: false,
+          gateOverrides: { xCollectorHasStrictAndDiscoveryLanes: false },
+        }),
+      },
+    })).not.toThrow();
+    expect(() => verifyHistoricalDegradedRecoveryInputArtifacts({
+      ...params,
+      files: {
+        ...params.files,
+        collectionQualityReportBytes: quality(dataset.aggregateSha256, {
+          blockingPassed: false,
+          gateOverrides: {
+            xCollectorHasStrictAndDiscoveryLanes: false,
+            xCollectorHasTopAndLatest: false,
+          },
+        }),
+      },
+    })).toThrow("fresh live truth");
+    expect(() => verifyHistoricalDegradedRecoveryInputArtifacts({
+      ...params,
+      files: {
+        ...params.files,
+        collectionQualityReportBytes: quality(dataset.aggregateSha256, {
+          blockingPassed: false,
+          gateOverrides: { xCollectorHasStrictAndDiscoveryLanes: false },
+          omitGate: "noRawSecretFragments",
+        }),
+      },
+    })).toThrow("fresh live truth");
     expect(() => verifyHistoricalDegradedRecoveryInputArtifacts({
       ...params,
       files: {

--- a/scripts/lib/reader-summary-historical-degraded-recovery-live.ts
+++ b/scripts/lib/reader-summary-historical-degraded-recovery-live.ts
@@ -57,6 +57,80 @@ const noModelCallServingContext = Object.freeze({
   recoveryKind: "historical-degraded-summary-reuse",
 });
 
+const historicalRecoveryQualityGateNames = [
+  "globalXCollectionSucceeded",
+  "postgresFeedItemsAvailable",
+  "allExpectedPrimarySourcesPresent",
+  "redditVisibleFeedItemsAtLeast50",
+  "xTwitterVisibleFeedItemsMeetProductionMinimum",
+  "everyPrimaryItemHasText",
+  "everyPrimaryItemHasCanonicalUrl",
+  "primaryDuplicateRateBelowFivePercent",
+  "primaryEngagementMetadataCoverageAtLeast90Percent",
+  "primaryFreshnessP90Below48Hours",
+  "xCollectorLedgerAvailable",
+  "xCollectorRunCountAtLeast20",
+  "xCollectorCompletedRunRateMeetsProductionMinimum",
+  "xCollectorUsableRunRateMeetsProductionMinimum",
+  "xCollectorNoNonTerminalOrUnknownRuns",
+  "xCollectorLedgerJsonValid",
+  "xCollectorReturnedAtLeast500Tweets",
+  "xCollectorHasTopAndLatest",
+  "xCollectorHasStrictAndDiscoveryLanes",
+  "xCollectorDistinctQueryHashesAtLeast4",
+  "xAccountPoolStateAvailable",
+  "xAccountPoolTracksPerAccount",
+  "dayWindowAuditAvailable",
+  "observedWindowFilterIsStrict",
+  "duplicateAndLowRelevanceCountsReported",
+  "summaryArtifactAbsenceIsExplicit",
+  "noOrphanFeedInterestReferences",
+  "noOrphanFeedSourceItemReferences",
+  "noOrphanFeedSourceBindingReferences",
+  "collectionIntegrityCleanForEval",
+  "noRawSecretFragments",
+] as const;
+
+const historicalRecoveryQualityReportPassed = (
+  quality: Readonly<Record<string, unknown>>,
+): boolean => {
+  if (
+    quality.schemaVersion !== 1 ||
+    quality.generatedBy !== "npm run check:yesterday-social-collection-quality" ||
+    quality.summaryQualityVerified !== false ||
+    quality.completionStatus !==
+      "collection_quality_verified_summary_artifact_missing"
+  ) {
+    return false;
+  }
+  const summaryArtifactCoverage = record(
+    quality.summaryArtifactCoverage,
+    "quality summary artifact coverage",
+  );
+  const qualityGates = record(quality.qualityGates, "quality gates");
+  const expectedGateNames = [...historicalRecoveryQualityGateNames].sort();
+  const actualGateNames = Object.keys(qualityGates).sort();
+  if (
+    summaryArtifactCoverage.verificationStatus !==
+      "not_verified_missing_summary_artifact" ||
+    stableJson(actualGateNames) !== stableJson(expectedGateNames) ||
+    Object.values(qualityGates).some((value) => typeof value !== "boolean")
+  ) {
+    return false;
+  }
+  const failedGateNames = Object.entries(qualityGates)
+    .filter(([, passed]) => passed === false)
+    .map(([name]) => name)
+    .sort();
+  return (
+    quality.collectionBlockingPassed === true && failedGateNames.length === 0
+  ) || (
+    quality.collectionBlockingPassed === false &&
+    stableJson(failedGateNames) ===
+      stableJson(["xCollectorHasStrictAndDiscoveryLanes"])
+  );
+};
+
 export class PrismaHistoricalDegradedRecoveryLiveVerifier
   implements HistoricalDegradedRecoveryLiveVerifier
 {
@@ -481,7 +555,7 @@ export const verifyHistoricalDegradedRecoveryInputArtifacts = (params: {
     ) !== baseCollection.xCount ||
     quality.artifactFormat !== "yesterday-social-collection-quality-report-v1" ||
     quality.collectionDate !== params.requestedUtcDate ||
-    quality.collectionBlockingPassed !== true ||
+    !historicalRecoveryQualityReportPassed(quality) ||
     qualityFreshness.mode !== "historical_regeneration_current_snapshot" ||
     qualityFreshness.generalAllowHistorical !== false ||
     qualityFreshness.manifestFileSha256 !== sha256(params.files.datasetManifestBytes) ||


### PR DESCRIPTION
## Summary
- keep the daily collection quality policy unchanged
- allow only the exact Aug 18/19 historical recovery to accept the retired X discovery-lane gate
- fail closed on missing gates, additional failed gates, stale manifests, wrong dates, or existing summary artifacts

## Evidence
- focused Jest: 12/12 passed
- project TypeScript compiler: passed
- source line cap: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of historical recovery quality reports.
  * Valid reports with a failed blocking status and one permitted failed quality gate are now accepted.
  * Reports with multiple failed gates, missing required security checks, incomplete metadata, or stale information are rejected.
  * Added coverage to verify acceptance and rejection of these quality-report scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->