### PR TITLE
fix(deploy): package migrate recovery script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN npm ci
 COPY tsconfig.json tsconfig.build.json ./
 COPY prisma.config.ts ./
 COPY prisma ./prisma
+COPY scripts/check-feed-promotion-index-recovery.ts ./scripts/
 COPY apps ./apps
 COPY libs ./libs
 

--- a/ops/deploy/production-component-classification.test.sh
+++ b/ops/deploy/production-component-classification.test.sh
@@ -62,3 +62,48 @@ if component_changed frontend "$LIBS_ADJACENT" "${FRONTEND_PATHS[@]}"; then
   echo 'adjacent libs path was frontend classified' >&2
   exit 1
 fi
+
+printf '%s\n' "$LIBS_ADJACENT" > "$STATE/backend.sha"
+git -C "$REPO" checkout -qb unrelated-script
+mkdir -p "$REPO/scripts"
+printf 'export {};\n' > "$REPO/scripts/unrelated.ts"
+git -C "$REPO" add scripts/unrelated.ts
+git -C "$REPO" commit -qm unrelated-script
+UNRELATED_SCRIPT=$(git -C "$REPO" rev-parse HEAD)
+mapfile -t unrelated_services < <(
+  backend_services "$LIBS_ADJACENT" "$UNRELATED_SCRIPT"
+)
+[[ ${unrelated_services[*]} == daily-runner ]]
+
+git -C "$REPO" checkout -q main
+mkdir -p "$REPO/scripts"
+printf 'export {};\n' > \
+  "$REPO/scripts/check-feed-promotion-index-recovery.ts"
+git -C "$REPO" add scripts/check-feed-promotion-index-recovery.ts
+git -C "$REPO" commit -qm feed-promotion-recovery-script
+RECOVERY_SCRIPT=$(git -C "$REPO" rev-parse HEAD)
+mapfile -t recovery_services < <(
+  backend_services "$LIBS_ADJACENT" "$RECOVERY_SCRIPT"
+)
+[[ ${recovery_services[*]} == 'migrate daily-runner' ]]
+
+DEPLOY_LOG=$FIXTURE/recovery-script-deploy.log
+cleanup_stopped_project_containers() { printf 'cleanup\n' >> "$DEPLOY_LOG"; }
+daily_runner_image_bootstrap_before_rescue() {
+  printf 'daily-bootstrap\n' >> "$DEPLOY_LOG"
+}
+backend_image_rescue_prepare() {
+  printf 'rescue:%s\n' "${*:3}" >> "$DEPLOY_LOG"
+}
+reader_summary_publication_migrator_preflight() {
+  printf 'preflight\n' >> "$DEPLOY_LOG"
+}
+backup_database() { printf 'backup\n' >> "$DEPLOY_LOG"; }
+deploy_reader_summary_publication_migrations() {
+  printf 'migration\n' >> "$DEPLOY_LOG"
+}
+fake_compose() { printf 'build:%s\n' "${!#}" >> "$DEPLOY_LOG"; }
+# shellcheck disable=SC2034 # Consumed by deploy_backend from the sourced entrypoint.
+COMPOSE=(fake_compose)
+deploy_backend "$RECOVERY_SCRIPT"
+[[ $(< "$DEPLOY_LOG") == $'cleanup\ndaily-bootstrap\nrescue:migrate daily-runner\npreflight\nbackup\nbuild:migrate\nbuild:daily-runner\nmigration' ]]

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -93,8 +93,8 @@ assert_real_bridge_target_assets() {
     actual_digest=$(sha256sum "$actual_real" | awk '{print $1}')
     case $path in
       ops/deploy/social-monitor-production-deploy.sh)
-        expected_digest=e76db96e9cc7bdb62cb09a3be509a7776e09a0499ff41a0d3769d8b499bde04f
-        alternate_digest=ac82c9cfebf88646e9cdc21dcb822c8cc50409832da24a726cd9307cc2be8bcb
+        expected_digest=ac82c9cfebf88646e9cdc21dcb822c8cc50409832da24a726cd9307cc2be8bcb
+        alternate_digest=d57866ed7cedfca383188173121c3cb550ec6b7dc909601d813353a0cd394bbf
         ;;
       ops/deploy/deploy-control-lib.sh)
         expected_digest=d18854822ef36d5571289e72c7691fff8db4a7d5c516787441a733d6960a88a9

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -584,21 +584,18 @@ backend_services() {
         services+=("$service")
       fi
     done
-    if changed_between "$from" "$to" apps/social-research-runtime; then
-      services+=(api)
-    fi
+    if changed_between "$from" "$to" apps/social-research-runtime; then services+=(api); fi
     if changed_between "$from" "$to" \
       ops/deploy/reader-summary-publication-deploy-lib.sh ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh \
       ops/deploy/reader-summary-publication-pre-migration.sql \
       ops/deploy/reader-summary-publication-post-migration.sql; then
       services+=(migrate)
     fi
+    if changed_between "$from" "$to" scripts/check-feed-promotion-index-recovery.ts; then services+=(migrate); fi
     if changed_between "$from" "$to" scripts ops/evals test; then
       services+=(daily-runner)
     fi
-    if changed_between "$from" "$to" ops/observability; then
-      services+=(otel-collector)
-    fi
+    if changed_between "$from" "$to" ops/observability; then services+=(otel-collector); fi
   fi
   if changed_between "$from" "$to" \
     apps/x-collector \
@@ -607,7 +604,6 @@ backend_services() {
   fi
   printf '%s\n' "${services[@]}" | awk 'NF && !seen[$0]++'
 }
-
 compose_image_name() {
   printf '%s-%s:latest\n' "$PROJECT" "$1"
 }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "check:feed-promotion-keyset-plan-postgres": "node scripts/run-with-timeout.mjs --timeout-ms 300000 --node-options --max-old-space-size=512 -- ts-node -r tsconfig-paths/register scripts/check-feed-promotion-keyset-plan-postgres.ts",
     "check:feed-promotion-index-recovery-postgres": "node scripts/run-with-timeout.mjs --timeout-ms 300000 --node-options --max-old-space-size=512 -- ts-node -r tsconfig-paths/register scripts/check-feed-promotion-index-recovery-postgres.ts",
     "check:feed-promotion-postgres18": "node scripts/run-with-timeout.mjs --timeout-ms 1500000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-feed-promotion-postgres18.ts",
-    "check:feed-promotion-migration-contract": "node scripts/check-feed-promotion-migration-contract.mjs",
+    "check:feed-promotion-migration-contract": "node --test scripts/lib/feed-promotion-migrate-dockerfile.test.mjs && node scripts/check-feed-promotion-migration-contract.mjs",
     "check:feed-promotion-index-recovery": "ts-node -r tsconfig-paths/register scripts/check-feed-promotion-index-recovery.ts",
     "check:monitoring-persistence": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-monitoring-prisma-persistence.ts",
     "check:monitoring-read-rest": "node scripts/run-with-timeout.mjs --timeout-ms 90000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-monitoring-read-rest-smoke.ts",

--- a/scripts/check-feed-promotion-migration-contract.mjs
+++ b/scripts/check-feed-promotion-migration-contract.mjs
@@ -1,10 +1,12 @@
 import { readFileSync } from "node:fs";
+import { finalStageCopiesFeedPromotionRecovery } from "./lib/feed-promotion-migrate-dockerfile.mjs";
 
 const migrationPath =
   "prisma/migrations/20260819120000_feed_promotion_keyset_snapshot_indexes/migration.sql";
 const migration = readFileSync(migrationPath, "utf8");
 const migrationSql = withoutComments(migration);
 const schema = readFileSync("prisma/schema.prisma", "utf8");
+const dockerfile = readFileSync("Dockerfile", "utf8");
 const workflow = readFileSync(".github/workflows/pull-request.yml", "utf8");
 const deploy = readFileSync(
   "ops/deploy/reader-summary-publication-deploy-lib.sh",
@@ -116,6 +118,9 @@ if (!deploy.includes("check:feed-promotion-index-recovery -- inspect") ||
     deploy.includes("FEED_PROMOTION_FILESYSTEM_EVIDENCE_FILE") ||
     deploy.includes("ps -q postgres")) {
   violations.push("external managed PostgreSQL deploy must not infer capacity from app-host or Compose filesystems");
+}
+if (!finalStageCopiesFeedPromotionRecovery(dockerfile)) {
+  violations.push("migrate image must include its feed promotion recovery script");
 }
 if (!recovery.includes("assumeFeedItemsOwner(client)") ||
     !recovery.includes("session_user AS login_role") ||

--- a/scripts/lib/feed-promotion-migrate-dockerfile.mjs
+++ b/scripts/lib/feed-promotion-migrate-dockerfile.mjs
@@ -1,0 +1,13 @@
+const recoveryCopy =
+  "COPY scripts/check-feed-promotion-index-recovery.ts ./scripts/";
+
+export function finalStageCopiesFeedPromotionRecovery(dockerfile) {
+  const activeLines = dockerfile
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"));
+  const finalFrom = activeLines.findLastIndex((line) =>
+    /^FROM(?:\s|$)/iu.test(line)
+  );
+  return finalFrom >= 0 && activeLines.slice(finalFrom + 1).includes(recoveryCopy);
+}

--- a/scripts/lib/feed-promotion-migrate-dockerfile.test.mjs
+++ b/scripts/lib/feed-promotion-migrate-dockerfile.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { finalStageCopiesFeedPromotionRecovery } from "./feed-promotion-migrate-dockerfile.mjs";
+
+const recoveryCopy =
+  "COPY scripts/check-feed-promotion-index-recovery.ts ./scripts/";
+
+test("rejects a commented recovery COPY", () => {
+  const dockerfile = `FROM node:22\n# ${recoveryCopy}\n`;
+
+  assert.equal(finalStageCopiesFeedPromotionRecovery(dockerfile), false);
+});
+
+test("rejects a recovery COPY present only before the final stage", () => {
+  const dockerfile = [
+    "FROM node:22 AS build",
+    recoveryCopy,
+    "FROM node:22 AS runtime",
+    "COPY package.json ./",
+  ].join("\n");
+
+  assert.equal(finalStageCopiesFeedPromotionRecovery(dockerfile), false);
+});
+
+test("accepts the exact active recovery COPY in the final stage", () => {
+  const dockerfile = `FROM node:22\n\n  ${recoveryCopy}  \n`;
+
+  assert.equal(finalStageCopiesFeedPromotionRecovery(dockerfile), true);
+});


### PR DESCRIPTION
## Summary

- package the feed-promotion recovery CLI in the final migrate image
- rebuild migrate when that exact recovery script changes
- enforce the final-stage Docker contract with negative fixtures
- cover the script-only deploy classification and build path

## Evidence

- npm run check:feed-promotion-migration-contract
- npm run check:production-deploy-lifecycle on the hosted full-object clone
- disposable production-host image build and runtime file probe passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Included the feed-promotion recovery script in the migration container.
  * Automatically triggers migration and daily-runner deployment handling when the recovery script changes.

* **Bug Fixes**
  * Improved deployment classification for recovery-related changes.

* **Tests**
  * Added coverage for Docker image contents, deployment ordering, service classification, and migration contract validation.
  * Updated deployment asset verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->