### PR TITLE
fix(summary): validate historical collection gates

### DIFF
--- a/scripts/lib/reader-summary-historical-degraded-recovery-live.spec.ts
+++ b/scripts/lib/reader-summary-historical-degraded-recovery-live.spec.ts
@@ -171,7 +171,29 @@ describe("historical degraded recovery live GitHub zero", () => {
           rss: 26,
         },
       },
-      blockingPassed: true,
+      qualityGates: {
+        targetBindingsPresent: true,
+        everyRequestedProviderSucceeded: false,
+        targetWindowFeedItemsAvailable: true,
+        everyRequestedProviderHasTargetItems: false,
+        noFreshOrphanInterestReferences: true,
+        noFreshOrphanSourceBindingReferences: true,
+        targetInterestSnapshotsPersisted: true,
+        targetSourceBindingSnapshotsPersisted: true,
+        freshSourceQueryLaneCoverageComplete: true,
+        freshMultipleQueryLanesObserved: true,
+        targetSourceQueryLaneCoverageComplete: true,
+        targetMultipleQueryLanesObserved: true,
+        providerCollectionObservabilityComplete: true,
+        providerAcquisitionModesAreConsistent: true,
+        everyRequestedProviderMeetsBlockingCoveragePolicy: false,
+        providerRetriesAreBounded: true,
+        durableSnapshotReuseIsSingleAttempt: true,
+        durableSnapshotProofMatchesRequestedDay: true,
+        partialProviderCoverageIsExplicit: true,
+        noRawSecretFragments: true,
+      },
+      blockingPassed: false,
     }));
     const qualityGates = {
       globalXCollectionSucceeded: true,
@@ -262,6 +284,18 @@ describe("historical degraded recovery live GitHub zero", () => {
         ...params.files,
         collectionArtifactBytes: Buffer.from(
           collection.toString("utf8").replace("local-postgres", "other-db"),
+        ),
+      },
+    })).toThrow("fresh live truth");
+    expect(() => verifyHistoricalDegradedRecoveryInputArtifacts({
+      ...params,
+      files: {
+        ...params.files,
+        collectionArtifactBytes: Buffer.from(
+          collection.toString("utf8").replace(
+            '"providerRetriesAreBounded":true',
+            '"providerRetriesAreBounded":false',
+          ),
         ),
       },
     })).toThrow("fresh live truth");

--- a/scripts/lib/reader-summary-historical-degraded-recovery-live.ts
+++ b/scripts/lib/reader-summary-historical-degraded-recovery-live.ts
@@ -91,6 +91,57 @@ const historicalRecoveryQualityGateNames = [
   "noRawSecretFragments",
 ] as const;
 
+const historicalRecoveryCollectionGateNames = [
+  "targetBindingsPresent",
+  "everyRequestedProviderSucceeded",
+  "targetWindowFeedItemsAvailable",
+  "everyRequestedProviderHasTargetItems",
+  "noFreshOrphanInterestReferences",
+  "noFreshOrphanSourceBindingReferences",
+  "targetInterestSnapshotsPersisted",
+  "targetSourceBindingSnapshotsPersisted",
+  "freshSourceQueryLaneCoverageComplete",
+  "freshMultipleQueryLanesObserved",
+  "targetSourceQueryLaneCoverageComplete",
+  "targetMultipleQueryLanesObserved",
+  "providerCollectionObservabilityComplete",
+  "providerAcquisitionModesAreConsistent",
+  "everyRequestedProviderMeetsBlockingCoveragePolicy",
+  "providerRetriesAreBounded",
+  "durableSnapshotReuseIsSingleAttempt",
+  "durableSnapshotProofMatchesRequestedDay",
+  "partialProviderCoverageIsExplicit",
+  "noRawSecretFragments",
+] as const;
+
+const historicalRecoveryCollectionReportPassed = (
+  collection: Readonly<Record<string, unknown>>,
+  requestedUtcDate: string,
+): boolean => {
+  const qualityGates = record(collection.qualityGates, "collection quality gates");
+  const expectedGateNames = [...historicalRecoveryCollectionGateNames].sort();
+  const actualGateNames = Object.keys(qualityGates).sort();
+  if (
+    collection.blockingPassed !== false ||
+    stableJson(actualGateNames) !== stableJson(expectedGateNames) ||
+    Object.values(qualityGates).some((value) => typeof value !== "boolean")
+  ) {
+    return false;
+  }
+  const failedGateNames = Object.entries(qualityGates)
+    .filter(([, passed]) => passed === false)
+    .map(([name]) => name)
+    .sort();
+  const expectedFailedGateNames = requestedUtcDate === "2026-08-18"
+    ? [
+      "everyRequestedProviderHasTargetItems",
+      "everyRequestedProviderMeetsBlockingCoveragePolicy",
+      "everyRequestedProviderSucceeded",
+    ]
+    : ["everyRequestedProviderMeetsBlockingCoveragePolicy"];
+  return stableJson(failedGateNames) === stableJson(expectedFailedGateNames);
+};
+
 const historicalRecoveryQualityReportPassed = (
   quality: Readonly<Record<string, unknown>>,
 ): boolean => {
@@ -560,7 +611,7 @@ export const verifyHistoricalDegradedRecoveryInputArtifacts = (params: {
     collection.generatedBy !==
       "npm run run:reader-summary-clean-real-day-collection" ||
     record(collection.run, "collection run").collectionDate !== params.requestedUtcDate ||
-    collection.blockingPassed !== true ||
+    !historicalRecoveryCollectionReportPassed(collection, params.requestedUtcDate) ||
     collectionInputs.database !== "local-postgres" ||
     collectionInputs.xCollectorConfigured !== true ||
     stableJson(stringArray(collectionInputs.providerKeys, "collection providers")) !==


### PR DESCRIPTION
## Summary
- bind the two allowlisted historical recoveries to the exact original collection gate sets
- require the complete collection gate schema and reject every unexpected failed gate
- retain the exact X backfill receipt and fresh live dataset verification as separate mandatory evidence

## Verification
- focused Jest: 12/12 passed
- changed-file ESLint passed
- source line cap passed
- repository-wide TypeScript baseline remains red on unrelated existing files; no changed-file TypeScript errors