### PR TITLE
fix(deploy): require exact Release B merge topology

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -513,6 +513,7 @@ jobs:
             ops/deploy/deploy-control-bridge-runtime-helper.test.sh
             ops/deploy/deploy-control-reviewed-library-source.test.sh
             ops/deploy/daily-c1-control-bridge-workflow.test.sh
+            ops/deploy/production-release-b-bridge-order.test.sh
             ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
             ops/deploy/reader-summary-publication-bridge-transition.test.sh
             ops/deploy/social-monitor-production-ssh-wrapper.sh
@@ -894,22 +895,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: production
+    env:
+      DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
+      DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
     steps:
       - name: Check out the release commit
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before Release B SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-      - name: Configure restricted production SSH
+      - name: Deploy reviewed bridge and reopen restricted SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
-        run: bash ops/deploy/github-production-deploy-client.sh configure
+        run: |
+          set -euo pipefail
+          client=ops/deploy/github-production-deploy-client.sh; bridge_release=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+          bash "$client" configure
+          bash "$client" deploy "$bridge_release"
+          bash "$client" cleanup; bash "$client" configure
       - name: Freshly require A-complete or B-complete
         id: b_state
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: |
           set -euo pipefail
           target_plan="$RUNNER_TEMP/recovery-target-before-deploy.plan"
@@ -938,17 +944,11 @@ jobs:
           path: ${{ runner.temp }}/frontend-artifact
       - name: Upload immutable frontend release
         if: needs.plan.outputs.frontend == 'true'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: >-
           bash ops/deploy/github-production-deploy-client.sh upload "$GITHUB_SHA"
           "$RUNNER_TEMP/frontend-artifact/social-monitor-frontend-release.tgz"
       - name: Deploy changed components
         if: steps.b_state.outputs.transition_state != 'target-complete'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
         run: bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"
       - name: Remove production SSH material
         if: always()

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -20,6 +20,8 @@ DEPLOY_CONTROL_SCHEDULED_SUMMARY_CATCH_UP_BASE=e377453d5b440aacc8077e8af1345eb5a
 DEPLOY_CONTROL_ROLLING_SUMMARY_FINAL_TREE=6a68fd8f88477811e220c042d5176e452241389f
 DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH=ops/deploy/deploy-control-bridge-runtime-helper.test.sh
 DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH=ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE=92afd97328c5412324c99be635de2c41db589d53
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -224,6 +226,88 @@ deploy_control_is_reviewed_rolling_summary_transition() {
   done <<< "$expected"
 }
 
+# The failed release already exists on main, so its control-only bridge is a
+# side parent from the pre-release main. GitHub must merge the reviewed PR head
+# directly into that failed release. Every intermediate parent and path delta is
+# exact so neither an extra commit nor drift on an allowlisted path is admitted.
+deploy_control_is_reviewed_failed_idle_release_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local reviewed_head join bridge_delta join_delta head_delta target_delta
+  local expected_head_delta expected_target_delta failed_release_delta
+  local join_bridge_delta target_tree reviewed_head_tree
+  local -a bridge_ancestry=() join_ancestry=() head_ancestry=()
+  local -a target_ancestry=()
+
+  git -C "$repository" cat-file -e \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE^{commit}" 2>/dev/null || return 1
+  git -C "$repository" cat-file -e \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE^{commit}" 2>/dev/null || return 1
+  read -r -a bridge_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#bridge_ancestry[@]} == 2 && \
+     ${bridge_ancestry[1]} == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || \
+    return 1
+  bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" "$bridge" -- 2>/dev/null) || \
+    return 1
+  [[ $bridge_delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+
+  read -r -a target_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$target" 2>/dev/null)" || return 1
+  [[ ${#target_ancestry[@]} == 3 && \
+     ${target_ancestry[1]} == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE" ]] || \
+    return 1
+  reviewed_head=${target_ancestry[2]}
+  target_tree=$(git -C "$repository" rev-parse "$target^{tree}" 2>/dev/null) || \
+    return 1
+  reviewed_head_tree=$(git -C "$repository" \
+    rev-parse "$reviewed_head^{tree}" 2>/dev/null) || return 1
+  [[ $target_tree == "$reviewed_head_tree" ]] || return 1
+
+  read -r -a head_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$reviewed_head" 2>/dev/null)" || return 1
+  [[ ${#head_ancestry[@]} == 2 ]] || return 1
+  join=${head_ancestry[1]}
+  expected_head_delta=$(printf '%s\n' \
+    .github/workflows/production-deploy.yml \
+    ops/deploy/production-release-b-bridge-order.test.sh \
+    "$DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH" | LC_ALL=C sort)
+  head_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$join" "$reviewed_head" -- 2>/dev/null | LC_ALL=C sort) || return 1
+  [[ $head_delta == "$expected_head_delta" ]] || return 1
+
+  read -r -a join_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$join" 2>/dev/null)" || return 1
+  [[ ${#join_ancestry[@]} == 3 && \
+     ${join_ancestry[1]} == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE" && \
+     ${join_ancestry[2]} == "$bridge" ]] || return 1
+  join_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE" "$join" -- 2>/dev/null) || \
+    return 1
+  [[ $join_delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+  [[ $(git -C "$repository" rev-parse \
+       "$bridge:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) == \
+     $(git -C "$repository" rev-parse \
+       "$join:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) ]] || return 1
+  failed_release_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE" -- 2>/dev/null | LC_ALL=C sort) || \
+    return 1
+  join_bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$bridge" "$join" -- 2>/dev/null | LC_ALL=C sort) || return 1
+  [[ $join_bridge_delta == "$failed_release_delta" ]] || return 1
+
+  expected_target_delta=$(printf '%s\n' \
+    .github/workflows/production-deploy.yml \
+    ops/deploy/production-release-b-bridge-order.test.sh \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" \
+    "$DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH" | LC_ALL=C sort)
+  target_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE" "$target" -- 2>/dev/null | \
+    LC_ALL=C sort) || return 1
+  [[ $target_delta == "$expected_target_delta" ]]
+}
+
 deploy_control_reviewed_transition_matches() {
   local bridge=$1 target=$2
   if deploy_control_daily_final_transition_matches "$bridge" "$target"; then
@@ -234,6 +318,10 @@ deploy_control_reviewed_transition_matches() {
     return 0
   fi
   if deploy_control_is_reviewed_rolling_summary_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
+  if deploy_control_is_reviewed_failed_idle_release_transition \
       "$bridge" "$target"; then
     return 0
   fi

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+SOURCE_REPO=${PRODUCTION_RELEASE_B_TEST_SOURCE_REPO:-$PROJECT_ROOT}
+WORKFLOW=$PROJECT_ROOT/.github/workflows/production-deploy.yml
+BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
+FAILED_RELEASE=92afd97328c5412324c99be635de2c41db589d53
+BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/release-b-bridge-order.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+REPO=$FIXTURE/repo
+
+git clone -q --shared "$SOURCE_REPO" "$REPO"
+git -C "$REPO" config user.name 'Release B Bridge Test'
+git -C "$REPO" config user.email release-b-bridge@example.invalid
+SOURCE_TIP=$(git -C "$REPO" rev-parse HEAD)
+read -r -a source_tip_ancestry <<< "$(git -C "$REPO" \
+  rev-list --parents -n 1 "$SOURCE_TIP")"
+REVIEWED_HEAD=$SOURCE_TIP
+if [[ ${#source_tip_ancestry[@]} == 3 && \
+      ${source_tip_ancestry[1]} == "$FAILED_RELEASE" && \
+      $(git -C "$REPO" rev-parse "$SOURCE_TIP^{tree}") == \
+        $(git -C "$REPO" rev-parse "${source_tip_ancestry[2]}^{tree}") ]]; then
+  REVIEWED_HEAD=${source_tip_ancestry[2]}
+fi
+
+# The pinned side parent must be obtainable from the reviewed repository, not
+# merely present in the current object's incidental local cache.
+git -C "$REPO" fetch -q "$SOURCE_REPO" "$BRIDGE"
+[[ $(git -C "$REPO" rev-parse FETCH_HEAD) == "$BRIDGE" ]]
+for commit in "$BASE" "$FAILED_RELEASE" "$BRIDGE" "$REVIEWED_HEAD"; do
+  git -C "$REPO" cat-file -e "$commit^{commit}"
+done
+
+# shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
+source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
+read -r -a head_ancestry <<< "$(git -C "$REPO" \
+  rev-list --parents -n 1 "$REVIEWED_HEAD")"
+[[ ${#head_ancestry[@]} == 2 ]]
+JOIN=${head_ancestry[1]}
+read -r -a join_ancestry <<< "$(git -C "$REPO" \
+  rev-list --parents -n 1 "$JOIN")"
+[[ ${#join_ancestry[@]} == 3 && \
+   ${join_ancestry[1]} == "$FAILED_RELEASE" && \
+   ${join_ancestry[2]} == "$BRIDGE" ]]
+read -r -a bridge_ancestry <<< "$(git -C "$REPO" \
+  rev-list --parents -n 1 "$BRIDGE")"
+[[ ${#bridge_ancestry[@]} == 2 && ${bridge_ancestry[1]} == "$BASE" ]]
+[[ $(git -C "$REPO" diff --name-only --no-renames "$BASE" "$BRIDGE") == \
+   ops/deploy/deploy-control-bridge-lib.sh ]]
+[[ $(git -C "$REPO" diff --name-only --no-renames \
+     "$FAILED_RELEASE" "$JOIN") == \
+   ops/deploy/deploy-control-bridge-lib.sh ]]
+expected_head_delta=$(printf '%s\n' \
+  .github/workflows/production-deploy.yml \
+  ops/deploy/production-release-b-bridge-order.test.sh \
+  ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh | LC_ALL=C sort)
+actual_head_delta=$(git -C "$REPO" diff --name-only --no-renames \
+  "$JOIN" "$REVIEWED_HEAD" | LC_ALL=C sort)
+[[ $actual_head_delta == "$expected_head_delta" ]]
+[[ $(git -C "$REPO" ls-tree "$BRIDGE" -- \
+     ops/deploy/deploy-control-bridge-lib.sh | awk '{print $1, $2}') == \
+   '100644 blob' ]]
+git -C "$REPO" merge-base --is-ancestor "$BRIDGE" "$REVIEWED_HEAD"
+
+TARGET=$(printf 'test: simulate exact GitHub merge\n' | git -C "$REPO" \
+  commit-tree "$(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}")" \
+  -p "$FAILED_RELEASE" -p "$REVIEWED_HEAD")
+if deploy_control_reviewed_transition_matches "$BASE" "$TARGET"; then
+  echo 'failed Release B unexpectedly bypasses its required bridge' >&2
+  exit 1
+fi
+if deploy_control_reviewed_transition_matches "$BRIDGE" "$REVIEWED_HEAD"; then
+  echo 'failed-idle bridge admitted the unmerged reviewed head' >&2
+  exit 1
+fi
+deploy_control_reviewed_transition_matches "$BRIDGE" "$TARGET"
+git -C "$REPO" merge-base --is-ancestor "$FAILED_RELEASE" "$TARGET"
+git -C "$REPO" merge-base --is-ancestor "$BRIDGE" "$TARGET"
+read -r -a target_ancestry <<< "$(git -C "$REPO" \
+  rev-list --parents -n 1 "$TARGET")"
+[[ ${#target_ancestry[@]} == 3 && \
+   ${target_ancestry[1]} == "$FAILED_RELEASE" && \
+   ${target_ancestry[2]} == "$REVIEWED_HEAD" ]]
+[[ $(git -C "$REPO" rev-parse "$TARGET^{tree}") == \
+   $(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}") ]]
+
+if [[ $SOURCE_TIP != "$REVIEWED_HEAD" ]]; then
+  deploy_control_reviewed_transition_matches "$BRIDGE" "$SOURCE_TIP"
+fi
+
+git -C "$REPO" checkout -q "$TARGET"
+printf '\n# unreviewed same-path drift\n' >> \
+  "$REPO/.github/workflows/production-deploy.yml"
+git -C "$REPO" add .github/workflows/production-deploy.yml
+git -C "$REPO" commit -qm 'test: add same-path Release B drift'
+SAME_PATH_DRIFT_TARGET=$(git -C "$REPO" rev-parse HEAD)
+if deploy_control_reviewed_transition_matches \
+    "$BRIDGE" "$SAME_PATH_DRIFT_TARGET"; then
+  echo 'failed-idle bridge admitted same-allowlisted-path drift' >&2
+  exit 1
+fi
+
+git -C "$REPO" checkout -q "$TARGET"
+printf 'unreviewed Release B drift\n' > "$REPO/unreviewed-release-b-drift"
+git -C "$REPO" add unreviewed-release-b-drift
+git -C "$REPO" commit -qm 'test: add unreviewed Release B drift'
+DRIFT_TARGET=$(git -C "$REPO" rev-parse HEAD)
+if deploy_control_reviewed_transition_matches "$BRIDGE" "$DRIFT_TARGET"; then
+  echo 'failed-idle bridge admitted unreviewed Release B drift' >&2
+  exit 1
+fi
+
+WRONG_TOPOLOGY_TARGET=$(printf 'test: wrong GitHub parent order\n' | \
+  git -C "$REPO" commit-tree \
+  "$(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}")" \
+  -p "$REVIEWED_HEAD" -p "$FAILED_RELEASE")
+if deploy_control_reviewed_transition_matches \
+    "$BRIDGE" "$WRONG_TOPOLOGY_TARGET"; then
+  echo 'failed-idle bridge admitted the wrong GitHub parent topology' >&2
+  exit 1
+fi
+
+python3 - "$WORKFLOW" "$BRIDGE" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+bridge = sys.argv[2]
+if "ops/deploy/production-release-b-bridge-order.test.sh" not in workflow:
+    raise SystemExit("Release B exact-topology regression is absent from CI")
+deploy = workflow[workflow.index("  deploy:"):workflow.index("  acceptance:")]
+bridge_step = deploy[
+    deploy.index("Deploy reviewed bridge and reopen restricted SSH"):
+    deploy.index("Freshly require A-complete or B-complete")
+]
+commands = (
+    f"bridge_release={bridge}",
+    'bash "$client" configure',
+    'bash "$client" deploy "$bridge_release"',
+    'bash "$client" cleanup',
+    'bash "$client" configure',
+)
+cursor = 0
+for command in commands:
+    cursor = bridge_step.index(command, cursor) + len(command)
+if deploy.index('deploy "$bridge_release"') > deploy.index('deploy "$GITHUB_SHA"'):
+    raise SystemExit("Release B target runs before its reviewed control bridge")
+PY
+
+printf 'Production Release B bridge ordering tests passed\n'

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -108,6 +108,7 @@ assert_real_bridge_target_assets() {
         ;;
       ops/deploy/deploy-control-bridge-lib.sh)
         expected_digest=e6f958555966b77d02b85da8d0b9195e13a200dcb2b19c8afc010fab6d28b65d
+        alternate_digest=d6f3b562e3445dce3ac3d21364793b43afa53fe56011c0b73d02fac721040cf7
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then
@@ -348,6 +349,8 @@ run_release_b() (
     install -d "$backup"
     printf '%s\n' "$backup"
   }
+  # Invoked indirectly by deploy_release after the fixture sources the target.
+  # shellcheck disable=SC2317
   rollback_backend_and_runtime_control() { return 1; }
   cleanup_stopped_project_containers() { :; }
   backend_image_rescue_prepare() { :; }


### PR DESCRIPTION
## Summary
- replace the draft bridge fix with a fail-closed three-commit graph rooted at exact main 92afd973
- require the eventual GitHub merge to have parents [failed release, reviewed PR head]
- require the reviewed head, join, bridge parent topology, target tree equality, and every per-commit path delta exactly
- deploy the pinned control-only bridge, discard SSH state, reconnect, then inspect and deploy Release B
- reject later same-allowlisted-path drift, unrelated drift, unmerged heads, and wrong parent order

## Independent review remediation
The first version admitted a future commit that changed an already allowlisted workflow path. This version was rebuilt after an xhigh review and has an executable same-path negative regression.

## Verification
- exact Release B topology regression passed
- same-path drift 16fba784 and wrong parent order a0b6400e rejected
- RabbitMQ quorum bridge transition passed
- deploy-control bridge runtime helper passed
- ShellCheck, Bash syntax, YAML parsing and git diff check passed
- npm run check:architecture passed
- npm run check:code-quality passed
- npm run check:source-line-cap passed
- fresh bundle recovery and patch apply checks passed

No production access or production E2E was performed by the worker.

## Merge requirement
Use merge commit. Do not squash or rebase: bridge 85c5d22f and join c941784d ancestry are part of the reviewed deployment contract. This PR must merge before unrelated main changes.