### PR TITLE
fix(deploy): bridge failed Release B before product restore

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -894,22 +894,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: production
+    env:
+      DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
+      DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
     steps:
       - name: Check out the release commit
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before Release B SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-      - name: Configure restricted production SSH
+      - name: Deploy reviewed bridge and reopen restricted SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
-        run: bash ops/deploy/github-production-deploy-client.sh configure
+        run: |
+          set -euo pipefail
+          client=ops/deploy/github-production-deploy-client.sh; bridge_release=cbd78b45e8ca9d30f496dc47eab7b7288073ea65
+          bash "$client" configure
+          bash "$client" deploy "$bridge_release"
+          bash "$client" cleanup
+          bash "$client" configure
       - name: Freshly require A-complete or B-complete
         id: b_state
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: |
           set -euo pipefail
           target_plan="$RUNNER_TEMP/recovery-target-before-deploy.plan"
@@ -938,17 +944,11 @@ jobs:
           path: ${{ runner.temp }}/frontend-artifact
       - name: Upload immutable frontend release
         if: needs.plan.outputs.frontend == 'true'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: >-
           bash ops/deploy/github-production-deploy-client.sh upload "$GITHUB_SHA"
           "$RUNNER_TEMP/frontend-artifact/social-monitor-frontend-release.tgz"
       - name: Deploy changed components
         if: steps.b_state.outputs.transition_state != 'target-complete'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"
       - name: Remove production SSH material
         if: always()

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -20,6 +20,8 @@ DEPLOY_CONTROL_SCHEDULED_SUMMARY_CATCH_UP_BASE=e377453d5b440aacc8077e8af1345eb5a
 DEPLOY_CONTROL_ROLLING_SUMMARY_FINAL_TREE=6a68fd8f88477811e220c042d5176e452241389f
 DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH=ops/deploy/deploy-control-bridge-runtime-helper.test.sh
 DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH=ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE=92afd97328c5412324c99be635de2c41db589d53
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -224,6 +226,46 @@ deploy_control_is_reviewed_rolling_summary_transition() {
   done <<< "$expected"
 }
 
+# The failed release already exists on main, so its control-only bridge is a
+# side parent from the pre-release main. The joined target must retain that
+# failed release's complete payload while carrying the exact installed bridge.
+deploy_control_is_reviewed_failed_idle_release_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local bridge_parent bridge_delta target_delta expected
+  local -a bridge_ancestry=()
+
+  git -C "$repository" cat-file -e \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE^{commit}" 2>/dev/null || return 1
+  git -C "$repository" cat-file -e \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE^{commit}" 2>/dev/null || return 1
+  bridge_parent=$(git -C "$repository" rev-parse "$bridge^" 2>/dev/null) || \
+    return 1
+  read -r -a bridge_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ $bridge_parent == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" && \
+     ${#bridge_ancestry[@]} == 2 ]] || return 1
+  bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" "$bridge" -- 2>/dev/null) || \
+    return 1
+  [[ $bridge_delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+  git -C "$repository" merge-base --is-ancestor \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE" "$target" 2>/dev/null || return 1
+  git -C "$repository" merge-base --is-ancestor \
+    "$bridge" "$target" 2>/dev/null || return 1
+  expected=$(printf '%s\n' \
+    .github/workflows/production-deploy.yml \
+    ops/deploy/production-release-b-bridge-order.test.sh \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" | LC_ALL=C sort)
+  target_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE" "$target" -- 2>/dev/null | \
+    LC_ALL=C sort) || return 1
+  [[ $target_delta == "$expected" ]] || return 1
+  [[ $(git -C "$repository" rev-parse \
+       "$bridge:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) == \
+     $(git -C "$repository" rev-parse \
+       "$target:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) ]]
+}
+
 deploy_control_reviewed_transition_matches() {
   local bridge=$1 target=$2
   if deploy_control_daily_final_transition_matches "$bridge" "$target"; then
@@ -234,6 +276,10 @@ deploy_control_reviewed_transition_matches() {
     return 0
   fi
   if deploy_control_is_reviewed_rolling_summary_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
+  if deploy_control_is_reviewed_failed_idle_release_transition \
       "$bridge" "$target"; then
     return 0
   fi

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+SOURCE_REPO=${PRODUCTION_RELEASE_B_TEST_SOURCE_REPO:-$PROJECT_ROOT}
+WORKFLOW=$PROJECT_ROOT/.github/workflows/production-deploy.yml
+BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
+FAILED_RELEASE=92afd97328c5412324c99be635de2c41db589d53
+BRIDGE=cbd78b45e8ca9d30f496dc47eab7b7288073ea65
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/release-b-bridge-order.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+REPO=$FIXTURE/repo
+
+git clone -q --shared "$SOURCE_REPO" "$REPO"
+TARGET=$(git -C "$REPO" rev-parse HEAD)
+for commit in "$BASE" "$FAILED_RELEASE" "$BRIDGE" "$TARGET"; do
+  git -C "$REPO" cat-file -e "$commit^{commit}"
+done
+
+# shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
+source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
+if deploy_control_reviewed_transition_matches "$BASE" "$TARGET"; then
+  echo 'failed Release B unexpectedly bypasses its required bridge' >&2
+  exit 1
+fi
+deploy_control_reviewed_transition_matches "$BRIDGE" "$TARGET"
+git -C "$REPO" merge-base --is-ancestor "$FAILED_RELEASE" "$TARGET"
+git -C "$REPO" merge-base --is-ancestor "$BRIDGE" "$TARGET"
+[[ $(git -C "$REPO" diff --name-only --no-renames "$BASE" "$BRIDGE") == \
+   ops/deploy/deploy-control-bridge-lib.sh ]]
+[[ $(git -C "$REPO" ls-tree "$BRIDGE" -- \
+     ops/deploy/deploy-control-bridge-lib.sh | awk '{print $1, $2}') == \
+   '100644 blob' ]]
+
+git -C "$REPO" config user.name 'Release B Bridge Test'
+git -C "$REPO" config user.email release-b-bridge@example.invalid
+printf 'unreviewed Release B drift\n' > "$REPO/unreviewed-release-b-drift"
+git -C "$REPO" add unreviewed-release-b-drift
+git -C "$REPO" commit -qm 'test: add unreviewed Release B drift'
+DRIFT_TARGET=$(git -C "$REPO" rev-parse HEAD)
+if deploy_control_reviewed_transition_matches "$BRIDGE" "$DRIFT_TARGET"; then
+  echo 'failed-idle bridge admitted unreviewed Release B drift' >&2
+  exit 1
+fi
+
+python3 - "$WORKFLOW" "$BRIDGE" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+bridge = sys.argv[2]
+deploy = workflow[workflow.index("  deploy:"):workflow.index("  acceptance:")]
+bridge_step = deploy[
+    deploy.index("Deploy reviewed bridge and reopen restricted SSH"):
+    deploy.index("Freshly require A-complete or B-complete")
+]
+commands = (
+    f"bridge_release={bridge}",
+    'bash "$client" configure',
+    'bash "$client" deploy "$bridge_release"',
+    'bash "$client" cleanup',
+    'bash "$client" configure',
+)
+cursor = 0
+for command in commands:
+    cursor = bridge_step.index(command, cursor) + len(command)
+if deploy.index('deploy "$bridge_release"') > deploy.index('deploy "$GITHUB_SHA"'):
+    raise SystemExit("Release B target runs before its reviewed control bridge")
+PY
+
+printf 'Production Release B bridge ordering tests passed\n'

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -108,6 +108,7 @@ assert_real_bridge_target_assets() {
         ;;
       ops/deploy/deploy-control-bridge-lib.sh)
         expected_digest=e6f958555966b77d02b85da8d0b9195e13a200dcb2b19c8afc010fab6d28b65d
+        alternate_digest=2187657d0a864a30e94d248eb97aec34694c3f9a3a79fb07650c296c2f863034
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then


### PR DESCRIPTION
## Summary
- preserve a real control-only bridge commit rooted at the pre-release main
- join that bridge with the failed Release B payload without weakening deploy-control validation
- deploy the pinned reviewed bridge, close SSH state, reconnect, then inspect and deploy Release B
- add an exact graph and ordering regression test that rejects direct B and unreviewed drift

## Root cause
Release B changed sealed deploy control together with runtime/backend assets. The installed controller correctly rejected the mixed transition and required a control-only bridge first.

## Verification
- focused Release B bridge-order test passed
- deploy-control runtime-helper tests passed
- GitHub production deploy-client tests passed
- ShellCheck and bash syntax passed
- workflow YAML parsing passed
- npm run check:architecture passed
- npm run check:code-quality passed
- npm run check:source-line-cap passed
- git diff --check passed

## Merge requirement
Use merge commit. Do not squash or rebase this PR: the immutable bridge commit cbd78b45 and its ancestry are part of the reviewed deployment contract.