### PR TITLE
fix(summary): preserve recovery provenance after promotion

### DIFF
--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.spec.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.spec.ts
@@ -461,12 +461,13 @@ describe("ExecuteReaderSummaryJobUseCase", () => {
     );
   });
 
-  it("fails closed as no-signal before generation when evidence misses the promotion floor", async () => {
+  it("keeps ordinary zero-primary-evidence execution model-free", async () => {
     const tenant = tenantId("tenant-reader-summary-use-case");
     const workspace = workspaceId("workspace-reader-summary-use-case");
     const jobs = new FakeReaderSummaryJobRepository();
     const artifacts = new FakeReaderSummaryArtifactRepository();
     const events = new CapturingSummaryEventPublisher();
+    const model = new CapturingReaderSummaryModel();
 
     await jobs.save(
       ReaderSummaryJob.request({
@@ -501,7 +502,7 @@ describe("ExecuteReaderSummaryJobUseCase", () => {
           });
         },
       },
-      new CapturingReaderSummaryModel(),
+      model,
       new CapturingReaderSummaryPublication(jobs, artifacts, events),
       new StaticIdGenerator(),
       new FixedClock(new Date("2026-06-26T08:05:00.000Z")),
@@ -550,6 +551,7 @@ describe("ExecuteReaderSummaryJobUseCase", () => {
     });
     expect(events.all()).toHaveLength(1);
     expect(events.all()[0]?.payload).toMatchObject({ status: "no_signal" });
+    expect(model.generatedEvidenceIds()).toEqual([]);
   });
 
   it("calibrates confidence before a preflight rejection and skips topic-map calls", async () => {

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.ts
@@ -48,9 +48,7 @@ import {
 import { publishReaderSummaryJob } from "./publish-reader-summary-job";
 import { ReaderSummaryExecutionLeasePolicy } from "./reader-summary-execution-lease.policy";
 import { buildPromotionNoSignalArtifact } from "./reader-summary-promotion-no-signal";
-import {
-  buildReaderSummaryDraftWithPromotionContent,
-} from "./reader-summary-promotion-content";
+import { buildReaderSummaryDraftWithPromotionContent } from "./reader-summary-promotion-content";
 import {
   claimReaderSummaryJobExecution,
   readerSummaryExecutionClaimLost,
@@ -343,7 +341,10 @@ export class ExecuteReaderSummaryJobUseCase {
       snapshot,
       evidence: primaryEvidence,
     });
-    if (primaryEvidence.selectedEvidence.length === 0) {
+    if (
+      primaryEvidence.selectedEvidence.length === 0 &&
+      this.recoveryProvenance === undefined
+    ) {
       return ok({
         evidence: publicationEvidence,
         editorialEvidence: modelEvidence,

--- a/libs/summary/features/execute-reader-summary-job/reader-summary-promotion-artifact-fields.ts
+++ b/libs/summary/features/execute-reader-summary-job/reader-summary-promotion-artifact-fields.ts
@@ -20,21 +20,23 @@ export const buildReaderSummaryPromotionArtifactFields = (params: {
   readonly modelEvidence: SummaryEvidenceSelection;
   readonly draft: ReaderSummaryDraft;
 }): PromotionArtifactFields => {
-  const promotionProjection = params.draft.content === undefined
-    ? undefined
-    : buildReaderPostPromotionProjection({
-        evidence: params.modelEvidence.selectedEvidence,
-        clusters: params.modelEvidence.clusters,
-        citations: params.draft.citationMap,
-        sourceWindow: params.modelEvidence.sourceWindow,
-        approvedSameStoryRelations:
-          params.modelEvidence.approvedSameStoryRelations,
-        relatedTopicRelations: params.modelEvidence.relatedTopicRelations,
-        attestationBinding: {
-          artifactId: params.artifactId,
+  const promotionProjection =
+    params.draft.content === undefined ||
+    params.modelEvidence.selectedEvidence.length === 0
+      ? undefined
+      : buildReaderPostPromotionProjection({
+          evidence: params.modelEvidence.selectedEvidence,
+          clusters: params.modelEvidence.clusters,
+          citations: params.draft.citationMap,
           sourceWindow: params.modelEvidence.sourceWindow,
-        },
-      });
+          approvedSameStoryRelations:
+            params.modelEvidence.approvedSameStoryRelations,
+          relatedTopicRelations: params.modelEvidence.relatedTopicRelations,
+          attestationBinding: {
+            artifactId: params.artifactId,
+            sourceWindow: params.modelEvidence.sourceWindow,
+          },
+        });
   return {
     promotionAttestations: promotionProjection?.attestations ?? [],
     promotionEvidenceFacts:

--- a/scripts/check-reader-summary-production-recovery-postgres.ts
+++ b/scripts/check-reader-summary-production-recovery-postgres.ts
@@ -18,6 +18,7 @@ import { assertReaderSummaryDailyCanonicalRecoveryV4InvalidProductRetrySetMigrat
 import { type CanonicalRecoveryAuthority, type CanonicalRecoveryFinalizer, type CanonicalRecoveryPublication, type CanonicalRecoveryWork, PostgresCanonicalRecoveryAmbiguityRetryAuthorizer, PostgresCanonicalRecoveryAuthority, canonicalJsonBytes, canonicalRecoveryDates, sha256 } from "./lib/reader-summary-daily-canonical-recovery-v4";
 import { ReaderSummaryDailyCanonicalRecoveryV4Executor } from "./lib/reader-summary-daily-canonical-recovery-v4-executor";
 import { createReaderSummaryDailyTerminalRuntimeConnection } from "./lib/reader-summary-daily-terminal-runtime-connection";
+import { applyReaderSummaryProductionRecoveryRelease } from "./lib/reader-summary-production-recovery-release";
 import { createReaderSummaryDailyCanonicalRecoveryV4Finalizer } from "./run-reader-summary-daily-canonical-recovery";
 import { fixtureReaderSummaryServingAuthority } from "./lib/reader-summary-serving-authority-fixture";
 type RecoveryPoolClient = RecoveryPostgresClient &
@@ -177,7 +178,11 @@ const invalidRuntimeTerminalMigration = "20260805180000_reader_summary_daily_v4_
 const invalidProductRetrySetMigration = "20260806010000_reader_summary_daily_v4_invalid_product_retry_set";
 const canonicalOutputReceiptMigration = "20260806010100_reader_summary_daily_v4_canonical_output_receipt_v3";
 const dailyDeliveryC1Migration = "20260811170000_reader_summary_daily_delivery_c1_retry_evidence";
-const postDailyDeliveryMigrations = readerSummaryMigrationNames().filter((migration) => migration > dailyDeliveryC1Migration);
+const telemetryMigration = "20260824120000_reader_summary_daily_model_job_telemetry";
+const defaultAclMigration = "20260824121000_reader_summary_daily_function_global_default_acl";
+const postDailyDeliveryMigrations = readerSummaryMigrationNames().filter(
+  (migration) => migration > dailyDeliveryC1Migration,
+);
 const ambiguityRetryMigrations = [
   "20260804130000_reader_summary_daily_v4_ambiguity_retry_schema",
   "20260804130100_reader_summary_daily_v4_ambiguity_retry_transitions",
@@ -627,27 +632,22 @@ const main = async (): Promise<void> => {
             auditor,
             "0",
           );
-        for (const migration of [
-          originalCutoffForwardMigration,
-          ...ambiguityRetryMigrations,
-          dailyDeliveryC1Migration,
-          ...postDailyDeliveryMigrations,
-        ]) {
-          cpSync(
-            join(process.cwd(), "prisma", "migrations", migration),
-            join(migrationWorkspace.directory, "migrations", migration),
-            { recursive: true },
-          );
-        }
-        applyOrderedReaderSummaryMigrations(
+        await applyReaderSummaryProductionRecoveryRelease({
           adminDatabaseUrl,
+          client: auditor,
+          defaultAclMigration,
+          migrationAdminRole,
+          migrations: [
+            originalCutoffForwardMigration,
+            ...ambiguityRetryMigrations,
+            dailyDeliveryC1Migration,
+            ...postDailyDeliveryMigrations,
+          ],
           migrationWorkspace,
-        );
-        await runReaderSummaryPublicationBootstrapSql(
-          "post",
-          adminDatabaseUrl,
+          runBootstrap: runReaderSummaryPublicationBootstrapSql,
           runtimeRole,
-        );
+          telemetryMigration,
+        });
         assertReaderSummaryMigrationDatabaseMatchesSchema(targetDatabaseUrl);
         const legacyRecoveryAfterForward =
           await assertReaderSummaryDailyCanonicalRecoveryV4GenericFixture(

--- a/scripts/lib/reader-summary-daily-frozen-publication-input.spec.ts
+++ b/scripts/lib/reader-summary-daily-frozen-publication-input.spec.ts
@@ -7,6 +7,7 @@ import {
   buildReaderSummaryCoveragePlan,
   buildReaderSummaryPeriod,
   defaultReaderSummaryGenerationPolicy,
+  type ReaderSummaryArtifact,
   ReaderSummaryJob,
   type ReaderSummaryPublicationPolicy,
 } from "@social-monitor/summary/domain";
@@ -18,6 +19,7 @@ import {
 import type {
   ReaderSummaryArtifactRepositoryPort,
   ReaderSummaryJobRepositoryPort,
+  ReaderSummaryModelPort,
   ReaderSummaryPolicyRepositoryPort,
   ReaderSummaryPublicationCommand,
   ReaderSummaryPublicationPort,
@@ -39,7 +41,7 @@ const scope = {
 const hash = (seed: string) => sha256(Buffer.from(seed, "utf8"));
 
 describe("reader summary daily frozen publication input", () => {
-  it("routes verified V4 provenance through Jul24 and every reviewed date", async () => {
+  it("invokes each sealed V4 no-signal model once and emits a V3 recovery audit", async () => {
     for (const requestedUtcDate of [
       "2026-07-24", "2026-07-25", "2026-07-26", "2026-07-27",
     ]) {
@@ -74,9 +76,16 @@ describe("reader summary daily frozen publication input", () => {
       expect(published.savedDecision).toMatchObject({ status: "published" });
       expect(published.result.value).toMatchObject({ status: "no_signal" });
       expect(published.publicationCommands).toHaveLength(1);
+      expect(published.modelInvocationCount).toBe(1);
+      expect(published.savedArtifact).toMatchObject({
+        headline: "Canonical day",
+        executiveSummary: "Immutable evidence only.",
+      });
       expect(published.savedAudit).toMatchObject({
         status: projectionMode === "historical_omission" ? "not_required" : "verified",
         recoveryV4: {
+          schemaVersion:
+            "reader_summary.daily_canonical_recovery_provenance.v3",
           recoveryVersion: "reader_summary.daily_canonical_recovery.v4",
           requestedUtcDate,
           selectedOutputKind: "output_text",
@@ -433,6 +442,15 @@ const executeVerifiedRecovery = async (
   if (wiring.model === undefined || wiring.topicMapBuilder === undefined) {
     throw new Error("verified Jul24 recovery wiring is incomplete");
   }
+  const persistedModel = wiring.model;
+  let modelInvocationCount = 0;
+  const model: ReaderSummaryModelPort = {
+    ...persistedModel,
+    generate: async (input, route) => {
+      modelInvocationCount += 1;
+      return persistedModel.generate(input, route);
+    },
+  };
   const period = buildReaderSummaryPeriod({
     cadence: "daily",
     startedAt: new Date(`${requestedUtcDate}T00:00:00.000Z`),
@@ -451,7 +469,7 @@ const executeVerifiedRecovery = async (
   const jobsById = new Map([[requested.toSnapshot().id, requested]]);
   const jobs: Pick<
     ReaderSummaryJobRepositoryPort,
-    "save" | "findById" | "claimForExecution"
+    "save" | "findById" | "claimForExecution" | "saveExecutionOutcome"
   > = {
     save: async (job) => {
       jobsById.set(job.toSnapshot().id, job);
@@ -465,11 +483,27 @@ const executeVerifiedRecovery = async (
       jobsById.set(readerSummaryJobId, running);
       return running;
     },
+    saveExecutionOutcome: async ({ job, expectedStartedAt }) => {
+      const snapshot = job.toSnapshot();
+      const current = jobsById.get(snapshot.id)?.toSnapshot();
+      if (
+        current?.status !== "running" ||
+        current.startedAt?.getTime() !== expectedStartedAt.getTime()
+      ) {
+        return false;
+      }
+      jobsById.set(snapshot.id, job);
+      return true;
+    },
   };
   let savedAudit: unknown;
+  let savedArtifact:
+    | ReturnType<ReaderSummaryArtifact["toSnapshot"]>
+    | undefined;
   let savedDecision: unknown;
   const artifacts: Pick<ReaderSummaryArtifactRepositoryPort, "save"> = {
     save: async (_artifact, options) => {
+      savedArtifact = _artifact.toSnapshot();
       savedAudit = options?.githubProjectionAudit;
       savedDecision = options?.publicationDecision;
     },
@@ -507,7 +541,7 @@ const executeVerifiedRecovery = async (
     artifacts as ReaderSummaryArtifactRepositoryPort,
     policies as ReaderSummaryPolicyRepositoryPort,
     wiring.evidenceSelector,
-    wiring.model,
+    model,
     publications,
     ids,
     clock,
@@ -525,7 +559,14 @@ const executeVerifiedRecovery = async (
     readerSummaryJobId: requested.toSnapshot().id,
     maxEvidenceItems: 200,
   });
-  return { result, publicationCommands, savedAudit, savedDecision };
+  return {
+    result,
+    publicationCommands,
+    savedAudit,
+    savedArtifact,
+    savedDecision,
+    modelInvocationCount,
+  };
 };
 
 const reviewedRecoveryDays = Object.freeze([

--- a/scripts/lib/reader-summary-daily-publication-finalizer.ts
+++ b/scripts/lib/reader-summary-daily-publication-finalizer.ts
@@ -364,13 +364,23 @@ const createReaderSummaryDailyPersistedResponseModel = (input: {
         throw new Error("Daily persisted response may be consumed only once");
       }
       generated = true;
-      const draft = normalizeOpenAiReaderSummaryDraft(
+      const normalizedDraft = normalizeOpenAiReaderSummaryDraft(
         response,
         modelInput,
         selectedRoute,
         artifactUsage(),
         "reader_summary.eval.mvp.v1",
       );
+      const draft = outputKind === "output_text"
+        ? {
+            ...normalizedDraft,
+            headline: requiredText(response.headline, "output_text headline"),
+            executiveSummary: requiredText(
+              response.executiveSummary,
+              "output_text executive summary",
+            ),
+          }
+        : normalizedDraft;
       await input.attestationSink.record(
         receiptAttestation ?? {
           taskRole: "summary",

--- a/scripts/lib/reader-summary-production-recovery-release-wiring.spec.ts
+++ b/scripts/lib/reader-summary-production-recovery-release-wiring.spec.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const checker = readFileSync(
+  join(
+    process.cwd(),
+    "scripts/check-reader-summary-production-recovery-postgres.ts",
+  ),
+  "utf8",
+);
+const releaseHelper = readFileSync(
+  join(
+    process.cwd(),
+    "scripts/lib/reader-summary-production-recovery-release.ts",
+  ),
+  "utf8",
+);
+
+describe("reader summary production recovery release wiring", () => {
+  it("wraps the one full staged forward pass in bootstrap authority", () => {
+    const positions = [
+      'params.runBootstrap(\n    "pre"',
+      "for (const migration of params.migrations)",
+      "applyOrderedReaderSummaryMigrations(",
+      'params.runBootstrap(\n    "post"',
+      "assertReaderSummaryDailyTelemetryReleaseDatabaseState(",
+    ].map((needle) => releaseHelper.indexOf(needle));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+    expect(releaseHelper.match(/applyOrderedReaderSummaryMigrations\(/gu))
+      .toHaveLength(1);
+    const releaseCall = checker.indexOf(
+      "await applyReaderSummaryProductionRecoveryRelease(",
+    );
+    const schemaParity = checker.indexOf(
+      "assertReaderSummaryMigrationDatabaseMatchesSchema(",
+      releaseCall,
+    );
+    const lateRecovery = checker.indexOf(
+      "const legacyRecoveryAfterForward",
+      releaseCall,
+    );
+    expect(releaseCall).toBeGreaterThan(-1);
+    expect(schemaParity).toBeGreaterThan(releaseCall);
+    expect(lateRecovery).toBeGreaterThan(schemaParity);
+  });
+
+  it("includes telemetry and global default ACL in the verified staged list", () => {
+    expect(checker).toMatch(
+      /const telemetryMigration =\s+"20260824120000_reader_summary_daily_model_job_telemetry";/u,
+    );
+    expect(checker).toMatch(
+      /const defaultAclMigration =\s+"20260824121000_reader_summary_daily_function_global_default_acl";/u,
+    );
+    expect(checker).toContain(
+      "(migration) => migration > dailyDeliveryC1Migration,",
+    );
+    expect(checker).not.toContain("migration !== telemetryMigration");
+    expect(checker).not.toContain("migration !== defaultAclMigration");
+    expect(checker).toContain(
+      "...postDailyDeliveryMigrations,\n          ],",
+    );
+    expect(checker).toContain(
+      "runBootstrap: runReaderSummaryPublicationBootstrapSql,",
+    );
+    expect(releaseHelper).toContain(
+      "defaultAclMigration: params.defaultAclMigration,",
+    );
+    expect(releaseHelper).toContain(
+      "telemetryMigration: params.telemetryMigration,",
+    );
+  });
+});

--- a/scripts/lib/reader-summary-production-recovery-release.ts
+++ b/scripts/lib/reader-summary-production-recovery-release.ts
@@ -1,0 +1,58 @@
+import { cpSync } from "node:fs";
+import { join } from "node:path";
+
+import { applyOrderedReaderSummaryMigrations } from
+  "./reader-summary-publication-postgres-migrations";
+import type { createReaderSummaryPublicationMigrationWorkspace } from
+  "./reader-summary-publication-postgres-migrations";
+import { assertReaderSummaryDailyTelemetryReleaseDatabaseState } from
+  "./reader-summary-daily-telemetry-release";
+
+type ReleaseDatabaseClient = Parameters<
+  typeof assertReaderSummaryDailyTelemetryReleaseDatabaseState
+>[0];
+
+export const applyReaderSummaryProductionRecoveryRelease = async (params: {
+  readonly adminDatabaseUrl: string;
+  readonly client: ReleaseDatabaseClient;
+  readonly defaultAclMigration: string;
+  readonly migrationAdminRole: string;
+  readonly migrations: readonly string[];
+  readonly migrationWorkspace: ReturnType<
+    typeof createReaderSummaryPublicationMigrationWorkspace
+  >;
+  readonly runBootstrap: (
+    phase: "pre" | "post",
+    adminDatabaseUrl: string,
+    runtimeRole: string,
+  ) => Promise<void>;
+  readonly runtimeRole: string;
+  readonly telemetryMigration: string;
+}): Promise<void> => {
+  await params.runBootstrap(
+    "pre",
+    params.adminDatabaseUrl,
+    params.runtimeRole,
+  );
+  for (const migration of params.migrations) {
+    cpSync(
+      join(process.cwd(), "prisma", "migrations", migration),
+      join(params.migrationWorkspace.directory, "migrations", migration),
+      { recursive: true },
+    );
+  }
+  applyOrderedReaderSummaryMigrations(
+    params.adminDatabaseUrl,
+    params.migrationWorkspace,
+  );
+  await params.runBootstrap(
+    "post",
+    params.adminDatabaseUrl,
+    params.runtimeRole,
+  );
+  await assertReaderSummaryDailyTelemetryReleaseDatabaseState(params.client, {
+    defaultAclMigration: params.defaultAclMigration,
+    migrationAdminRole: params.migrationAdminRole,
+    telemetryMigration: params.telemetryMigration,
+  });
+};


### PR DESCRIPTION
## Summary

- restore pre-bootstrap authority before the one staged production-recovery migration pass
- apply telemetry and global default ACL migrations exactly once, then verify database state and schema parity before runtime checks
- preserve ordinary promotion no-signal short-circuiting while forcing sealed V4 persisted replay through exactly one model normalization pass
- preserve direct persisted output_text headline and executive summary at the recovery-specific adapter boundary
- split release staging into a focused helper to keep the production checker within the source line cap

## Root cause

The production deploy remained fail-closed before deployment. The recovery release checker applied later migrations after post-bootstrap had removed temporary migration authority. Once that was fixed, the full PostgreSQL 18 path exposed two downstream regressions from mandatory promotion admission: sealed no-signal V4 replay skipped the persisted model and therefore lost its immutable cutoff/provenance binding, then shared no-signal normalization changed direct output_text fields required by the SQL evidence contract.

The fix does not weaken SQL provenance checks, defer current-schema migrations, invent promotion facts, or change ordinary generated-summary normalization.

## Verification

- focused Jest: 24/24 passed
- touched-file ESLint: passed
- build/typecheck: passed
- source line cap and diff check: passed
- full clean PostgreSQL 18 production-recovery gate: passed in 1184.12s
  - migrations fixture
  - invalid runtime and retry race
  - V4 authority and least-privilege audits
  - negative probes
  - all eight dates
  - replay, final aggregate, post-execution assertions, cleanup

Production has not been changed by the failed earlier deploy run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recovery handling so daily summaries can still be generated when primary evidence is unavailable.
  * Added stronger validation for generated headlines and executive summaries.
  * Recovery-generated summaries now retain clearer provenance and audit information.

* **Bug Fixes**
  * Prevented incomplete post-promotion details from appearing when summaries lack content or supporting evidence.

* **Reliability**
  * Improved production recovery release checks and migration handling for more consistent summary availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->