### PR TITLE
fix(deploy): make Release B bridge installation idempotent

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -605,6 +605,7 @@ jobs:
           bash ops/deploy/x-collector-image-deploy-lib.test.sh
           if [[ $bridge_phase == false ]]; then
             bash ops/deploy/github-production-deploy-client.test.sh
+            bash ops/deploy/production-release-b-bridge-order.test.sh
           fi
           bash ops/deploy/production-release-a-transition.test.sh
           bash ops/deploy/postgres-pool-atomic-bootstrap-lib.test.sh
@@ -904,15 +905,15 @@ jobs:
         with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before Release B SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-      - name: Deploy reviewed bridge and reopen restricted SSH
+      - name: Install reviewed failed-idle bridge and reopen restricted SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
-          client=ops/deploy/github-production-deploy-client.sh; bridge_release=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+          client=ops/deploy/github-production-deploy-client.sh; release_b_failed_idle_bridge_sha=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
           bash "$client" configure
-          bash "$client" deploy "$bridge_release"
+          bash "$client" install-release-b-failed-idle-bridge "$release_b_failed_idle_bridge_sha"
           bash "$client" cleanup; bash "$client" configure
       - name: Freshly require A-complete or B-complete
         id: b_state

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -585,9 +585,8 @@ jobs:
           fi
           echo "backend-gate=deploy-shell-tests bridge=$bridge_phase"
           if [[ $bridge_phase == true ]]; then
-            # Final runtime assets are deliberately absent from the control-only
-            # bridge. Run the bridge-safe controller closure here; the complete
-            # controller and client suites run with the BLOCKED final release.
+            # The control-only bridge runs the bridge-safe controller closure;
+            # complete controller/client suites run with the BLOCKED final release.
             bash ops/deploy/deploy-control-bridge-runtime-helper.test.sh
             bash ops/deploy/deploy-control-reviewed-library-source.test.sh
             bash ops/deploy/daily-c1-control-bridge-workflow.test.sh

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -6,6 +6,7 @@ PATH=/usr/local/bin:/usr/bin:/bin
 ZERO_SHA=0000000000000000000000000000000000000000
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
 DAILY_C1_BRIDGE_POLICY_SHA=944fdb6da3071f70a69c7048c9fcdf1c2552603e
+RELEASE_B_FAILED_IDLE_BRIDGE_SHA=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
 SSH_DIRECTORY=${DEPLOY_SSH_DIRECTORY:-${HOME:?HOME is required}/.ssh}
 SSH_KEY_PATH=${DEPLOY_SSH_KEY_PATH:-$SSH_DIRECTORY/social-monitor-production}
 SSH_KNOWN_HOSTS_PATH=${DEPLOY_SSH_KNOWN_HOSTS_PATH:-$SSH_DIRECTORY/known_hosts}
@@ -611,6 +612,19 @@ install_daily_c1_bridge_policy() {
     fail "daily C1 bridge policy install failed with status $status"
 }
 
+install_release_b_failed_idle_bridge() {
+  local sha=$1 status
+  [[ $sha == "$RELEASE_B_FAILED_IDLE_BRIDGE_SHA" ]] || \
+    fail 'Release B failed-idle bridge SHA is not the reviewed pin'
+  if run_remote deploy "$sha"; then
+    status=0
+  else
+    status=$?
+  fi
+  ((status == 0 || status == 255)) || \
+    fail "Release B failed-idle bridge install failed with status $status"
+}
+
 upload_frontend() {
   local sha=$1
   local archive=${2:-}
@@ -660,6 +674,12 @@ case $action in
     validate_sha "$2"
     validate_remote_environment
     install_daily_c1_bridge_policy "$2"
+    ;;
+  install-release-b-failed-idle-bridge)
+    [[ $# == 2 ]] || fail 'install-release-b-failed-idle-bridge requires its pinned SHA'
+    validate_sha "$2"
+    validate_remote_environment
+    install_release_b_failed_idle_bridge "$2"
     ;;
   maintenance)
     [[ $# == 3 || $# == 4 || $# == 5 || $# == 6 ]] || \

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -106,8 +106,14 @@ fake_ssh() {
     maintenance_success:"disk-report $TARGET_SHA"|maintenance_success:"project-disk-cleanup $TARGET_SHA"|maintenance_success:"reader-summary-recover-missing-days $TARGET_SHA"|maintenance_success:"reader-summary-weekly-run $TARGET_SHA"|maintenance_success:"reader-summary-production-history $TARGET_SHA 2026-08-11"|maintenance_success:"reader-summary-daily-terminal-set-receipt-v1 $TARGET_SHA"|maintenance_success:"reader-summary-daily-scan-terminal-preimage-c1 $TARGET_SHA"|maintenance_success:"reader-summary-daily-canonical-recovery-v4 $TARGET_SHA invalid-product-retry-set-v1 $TERMINAL_SET_SHA256"|maintenance_success:"reader-summary-daily-canonical-recovery-v4 $TARGET_SHA reader-summary-daily-canonical-recovery-v4 $MODEL_JOB_IDENTITY $AUTHORITY_SHA256"|maintenance_success:"reader-summary-daily-scan-terminal-repair-c1 $TARGET_SHA reader-summary-daily-scan-terminal-repair-c1 $TERMINAL_SET_SHA256"|maintenance_success:"reader-summary-daily-delivery-c1-run $TARGET_SHA reader-summary-daily-delivery-c1-run 2026-08-10"|maintenance_success:"reader-summary-daily-delivery-c1-contain $TARGET_SHA reader-summary-daily-delivery-c1-contain $TARGET_SHA")
       printf 'maintenance=%s\n' "${command%% *}"
       ;;
-    normal_success:"deploy $TARGET_SHA"|normal_success:"deploy 944fdb6da3071f70a69c7048c9fcdf1c2552603e")
+    normal_success:"deploy $TARGET_SHA"|normal_success:"deploy 944fdb6da3071f70a69c7048c9fcdf1c2552603e"|normal_success:"deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA")
       printf 'deployed=%s\n' "$TARGET_SHA"
+      ;;
+    bridge_disconnect:"deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA")
+      exit 255
+      ;;
+    bridge_non_255:"deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA")
+      exit 42
       ;;
     atomic_success:"deploy $TARGET_SHA")
       printf 'postgres-pool-bootstrap=%s replay=false\n' "$TARGET_SHA"
@@ -196,6 +202,7 @@ trap 'rm -rf "$FIXTURE"' EXIT
 TARGET_SHA=1234567890abcdef1234567890abcdef12345678
 BACKEND_SHA=4f47fac7faed7dc24110f4a43e88820d776b8a40
 CURRENT_BACKEND_SHA=617e284607f3dde74c27164af2b981770b9a62ed
+RELEASE_B_FAILED_IDLE_BRIDGE_SHA=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
 MODEL_JOB_IDENTITY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 AUTHORITY_SHA256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 TERMINAL_SET_SHA256=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -212,7 +219,8 @@ DEPLOY_SSH_KNOWN_HOSTS_PATH=$FIXTURE/ssh/pinned-known-hosts
 DEPLOY_HOST=production.example.invalid
 DEPLOY_USER=social-monitor-deploy
 
-export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA MODEL_JOB_IDENTITY AUTHORITY_SHA256 TERMINAL_SET_SHA256
+export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA RELEASE_B_FAILED_IDLE_BRIDGE_SHA
+export MODEL_JOB_IDENTITY AUTHORITY_SHA256 TERMINAL_SET_SHA256
 export FAKE_SSH_LOG FAKE_SSH_STATE FAKE_UPLOAD_PATH
 export DEPLOY_SSH_DIRECTORY DEPLOY_SSH_KEY_PATH DEPLOY_SSH_KNOWN_HOSTS_PATH
 export DEPLOY_HOST DEPLOY_USER GITHUB_OUTPUT
@@ -539,6 +547,25 @@ assert_call_count 0 \
 
 assert_fails normal_success install-daily-c1-bridge-policy "$TARGET_SHA"
 assert_call_count 0 "deploy $TARGET_SHA"
+
+run_client normal_success install-release-b-failed-idle-bridge \
+  "$RELEASE_B_FAILED_IDLE_BRIDGE_SHA" >/dev/null
+assert_call_count 1 "deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
+assert_call_count 0 "plan $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
+
+run_client bridge_disconnect install-release-b-failed-idle-bridge \
+  "$RELEASE_B_FAILED_IDLE_BRIDGE_SHA" >/dev/null
+assert_call_count 1 "deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
+assert_call_count 0 "plan $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
+
+assert_fails normal_success install-release-b-failed-idle-bridge "$TARGET_SHA"
+[[ ! -s $FAKE_SSH_LOG ]]
+assert_call_count 0 "deploy $TARGET_SHA"
+
+assert_fails bridge_non_255 install-release-b-failed-idle-bridge \
+  "$RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
+assert_call_count 1 "deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
+assert_call_count 0 "plan $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
 
 run_client disconnect_eventual deploy "$TARGET_SHA" >/dev/null
 assert_call_count 1 "deploy $TARGET_SHA"

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -8,6 +8,7 @@ WORKFLOW=$PROJECT_ROOT/.github/workflows/production-deploy.yml
 BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
 FAILED_RELEASE=92afd97328c5412324c99be635de2c41db589d53
 BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+INTEGRATED_RELEASE=8b4aeb31e855ed379349a4e4827600009e174132
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/release-b-bridge-order.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
 REPO=$FIXTURE/repo
@@ -16,21 +17,21 @@ git clone -q --shared "$SOURCE_REPO" "$REPO"
 git -C "$REPO" config user.name 'Release B Bridge Test'
 git -C "$REPO" config user.email release-b-bridge@example.invalid
 SOURCE_TIP=$(git -C "$REPO" rev-parse HEAD)
-read -r -a source_tip_ancestry <<< "$(git -C "$REPO" \
-  rev-list --parents -n 1 "$SOURCE_TIP")"
-REVIEWED_HEAD=$SOURCE_TIP
-if [[ ${#source_tip_ancestry[@]} == 3 && \
-      ${source_tip_ancestry[1]} == "$FAILED_RELEASE" && \
-      $(git -C "$REPO" rev-parse "$SOURCE_TIP^{tree}") == \
-        $(git -C "$REPO" rev-parse "${source_tip_ancestry[2]}^{tree}") ]]; then
-  REVIEWED_HEAD=${source_tip_ancestry[2]}
-fi
+read -r -a integrated_ancestry <<< "$(git -C "$REPO" \
+  rev-list --parents -n 1 "$INTEGRATED_RELEASE")"
+[[ ${#integrated_ancestry[@]} == 3 && \
+   ${integrated_ancestry[1]} == "$FAILED_RELEASE" ]]
+REVIEWED_HEAD=${integrated_ancestry[2]}
+[[ $(git -C "$REPO" rev-parse "$INTEGRATED_RELEASE^{tree}") == \
+   $(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}") ]]
+git -C "$REPO" merge-base --is-ancestor "$INTEGRATED_RELEASE" "$SOURCE_TIP"
 
 # The pinned side parent must be obtainable from the reviewed repository, not
 # merely present in the current object's incidental local cache.
 git -C "$REPO" fetch -q "$SOURCE_REPO" "$BRIDGE"
 [[ $(git -C "$REPO" rev-parse FETCH_HEAD) == "$BRIDGE" ]]
-for commit in "$BASE" "$FAILED_RELEASE" "$BRIDGE" "$REVIEWED_HEAD"; do
+for commit in "$BASE" "$FAILED_RELEASE" "$BRIDGE" "$INTEGRATED_RELEASE" \
+  "$REVIEWED_HEAD"; do
   git -C "$REPO" cat-file -e "$commit^{commit}"
 done
 
@@ -87,9 +88,7 @@ read -r -a target_ancestry <<< "$(git -C "$REPO" \
 [[ $(git -C "$REPO" rev-parse "$TARGET^{tree}") == \
    $(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}") ]]
 
-if [[ $SOURCE_TIP != "$REVIEWED_HEAD" ]]; then
-  deploy_control_reviewed_transition_matches "$BRIDGE" "$SOURCE_TIP"
-fi
+deploy_control_reviewed_transition_matches "$BRIDGE" "$INTEGRATED_RELEASE"
 
 git -C "$REPO" checkout -q "$TARGET"
 printf '\n# unreviewed same-path drift\n' >> \
@@ -129,25 +128,42 @@ import sys
 
 workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 bridge = sys.argv[2]
-if "ops/deploy/production-release-b-bridge-order.test.sh" not in workflow:
-    raise SystemExit("Release B exact-topology regression is absent from CI")
+if "bash ops/deploy/production-release-b-bridge-order.test.sh" not in workflow:
+    raise SystemExit("Release B exact-topology regression is not executed in CI")
 deploy = workflow[workflow.index("  deploy:"):workflow.index("  acceptance:")]
+bridge_step_name = "Install reviewed failed-idle bridge and reopen restricted SSH"
+fresh_step_name = "Freshly require A-complete or B-complete"
 bridge_step = deploy[
-    deploy.index("Deploy reviewed bridge and reopen restricted SSH"):
-    deploy.index("Freshly require A-complete or B-complete")
+    deploy.index(bridge_step_name):deploy.index(fresh_step_name)
 ]
 commands = (
-    f"bridge_release={bridge}",
+    f"release_b_failed_idle_bridge_sha={bridge}",
     'bash "$client" configure',
-    'bash "$client" deploy "$bridge_release"',
+    'bash "$client" install-release-b-failed-idle-bridge "$release_b_failed_idle_bridge_sha"',
     'bash "$client" cleanup',
     'bash "$client" configure',
 )
 cursor = 0
 for command in commands:
     cursor = bridge_step.index(command, cursor) + len(command)
-if deploy.index('deploy "$bridge_release"') > deploy.index('deploy "$GITHUB_SHA"'):
-    raise SystemExit("Release B target runs before its reviewed control bridge")
+fresh_step_start = deploy.index(fresh_step_name)
+fresh_step_end = deploy.index("Download immutable frontend artifact", fresh_step_start)
+fresh_step = deploy[fresh_step_start:fresh_step_end]
+for command in (
+    'inspect-plan "$GITHUB_SHA"',
+    'state "$GITHUB_SHA" TARGET',
+    'inspect-plan "$release_b2"',
+    'state "$GITHUB_SHA" B2',
+    'transition_state=target-pending',
+    'transition_state=target-complete',
+    'transition_state=A-complete',
+    'transition_state=B-complete',
+):
+    if command not in fresh_step:
+        raise SystemExit(f"fresh Release B state inspection is missing: {command}")
+for command in ('upload "$GITHUB_SHA"', 'deploy "$GITHUB_SHA"'):
+    if deploy.index(command) < fresh_step_end:
+        raise SystemExit(f"Release B target action runs before fresh state inspection: {command}")
 PY
 
 printf 'Production Release B bridge ordering tests passed\n'

--- a/ops/deploy/production-runtime/rolling-run.sh
+++ b/ops/deploy/production-runtime/rolling-run.sh
@@ -142,13 +142,20 @@ container_body=$(cat <<'ROLLING_CONTAINER_BODY'
       --exact-date-artifact-directory "$collection_staging_directory" \
       --providers "$required_providers" || collection_exit=$?
 
-    if [ "$collection_exit" -ne 0 ]; then
-      echo "rolling collection failed for current pass $ROLLING_RUN_ID (exit $collection_exit)" >&2
-      exit "$collection_exit"
-    fi
-
+    collection_validation_exit=0
     node ops/deploy/production-runtime/rolling-summary-receipt.mjs \
-      validate-collection "$collection_staging_source" "$ROLLING_COLLECTION_DATE"
+      validate-collection "$collection_staging_source" "$ROLLING_COLLECTION_DATE" || \
+      collection_validation_exit=$?
+    if [ "$collection_validation_exit" -ne 0 ]; then
+      echo "rolling collection produced no valid current-pass artifact for $ROLLING_RUN_ID" >&2
+      if [ "$collection_exit" -ne 0 ]; then
+        exit "$collection_exit"
+      fi
+      exit "$collection_validation_exit"
+    fi
+    if [ "$collection_exit" -ne 0 ]; then
+      echo "rolling collection is degraded for $ROLLING_RUN_ID (exit $collection_exit); publishing from terminal current-pass evidence" >&2
+    fi
     cp "$collection_staging_source" "$collection_source.next.$ROLLING_RUN_ID"
     chmod 0444 "$collection_source.next.$ROLLING_RUN_ID"
     mv "$collection_source.next.$ROLLING_RUN_ID" "$collection_source"

--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -70,48 +70,67 @@ grep -Fx 'Persistent=true' \
   "$REPO/ops/deploy/production-runtime/social-monitor-rolling.timer" >/dev/null
 
 successful_collection_bytes=$(sha256sum "$exact_collection" | cut -d' ' -f1)
+SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T12:15:00.000Z \
+SOCIAL_MONITOR_ROLLING_RUN_TEST_DEGRADED_COLLECTION_RUN_ID=20260815T121500000Z \
+  bash "$RUNNER"
+grep -Fx 'collection-degraded 20260815T121500000Z 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
+degraded_collection_bytes=$(sha256sum "$exact_collection" | cut -d' ' -f1)
+[[ $degraded_collection_bytes != "$successful_collection_bytes" ]]
+[[ -e $TEST_ROOT/artifacts/rolling-summary/rolling-summary.20260815T121500000Z.collection.v1.json ]]
+[[ -e $TEST_ROOT/artifacts/rolling-summary/rolling-summary.20260815T121500000Z.receipt.v1.json ]]
+
 if SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
-  SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T12:15:00.000Z \
-  SOCIAL_MONITOR_ROLLING_RUN_TEST_FAIL_COLLECTION_RUN_ID=20260815T121500000Z \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T13:15:00.000Z \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_FAIL_COLLECTION_RUN_ID=20260815T131500000Z \
     bash "$RUNNER"; then
   echo 'rolling run published a stale same-day collection after current collection failure' >&2
   exit 1
 fi
-grep -Fx 'collection-failed 20260815T121500000Z 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
-[[ $(sha256sum "$exact_collection" | cut -d' ' -f1) == "$successful_collection_bytes" ]]
-[[ ! -e $TEST_ROOT/artifacts/rolling-summary/rolling-summary.20260815T121500000Z.collection.v1.json ]]
-[[ ! -e $TEST_ROOT/artifacts/rolling-summary/rolling-summary.20260815T121500000Z.receipt.v1.json ]]
-[[ ! -e $TEST_ROOT/artifacts/rolling-summary/collections/runs/20260815T121500000Z/reader-summary-clean-real-day-collection.2026-08-15.v1.json ]]
+grep -Fx 'collection-failed 20260815T131500000Z 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
+[[ $(sha256sum "$exact_collection" | cut -d' ' -f1) == "$degraded_collection_bytes" ]]
+[[ ! -e $TEST_ROOT/artifacts/rolling-summary/rolling-summary.20260815T131500000Z.collection.v1.json ]]
+[[ ! -e $TEST_ROOT/artifacts/rolling-summary/rolling-summary.20260815T131500000Z.receipt.v1.json ]]
+[[ ! -e $TEST_ROOT/artifacts/rolling-summary/collections/runs/20260815T131500000Z/reader-summary-clean-real-day-collection.2026-08-15.v1.json ]]
 
 ln -sfn /usr/bin/false "$refresh"
 if SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
   SOCIAL_MONITOR_ROLLING_RUN_TEST_FLOCK=$fake_flock \
-  SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T13:15:00.000Z \
+  SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T14:15:00.000Z \
     bash "$RUNNER"; then
   echo 'rolling run accepted unavailable summary auth' >&2
   exit 1
 fi
 grep -F -- '-e ROLLING_AUTH_READY=false' "$TEST_ROOT/docker.log" >/dev/null
 [[ $(grep -Fc -- '--profile app up -d --no-deps agent-runtime' \
-  "$TEST_ROOT/docker.log") == 2 ]]
+  "$TEST_ROOT/docker.log") == 3 ]]
 
 collection_line=$(grep -n 'npm run run:reader-summary-clean-real-day-collection' \
   "$RUNNER" | cut -d: -f1)
 collection_staging_clear_line=$(grep -n 'rm -f "\$collection_staging_source"' \
   "$RUNNER" | head -1 | cut -d: -f1)
-collection_failure_guard_line=$(grep -n '"\$collection_exit" -ne 0' \
+collection_validation_line=$(grep -n 'collection_validation_exit=0' \
+  "$RUNNER" | cut -d: -f1)
+collection_failure_guard_line=$(grep -n '"\$collection_validation_exit" -ne 0' \
+  "$RUNNER" | cut -d: -f1)
+collection_degraded_line=$(grep -n 'publishing from terminal current-pass evidence' \
   "$RUNNER" | cut -d: -f1)
 collection_promotion_line=$(grep -n 'cp "\$collection_staging_source" "\$collection_source' \
   "$RUNNER" | cut -d: -f1)
 auth_guard_line=$(grep -n 'ROLLING_AUTH_READY.*!= true' "$RUNNER" | cut -d: -f1)
 ((collection_staging_clear_line < collection_line))
-((collection_line < collection_failure_guard_line))
-((collection_failure_guard_line < collection_promotion_line))
+((collection_line < collection_validation_line))
+((collection_validation_line < collection_failure_guard_line))
+((collection_failure_guard_line < collection_degraded_line))
+((collection_degraded_line < collection_promotion_line))
 ((collection_line < auth_guard_line))
 grep -F 'if [ "$ROLLING_AUTH_READY" != true ]; then' "$RUNNER" >/dev/null
 ! grep -F 'if [[ "$ROLLING_AUTH_READY"' "$RUNNER" >/dev/null

--- a/ops/deploy/production-runtime/rolling-summary-receipt.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.mjs
@@ -65,9 +65,6 @@ function writeReceipt(args) {
     endedAt,
     collectionExit,
   ] = args;
-  if (collectionExit !== "0") {
-    throw new Error("rolling collection command did not succeed");
-  }
   const evidence = readJson(evidencePath);
   const collection = readJson(collectionPath);
   validateCollection(collection, date);

--- a/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
@@ -80,9 +80,10 @@ try {
     "0",
   );
   run("validate-receipt", receiptPath, runId, date);
-  runFailure(
+  const degradedReceiptPath = join(directory, "degraded-receipt.json");
+  run(
     "write-receipt",
-    join(directory, "failed-collection-receipt.json"),
+    degradedReceiptPath,
     evidencePath,
     collectionPath,
     runId,
@@ -90,6 +91,7 @@ try {
     "2026-08-15T12:15:00.000Z",
     "1",
   );
+  run("validate-receipt", degradedReceiptPath, runId, date);
   runFailure(
     "write-receipt",
     join(directory, "stale-receipt.json"),
@@ -102,6 +104,10 @@ try {
   );
 
   const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+  const degradedReceipt = JSON.parse(
+    readFileSync(degradedReceiptPath, "utf8"),
+  );
+  assert.equal(degradedReceipt.collection.commandExitCode, 1);
   assert.equal(receipt.collection.finalDayQualityGatePassed, false);
   assert.equal(receipt.collection.providers.length, 5);
   assert.equal(receipt.publication.readerSummaryId, "summary-id");

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-ctr.sh
@@ -23,6 +23,9 @@ mkdir -p "$collection_staging_directory"
 if [[ ${SOCIAL_MONITOR_ROLLING_RUN_TEST_FAIL_COLLECTION_RUN_ID:-} == "$SOCIAL_MONITOR_ROLLING_RUN_ID" ]]; then
   printf 'collection-failed %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
   exit 1
+elif [[ ${SOCIAL_MONITOR_ROLLING_RUN_TEST_DEGRADED_COLLECTION_RUN_ID:-} == "$SOCIAL_MONITOR_ROLLING_RUN_ID" ]]; then
+  printf '%s\n' "{\"run\":{\"collectionDate\":\"$collection_date\"},\"blockingPassed\":false,\"scans\":[{\"providerKey\":\"github-trending-page\",\"status\":\"succeeded\"},{\"providerKey\":\"hacker-news\",\"status\":\"succeeded\"},{\"providerKey\":\"reddit\",\"status\":\"failed\"},{\"providerKey\":\"rss\",\"status\":\"succeeded\"},{\"providerKey\":\"x-twitter\",\"status\":\"succeeded\"}]}" > "$collection_staging_path"
+  printf 'collection-degraded %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
 elif [[ -f $collection_staging_path ]]; then
   printf 'collection-reused %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
 else

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-docker.sh
@@ -37,6 +37,9 @@ if [[ $* == *' daily-runner sh -lc '* ]]; then
   if [[ ${SOCIAL_MONITOR_ROLLING_RUN_TEST_FAIL_COLLECTION_RUN_ID:-} == "$SOCIAL_MONITOR_ROLLING_RUN_ID" ]]; then
     printf 'collection-failed %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
     exit 1
+  elif [[ ${SOCIAL_MONITOR_ROLLING_RUN_TEST_DEGRADED_COLLECTION_RUN_ID:-} == "$SOCIAL_MONITOR_ROLLING_RUN_ID" ]]; then
+    printf '%s\n' "{\"run\":{\"collectionDate\":\"$collection_date\"},\"blockingPassed\":false,\"scans\":[{\"providerKey\":\"github-trending-page\",\"status\":\"succeeded\"},{\"providerKey\":\"hacker-news\",\"status\":\"succeeded\"},{\"providerKey\":\"reddit\",\"status\":\"failed\"},{\"providerKey\":\"rss\",\"status\":\"succeeded\"},{\"providerKey\":\"x-twitter\",\"status\":\"succeeded\"}]}" > "$collection_staging_path"
+    printf 'collection-degraded %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
   elif [[ -f $collection_staging_path ]]; then
     printf 'collection-reused %s %s\n' "$SOCIAL_MONITOR_ROLLING_RUN_ID" "$collection_date" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
   else


### PR DESCRIPTION
## Problem

Production is already newer than the pinned failed-idle bridge. The host correctly returns `already-deployed-or-newer`, but the generic deploy client then waits for the old bridge plan to become exact for 45 attempts. That state is impossible without rolling production backwards.

## Fix

- add an exact-pinned one-shot bridge installation action
- keep generic exact-head reconciliation unchanged
- require fresh target/A/B inspection before any target upload or deploy
- execute the bridge topology regression in CI

## Evidence

- hosted deploy-client tests passed
- hosted Release B bridge ordering test passed
- hosted ShellCheck and Bash syntax passed
- source line-cap passed with the workflow at exactly 1000 lines
- automatic 04:15 UTC interval trigger was observed independently; its old image still fails at the already-fixed summary compile error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a controlled Release B bridge deployment option using a reviewed, pinned release.
  - Rolling production runs can now publish validated degraded results when collection partially fails.

- **Bug Fixes**
  - Degraded receipts are generated and recorded even when collection exits with a failure code.
  - Failed follow-up runs preserve the latest valid degraded collection instead of creating invalid artifacts.

- **Tests**
  - Expanded deployment and rolling-run coverage for bridge ordering, failure handling, degraded results, and artifact preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->