### PR TITLE
fix(migrations): retain schema grant through telemetry rewrites

### DIFF
--- a/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
@@ -486,6 +486,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/lib/reader-summary-current-publication-bindings.ts
       scripts/lib/reader-summary-daily-canonical-recovery-v4-delivery-c1.ts
       scripts/lib/reader-summary-daily-canonical-recovery-v4-scan-terminal-repair-cli.ts
+      scripts/lib/reader-summary-daily-production-owner-topology-postgres.ts
       scripts/lib/reader-summary-daily-terminal-runtime-connection.spec.ts
       scripts/lib/reader-summary-daily-terminal-runtime-connection.ts
       scripts/lib/reader-summary-production-day-scope.spec.ts

--- a/prisma/migrations/20260824120000_reader_summary_daily_model_job_telemetry/migration.sql
+++ b/prisma/migrations/20260824120000_reader_summary_daily_model_job_telemetry/migration.sql
@@ -448,8 +448,6 @@ ALTER FUNCTION public."complete_reader_summary_daily_model_job_v2"(
   UUID, UUID, DATE, TEXT, BIGINT, TIMESTAMPTZ, BYTEA, CHAR,
   JSONB, BYTEA, CHAR, BYTEA, CHAR, BIGINT, BIGINT, BIGINT, TEXT, BIGINT
 ) OWNER TO social_monitor_reader_summary_daily_publication_definer;
-REVOKE CREATE ON SCHEMA public
-  FROM social_monitor_reader_summary_daily_publication_definer;
 SET LOCAL ROLE social_monitor_reader_summary_daily_publication_definer;
 
 -- Historical rows remain readable and replayable through their persisted
@@ -478,6 +476,7 @@ DECLARE
   v_definition TEXT;
   v_owner_oid OID;
   v_owner_name NAME;
+  v_owner_had_schema_create BOOLEAN;
   v_session_user_oid OID;
   v_boundary_current_user_oid OID;
   v_version_from CONSTANT TEXT := '''reader-summary-daily:v1''';
@@ -505,7 +504,6 @@ BEGIN
   ])) IS NOT TRUE THEN
     RAISE EXCEPTION 'daily active claim has unexpected owner';
   END IF;
-  EXECUTE pg_catalog.format('SET LOCAL ROLE %I', v_owner_name);
   IF (pg_catalog.length(v_definition) - pg_catalog.length(
         pg_catalog.replace(v_definition, v_version_from, '')))
       / pg_catalog.length(v_version_from) <> 1
@@ -515,11 +513,29 @@ BEGIN
     OR pg_catalog.strpos(v_definition, v_version_to) <> 0 THEN
     RAISE EXCEPTION 'daily active claim profile is not the expected v1/xhigh definition';
   END IF;
+  v_owner_had_schema_create := pg_catalog.has_schema_privilege(
+    v_owner_oid, 'public', 'CREATE'
+  );
+  IF NOT v_owner_had_schema_create THEN
+    EXECUTE 'SET LOCAL ROLE social_monitor_public_schema_owner';
+    EXECUTE pg_catalog.format(
+      'GRANT CREATE ON SCHEMA public TO %I GRANTED BY CURRENT_USER',
+      v_owner_name
+    );
+  END IF;
+  EXECUTE pg_catalog.format('SET LOCAL ROLE %I', v_owner_name);
   EXECUTE pg_catalog.replace(
     pg_catalog.replace(v_definition, v_version_from, v_version_to),
     v_effort_from,
     v_effort_to
   );
+  IF NOT v_owner_had_schema_create THEN
+    EXECUTE 'SET LOCAL ROLE social_monitor_public_schema_owner';
+    EXECUTE pg_catalog.format(
+      'REVOKE CREATE ON SCHEMA public FROM %I GRANTED BY CURRENT_USER',
+      v_owner_name
+    );
+  END IF;
 END;
 $daily_active_claim_profile$;
 RESET ROLE;
@@ -529,6 +545,7 @@ DECLARE
   v_definition TEXT;
   v_owner_oid OID;
   v_owner_name NAME;
+  v_owner_had_schema_create BOOLEAN;
   v_session_user_oid OID;
   v_boundary_current_user_oid OID;
   v_version_from CONSTANT TEXT := '''reader-summary-daily:v1''';
@@ -556,7 +573,6 @@ BEGIN
   ])) IS NOT TRUE THEN
     RAISE EXCEPTION 'bounded daily active claim has unexpected owner';
   END IF;
-  EXECUTE pg_catalog.format('SET LOCAL ROLE %I', v_owner_name);
   IF (pg_catalog.length(v_definition) - pg_catalog.length(
         pg_catalog.replace(v_definition, v_version_from, '')))
       / pg_catalog.length(v_version_from) <> 1
@@ -566,13 +582,35 @@ BEGIN
     OR pg_catalog.strpos(v_definition, v_version_to) <> 0 THEN
     RAISE EXCEPTION 'bounded daily active claim profile is not the expected v1/xhigh definition';
   END IF;
+  v_owner_had_schema_create := pg_catalog.has_schema_privilege(
+    v_owner_oid, 'public', 'CREATE'
+  );
+  IF NOT v_owner_had_schema_create THEN
+    EXECUTE 'SET LOCAL ROLE social_monitor_public_schema_owner';
+    EXECUTE pg_catalog.format(
+      'GRANT CREATE ON SCHEMA public TO %I GRANTED BY CURRENT_USER',
+      v_owner_name
+    );
+  END IF;
+  EXECUTE pg_catalog.format('SET LOCAL ROLE %I', v_owner_name);
   EXECUTE pg_catalog.replace(
     pg_catalog.replace(v_definition, v_version_from, v_version_to),
     v_effort_from,
     v_effort_to
   );
+  IF NOT v_owner_had_schema_create THEN
+    EXECUTE 'SET LOCAL ROLE social_monitor_public_schema_owner';
+    EXECUTE pg_catalog.format(
+      'REVOKE CREATE ON SCHEMA public FROM %I GRANTED BY CURRENT_USER',
+      v_owner_name
+    );
+  END IF;
 END;
 $daily_bounded_active_claim_profile$;
+RESET ROLE;
+SET LOCAL ROLE social_monitor_public_schema_owner;
+REVOKE CREATE ON SCHEMA public
+  FROM social_monitor_reader_summary_daily_publication_definer;
 RESET ROLE;
 REVOKE social_monitor_reader_summary_daily_publication_definer
   FROM social_monitor_public_schema_owner GRANTED BY CURRENT_USER;

--- a/scripts/check-reader-summary-daily-execution-cursor-postgres.ts
+++ b/scripts/check-reader-summary-daily-execution-cursor-postgres.ts
@@ -9,6 +9,7 @@ import {
   assertReaderSummaryDailyCanonicalPublicationFixtureContract,
   assertReaderSummaryDailyCheckerFixtureRoleContract,
   assertReaderSummaryDailyCheckerRoleBootstrapContract,
+  assertReaderSummaryDailyProductionOwnerTopologyFixtureContract,
   assertReaderSummaryDailyExecutionCursorPostgresContract,
   assertReaderSummaryDailyActivationMigrationContract,
   assertReaderSummaryDailyMigrationContract,
@@ -17,6 +18,8 @@ import {
   executePostgresMigrationWithDiagnostics,
 } from
   "./lib/postgres-migration-diagnostics";
+import { grantAndAssertReaderSummaryDailyProductionOwnerTopology } from
+  "./lib/reader-summary-daily-production-owner-topology-postgres";
 
 const terminalRole = "social_monitor_reader_summary_daily_terminal";
 const schemaOwnerRole = "social_monitor_public_schema_owner";
@@ -51,6 +54,9 @@ const checkerSource = readFileSync(
   "scripts/check-reader-summary-daily-execution-cursor-postgres.ts",
   "utf8",
 );
+const productionOwnerTopologyFixtureSource = readFileSync(
+  "scripts/lib/reader-summary-daily-production-owner-topology-postgres.ts", "utf8",
+);
 const serverUrl = requiredAdminUrl(process.env);
 const targetUrl = databaseUrl(serverUrl, databaseName);
 const server = new Pool({ connectionString: serverUrl, max: 1 });
@@ -71,6 +77,9 @@ const main = async (): Promise<void> => {
   );
   assertReaderSummaryDailyCheckerFixtureRoleContract(checkerSource);
   assertReaderSummaryDailyCheckerRoleBootstrapContract(checkerSource);
+  assertReaderSummaryDailyProductionOwnerTopologyFixtureContract(
+    productionOwnerTopologyFixtureSource,
+  );
   assertReaderSummaryDailyMigrationContract(migration);
   assertReaderSummaryDailyActivationMigrationContract(activationMigration);
   const version = await server.query<{ version: number }>(
@@ -236,9 +245,6 @@ const main = async (): Promise<void> => {
     await admin.query(`
       ALTER FUNCTION public.reject_reader_summary_daily_source_authority_mutation()
         OWNER TO ${quoteIdentifier(schemaOwnerRole)};
-      ALTER FUNCTION public.claim_reader_summary_daily_execution(
-        UUID, UUID, TEXT, DATE, TIMESTAMPTZ
-      ) OWNER TO ${quoteIdentifier(schemaOwnerRole)};
       ALTER FUNCTION public.renew_reader_summary_daily_execution_lease(
         UUID, UUID, DATE, TEXT, BIGINT, TIMESTAMPTZ
       ) OWNER TO ${quoteIdentifier(schemaOwnerRole)};
@@ -246,6 +252,7 @@ const main = async (): Promise<void> => {
         UUID, UUID, DATE, TEXT, BIGINT, TIMESTAMPTZ
       ) OWNER TO ${quoteIdentifier(schemaOwnerRole)};
     `);
+    await transferActiveClaimOwner(admin, firstPool, migrationAdminRole);
     const activationAclSchemaPrivileges = await admin.query<{
       publication_owner_has_usage: boolean;
       publication_owner_has_create: boolean;
@@ -276,6 +283,9 @@ const main = async (): Promise<void> => {
       false, "daily activation publication owner lost durable schema USAGE or retained CREATE");
     await admin.query("RESET ROLE");
     await admin.query(boundedMaintenanceMigration);
+    await grantAndAssertReaderSummaryDailyProductionOwnerTopology({
+      admin, migrationAdminRole, schemaOwnerRole,
+    });
     const { historicalScope, upgradeScopes } =
       await withSchemaOwnerFixtureRole(admin, async (fixtureAdmin) => ({
         historicalScope: await seedHistoricalCompletedDailyJob(fixtureAdmin),
@@ -330,7 +340,73 @@ const main = async (): Promise<void> => {
         WHERE tenant_id = $1 AND workspace_id = $2`,
       [upgradeScopes.reserved.tenantId, upgradeScopes.reserved.workspaceId]);
     });
+    await transferActiveClaimOwner(admin, firstPool, publicationOwnerRole);
+    let unexpectedOwnerFailure = "";
+    try {
+      await applyTelemetryMigrationAsMigrationAdmin(admin);
+    } catch (error) {
+      unexpectedOwnerFailure = error instanceof Error ? error.message : String(error);
+      await admin.query("ROLLBACK");
+    }
+    const unexpectedOwnerRollback = await admin.query<{
+      completion_function: string | null;
+      owner_has_create: boolean;
+    }>(`SELECT pg_catalog.to_regprocedure(
+          'public.complete_reader_summary_daily_model_job_v2(uuid,uuid,date,text,bigint,timestamptz,bytea,character,jsonb,bytea,character,bytea,character,bigint,bigint,bigint,text,bigint)'
+        )::TEXT AS completion_function,
+        pg_catalog.has_schema_privilege($1, 'public', 'CREATE')
+          AS owner_has_create`, [publicationOwnerRole]);
+    assert(unexpectedOwnerFailure.includes("daily active claim has unexpected owner") &&
+      unexpectedOwnerRollback.rows[0]?.completion_function === null &&
+      unexpectedOwnerRollback.rows[0]?.owner_has_create === false,
+    "unaccepted daily claim owner did not abort without durable migration effects");
+    await transferActiveClaimOwner(admin, firstPool, migrationAdminRole);
     await applyTelemetryMigrationAsMigrationAdmin(admin);
+    const rewrittenClaimProfiles = await admin.query<{
+      active_definition: string;
+      active_owner: string;
+      active_owner_has_create: boolean;
+      bounded_definition: string;
+      bounded_owner: string;
+      definer_has_create: boolean;
+    }>(`SELECT
+        pg_catalog.pg_get_functiondef(
+          'public.claim_reader_summary_daily_execution(uuid,uuid,text,date,timestamp with time zone)'::pg_catalog.regprocedure
+        ) AS active_definition,
+        pg_catalog.pg_get_userbyid(active_claim.proowner) AS active_owner,
+        pg_catalog.has_schema_privilege($1, 'public', 'CREATE')
+          AS active_owner_has_create,
+        pg_catalog.pg_get_functiondef(
+          'public.claim_reader_summary_daily_execution_bounded_maintenance(uuid,uuid,text,date,timestamp with time zone)'::pg_catalog.regprocedure
+        ) AS bounded_definition,
+        pg_catalog.pg_get_userbyid(bounded_claim.proowner) AS bounded_owner,
+        pg_catalog.has_schema_privilege($2, 'public', 'CREATE')
+          AS definer_has_create
+      FROM pg_catalog.pg_proc AS active_claim
+      CROSS JOIN pg_catalog.pg_proc AS bounded_claim
+      WHERE active_claim.oid =
+          'public.claim_reader_summary_daily_execution(uuid,uuid,text,date,timestamp with time zone)'::pg_catalog.regprocedure
+        AND bounded_claim.oid =
+          'public.claim_reader_summary_daily_execution_bounded_maintenance(uuid,uuid,text,date,timestamp with time zone)'::pg_catalog.regprocedure`,
+    [migrationAdminRole, definerRole]);
+    for (const [claim, definition] of [
+      ["active", rewrittenClaimProfiles.rows[0]?.active_definition],
+      ["bounded", rewrittenClaimProfiles.rows[0]?.bounded_definition],
+    ] as const) {
+      assert(definition?.includes("'reader-summary-daily:v2'") === true &&
+        definition.includes("'reader-summary-daily:v1'") === false &&
+        definition.split("'high'").length - 1 === 2 &&
+        definition.includes("'xhigh'") === false,
+      `${claim} daily claim was not rewritten from v1/xhigh to v2/high`);
+    }
+    assert(
+      rewrittenClaimProfiles.rows[0]?.active_owner === migrationAdminRole &&
+        rewrittenClaimProfiles.rows[0]?.bounded_owner === schemaOwnerRole &&
+        rewrittenClaimProfiles.rows[0]?.active_owner_has_create === false &&
+        rewrittenClaimProfiles.rows[0]?.definer_has_create === false,
+      "daily telemetry migration changed mixed ownership or retained accepted-owner CREATE",
+    );
+    await transferActiveClaimOwner(admin, firstPool, schemaOwnerRole);
     await withSchemaOwnerFixtureRole(admin, async (fixtureAdmin) => {
       const historical = await fixtureAdmin.query<{
         usage_source: string;
@@ -410,7 +486,6 @@ const main = async (): Promise<void> => {
   }
   console.log("Reader summary daily execution cursor PostgreSQL 18 gate OK");
 };
-
 const cleanup = async (): Promise<void> => {
   if (databaseCreated) {
     await server.query(
@@ -430,7 +505,6 @@ const cleanup = async (): Promise<void> => {
   }
   await server.end();
 };
-
 let schemaOwnerFixtureRoleActive = false;
 
 const withSchemaOwnerFixtureRole = async <T>(
@@ -482,6 +556,25 @@ const applyTelemetryMigrationAsMigrationAdmin = async (
   });
 };
 
+const transferActiveClaimOwner = async (
+  admin: PoolClient,
+  bootstrapTarget: Pool,
+  ownerRole: string,
+): Promise<void> => {
+  const result = await admin.query<{
+    current_owner: string; owner_has_create: boolean;
+  }>(`SELECT pg_catalog.pg_get_userbyid(proowner) AS current_owner,
+      pg_catalog.has_schema_privilege(proowner, 'public', 'CREATE') AS owner_has_create
+    FROM pg_catalog.pg_proc WHERE oid =
+      'public.claim_reader_summary_daily_execution(uuid,uuid,text,date,timestamp with time zone)'::pg_catalog.regprocedure`);
+  const currentOwner = result.rows[0]?.current_owner;
+  assert(currentOwner !== undefined && result.rows[0]?.owner_has_create === false,
+    "active-claim fixture transfer requires the current owner without schema CREATE");
+  await bootstrapTarget.query(`
+    ALTER FUNCTION public.claim_reader_summary_daily_execution(
+      UUID, UUID, TEXT, DATE, TIMESTAMPTZ
+    ) OWNER TO ${quoteIdentifier(ownerRole)}`);
+};
 const roleExists = async (role: string, admin: PoolClient): Promise<boolean> => {
   const result = await admin.query<{ present: boolean }>(
     "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = $1) AS present",
@@ -514,7 +607,6 @@ const assertRoleCanResolveActivationRelation = async (
   assert(failure === undefined,
     `${diagnostic}: ${failure instanceof Error ? failure.message : String(failure)}`);
 };
-
 const assertBootstrapSessionIsSuperuser = async (): Promise<void> => {
   const result = await server.query<{ safe: boolean }>(`SELECT role.rolsuper AS safe
     FROM pg_catalog.pg_roles AS role WHERE role.rolname = session_user`);

--- a/scripts/lib/reader-summary-daily-execution-cursor-postgres-contract.spec.ts
+++ b/scripts/lib/reader-summary-daily-execution-cursor-postgres-contract.spec.ts
@@ -7,6 +7,7 @@ import {
   assertReaderSummaryDailyCheckerCanonicalRlsContract,
   assertReaderSummaryDailyCheckerFixtureRoleContract,
   assertReaderSummaryDailyCheckerRoleBootstrapContract,
+  assertReaderSummaryDailyProductionOwnerTopologyFixtureContract,
   assertReaderSummaryDailyActivationMigrationContract,
   assertReaderSummaryDailyMigrationContract,
   withCanonicalPublicationFixtureRole,
@@ -212,6 +213,29 @@ describe("reader summary daily execution cursor PostgreSQL contract", () => {
       `${checker}\nREVOKE USAGE ON SCHEMA public ` +
         "FROM ${quoteIdentifier(publicationOwnerRole)};",
     )).toThrow("must not revoke durable publication-owner schema USAGE");
+  });
+
+  it("pins production mixed-owner table ACLs before the PG18 migration", () => {
+    const source = readFileSync(
+      "scripts/lib/reader-summary-daily-production-owner-topology-postgres.ts",
+      "utf8",
+    );
+    expect(() => assertReaderSummaryDailyProductionOwnerTopologyFixtureContract(source))
+      .not.toThrow();
+    for (const mutation of [
+      "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE",
+      "GRANTED BY CURRENT_USER",
+      "acl.grantor = cursor_relation.relowner",
+      "acl.grantor = job_relation.relowner",
+      "row.active_owner_has_create === false",
+      "row.cursor_acl_exact === true",
+      "row.job_acl_exact === true",
+      "row.bounded_owner_has_create === true",
+    ]) {
+      expect(() => assertReaderSummaryDailyProductionOwnerTopologyFixtureContract(
+        source.replace(mutation, "removed"),
+      )).toThrow("grant and prove exact owner table ACLs");
+    }
   });
 
   it("rejects a dormant daily table handoff moved after activation", () => {

--- a/scripts/lib/reader-summary-daily-execution-cursor-postgres-contract.ts
+++ b/scripts/lib/reader-summary-daily-execution-cursor-postgres-contract.ts
@@ -130,7 +130,7 @@ export const assertReaderSummaryDailyCheckerFixtureRoleContract = (
     ) && telemetryHelperSource.includes("sql: telemetryMigration"),
   "daily checker telemetry migrations must reset to migration admin first");
   assert(!source.includes("admin.query(telemetryMigration)") &&
-    source.match(/await applyTelemetryMigrationAsMigrationAdmin\(admin\)/gu)?.length === 3,
+    source.match(/await applyTelemetryMigrationAsMigrationAdmin\(admin\)/gu)?.length === 4,
   "daily checker must route every telemetry migration through diagnosed reset boundary");
   assert(source.includes(`await admin.query("RESET ROLE");
     await admin.query(boundedMaintenanceMigration);`),
@@ -265,7 +265,6 @@ export const assertReaderSummaryDailyCheckerActivationOwnershipContract = (
   }
   for (const signature of [
     "reject_reader_summary_daily_source_authority_mutation()",
-    "claim_reader_summary_daily_execution(",
     "renew_reader_summary_daily_execution_lease(",
     "mark_reader_summary_daily_model_job_running(",
   ]) {
@@ -273,10 +272,45 @@ export const assertReaderSummaryDailyCheckerActivationOwnershipContract = (
     assert(functionHandoff > activation && functionHandoff < activationAcl,
       `daily checker must hand ${signature} to the schema owner after activation`);
   }
-  assert(!source.slice(schemaHandoff).includes(
-    "GRANT USAGE, CREATE ON SCHEMA public\n" +
-      "        TO ${quoteIdentifier(migrationAdminRole)}",
-  ), "daily checker must not restore schema CREATE to the migration admin");
+  const activeClaimHandoff = source.indexOf(
+    "await transferActiveClaimOwner(admin, firstPool, migrationAdminRole);",
+  );
+  const transferHelper = source.slice(
+    source.indexOf("const transferActiveClaimOwner = async"),
+    source.indexOf("const roleExists = async"),
+  );
+  assert(activeClaimHandoff > activation && activeClaimHandoff < activationAcl &&
+    source.match(/await transferActiveClaimOwner\(admin, firstPool, migrationAdminRole\);/gu)
+      ?.length === 2 &&
+    source.match(/await transferActiveClaimOwner\(admin, firstPool, publicationOwnerRole\);/gu)
+      ?.length === 1 &&
+    source.match(/await transferActiveClaimOwner\(admin, firstPool, schemaOwnerRole\);/gu)
+      ?.length === 1,
+  "daily checker must reproduce and restore the mixed and unaccepted owner topologies");
+  const mixedOwnerProof = source.indexOf("rewrittenClaimProfiles");
+  const runtimeOwnerHandoff = source.indexOf(
+    "await transferActiveClaimOwner(admin, firstPool, schemaOwnerRole);",
+  );
+  const runtimeContract = source.indexOf(
+    "await assertReaderSummaryDailyExecutionCursorPostgresContract({",
+  );
+  assert(mixedOwnerProof > activeClaimHandoff && runtimeOwnerHandoff > mixedOwnerProof &&
+    runtimeContract > runtimeOwnerHandoff &&
+    source.includes("grantAndAssertReaderSummaryDailyProductionOwnerTopology({\n" +
+      "      admin, migrationAdminRole, schemaOwnerRole,\n" +
+      "    });"),
+  "daily checker must reproduce and prove the production mixed-owner topology");
+  assert(transferHelper.includes(
+    "pg_catalog.pg_get_userbyid(proowner) AS current_owner",
+  ) && transferHelper.includes(
+    "owner_has_create === false",
+  ) && transferHelper.includes(
+    "bootstrapTarget: Pool",
+  ) && transferHelper.includes(
+    "await bootstrapTarget.query(`\n    ALTER FUNCTION " +
+      "public.claim_reader_summary_daily_execution(",
+  ) && !transferHelper.includes("RESET SESSION AUTHORIZATION"),
+  "daily checker must use its authenticated PG18 bootstrap role only for fixture handoff");
   assert(!source.includes("REFERENCES ON TABLE public.reader_summary_jobs"),
     "daily checker must not grant migration-admin REFERENCES after table handoff");
   const activationDiagnostics = source.slice(
@@ -291,6 +325,34 @@ export const assertReaderSummaryDailyCheckerActivationOwnershipContract = (
     !source.includes("locatePostgresMigrationFailureForTestDiagnostics") &&
     !source.includes("activationParams"),
   "daily checker must execute the whole activation migration exactly once");
+};
+
+export const assertReaderSummaryDailyProductionOwnerTopologyFixtureContract = (
+  source: string,
+): void => {
+  const grant = source.indexOf("GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE");
+  const topology = source.indexOf("const topology = await admin.query");
+  const proof = source.indexOf("const row = topology.rows[0]");
+  assert(grant >= 0 && topology > grant && proof > topology &&
+    source.includes("SET ROLE ${quoteIdentifier(schemaOwnerRole)};") &&
+    source.includes("TO ${quoteIdentifier(migrationAdminRole)} GRANTED BY CURRENT_USER") &&
+    source.includes("public.reader_summary_daily_execution_cursors") &&
+    source.includes("public.reader_summary_daily_model_jobs") &&
+    source.match(/pg_catalog\.count\(\*\) = 4/gu)?.length === 2 &&
+    source.match(/ARRAY\['SELECT', 'INSERT', 'UPDATE', 'DELETE'\]/gu)?.length === 2 &&
+    source.includes("acl.grantor = cursor_relation.relowner") &&
+    source.includes("acl.grantor = job_relation.relowner") &&
+    source.match(/NOT pg_catalog\.bool_or\(acl\.is_grantable\)/gu)?.length === 2 &&
+    source.includes("row.active_owner_has_create === false") &&
+    source.includes("row.cursor_owner === schemaOwnerRole") &&
+    source.includes("row.cursor_acl_exact === true") &&
+    source.includes("row.job_owner === schemaOwnerRole") &&
+    source.includes("row.job_acl_exact === true") &&
+    source.includes("row.bounded_owner === schemaOwnerRole") &&
+    source.includes("row.bounded_owner_has_create === true") &&
+    source.includes("row.fixture_current_user === migrationAdminRole") &&
+    source.includes("row.fixture_session_user === migrationAdminRole"),
+  "daily production topology fixture must grant and prove exact owner table ACLs");
 };
 
 export const assertReaderSummaryDailyCheckerCanonicalRlsContract = (

--- a/scripts/lib/reader-summary-daily-model-telemetry-postgres-contract.spec.ts
+++ b/scripts/lib/reader-summary-daily-model-telemetry-postgres-contract.spec.ts
@@ -71,6 +71,15 @@ WHERE session_principal.rolname = session_user
   ])) IS NOT TRUE THEN`,
       setDiscoveredOwner:
         "EXECUTE pg_catalog.format('SET LOCAL ROLE %I', v_owner_name);",
+      discoveredOwnerCreateCheck: `v_owner_had_schema_create := pg_catalog.has_schema_privilege(
+    v_owner_oid, 'public', 'CREATE'
+  );`,
+      setSchemaOwnerForDiscoveredOwner:
+        "EXECUTE 'SET LOCAL ROLE social_monitor_public_schema_owner';",
+      grantDiscoveredOwnerCreate:
+        "'GRANT CREATE ON SCHEMA public TO %I GRANTED BY CURRENT_USER'",
+      revokeDiscoveredOwnerCreate:
+        "'REVOKE CREATE ON SCHEMA public FROM %I GRANTED BY CURRENT_USER'",
       resetToSession: "RESET ROLE;",
       membershipRevoke: `REVOKE social_monitor_reader_summary_daily_publication_definer
   FROM social_monitor_public_schema_owner GRANTED BY CURRENT_USER;`,
@@ -83,7 +92,6 @@ WHERE session_principal.rolname = session_user
       statements.setSchemaOwner,
       statements.createGrant,
       statements.ownerTransfer,
-      statements.createRevoke,
       statements.setDefiner,
       statements.revokeLegacyExecute,
       statements.revokePublicExecute,
@@ -98,6 +106,9 @@ WHERE session_principal.rolname = session_user
       statements.ownerDiscovery,
       statements.ownerAllowlist,
       statements.setDiscoveredOwner,
+      statements.resetToSession,
+      statements.setSchemaOwner,
+      statements.createRevoke,
       statements.resetToSession,
       statements.membershipRevoke,
       statements.commit,
@@ -139,6 +150,12 @@ WHERE session_principal.rolname = session_user
     expect(sql.match(/SELECT proc\.proowner, owner_role\.rolname,/gu)).toHaveLength(2);
     expect(sql.match(/IF \(v_owner_oid = ANY \(ARRAY\[/gu)).toHaveLength(2);
     expect(sql.match(/SET LOCAL ROLE %I/gu)).toHaveLength(2);
+    expect(sql.match(/v_owner_had_schema_create :=/gu)).toHaveLength(2);
+    expect(sql.match(/IF NOT v_owner_had_schema_create THEN/gu)).toHaveLength(4);
+    expect(sql.match(/GRANT CREATE ON SCHEMA public TO %I GRANTED BY CURRENT_USER/gu))
+      .toHaveLength(2);
+    expect(sql.match(/REVOKE CREATE ON SCHEMA public FROM %I GRANTED BY CURRENT_USER/gu))
+      .toHaveLength(2);
     expect(
       sql.match(/RAISE EXCEPTION 'daily active claim has unexpected owner';/gu),
     ).toHaveLength(1);
@@ -154,15 +171,28 @@ WHERE session_principal.rolname = session_user
     );
     const boundedRewrite = sql.slice(
       sql.indexOf(statements.boundedClaimRewrite),
-      sql.indexOf(statements.membershipRevoke),
+      sql.indexOf(
+        statements.setSchemaOwner,
+        sql.indexOf(statements.boundedClaimRewrite),
+      ),
     );
     for (const rewrite of [activeRewrite, boundedRewrite]) {
-      expect(rewrite).not.toMatch(
-        /SET(?: LOCAL)? ROLE social_monitor_(?:public_schema_owner|reader_summary_daily_publication_definer)/u,
-      );
       expect(rewrite).toContain(statements.ownerDiscovery);
       expect(rewrite).toContain(statements.ownerAllowlist);
+      expect(rewrite).toContain(statements.discoveredOwnerCreateCheck);
+      expect(rewrite).toContain(statements.setSchemaOwnerForDiscoveredOwner);
+      expect(rewrite).toContain(statements.grantDiscoveredOwnerCreate);
       expect(rewrite).toContain(statements.setDiscoveredOwner);
+      expect(rewrite).toContain(statements.revokeDiscoveredOwnerCreate);
+      expect(rewrite.indexOf(statements.ownerAllowlist)).toBeLessThan(
+        rewrite.indexOf(statements.grantDiscoveredOwnerCreate),
+      );
+      expect(rewrite.indexOf(statements.grantDiscoveredOwnerCreate)).toBeLessThan(
+        rewrite.indexOf(statements.setDiscoveredOwner),
+      );
+      expect(rewrite.indexOf(statements.setDiscoveredOwner)).toBeLessThan(
+        rewrite.indexOf(statements.revokeDiscoveredOwnerCreate),
+      );
       expect(rewrite.trimEnd().endsWith(statements.resetToSession)).toBe(true);
     }
     expect(sql).not.toMatch(/GRANT EXECUTE ON FUNCTION[\s\S]*?TO PUBLIC;/u);

--- a/scripts/lib/reader-summary-daily-production-owner-topology-postgres.ts
+++ b/scripts/lib/reader-summary-daily-production-owner-topology-postgres.ts
@@ -1,0 +1,85 @@
+import type { PoolClient } from "pg";
+
+type ProductionOwnerTopologyFixture = {
+  admin: PoolClient;
+  migrationAdminRole: string;
+  schemaOwnerRole: string;
+};
+
+type ProductionOwnerTopology = {
+  active_owner: string;
+  active_owner_has_create: boolean;
+  bounded_owner: string;
+  bounded_owner_has_create: boolean;
+  cursor_owner: string;
+  cursor_acl_exact: boolean;
+  job_owner: string;
+  job_acl_exact: boolean;
+  fixture_current_user: string;
+  fixture_session_user: string;
+};
+
+export const grantAndAssertReaderSummaryDailyProductionOwnerTopology = async ({
+  admin,
+  migrationAdminRole,
+  schemaOwnerRole,
+}: ProductionOwnerTopologyFixture): Promise<void> => {
+  await admin.query(`SET ROLE ${quoteIdentifier(schemaOwnerRole)};
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
+      public.reader_summary_daily_execution_cursors,
+      public.reader_summary_daily_model_jobs
+    TO ${quoteIdentifier(migrationAdminRole)} GRANTED BY CURRENT_USER;
+    RESET ROLE`);
+  const topology = await admin.query<ProductionOwnerTopology>(`SELECT
+      pg_catalog.pg_get_userbyid(active_claim.proowner) AS active_owner,
+      pg_catalog.has_schema_privilege(active_claim.proowner, 'public', 'CREATE')
+        AS active_owner_has_create,
+      pg_catalog.pg_get_userbyid(cursor_relation.relowner) AS cursor_owner,
+      (SELECT pg_catalog.count(*) = 4
+          AND pg_catalog.bool_and(acl.privilege_type = ANY (
+            ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']))
+          AND pg_catalog.bool_and(acl.grantor = cursor_relation.relowner)
+          AND NOT pg_catalog.bool_or(acl.is_grantable)
+        FROM pg_catalog.aclexplode(cursor_relation.relacl) AS acl
+        WHERE acl.grantee = active_claim.proowner) AS cursor_acl_exact,
+      pg_catalog.pg_get_userbyid(job_relation.relowner) AS job_owner,
+      (SELECT pg_catalog.count(*) = 4
+          AND pg_catalog.bool_and(acl.privilege_type = ANY (
+            ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']))
+          AND pg_catalog.bool_and(acl.grantor = job_relation.relowner)
+          AND NOT pg_catalog.bool_or(acl.is_grantable)
+        FROM pg_catalog.aclexplode(job_relation.relacl) AS acl
+        WHERE acl.grantee = active_claim.proowner) AS job_acl_exact,
+      pg_catalog.pg_get_userbyid(bounded_claim.proowner) AS bounded_owner,
+      pg_catalog.has_schema_privilege(bounded_claim.proowner, 'public', 'CREATE')
+        AS bounded_owner_has_create,
+      current_user AS fixture_current_user, session_user AS fixture_session_user
+    FROM pg_catalog.pg_proc AS active_claim
+    CROSS JOIN pg_catalog.pg_proc AS bounded_claim
+    CROSS JOIN pg_catalog.pg_class AS cursor_relation
+    CROSS JOIN pg_catalog.pg_class AS job_relation
+    WHERE active_claim.oid =
+        'public.claim_reader_summary_daily_execution(uuid,uuid,text,date,timestamp with time zone)'::pg_catalog.regprocedure
+      AND bounded_claim.oid =
+        'public.claim_reader_summary_daily_execution_bounded_maintenance(uuid,uuid,text,date,timestamp with time zone)'::pg_catalog.regprocedure
+      AND cursor_relation.oid =
+        'public.reader_summary_daily_execution_cursors'::pg_catalog.regclass
+      AND job_relation.oid =
+        'public.reader_summary_daily_model_jobs'::pg_catalog.regclass`);
+  const row = topology.rows[0];
+  assert(row?.active_owner === migrationAdminRole &&
+    row.active_owner_has_create === false &&
+    row.cursor_owner === schemaOwnerRole && row.cursor_acl_exact === true &&
+    row.job_owner === schemaOwnerRole && row.job_acl_exact === true &&
+    row.bounded_owner === schemaOwnerRole && row.bounded_owner_has_create === true &&
+    row.fixture_current_user === migrationAdminRole &&
+    row.fixture_session_user === migrationAdminRole,
+  "daily telemetry PG18 fixture does not match production mixed-owner topology");
+};
+
+const quoteIdentifier = (input: string): string =>
+  `"${input.replaceAll('"', '""')}"`;
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## What changed

- attest discovered production function owners before rewrite
- grant schema CREATE only for the migration transaction when required, then revoke it
- reproduce production ACL topology in the PostgreSQL 18 regression fixture
- cover mixed-owner and unexpected-owner fail-closed paths

## Evidence

- PostgreSQL 18.4 disposable regression: PASS
- 3 focused suites, 35 tests: PASS
- migration/source-cap/lint/diff gates: PASS
- independent gpt-5.6-sol xhigh review on commit 750c32b7: no findings

This matches the exact SQL checksum already used for the bounded production recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily telemetry migrations to safely handle schema privileges across different ownership configurations.
  * Prevented migrations from completing when production ownership or permission requirements are not met.
  * Preserved database state when validation fails.

* **Tests**
  * Added coverage for mixed-owner production setups, table permissions, function ownership, and PostgreSQL 18 migration behavior.
  * Expanded verification of claim-function rewrites and privilege cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->