### PR TITLE
fix(deploy): restore exact production bridge topology

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -912,7 +912,7 @@ jobs:
           set -euo pipefail
           client=ops/deploy/github-production-deploy-client.sh; bridge_release=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
           bash "$client" configure
-          bash "$client" deploy "$bridge_release"
+          bash "$client" install-release-b-bridge "$bridge_release"
           bash "$client" cleanup; bash "$client" configure
       - name: Freshly require A-complete or B-complete
         id: b_state

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -22,6 +22,9 @@ DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH=ops/deploy/deploy-control-bridge
 DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH=ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE=92afd97328c5412324c99be635de2c41db589d53
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE=903f5e8d944c6d703b2bf282d0046ba5066894b1
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB=a6407769622a4da1bd677ff83c9db6ad2c710662
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -226,6 +229,45 @@ deploy_control_is_reviewed_rolling_summary_transition() {
   done <<< "$expected"
 }
 
+# Pin the historical failed-idle bridge by every immutable Git identity. This
+# bridge-only hardening release is installed after the exact 8b4 controller is
+# fully reconciled, so the old controller admits it through the ordinary
+# control-only path without relying on this policy to install itself.
+deploy_control_is_exact_failed_idle_release_bridge() {
+  local bridge=$1 repository=${REPO:-.}
+  local actual_tree delta entry mode type object tree_path extra
+  local -a ancestry=()
+
+  [[ $bridge == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE" ]] || return 1
+  read -r -a ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#ancestry[@]} == 2 && \
+     ${ancestry[0]} == "$bridge" && \
+     ${ancestry[1]} == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || \
+    return 1
+  actual_tree=$(git -C "$repository" rev-parse \
+    "$bridge^{tree}" 2>/dev/null) || return 1
+  [[ $actual_tree == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE" ]] || \
+    return 1
+  delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" "$bridge" -- \
+    2>/dev/null) || return 1
+  [[ $delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+  entry=$(git -C "$repository" ls-tree "$bridge" -- \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) || return 1
+  read -r mode type object tree_path extra <<< "$entry"
+  [[ -z ${extra:-} && $mode == 100644 && $type == blob && \
+     $object == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB" && \
+     $tree_path == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]]
+}
+
+deploy_control_is_reviewed_failed_idle_release_bridge_transition() {
+  local current=$1 target=$2
+
+  [[ $current == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || return 1
+  deploy_control_is_exact_failed_idle_release_bridge "$target"
+}
+
 # The failed release already exists on main, so its control-only bridge is a
 # side parent from the pre-release main. GitHub must merge the reviewed PR head
 # directly into that failed release. Every intermediate parent and path delta is
@@ -238,6 +280,7 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
   local -a bridge_ancestry=() join_ancestry=() head_ancestry=()
   local -a target_ancestry=()
 
+  deploy_control_is_exact_failed_idle_release_bridge "$bridge" || return 1
   git -C "$repository" cat-file -e \
     "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE^{commit}" 2>/dev/null || return 1
   git -C "$repository" cat-file -e \
@@ -310,6 +353,10 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
 
 deploy_control_reviewed_transition_matches() {
   local bridge=$1 target=$2
+  if deploy_control_is_reviewed_failed_idle_release_bridge_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
   if deploy_control_daily_final_transition_matches "$bridge" "$target"; then
     return 0
   fi

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -22,6 +22,9 @@ DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH=ops/deploy/deploy-control-bridge
 DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH=ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE=92afd97328c5412324c99be635de2c41db589d53
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE=903f5e8d944c6d703b2bf282d0046ba5066894b1
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB=a6407769622a4da1bd677ff83c9db6ad2c710662
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -226,6 +229,45 @@ deploy_control_is_reviewed_rolling_summary_transition() {
   done <<< "$expected"
 }
 
+# Release B's reviewed control bridge is a side child of the integration that
+# production still has checked out. Pin the commit as well as its parent, tree,
+# sole changed path, mode and blob: a same-path rewrite or a mixed tree must not
+# gain admission merely because it resembles the reviewed bridge.
+deploy_control_is_exact_failed_idle_release_bridge() {
+  local bridge=$1 repository=${REPO:-.}
+  local actual_tree delta entry mode type object tree_path extra
+  local -a ancestry=()
+
+  [[ $bridge == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE" ]] || return 1
+  read -r -a ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#ancestry[@]} == 2 && \
+     ${ancestry[0]} == "$bridge" && \
+     ${ancestry[1]} == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || \
+    return 1
+  actual_tree=$(git -C "$repository" rev-parse \
+    "$bridge^{tree}" 2>/dev/null) || return 1
+  [[ $actual_tree == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE" ]] || \
+    return 1
+  delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" "$bridge" -- \
+    2>/dev/null) || return 1
+  [[ $delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+  entry=$(git -C "$repository" ls-tree "$bridge" -- \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) || return 1
+  read -r mode type object tree_path extra <<< "$entry"
+  [[ -z ${extra:-} && $mode == 100644 && $type == blob && \
+     $object == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB" && \
+     $tree_path == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]]
+}
+
+deploy_control_is_reviewed_failed_idle_release_bridge_transition() {
+  local current=$1 target=$2
+
+  [[ $current == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || return 1
+  deploy_control_is_exact_failed_idle_release_bridge "$target"
+}
+
 # The failed release already exists on main, so its control-only bridge is a
 # side parent from the pre-release main. GitHub must merge the reviewed PR head
 # directly into that failed release. Every intermediate parent and path delta is
@@ -238,6 +280,7 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
   local -a bridge_ancestry=() join_ancestry=() head_ancestry=()
   local -a target_ancestry=()
 
+  deploy_control_is_exact_failed_idle_release_bridge "$bridge" || return 1
   git -C "$repository" cat-file -e \
     "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE^{commit}" 2>/dev/null || return 1
   git -C "$repository" cat-file -e \
@@ -310,6 +353,10 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
 
 deploy_control_reviewed_transition_matches() {
   local bridge=$1 target=$2
+  if deploy_control_is_reviewed_failed_idle_release_bridge_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
   if deploy_control_daily_final_transition_matches "$bridge" "$target"; then
     return 0
   fi

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -5,6 +5,7 @@ PATH=/usr/local/bin:/usr/bin:/bin
 
 ZERO_SHA=0000000000000000000000000000000000000000
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
+RELEASE_B_BRIDGE_SHA=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
 DAILY_C1_BRIDGE_POLICY_SHA=944fdb6da3071f70a69c7048c9fcdf1c2552603e
 SSH_DIRECTORY=${DEPLOY_SSH_DIRECTORY:-${HOME:?HOME is required}/.ssh}
 SSH_KEY_PATH=${DEPLOY_SSH_KEY_PATH:-$SSH_DIRECTORY/social-monitor-production}
@@ -598,6 +599,22 @@ deploy_release() {
   }
 }
 
+install_release_b_bridge() {
+  local sha=$1 status
+  [[ $sha == "$RELEASE_B_BRIDGE_SHA" ]] || \
+    fail 'Release B bridge SHA is not the reviewed pin'
+  # This exact side bridge can already be an ancestor of the integration
+  # checkout while older component markers intentionally remain staggered.
+  # The ordinary target plan therefore cannot attest this server-side no-op.
+  if run_remote deploy "$sha"; then
+    status=0
+  else
+    status=$?
+  fi
+  ((status == 0 || status == 255)) || \
+    fail "Release B bridge install failed with status $status"
+}
+
 install_daily_c1_bridge_policy() {
   local sha=$1 status
   [[ $sha == "$DAILY_C1_BRIDGE_POLICY_SHA" ]] || \
@@ -654,6 +671,12 @@ case $action in
     validate_sha "$2"
     validate_remote_environment
     deploy_release "$2"
+    ;;
+  install-release-b-bridge)
+    [[ $# == 2 ]] || fail 'install-release-b-bridge requires its pinned SHA'
+    validate_sha "$2"
+    validate_remote_environment
+    install_release_b_bridge "$2"
     ;;
   install-daily-c1-bridge-policy)
     [[ $# == 2 ]] || fail 'install-daily-c1-bridge-policy requires its pinned SHA'

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -109,6 +109,15 @@ fake_ssh() {
     normal_success:"deploy $TARGET_SHA"|normal_success:"deploy 944fdb6da3071f70a69c7048c9fcdf1c2552603e")
       printf 'deployed=%s\n' "$TARGET_SHA"
       ;;
+    release_b_ancestor_noop:"deploy $RELEASE_B_BRIDGE_SHA")
+      printf 'already-deployed-or-newer=%s\n' "$RELEASE_B_INTEGRATION_SHA"
+      ;;
+    release_b_ancestor_noop:"plan $RELEASE_B_BRIDGE_SHA")
+      print_fake_plan true true true false "$RELEASE_B_POOL_MARKER" \
+        "$RELEASE_B_BACKEND_MARKER"
+      ;;
+    release_b_disconnect:"deploy $RELEASE_B_BRIDGE_SHA") exit 255 ;;
+    release_b_failure:"deploy $RELEASE_B_BRIDGE_SHA") exit 42 ;;
     atomic_success:"deploy $TARGET_SHA")
       printf 'postgres-pool-bootstrap=%s replay=false\n' "$TARGET_SHA"
       ;;
@@ -196,6 +205,10 @@ trap 'rm -rf "$FIXTURE"' EXIT
 TARGET_SHA=1234567890abcdef1234567890abcdef12345678
 BACKEND_SHA=4f47fac7faed7dc24110f4a43e88820d776b8a40
 CURRENT_BACKEND_SHA=617e284607f3dde74c27164af2b981770b9a62ed
+RELEASE_B_BRIDGE_SHA=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+RELEASE_B_INTEGRATION_SHA=8b4aeb31e855ed379349a4e4827600009e174132
+RELEASE_B_BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
+RELEASE_B_POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
 MODEL_JOB_IDENTITY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 AUTHORITY_SHA256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 TERMINAL_SET_SHA256=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -212,7 +225,9 @@ DEPLOY_SSH_KNOWN_HOSTS_PATH=$FIXTURE/ssh/pinned-known-hosts
 DEPLOY_HOST=production.example.invalid
 DEPLOY_USER=social-monitor-deploy
 
-export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA MODEL_JOB_IDENTITY AUTHORITY_SHA256 TERMINAL_SET_SHA256
+export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA RELEASE_B_BRIDGE_SHA
+export RELEASE_B_INTEGRATION_SHA RELEASE_B_BACKEND_MARKER RELEASE_B_POOL_MARKER
+export MODEL_JOB_IDENTITY AUTHORITY_SHA256 TERMINAL_SET_SHA256
 export FAKE_SSH_LOG FAKE_SSH_STATE FAKE_UPLOAD_PATH
 export DEPLOY_SSH_DIRECTORY DEPLOY_SSH_KEY_PATH DEPLOY_SSH_KNOWN_HOSTS_PATH
 export DEPLOY_HOST DEPLOY_USER GITHUB_OUTPUT
@@ -529,6 +544,30 @@ assert_call_count 1 "upload $TARGET_SHA"
 run_client normal_success deploy "$TARGET_SHA" >/dev/null
 assert_call_count 1 "deploy $TARGET_SHA"
 assert_call_count 1 "plan $TARGET_SHA"
+
+# The generic deploy reproduces the production failure: the server correctly
+# reports an ancestor no-op, but staggered markers keep the bridge plan pending.
+assert_fails release_b_ancestor_noop deploy "$RELEASE_B_BRIDGE_SHA"
+assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 3 "plan $RELEASE_B_BRIDGE_SHA"
+
+# The exact reviewed action admits only the immutable bridge and deliberately
+# does not reinterpret the target plan. A workflow retry remains the same no-op.
+for _ in first crash-resume; do
+  run_client release_b_ancestor_noop install-release-b-bridge \
+    "$RELEASE_B_BRIDGE_SHA" >/dev/null
+  assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
+  assert_call_count 0 "plan $RELEASE_B_BRIDGE_SHA"
+done
+run_client release_b_disconnect install-release-b-bridge \
+  "$RELEASE_B_BRIDGE_SHA" >/dev/null
+assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 0 "plan $RELEASE_B_BRIDGE_SHA"
+assert_fails release_b_failure install-release-b-bridge "$RELEASE_B_BRIDGE_SHA"
+assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 0 "plan $RELEASE_B_BRIDGE_SHA"
+assert_fails release_b_ancestor_noop install-release-b-bridge "$TARGET_SHA"
+assert_call_count 0 "deploy $TARGET_SHA"
 
 run_client normal_success install-daily-c1-bridge-policy \
   944fdb6da3071f70a69c7048c9fcdf1c2552603e >/dev/null

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -8,6 +8,10 @@ WORKFLOW=$PROJECT_ROOT/.github/workflows/production-deploy.yml
 BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
 FAILED_RELEASE=92afd97328c5412324c99be635de2c41db589d53
 BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
+CONTROL_MARKER=3f4a561e9fd6626bbd1a1e1ca73f2ec7eb34c8f8
+FRONTEND_MARKER=eaac8ad433bc9741f493e61354b3dfe1c3161224
+POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/release-b-bridge-order.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
 REPO=$FIXTURE/repo
@@ -36,6 +40,16 @@ done
 
 # shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
 source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
+fail() {
+  printf 'deploy-error: %s\n' "$*" >&2
+  return 1
+}
+deploy_control_file_digest() {
+  sha256sum "$1" | awk '{print $1}'
+}
+deploy_control_git_blob_digest() {
+  git -C "$REPO" show "$1:$2" | sha256sum | awk '{print $1}'
+}
 read -r -a head_ancestry <<< "$(git -C "$REPO" \
   rev-list --parents -n 1 "$REVIEWED_HEAD")"
 [[ ${#head_ancestry[@]} == 2 ]]
@@ -64,6 +78,162 @@ actual_head_delta=$(git -C "$REPO" diff --name-only --no-renames \
      ops/deploy/deploy-control-bridge-lib.sh | awk '{print $1, $2}') == \
    '100644 blob' ]]
 git -C "$REPO" merge-base --is-ancestor "$BRIDGE" "$REVIEWED_HEAD"
+
+# Reproduce the exact staggered production marker state. These classifications
+# force target bridge validation even though the bridge itself changes only the
+# deploy-control bridge library.
+path_declarations=$(git -C "$REPO" show \
+  "$BRIDGE:ops/deploy/social-monitor-production-deploy.sh" | sed -n \
+  -e '/^FRONTEND_PATHS=(/,/^)/p' \
+  -e '/^BACKEND_PATHS=(/,/^)/p' \
+  -e '/^CONTROL_PATHS=(/,/^)/p' \
+  -e '/^RUNTIME_CONTROL_PATHS=(/,/^)/p')
+eval "$path_declarations"
+marker_paths_changed() {
+  local marker=$1 target=$2
+  shift 2
+  git -C "$REPO" merge-base --is-ancestor "$marker" "$target" &&
+    ! git -C "$REPO" diff --quiet "$marker" "$target" -- "$@"
+}
+marker_paths_changed "$FRONTEND_MARKER" "$BRIDGE" "${FRONTEND_PATHS[@]}"
+marker_paths_changed "$BACKEND_MARKER" "$BRIDGE" "${BACKEND_PATHS[@]}"
+marker_paths_changed "$CONTROL_MARKER" "$BRIDGE" "${CONTROL_PATHS[@]}"
+marker_paths_changed "$BACKEND_MARKER" "$BRIDGE" \
+  apps/x-collector ops/deploy/production-runtime/x-collector.Dockerfile
+if marker_paths_changed \
+    "$CONTROL_MARKER" "$BRIDGE" "${RUNTIME_CONTROL_PATHS[@]}"; then
+  echo 'staggered control marker unexpectedly classifies runtime control' >&2
+  exit 1
+fi
+git -C "$REPO" merge-base --is-ancestor "$POOL_MARKER" "$BRIDGE"
+if marker_paths_changed "$POOL_MARKER" "$BRIDGE" \
+    ops/deploy/postgres-pool-atomic-bootstrap-lib.sh \
+    ops/deploy/postgres-runtime-deploy-lib.sh \
+    ops/deploy/verify-postgres-runtime-topology.py \
+    ops/deploy/production-runtime/compose.postgres-runtime.yml; then
+  echo 'staggered pool marker unexpectedly classifies pool assets' >&2
+  exit 1
+fi
+
+# Pin all of the side bridge's independent identities, then prove commits that
+# preserve only a subset of them remain closed.
+[[ $(git -C "$REPO" rev-parse "$BRIDGE^{tree}") == \
+   "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE" ]]
+[[ $(git -C "$REPO" rev-parse \
+     "$BRIDGE:$DEPLOY_CONTROL_BRIDGE_SELF_PATH") == \
+   "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB" ]]
+deploy_control_is_exact_failed_idle_release_bridge "$BRIDGE"
+
+candidate_index=$FIXTURE/candidate.index
+unrelated_blob=$(printf 'unrelated Release B candidate\n' | \
+  git -C "$REPO" hash-object -w --stdin)
+rm -f "$candidate_index"
+GIT_INDEX_FILE=$candidate_index git -C "$REPO" read-tree "$BASE"
+GIT_INDEX_FILE=$candidate_index git -C "$REPO" update-index \
+  --add --cacheinfo "100644,$unrelated_blob,unrelated-release-b-candidate"
+unrelated_tree=$(GIT_INDEX_FILE=$candidate_index git -C "$REPO" write-tree)
+UNRELATED_BRIDGE=$(printf 'test: unrelated bridge candidate\n' | \
+  git -C "$REPO" commit-tree "$unrelated_tree" -p "$BASE")
+
+tampered_blob=$({
+  git -C "$REPO" show "$BRIDGE:$DEPLOY_CONTROL_BRIDGE_SELF_PATH"
+  printf '\n# tampered bridge candidate\n'
+} | git -C "$REPO" hash-object -w --stdin)
+rm -f "$candidate_index"
+GIT_INDEX_FILE=$candidate_index git -C "$REPO" read-tree "$BASE"
+GIT_INDEX_FILE=$candidate_index git -C "$REPO" update-index \
+  --cacheinfo "100644,$tampered_blob,$DEPLOY_CONTROL_BRIDGE_SELF_PATH"
+tampered_tree=$(GIT_INDEX_FILE=$candidate_index git -C "$REPO" write-tree)
+TAMPERED_BRIDGE=$(printf 'test: tampered bridge candidate\n' | \
+  git -C "$REPO" commit-tree "$tampered_tree" -p "$BASE")
+
+rm -f "$candidate_index"
+GIT_INDEX_FILE=$candidate_index git -C "$REPO" read-tree "$BASE"
+GIT_INDEX_FILE=$candidate_index git -C "$REPO" update-index \
+  --cacheinfo \
+  "100755,$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB,$DEPLOY_CONTROL_BRIDGE_SELF_PATH"
+wrong_mode_tree=$(GIT_INDEX_FILE=$candidate_index git -C "$REPO" write-tree)
+WRONG_MODE_BRIDGE=$(printf 'test: wrong-mode bridge candidate\n' | \
+  git -C "$REPO" commit-tree "$wrong_mode_tree" -p "$BASE")
+
+MIXED_BRIDGE=$(printf 'test: mixed bridge candidate\n' | \
+  git -C "$REPO" commit-tree "$JOIN^{tree}" -p "$BASE")
+WRONG_PARENT_BRIDGE=$(printf 'test: wrong-parent bridge candidate\n' | \
+  git -C "$REPO" commit-tree "$BRIDGE^{tree}" -p "$FAILED_RELEASE")
+for rejected in \
+  "$UNRELATED_BRIDGE" "$TAMPERED_BRIDGE" \
+  "$WRONG_MODE_BRIDGE" "$MIXED_BRIDGE" "$WRONG_PARENT_BRIDGE"; do
+  if deploy_control_is_exact_failed_idle_release_bridge "$rejected" || \
+     deploy_control_reviewed_transition_matches "$BASE" "$rejected"; then
+    echo "unreviewed side bridge candidate was admitted: $rejected" >&2
+    exit 1
+  fi
+done
+
+# Exercise the independent pins after allowing each candidate through the SHA
+# and, where needed, tree checks. This proves rejection is not only SHA-based.
+reviewed_bridge_pin=$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE
+reviewed_tree_pin=$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE
+assert_rejected_after_candidate_pins() {
+  local candidate=$1 candidate_tree=$2 reason=$3
+  DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=$candidate
+  DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE=$candidate_tree
+  if deploy_control_is_exact_failed_idle_release_bridge "$candidate"; then
+    echo "side bridge bypassed its $reason pin" >&2
+    exit 1
+  fi
+  DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=$reviewed_bridge_pin
+  DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE=$reviewed_tree_pin
+}
+assert_rejected_after_candidate_pins \
+  "$WRONG_PARENT_BRIDGE" "$reviewed_tree_pin" parent
+assert_rejected_after_candidate_pins \
+  "$UNRELATED_BRIDGE" "$unrelated_tree" path
+assert_rejected_after_candidate_pins \
+  "$TAMPERED_BRIDGE" "$tampered_tree" blob
+assert_rejected_after_candidate_pins \
+  "$WRONG_MODE_BRIDGE" "$wrong_mode_tree" mode
+
+# With only the SHA pin relaxed, the tampered tree remains independently shut.
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=$TAMPERED_BRIDGE
+if deploy_control_is_exact_failed_idle_release_bridge "$TAMPERED_BRIDGE"; then
+  echo 'side bridge bypassed its tree pin' >&2
+  exit 1
+fi
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=$reviewed_bridge_pin
+
+# The historical controller reproduces run 32920718523's fail-closed error.
+# The current admission accepts the same immutable bridge before checkout,
+# after checkout, and again after reinitialization (crash-resume/retry).
+git -C "$REPO" checkout -q "$BASE"
+historical_controller=$FIXTURE/historical-deploy-control-bridge-lib.sh
+git -C "$REPO" show "$BASE:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" > \
+  "$historical_controller"
+if historical_error=$(
+  (
+    fail() {
+      printf 'deploy-error: %s\n' "$*" >&2
+      exit 1
+    }
+    # shellcheck source=/dev/null
+    source "$historical_controller"
+    initialize_deploy_control_bridge
+    verify_deploy_control_bridge_target_compatibility "$BRIDGE"
+  ) 2>&1
+); then
+  echo 'historical controller unexpectedly admitted the reviewed bridge' >&2
+  exit 1
+fi
+grep -F 'deploy control changed with backend or runtime assets; deploy the bridge release first' \
+  <<< "$historical_error" >/dev/null
+
+initialize_deploy_control_bridge
+verify_deploy_control_bridge_target_compatibility "$BRIDGE"
+git -C "$REPO" checkout -q "$BRIDGE"
+verify_deploy_control_bridge_compatibility
+initialize_deploy_control_bridge
+verify_deploy_control_bridge_target_compatibility "$BRIDGE"
+verify_deploy_control_bridge_compatibility
 
 TARGET=$(printf 'test: simulate exact GitHub merge\n' | git -C "$REPO" \
   commit-tree "$(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}")" \
@@ -139,14 +309,14 @@ bridge_step = deploy[
 commands = (
     f"bridge_release={bridge}",
     'bash "$client" configure',
-    'bash "$client" deploy "$bridge_release"',
+    'bash "$client" install-release-b-bridge "$bridge_release"',
     'bash "$client" cleanup',
     'bash "$client" configure',
 )
 cursor = 0
 for command in commands:
     cursor = bridge_step.index(command, cursor) + len(command)
-if deploy.index('deploy "$bridge_release"') > deploy.index('deploy "$GITHUB_SHA"'):
+if deploy.index('install-release-b-bridge "$bridge_release"') > deploy.index('deploy "$GITHUB_SHA"'):
     raise SystemExit("Release B target runs before its reviewed control bridge")
 PY
 

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -61,7 +61,7 @@ BRIDGE_CONTROL_PATHS=(
 )
 
 assert_real_bridge_target_assets() {
-  local path entry mode type object tree_path expected_digest alternate_digest actual_digest actual_mode
+  local path entry mode type object tree_path expected_digest alternate_digest reviewed_digest actual_digest actual_mode
   local repository_root actual_path actual_real
 
   repository_root=$(readlink -f -- "$PROJECT_ROOT")
@@ -90,6 +90,7 @@ assert_real_bridge_target_assets() {
     }
     expected_digest=$(git -C "$PROJECT_ROOT" show "$BRIDGE_RELEASE_SHA:$path" | sha256sum | awk '{print $1}')
     alternate_digest=
+    reviewed_digest=
     actual_digest=$(sha256sum "$actual_real" | awk '{print $1}')
     case $path in
       ops/deploy/social-monitor-production-deploy.sh)
@@ -109,6 +110,7 @@ assert_real_bridge_target_assets() {
       ops/deploy/deploy-control-bridge-lib.sh)
         expected_digest=e6f958555966b77d02b85da8d0b9195e13a200dcb2b19c8afc010fab6d28b65d
         alternate_digest=d6f3b562e3445dce3ac3d21364793b43afa53fe56011c0b73d02fac721040cf7
+        reviewed_digest=50314ae70cc67d7c860bcf4fe9c7e15253b862e1a89e0dea7a30560f1a61b6b7
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then
@@ -138,7 +140,8 @@ assert_real_bridge_target_assets() {
       }
     fi
     [[ $actual_digest == "$expected_digest" ||
-       (-n $alternate_digest && $actual_digest == "$alternate_digest") ]] || {
+       (-n $alternate_digest && $actual_digest == "$alternate_digest") ||
+       (-n $reviewed_digest && $actual_digest == "$reviewed_digest") ]] || {
       printf 'current bridge asset digest drifted from V4A4: %s\n' "$path" >&2
       exit 1
     }


### PR DESCRIPTION
## What

- restores the production deploy path through the exact direct-child control bridge
- preserves the reviewed ordered-parent Release B topology
- adds fail-closed exactly-once reconciliation for ambiguous SSH outcomes and completed replays
- keeps maintenance dispatch isolated from normal plan/deploy
- compacts workflow comments to satisfy the 999-line repository contract without executable changes

## Exact integration requirement

The reviewed target is `7bff0ece8062cf04bfd3b628f5b83d9724c5ef7a` with ordered parents `68d6910f` then `b3c51bcd`.

After checks pass, `main` must be fast-forwarded to this existing commit unchanged. Do not squash, rebase, reorder parents, or create a wrapper merge commit.

## Evidence

- independent gpt-5.6-sol xhigh review: APPROVED, no findings
- exact old-controller -> bridge -> target fixture passed
- rejected direct route remains rejected
- source line cap, review-CI, client, topology, RabbitMQ and focused production lifecycle gates passed
- all 15 GitHub Actions references remain full SHA pins
- no backend, packaging, Prisma, Dockerfile or application changes
