### PR TITLE
fix(summary): verify historical collection contract

### DIFF
--- a/scripts/lib/reader-summary-historical-degraded-recovery-live.spec.ts
+++ b/scripts/lib/reader-summary-historical-degraded-recovery-live.spec.ts
@@ -131,12 +131,36 @@ describe("historical degraded recovery live GitHub zero", () => {
       },
     }));
     const collection = Buffer.from(JSON.stringify({
+      schemaVersion: 1,
       artifactFormat: "reader-summary-clean-real-day-collection-v1",
+      generatedBy: "npm run run:reader-summary-clean-real-day-collection",
       run: { collectionDate: "2026-08-18" },
+      model: {
+        mode: "targeted_real_binding_collection",
+        liveNetwork: true,
+        liveNetworkProviderKeys: [
+          "hacker-news",
+          "reddit",
+          "rss",
+          "x-twitter",
+        ],
+        durableSnapshotReuseProviderKeys: [],
+        rawProviderPayloadPersistedInReport: false,
+        rawPostTextPersistedInReport: false,
+        rawProviderConfigPersistedInReport: false,
+      },
       inputs: {
-        scope: {
-          tenantId: "00000000-0000-7000-8000-000000006101",
-          workspaceId: "00000000-0000-7000-8000-000000006102",
+        database: "local-postgres",
+        providerKeys: [
+          "hacker-news",
+          "reddit",
+          "rss",
+          "x-twitter",
+        ],
+        xCollectorConfigured: true,
+        targetPublishedWindow: {
+          startInclusive: "2026-08-18T00:00:00.000Z",
+          endExclusive: "2026-08-19T00:00:00.000Z",
         },
       },
       targetWindow: {
@@ -232,6 +256,15 @@ describe("historical degraded recovery live GitHub zero", () => {
 
     expect(() => verifyHistoricalDegradedRecoveryInputArtifacts(params))
       .not.toThrow();
+    expect(() => verifyHistoricalDegradedRecoveryInputArtifacts({
+      ...params,
+      files: {
+        ...params.files,
+        collectionArtifactBytes: Buffer.from(
+          collection.toString("utf8").replace("local-postgres", "other-db"),
+        ),
+      },
+    })).toThrow("fresh live truth");
     expect(() => verifyHistoricalDegradedRecoveryInputArtifacts({
       ...params,
       files: {

--- a/scripts/lib/reader-summary-historical-degraded-recovery-live.ts
+++ b/scripts/lib/reader-summary-historical-degraded-recovery-live.ts
@@ -527,7 +527,11 @@ export const verifyHistoricalDegradedRecoveryInputArtifacts = (params: {
   const manifestScope = record(manifest.scope, "manifest scope");
   const manifestPeriod = record(manifest.period, "manifest period");
   const collectionInputs = record(collection.inputs, "collection inputs");
-  const collectionScope = record(collectionInputs.scope, "collection scope");
+  const collectionModel = record(collection.model, "collection model");
+  const collectionPublishedWindow = record(
+    collectionInputs.targetPublishedWindow,
+    "collection published window",
+  );
   const collectionWindow = record(collection.targetWindow, "collection target window");
   const qualityInputs = record(quality.inputs, "quality inputs");
   const qualityFreshness = record(
@@ -541,12 +545,42 @@ export const verifyHistoricalDegradedRecoveryInputArtifacts = (params: {
   const baseCollection = params.requestedUtcDate === "2026-08-18"
     ? { count: 205, xCount: 0 }
     : { count: 226, xCount: 10 };
+  const expectedCollectionProviders = [
+    "hacker-news",
+    "reddit",
+    "rss",
+    "x-twitter",
+  ];
+  const expectedEndedAt = new Date(
+    Date.parse(`${params.requestedUtcDate}T00:00:00.000Z`) + 86_400_000,
+  ).toISOString();
   if (
+    collection.schemaVersion !== 1 ||
     collection.artifactFormat !== "reader-summary-clean-real-day-collection-v1" ||
+    collection.generatedBy !==
+      "npm run run:reader-summary-clean-real-day-collection" ||
     record(collection.run, "collection run").collectionDate !== params.requestedUtcDate ||
     collection.blockingPassed !== true ||
-    collectionScope.tenantId !== historicalDegradedRecoveryTenantId ||
-    collectionScope.workspaceId !== historicalDegradedRecoveryWorkspaceId ||
+    collectionInputs.database !== "local-postgres" ||
+    collectionInputs.xCollectorConfigured !== true ||
+    stableJson(stringArray(collectionInputs.providerKeys, "collection providers")) !==
+      stableJson(expectedCollectionProviders) ||
+    collectionPublishedWindow.startInclusive !==
+      `${params.requestedUtcDate}T00:00:00.000Z` ||
+    collectionPublishedWindow.endExclusive !== expectedEndedAt ||
+    collectionModel.mode !== "targeted_real_binding_collection" ||
+    collectionModel.liveNetwork !== true ||
+    stableJson(stringArray(
+      collectionModel.liveNetworkProviderKeys,
+      "collection live providers",
+    )) !== stableJson(expectedCollectionProviders) ||
+    stringArray(
+      collectionModel.durableSnapshotReuseProviderKeys,
+      "collection durable providers",
+    ).length !== 0 ||
+    collectionModel.rawProviderPayloadPersistedInReport !== false ||
+    collectionModel.rawPostTextPersistedInReport !== false ||
+    collectionModel.rawProviderConfigPersistedInReport !== false ||
     collectionWindow.feedItemCount !== baseCollection.count ||
     Number(
       record(collectionWindow.providerCounts, "collection provider counts")[
@@ -564,9 +598,7 @@ export const verifyHistoricalDegradedRecoveryInputArtifacts = (params: {
     manifestScope.tenantId !== historicalDegradedRecoveryTenantId ||
     manifestScope.workspaceId !== historicalDegradedRecoveryWorkspaceId ||
     manifestPeriod.startedAt !== `${params.requestedUtcDate}T00:00:00.000Z` ||
-    manifestPeriod.endedAt !== new Date(
-      Date.parse(`${params.requestedUtcDate}T00:00:00.000Z`) + 86_400_000,
-    ).toISOString() ||
+    manifestPeriod.endedAt !== expectedEndedAt ||
     manifestPeriod.timezone !== "UTC" ||
     manifestDataset.feedRowCount !== params.dataset.liveCount ||
     manifestDataset.aggregateSha256 !== params.dataset.aggregateSha256 ||


### PR DESCRIPTION
## Summary
- validate the actual production collection receipt shape instead of a nonexistent inputs.scope field
- keep tenant and workspace binding on the fresh dataset manifest and live database capture
- fail closed on provider, window, database mode, network mode, or raw-payload contract drift

## Evidence
- focused recovery Jest: 12/12 passed
- project TypeScript compiler: passed