### PR TITLE
fix(production): restore rolling collection reliability

### DIFF
--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
@@ -653,7 +653,7 @@ wait_postgres_runtime_daily_c1_services_idle() {
     for service in \
       "$POSTGRES_RUNTIME_DAILY_SERVICE" "$POSTGRES_RUNTIME_DAILY_V6_SERVICE"; do
       state=$(systemctl show --property=ActiveState --value "$service") || return
-      [[ $state == inactive ]] || all_idle=false
+      [[ $state == inactive || $state == failed ]] || all_idle=false
     done
     [[ $all_idle == true ]] && return 0
     sleep 1

--- a/ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
+++ b/ops/deploy/postgres-runtime-daily-c1-readiness-lib.test.sh
@@ -322,11 +322,22 @@ if prove_postgres_runtime_daily_c1_flip_idle >/dev/null 2>&1; then
   exit 1
 fi
 reset_v6_topology
+LEGACY_SERVICE_STATE=failed
+prove_postgres_runtime_daily_c1_flip_idle
+reset_v6_topology
 V6_SERVICE_STATE=active
 if prove_postgres_runtime_daily_c1_flip_idle >/dev/null 2>&1; then
   echo 'daily C1 handoff accepted an active v6 service' >&2
   exit 1
 fi
+for ambiguous_state in active activating deactivating reloading unknown; do
+  reset_v6_topology
+  LEGACY_SERVICE_STATE=$ambiguous_state
+  if prove_postgres_runtime_daily_c1_flip_idle >/dev/null 2>&1; then
+    echo "daily C1 handoff accepted ambiguous service state: $ambiguous_state" >&2
+    exit 1
+  fi
+done
 
 # A failure before the durable owner flip remains rollback-safe: legacy is only
 # enabled, never started, and V6 remains the effective owner.

--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -122,26 +122,41 @@ container_body=$(cat <<'ROLLING_CONTAINER_BODY'
 
     artifact_root=/var/lib/social-monitor/artifacts/rolling-summary
     collection_directory="$artifact_root/collections"
+    collection_staging_directory="$collection_directory/runs/$ROLLING_RUN_ID"
     collection_source="$collection_directory/reader-summary-clean-real-day-collection.$ROLLING_COLLECTION_DATE.v1.json"
+    collection_staging_source="$collection_staging_directory/reader-summary-clean-real-day-collection.$ROLLING_COLLECTION_DATE.v1.json"
     collection_artifact="$artifact_root/rolling-summary.$ROLLING_RUN_ID.collection.v1.json"
     evidence_path="$artifact_root/rolling-summary.$ROLLING_RUN_ID.evidence.v1.json"
     frontend_path="$artifact_root/rolling-summary.$ROLLING_RUN_ID.frontend.v1.json"
     period_started_at="${ROLLING_COLLECTION_DATE}T00:00:00.000Z"
     required_providers=github-trending-page,hacker-news,reddit,rss,x-twitter
 
-    mkdir -p "$collection_directory"
+    mkdir -p "$collection_staging_directory"
+    rm -f "$collection_staging_source" \
+      "$collection_source.next.$ROLLING_RUN_ID" \
+      "$collection_artifact.next"
     collection_exit=0
     npm run run:reader-summary-clean-real-day-collection -- \
       --update \
       --date "$ROLLING_COLLECTION_DATE" \
-      --exact-date-artifact-directory "$collection_directory" \
+      --exact-date-artifact-directory "$collection_staging_directory" \
       --providers "$required_providers" || collection_exit=$?
 
+    if [ "$collection_exit" -ne 0 ]; then
+      echo "rolling collection failed for current pass $ROLLING_RUN_ID (exit $collection_exit)" >&2
+      exit "$collection_exit"
+    fi
+
     node ops/deploy/production-runtime/rolling-summary-receipt.mjs \
-      validate-collection "$collection_source" "$ROLLING_COLLECTION_DATE"
-    cp "$collection_source" "$collection_artifact.next"
+      validate-collection "$collection_staging_source" "$ROLLING_COLLECTION_DATE"
+    cp "$collection_staging_source" "$collection_source.next.$ROLLING_RUN_ID"
+    chmod 0444 "$collection_source.next.$ROLLING_RUN_ID"
+    mv "$collection_source.next.$ROLLING_RUN_ID" "$collection_source"
+    cp "$collection_staging_source" "$collection_artifact.next"
     chmod 0444 "$collection_artifact.next"
     mv "$collection_artifact.next" "$collection_artifact"
+    rm -f "$collection_staging_source"
+    rmdir "$collection_staging_directory" 2>/dev/null || true
     rolling_observation_cutoff=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
 
     if [ "$ROLLING_AUTH_READY" != true ]; then

--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -121,18 +121,20 @@ container_body=$(cat <<'ROLLING_CONTAINER_BODY'
     set -eu
 
     artifact_root=/var/lib/social-monitor/artifacts/rolling-summary
-    collection_source=ops/evals/reader-summary-clean-real-day-collection.v1.json
+    collection_directory="$artifact_root/collections"
+    collection_source="$collection_directory/reader-summary-clean-real-day-collection.$ROLLING_COLLECTION_DATE.v1.json"
     collection_artifact="$artifact_root/rolling-summary.$ROLLING_RUN_ID.collection.v1.json"
     evidence_path="$artifact_root/rolling-summary.$ROLLING_RUN_ID.evidence.v1.json"
     frontend_path="$artifact_root/rolling-summary.$ROLLING_RUN_ID.frontend.v1.json"
     period_started_at="${ROLLING_COLLECTION_DATE}T00:00:00.000Z"
     required_providers=github-trending-page,hacker-news,reddit,rss,x-twitter
 
-    mkdir -p "$artifact_root"
+    mkdir -p "$collection_directory"
     collection_exit=0
     npm run run:reader-summary-clean-real-day-collection -- \
       --update \
       --date "$ROLLING_COLLECTION_DATE" \
+      --exact-date-artifact-directory "$collection_directory" \
       --providers "$required_providers" || collection_exit=$?
 
     node ops/deploy/production-runtime/rolling-summary-receipt.mjs \

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -14,6 +14,7 @@ mkdir -p \
   "$TEST_ROOT/runtime/x-collector" \
   "$TEST_ROOT/secrets" \
   "$TEST_ROOT/secrets/db" \
+  "$TEST_ROOT/artifacts/evals" \
   "$TEST_ROOT/artifacts/rolling-summary"
 sha=1111111111111111111111111111111111111111
 printf '%s\n' "$sha" > "$TEST_ROOT/control/postgres-runtime-current/READY"
@@ -29,6 +30,9 @@ fake_agent_restart=$REPO/ops/deploy/production-runtime/test-fixtures/rolling-run
 refresh=$TEST_ROOT/control/refresh-codex-auth.sh
 ln -s /usr/bin/true "$refresh"
 export SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG=$TEST_ROOT/docker.log
+prior_alias=$TEST_ROOT/artifacts/evals/reader-summary-clean-real-day-collection.v1.json
+printf '%s\n' '{"run":{"collectionDate":"2026-08-14"},"sentinel":"prior-day"}' > "$prior_alias"
+prior_alias_bytes=$(sha256sum "$prior_alias" | cut -d' ' -f1)
 
 SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
 SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
@@ -42,6 +46,14 @@ grep -F -- '--profile daily run --rm --no-deps' "$TEST_ROOT/docker.log" >/dev/nu
 grep -F -- '-e ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '-e ROLLING_AUTH_READY=true' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- 'daily-runner sh -lc' "$TEST_ROOT/docker.log" >/dev/null
+grep -F -- '--exact-date-artifact-directory "$collection_directory"' "$RUNNER" >/dev/null
+grep -F -- 'reader-summary-clean-real-day-collection.$ROLLING_COLLECTION_DATE.v1.json' "$RUNNER" >/dev/null
+! grep -F -- 'collection_source=ops/evals/reader-summary-clean-real-day-collection.v1.json' "$RUNNER" >/dev/null
+[[ $(sha256sum "$prior_alias" | cut -d' ' -f1) == "$prior_alias_bytes" ]]
+exact_collection=$TEST_ROOT/artifacts/rolling-summary/collections/reader-summary-clean-real-day-collection.2026-08-15.v1.json
+node "$REPO/ops/deploy/production-runtime/rolling-summary-receipt.mjs" \
+  validate-collection "$exact_collection" 2026-08-15
+grep -Fx 'collection-created 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- "--providers \"\$required_providers\"" "$RUNNER" >/dev/null
 grep -F -- 'npm run capture:durable-reader-summary' "$RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_MODEL=agent-runtime' "$RUNNER" >/dev/null
@@ -92,6 +104,7 @@ SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
 SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T16:15:00.000Z \
 SOCIAL_MONITOR_ROLLING_RUNTIME=containerd \
   bash "$RUNNER"
+grep -Fx 'collection-reused 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '-n moby run --rm --net-host' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '--env ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '--env ROLLING_AUTH_READY=true' "$TEST_ROOT/docker.log" >/dev/null

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -46,14 +46,15 @@ grep -F -- '--profile daily run --rm --no-deps' "$TEST_ROOT/docker.log" >/dev/nu
 grep -F -- '-e ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '-e ROLLING_AUTH_READY=true' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- 'daily-runner sh -lc' "$TEST_ROOT/docker.log" >/dev/null
-grep -F -- '--exact-date-artifact-directory "$collection_directory"' "$RUNNER" >/dev/null
+grep -F -- '--exact-date-artifact-directory "$collection_staging_directory"' "$RUNNER" >/dev/null
 grep -F -- 'reader-summary-clean-real-day-collection.$ROLLING_COLLECTION_DATE.v1.json' "$RUNNER" >/dev/null
+grep -F -- 'collection_directory/runs/$ROLLING_RUN_ID' "$RUNNER" >/dev/null
 ! grep -F -- 'collection_source=ops/evals/reader-summary-clean-real-day-collection.v1.json' "$RUNNER" >/dev/null
 [[ $(sha256sum "$prior_alias" | cut -d' ' -f1) == "$prior_alias_bytes" ]]
 exact_collection=$TEST_ROOT/artifacts/rolling-summary/collections/reader-summary-clean-real-day-collection.2026-08-15.v1.json
 node "$REPO/ops/deploy/production-runtime/rolling-summary-receipt.mjs" \
   validate-collection "$exact_collection" 2026-08-15
-grep -Fx 'collection-created 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
+grep -Fx 'collection-created 20260815T081500000Z 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- "--providers \"\$required_providers\"" "$RUNNER" >/dev/null
 grep -F -- 'npm run capture:durable-reader-summary' "$RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_MODEL=agent-runtime' "$RUNNER" >/dev/null
@@ -68,23 +69,49 @@ grep -Fx 'OnCalendar=*-*-* 04,08,12,16,20:15:00 UTC' \
 grep -Fx 'Persistent=true' \
   "$REPO/ops/deploy/production-runtime/social-monitor-rolling.timer" >/dev/null
 
-ln -sfn /usr/bin/false "$refresh"
+successful_collection_bytes=$(sha256sum "$exact_collection" | cut -d' ' -f1)
 if SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T12:15:00.000Z \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_FAIL_COLLECTION_RUN_ID=20260815T121500000Z \
+    bash "$RUNNER"; then
+  echo 'rolling run published a stale same-day collection after current collection failure' >&2
+  exit 1
+fi
+grep -Fx 'collection-failed 20260815T121500000Z 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
+[[ $(sha256sum "$exact_collection" | cut -d' ' -f1) == "$successful_collection_bytes" ]]
+[[ ! -e $TEST_ROOT/artifacts/rolling-summary/rolling-summary.20260815T121500000Z.collection.v1.json ]]
+[[ ! -e $TEST_ROOT/artifacts/rolling-summary/rolling-summary.20260815T121500000Z.receipt.v1.json ]]
+[[ ! -e $TEST_ROOT/artifacts/rolling-summary/collections/runs/20260815T121500000Z/reader-summary-clean-real-day-collection.2026-08-15.v1.json ]]
+
+ln -sfn /usr/bin/false "$refresh"
+if SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T13:15:00.000Z \
     bash "$RUNNER"; then
   echo 'rolling run accepted unavailable summary auth' >&2
   exit 1
 fi
 grep -F -- '-e ROLLING_AUTH_READY=false' "$TEST_ROOT/docker.log" >/dev/null
 [[ $(grep -Fc -- '--profile app up -d --no-deps agent-runtime' \
-  "$TEST_ROOT/docker.log") == 1 ]]
+  "$TEST_ROOT/docker.log") == 2 ]]
 
 collection_line=$(grep -n 'npm run run:reader-summary-clean-real-day-collection' \
   "$RUNNER" | cut -d: -f1)
+collection_staging_clear_line=$(grep -n 'rm -f "\$collection_staging_source"' \
+  "$RUNNER" | head -1 | cut -d: -f1)
+collection_failure_guard_line=$(grep -n '"\$collection_exit" -ne 0' \
+  "$RUNNER" | cut -d: -f1)
+collection_promotion_line=$(grep -n 'cp "\$collection_staging_source" "\$collection_source' \
+  "$RUNNER" | cut -d: -f1)
 auth_guard_line=$(grep -n 'ROLLING_AUTH_READY.*!= true' "$RUNNER" | cut -d: -f1)
+((collection_staging_clear_line < collection_line))
+((collection_line < collection_failure_guard_line))
+((collection_failure_guard_line < collection_promotion_line))
 ((collection_line < auth_guard_line))
 grep -F 'if [ "$ROLLING_AUTH_READY" != true ]; then' "$RUNNER" >/dev/null
 ! grep -F 'if [[ "$ROLLING_AUTH_READY"' "$RUNNER" >/dev/null
@@ -104,7 +131,7 @@ SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
 SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T16:15:00.000Z \
 SOCIAL_MONITOR_ROLLING_RUNTIME=containerd \
   bash "$RUNNER"
-grep -Fx 'collection-reused 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
+grep -Fx 'collection-created 20260815T161500000Z 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '-n moby run --rm --net-host' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '--env ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '--env ROLLING_AUTH_READY=true' "$TEST_ROOT/docker.log" >/dev/null

--- a/ops/deploy/production-runtime/rolling-summary-receipt.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.mjs
@@ -65,6 +65,9 @@ function writeReceipt(args) {
     endedAt,
     collectionExit,
   ] = args;
+  if (collectionExit !== "0") {
+    throw new Error("rolling collection command did not succeed");
+  }
   const evidence = readJson(evidencePath);
   const collection = readJson(collectionPath);
   validateCollection(collection, date);

--- a/ops/deploy/production-runtime/rolling-summary-receipt.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.mjs
@@ -16,15 +16,7 @@ const [command, ...args] = process.argv.slice(2);
 if (command === "validate-collection") {
   const [path, date] = args;
   const report = readJson(path);
-  if (report?.run?.collectionDate !== date) {
-    throw new Error("rolling collection date mismatch");
-  }
-  const scans = Array.isArray(report.scans) ? report.scans : [];
-  for (const provider of requiredProviders) {
-    if (!scans.some((scan) => scan?.providerKey === provider)) {
-      throw new Error(`rolling collection did not attempt ${provider}`);
-    }
-  }
+  validateCollection(report, date);
 } else if (command === "write-receipt") {
   writeReceipt(args);
 } else if (command === "validate-receipt") {
@@ -45,6 +37,24 @@ if (command === "validate-collection") {
   throw new Error("rolling summary receipt command is invalid");
 }
 
+function validateCollection(report, date) {
+  if (report?.run?.collectionDate !== date) {
+    throw new Error("rolling collection date mismatch");
+  }
+  const scans = Array.isArray(report.scans) ? report.scans : [];
+  for (const provider of requiredProviders) {
+    if (
+      !scans.some(
+        (scan) =>
+          scan?.providerKey === provider &&
+          ["succeeded", "failed", "skipped"].includes(scan.status),
+      )
+    ) {
+      throw new Error(`rolling collection lacks terminal ${provider} evidence`);
+    }
+  }
+}
+
 function writeReceipt(args) {
   const [
     receiptPath,
@@ -57,6 +67,7 @@ function writeReceipt(args) {
   ] = args;
   const evidence = readJson(evidencePath);
   const collection = readJson(collectionPath);
+  validateCollection(collection, date);
   const receipt = {
     schemaVersion: 1,
     artifactFormat: "social-monitor-rolling-summary-receipt-v1",

--- a/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
@@ -77,9 +77,19 @@ try {
     runId,
     date,
     "2026-08-15T08:15:00.000Z",
-    "1",
+    "0",
   );
   run("validate-receipt", receiptPath, runId, date);
+  runFailure(
+    "write-receipt",
+    join(directory, "failed-collection-receipt.json"),
+    evidencePath,
+    collectionPath,
+    runId,
+    date,
+    "2026-08-15T12:15:00.000Z",
+    "1",
+  );
   runFailure(
     "write-receipt",
     join(directory, "stale-receipt.json"),

--- a/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
@@ -14,6 +14,7 @@ const collectionPath = join(directory, "collection.json");
 const evidencePath = join(directory, "evidence.json");
 const receiptPath = join(directory, "receipt.json");
 const invalidReceiptPath = join(directory, "invalid-receipt.json");
+const priorCollectionPath = join(directory, "collection.2026-08-14.json");
 
 try {
   writeFileSync(
@@ -48,8 +49,26 @@ try {
       redaction: { secretsIncluded: false },
     }),
   );
+  writeFileSync(
+    priorCollectionPath,
+    JSON.stringify({
+      ...JSON.parse(readFileSync(collectionPath, "utf8")),
+      run: { collectionDate: "2026-08-14" },
+    }),
+  );
 
   run("validate-collection", collectionPath, date);
+  runFailure("validate-collection", priorCollectionPath, date);
+  const nonterminalCollection = JSON.parse(
+    readFileSync(collectionPath, "utf8"),
+  );
+  nonterminalCollection.scans[0].status = "running";
+  const nonterminalCollectionPath = join(directory, "collection.running.json");
+  writeFileSync(
+    nonterminalCollectionPath,
+    JSON.stringify(nonterminalCollection),
+  );
+  runFailure("validate-collection", nonterminalCollectionPath, date);
   run(
     "write-receipt",
     receiptPath,
@@ -61,6 +80,16 @@ try {
     "1",
   );
   run("validate-receipt", receiptPath, runId, date);
+  runFailure(
+    "write-receipt",
+    join(directory, "stale-receipt.json"),
+    evidencePath,
+    priorCollectionPath,
+    runId,
+    date,
+    "2026-08-15T08:15:00.000Z",
+    "0",
+  );
 
   const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
   assert.equal(receipt.collection.finalDayQualityGatePassed, false);

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
@@ -10,6 +10,20 @@ for ((index = 0; index < ${#args[@]}; index += 1)); do
   fi
 done
 [[ $* != *'--env ROLLING_AUTH_READY=false'* ]] || exit 75
+collection_date=
+if [[ $* =~ --env[[:space:]]ROLLING_COLLECTION_DATE=([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
+  collection_date=${BASH_REMATCH[1]}
+fi
+artifact_root=${SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH%/*}
+collection_directory=$artifact_root/collections
+collection_path=$collection_directory/reader-summary-clean-real-day-collection.$collection_date.v1.json
+mkdir -p "$collection_directory"
+if [[ -f $collection_path ]]; then
+  printf 'collection-reused %s\n' "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+else
+  printf '%s\n' "{\"run\":{\"collectionDate\":\"$collection_date\"},\"blockingPassed\":true,\"scans\":[{\"providerKey\":\"github-trending-page\",\"status\":\"succeeded\"},{\"providerKey\":\"hacker-news\",\"status\":\"succeeded\"},{\"providerKey\":\"reddit\",\"status\":\"succeeded\"},{\"providerKey\":\"rss\",\"status\":\"succeeded\"},{\"providerKey\":\"x-twitter\",\"status\":\"succeeded\"}]}" > "$collection_path"
+  printf 'collection-created %s\n' "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+fi
 printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS","publication":{"readerSummaryJobId":"test-job","readerSummaryId":"test-summary","status":"completed"}}\n' \
   "$SOCIAL_MONITOR_ROLLING_RUN_ID" > \
   "$SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH"

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
@@ -9,21 +9,32 @@ for ((index = 0; index < ${#args[@]}; index += 1)); do
       "${args[$((index + 1))]}" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
   fi
 done
-[[ $* != *'--env ROLLING_AUTH_READY=false'* ]] || exit 75
 collection_date=
 if [[ $* =~ --env[[:space:]]ROLLING_COLLECTION_DATE=([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
   collection_date=${BASH_REMATCH[1]}
 fi
 artifact_root=${SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH%/*}
 collection_directory=$artifact_root/collections
+collection_staging_directory=$collection_directory/runs/$SOCIAL_MONITOR_ROLLING_RUN_ID
 collection_path=$collection_directory/reader-summary-clean-real-day-collection.$collection_date.v1.json
-mkdir -p "$collection_directory"
-if [[ -f $collection_path ]]; then
-  printf 'collection-reused %s\n' "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+collection_staging_path=$collection_staging_directory/reader-summary-clean-real-day-collection.$collection_date.v1.json
+collection_run_path=$artifact_root/rolling-summary.$SOCIAL_MONITOR_ROLLING_RUN_ID.collection.v1.json
+mkdir -p "$collection_staging_directory"
+if [[ ${SOCIAL_MONITOR_ROLLING_RUN_TEST_FAIL_COLLECTION_RUN_ID:-} == "$SOCIAL_MONITOR_ROLLING_RUN_ID" ]]; then
+  printf 'collection-failed %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+  exit 1
+elif [[ -f $collection_staging_path ]]; then
+  printf 'collection-reused %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
 else
-  printf '%s\n' "{\"run\":{\"collectionDate\":\"$collection_date\"},\"blockingPassed\":true,\"scans\":[{\"providerKey\":\"github-trending-page\",\"status\":\"succeeded\"},{\"providerKey\":\"hacker-news\",\"status\":\"succeeded\"},{\"providerKey\":\"reddit\",\"status\":\"succeeded\"},{\"providerKey\":\"rss\",\"status\":\"succeeded\"},{\"providerKey\":\"x-twitter\",\"status\":\"succeeded\"}]}" > "$collection_path"
-  printf 'collection-created %s\n' "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+  printf '%s\n' "{\"run\":{\"collectionDate\":\"$collection_date\"},\"blockingPassed\":true,\"scans\":[{\"providerKey\":\"github-trending-page\",\"status\":\"succeeded\"},{\"providerKey\":\"hacker-news\",\"status\":\"succeeded\"},{\"providerKey\":\"reddit\",\"status\":\"succeeded\"},{\"providerKey\":\"rss\",\"status\":\"succeeded\"},{\"providerKey\":\"x-twitter\",\"status\":\"succeeded\"}]}" > "$collection_staging_path"
+  printf 'collection-created %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
 fi
+cp "$collection_staging_path" "$collection_path.next.$SOCIAL_MONITOR_ROLLING_RUN_ID"
+mv "$collection_path.next.$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_path"
+cp "$collection_staging_path" "$collection_run_path"
+rm -f "$collection_staging_path"
+rmdir "$collection_staging_directory"
+[[ $* != *'--env ROLLING_AUTH_READY=false'* ]] || exit 75
 printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS","publication":{"readerSummaryJobId":"test-job","readerSummaryId":"test-summary","status":"completed"}}\n' \
   "$SOCIAL_MONITOR_ROLLING_RUN_ID" > \
   "$SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH"

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
@@ -24,6 +24,20 @@ if [[ $* == *' config --format json'* ]]; then
 fi
 if [[ $* == *' daily-runner sh -lc '* ]]; then
   [[ $* != *'-e ROLLING_AUTH_READY=false'* ]] || exit 75
+  collection_date=
+  if [[ $* =~ -e[[:space:]]ROLLING_COLLECTION_DATE=([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
+    collection_date=${BASH_REMATCH[1]}
+  fi
+  artifact_root=${SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH%/*}
+  collection_directory=$artifact_root/collections
+  collection_path=$collection_directory/reader-summary-clean-real-day-collection.$collection_date.v1.json
+  mkdir -p "$collection_directory"
+  if [[ -f $collection_path ]]; then
+    printf 'collection-reused %s\n' "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+  else
+    printf '%s\n' "{\"run\":{\"collectionDate\":\"$collection_date\"},\"blockingPassed\":true,\"scans\":[{\"providerKey\":\"github-trending-page\",\"status\":\"succeeded\"},{\"providerKey\":\"hacker-news\",\"status\":\"succeeded\"},{\"providerKey\":\"reddit\",\"status\":\"succeeded\"},{\"providerKey\":\"rss\",\"status\":\"succeeded\"},{\"providerKey\":\"x-twitter\",\"status\":\"succeeded\"}]}" > "$collection_path"
+    printf 'collection-created %s\n' "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+  fi
   printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS","publication":{"readerSummaryJobId":"test-job","readerSummaryId":"test-summary","status":"completed"}}\n' \
     "$SOCIAL_MONITOR_ROLLING_RUN_ID" > \
     "$SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH"

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
@@ -23,21 +23,32 @@ if [[ $* == *' config --format json'* ]]; then
   exit 0
 fi
 if [[ $* == *' daily-runner sh -lc '* ]]; then
-  [[ $* != *'-e ROLLING_AUTH_READY=false'* ]] || exit 75
   collection_date=
   if [[ $* =~ -e[[:space:]]ROLLING_COLLECTION_DATE=([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
     collection_date=${BASH_REMATCH[1]}
   fi
   artifact_root=${SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH%/*}
   collection_directory=$artifact_root/collections
+  collection_staging_directory=$collection_directory/runs/$SOCIAL_MONITOR_ROLLING_RUN_ID
   collection_path=$collection_directory/reader-summary-clean-real-day-collection.$collection_date.v1.json
-  mkdir -p "$collection_directory"
-  if [[ -f $collection_path ]]; then
-    printf 'collection-reused %s\n' "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+  collection_staging_path=$collection_staging_directory/reader-summary-clean-real-day-collection.$collection_date.v1.json
+  collection_run_path=$artifact_root/rolling-summary.$SOCIAL_MONITOR_ROLLING_RUN_ID.collection.v1.json
+  mkdir -p "$collection_staging_directory"
+  if [[ ${SOCIAL_MONITOR_ROLLING_RUN_TEST_FAIL_COLLECTION_RUN_ID:-} == "$SOCIAL_MONITOR_ROLLING_RUN_ID" ]]; then
+    printf 'collection-failed %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+    exit 1
+  elif [[ -f $collection_staging_path ]]; then
+    printf 'collection-reused %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
   else
-    printf '%s\n' "{\"run\":{\"collectionDate\":\"$collection_date\"},\"blockingPassed\":true,\"scans\":[{\"providerKey\":\"github-trending-page\",\"status\":\"succeeded\"},{\"providerKey\":\"hacker-news\",\"status\":\"succeeded\"},{\"providerKey\":\"reddit\",\"status\":\"succeeded\"},{\"providerKey\":\"rss\",\"status\":\"succeeded\"},{\"providerKey\":\"x-twitter\",\"status\":\"succeeded\"}]}" > "$collection_path"
-    printf 'collection-created %s\n' "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
+    printf '%s\n' "{\"run\":{\"collectionDate\":\"$collection_date\"},\"blockingPassed\":true,\"scans\":[{\"providerKey\":\"github-trending-page\",\"status\":\"succeeded\"},{\"providerKey\":\"hacker-news\",\"status\":\"succeeded\"},{\"providerKey\":\"reddit\",\"status\":\"succeeded\"},{\"providerKey\":\"rss\",\"status\":\"succeeded\"},{\"providerKey\":\"x-twitter\",\"status\":\"succeeded\"}]}" > "$collection_staging_path"
+    printf 'collection-created %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
   fi
+  cp "$collection_staging_path" "$collection_path.next.$SOCIAL_MONITOR_ROLLING_RUN_ID"
+  mv "$collection_path.next.$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_path"
+  cp "$collection_staging_path" "$collection_run_path"
+  rm -f "$collection_staging_path"
+  rmdir "$collection_staging_directory"
+  [[ $* != *'-e ROLLING_AUTH_READY=false'* ]] || exit 75
   printf '{"runId":"%s","collectionDate":"2026-08-15","status":"SUCCESS","publication":{"readerSummaryJobId":"test-job","readerSummaryId":"test-summary","status":"completed"}}\n' \
     "$SOCIAL_MONITOR_ROLLING_RUN_ID" > \
     "$SOCIAL_MONITOR_ROLLING_RUN_RECEIPT_HOST_PATH"

--- a/scripts/lib/reader-summary-clean-real-day-collection-artifact.spec.ts
+++ b/scripts/lib/reader-summary-clean-real-day-collection-artifact.spec.ts
@@ -128,6 +128,41 @@ describe("reader summary exact-day collection artifacts", () => {
     }
   });
 
+  it("enforces an exact dated path without imposing maintenance scope", () => {
+    const directory = mkdtempSync(join(tmpdir(), "reader-summary-collection-"));
+    const priorDayPath = readerSummaryDailyCollectionArtifactPath({
+      directory,
+      collectionDate: "2026-08-24",
+    });
+    try {
+      writeCollectionArtifactAtomically({
+        path: priorDayPath,
+        report: report("2026-08-24"),
+        requireExactDatePath: true,
+      });
+
+      expect(() =>
+        readExactDayCollectionArtifact({
+          path: priorDayPath,
+          collectionDate: "2026-08-25",
+          requireExactDatePath: true,
+        }),
+      ).toThrow("not explicit for its requested date");
+      expect(() =>
+        writeCollectionArtifactAtomically({
+          path: join(
+            directory,
+            "reader-summary-clean-real-day-collection.v1.json",
+          ),
+          report: report("2026-08-25"),
+          requireExactDatePath: true,
+        }),
+      ).toThrow("not explicit for its report date");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a non-date artifact name before it can overwrite another day", () => {
     expect(() =>
       readerSummaryDailyCollectionArtifactPath({

--- a/scripts/lib/reader-summary-clean-real-day-collection-artifact.ts
+++ b/scripts/lib/reader-summary-clean-real-day-collection-artifact.ts
@@ -56,11 +56,13 @@ export const readExactDayCollectionArtifact = (params: {
   readonly path: string;
   readonly collectionDate: string;
   readonly expectedScope?: ReaderSummaryDailyMaintenanceScope;
+  readonly requireExactDatePath?: boolean;
 }): CleanRealDayCollectionReport | null => {
   assertExpectedMaintenanceScope(params.expectedScope);
   assertSafeCollectionArtifactPath(params.path);
   if (
-    params.expectedScope !== undefined &&
+    (params.expectedScope !== undefined ||
+      params.requireExactDatePath === true) &&
     basename(params.path) !==
       readerSummaryDailyCollectionArtifactFileName(params.collectionDate)
   ) {
@@ -110,12 +112,14 @@ export const writeCollectionArtifactAtomically = (params: {
   readonly path: string;
   readonly report: CleanRealDayCollectionReport;
   readonly expectedScope?: ReaderSummaryDailyMaintenanceScope;
+  readonly requireExactDatePath?: boolean;
 }): void => {
   assertExpectedMaintenanceScope(params.expectedScope);
   assertSafeCollectionArtifactPath(params.path);
   assertExactDayIdentity(params.report, params.report.run.collectionDate);
   if (
-    params.expectedScope !== undefined &&
+    (params.expectedScope !== undefined ||
+      params.requireExactDatePath === true) &&
     basename(params.path) !==
       readerSummaryDailyCollectionArtifactFileName(
         params.report.run.collectionDate,

--- a/scripts/lib/reader-summary-clean-real-day-collection-cli.spec.ts
+++ b/scripts/lib/reader-summary-clean-real-day-collection-cli.spec.ts
@@ -17,6 +17,26 @@ describe("clean real-day collection CLI", () => {
     );
     expect(cli.targetDiscoveryScopePredicate).toBe("");
     expect(cli.targetDiscoveryScopeValues).toEqual([]);
+    expect(cli.exactDateArtifact).toBe(false);
+  });
+
+  it("binds scheduled collection output to the requested date without maintenance scope", () => {
+    const cli = withArgs(
+      [
+        "--update",
+        "--date",
+        "2026-08-25",
+        "--exact-date-artifact-directory",
+        "/durable/rolling-summary/collections",
+      ],
+      () => readCli(),
+    );
+
+    expect(cli.outputPath).toBe(
+      "/durable/rolling-summary/collections/reader-summary-clean-real-day-collection.2026-08-25.v1.json",
+    );
+    expect(cli.exactDateArtifact).toBe(true);
+    expect(cli.maintenanceScope).toBeUndefined();
   });
 
   it("requires the canonical scope and exact per-day artifact for bounded maintenance", () => {

--- a/scripts/lib/reader-summary-clean-real-day-collection-cli.ts
+++ b/scripts/lib/reader-summary-clean-real-day-collection-cli.ts
@@ -35,6 +35,7 @@ export type ReaderSummaryCleanRealDayCollectionCli = Readonly<{
   targetCollectionDate: string;
   requestedProviderKeys: readonly CleanRealDayCollectionProviderKey[];
   outputPath: string;
+  exactDateArtifact: boolean;
   targetPublishedWindow: Readonly<{
     startInclusive: string;
     endExclusive: string;
@@ -68,6 +69,17 @@ export const readReaderSummaryCleanRealDayCollectionCli = (params: {
     collectionDateOptionOrDefault(dateOnly(params.collectionPolicyEvaluatedAt));
   const requestedProviderKeys = readProviderKeys();
   const artifactDirectory = readOption("--artifact-directory");
+  const exactDateArtifactDirectory = readOption(
+    "--exact-date-artifact-directory",
+  );
+  if (
+    artifactDirectory !== undefined &&
+    exactDateArtifactDirectory !== undefined
+  ) {
+    throw new Error(
+      "--artifact-directory and --exact-date-artifact-directory are exclusive",
+    );
+  }
   const productionHistoryFirstAttempt = process.argv.includes(
     "--production-history-scope",
   );
@@ -196,12 +208,18 @@ export const readReaderSummaryCleanRealDayCollectionCli = (params: {
     targetCollectionDate,
     requestedProviderKeys,
     outputPath:
-      artifactDirectory === undefined
-        ? "ops/evals/reader-summary-clean-real-day-collection.v1.json"
-        : readerSummaryDailyCollectionArtifactPath({
-            directory: artifactDirectory,
+      exactDateArtifactDirectory !== undefined
+        ? readerSummaryDailyCollectionArtifactPath({
+            directory: exactDateArtifactDirectory,
             collectionDate: targetCollectionDate,
-          }),
+          })
+        : artifactDirectory === undefined
+          ? "ops/evals/reader-summary-clean-real-day-collection.v1.json"
+          : readerSummaryDailyCollectionArtifactPath({
+              directory: artifactDirectory,
+              collectionDate: targetCollectionDate,
+            }),
+    exactDateArtifact: exactDateArtifactDirectory !== undefined,
     targetPublishedWindow,
     targetPublishedWindowConfig: {
       ...targetPublishedWindow,

--- a/scripts/run-reader-summary-clean-real-day-collection.ts
+++ b/scripts/run-reader-summary-clean-real-day-collection.ts
@@ -107,6 +107,7 @@ const {
   targetCollectionDate,
   requestedProviderKeys,
   outputPath,
+  exactDateArtifact,
   targetPublishedWindow,
   targetPublishedWindowConfig,
   maintenanceScope,
@@ -151,6 +152,7 @@ async function main(): Promise<void> {
     writeCollectionArtifactAtomically({
       path: outputPath,
       report,
+      requireExactDatePath: exactDateArtifact,
       ...(maintenanceScope === undefined
         ? {}
         : { expectedScope: maintenanceScope }),
@@ -264,6 +266,7 @@ async function tryRunCollection(): Promise<
       ? readExactDayCollectionArtifact({
           path: outputPath,
           collectionDate: targetCollectionDate,
+          requireExactDatePath: exactDateArtifact,
           ...(maintenanceScope === undefined
             ? {}
             : { expectedScope: maintenanceScope }),
@@ -871,14 +874,17 @@ function validateExistingReport(): void {
   }
 
   const report =
-    maintenanceScope === undefined
+    maintenanceScope === undefined && !exactDateArtifact
       ? (JSON.parse(
           readFileSync(outputPath, "utf8"),
         ) as CleanRealDayCollectionReport)
       : readExactDayCollectionArtifact({
           path: outputPath,
           collectionDate: targetCollectionDate,
-          expectedScope: maintenanceScope,
+          requireExactDatePath: exactDateArtifact,
+          ...(maintenanceScope === undefined
+            ? {}
+            : { expectedScope: maintenanceScope }),
         });
   if (report === null)
     throw new Error(


### PR DESCRIPTION
## Summary

- store scheduled rolling collection evidence as an exact-date artifact under the persistent rolling-summary mount
- collect each four-hour pass into run-scoped staging and fail closed before publication when the current pass fails
- atomically promote only a validated current-pass artifact to the same-day canonical path
- keep refreshing all five providers on every healthy pass and leave the legacy mutable eval alias untouched
- accept a stopped failed oneshot daily service as quiescent only after the singleton guard proves no collection is running
- preserve strict prior-day rejection and Docker/containerd parity

## Verification

- exact-head implementation review found and fixed the stale same-day publication P1
- focused Jest: 2 suites, 15 tests
- rolling receipt and rolling runtime shell tests passed
- Bash syntax and ShellCheck passed
- focused ESLint and TypeScript build passed
- source/test line-cap and git diff checks passed
- full pull request CI is running on the combined release head

## Release intent

This PR combines the collection artifact fix and the deploy readiness fix so production receives one release and one deployment pipeline instead of two queued heavy deploys.
