### PR TITLE
fix(deploy): accept failed idle daily service

### DIFF
--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
@@ -653,7 +653,7 @@ wait_postgres_runtime_daily_c1_services_idle() {
     for service in \
       "$POSTGRES_RUNTIME_DAILY_SERVICE" "$POSTGRES_RUNTIME_DAILY_V6_SERVICE"; do
       state=$(systemctl show --property=ActiveState --value "$service") || return
-      [[ $state == inactive ]] || all_idle=false
+      [[ $state == inactive || $state == failed ]] || all_idle=false
     done
     [[ $all_idle == true ]] && return 0
     sleep 1

--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
@@ -322,11 +322,22 @@ if prove_postgres_runtime_daily_c1_flip_idle >/dev/null 2>&1; then
   exit 1
 fi
 reset_v6_topology
+LEGACY_SERVICE_STATE=failed
+prove_postgres_runtime_daily_c1_flip_idle
+reset_v6_topology
 V6_SERVICE_STATE=active
 if prove_postgres_runtime_daily_c1_flip_idle >/dev/null 2>&1; then
   echo 'daily C1 handoff accepted an active v6 service' >&2
   exit 1
 fi
+for ambiguous_state in active activating deactivating reloading unknown; do
+  reset_v6_topology
+  LEGACY_SERVICE_STATE=$ambiguous_state
+  if prove_postgres_runtime_daily_c1_flip_idle >/dev/null 2>&1; then
+    echo "daily C1 handoff accepted ambiguous service state: $ambiguous_state" >&2
+    exit 1
+  fi
+done
 
 # A failure before the durable owner flip remains rollback-safe: legacy is only
 # enabled, never started, and V6 remains the effective owner.


### PR DESCRIPTION
## Summary

- treat a stopped failed oneshot daily service as quiescent during deploy readiness
- keep active, activating, deactivating, reloading, and unknown states fail-closed
- retain the independent singleton-lock check before deploy

## Verification

- focused readiness library test passed
- ShellCheck passed
- bash syntax check passed
- git diff check passed