### PR TITLE
fix(summary): bind late historical RSS item

### DIFF
--- a/scripts/lib/reader-summary-historical-degraded-recovery-authority.spec.ts
+++ b/scripts/lib/reader-summary-historical-degraded-recovery-authority.spec.ts
@@ -17,7 +17,7 @@ describe("historical degraded recovery authority", () => {
 
   it.each([
     ["2026-08-18", 277],
-    ["2026-08-19", 303],
+    ["2026-08-19", 304],
   ] as const)("prepares canonical authority for %s", (date, count) => {
     const prepared = prepareHistoricalDegradedRecoveryAuthority(
       preparation(date, count),
@@ -294,7 +294,7 @@ function buildDataset(
   aggregateSha256: sha256(`dataset:${count}`),
   providerCounts: date === "2026-08-18"
     ? { "hacker-news": 100, reddit: 79, rss: 26, "x-twitter": 72 }
-    : { "hacker-news": 99, reddit: 90, rss: 27, "x-twitter": 87 },
+    : { "hacker-news": 99, reddit: 90, rss: 28, "x-twitter": 87 },
   };
 }
 

--- a/scripts/lib/reader-summary-historical-degraded-recovery-authority.ts
+++ b/scripts/lib/reader-summary-historical-degraded-recovery-authority.ts
@@ -29,13 +29,13 @@ const allowedDays = Object.freeze({
     }),
   }),
   "2026-08-19": Object.freeze({
-    count: 303,
+    count: 304,
     xBackfillRowCount: 77,
     xBaseRowCount: 10,
     providerCounts: Object.freeze({
       "hacker-news": 99,
       reddit: 90,
-      rss: 27,
+      rss: 28,
       "x-twitter": 87,
     }),
   }),


### PR DESCRIPTION
## Summary
- bind the allowlisted Aug 19 recovery to the current 304-row production snapshot
- account for one real RSS item ingested late on Aug 23 while preserving the exact X backfill receipt

## Evidence
- late row: OpenAI Zero Data Retention article, published Aug 19 and ingested Aug 23
- focused recovery tests: 31/31 passed
- changed-file ESLint passed
- source line cap passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated historical recovery validation for August 19, 2026.
  * Adjusted expected totals to reflect 304 datasets, including 28 RSS-provided datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->