### PR TITLE
fix(deploy): restore current-main production bridge

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -604,8 +604,8 @@ jobs:
           bash ops/deploy/x-collector-image-deploy-lib.test.sh
           if [[ $bridge_phase == false ]]; then
             bash ops/deploy/github-production-deploy-client.test.sh
-            bash ops/deploy/production-release-b-bridge-order.test.sh
           fi
+          bash ops/deploy/production-release-b-bridge-order.test.sh
           bash ops/deploy/production-release-a-transition.test.sh
           bash ops/deploy/postgres-pool-atomic-bootstrap-lib.test.sh
           bash ops/deploy/social-monitor-production-ssh-wrapper.test.sh
@@ -904,15 +904,15 @@ jobs:
         with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before Release B SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-      - name: Install reviewed failed-idle bridge and reopen restricted SSH
+      - name: Reconcile the old controller, deploy its reviewed bridge, and reopen SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
-          client=ops/deploy/github-production-deploy-client.sh; release_b_failed_idle_bridge_sha=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
-          bash "$client" configure
-          bash "$client" install-release-b-failed-idle-bridge "$release_b_failed_idle_bridge_sha"
+          client=ops/deploy/github-production-deploy-client.sh; controller_release=8b4aeb31e855ed379349a4e4827600009e174132; bridge_release=db4537fea87a5c184a9f926867a6e6aa763ff9bd
+          current_main=d7d0fc88e6a7bcd8e9929e35efd74002a7601449; bash "$client" configure
+          bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$GITHUB_SHA"
           bash "$client" cleanup; bash "$client" configure
       - name: Freshly require A-complete or B-complete
         id: b_state

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -22,6 +22,11 @@ DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH=ops/deploy/deploy-control-bridge
 DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH=ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE=92afd97328c5412324c99be635de2c41db589d53
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE=903f5e8d944c6d703b2bf282d0046ba5066894b1
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB=a6407769622a4da1bd677ff83c9db6ad2c710662
+DEPLOY_CONTROL_RELEASE_B_CONTROLLER=8b4aeb31e855ed379349a4e4827600009e174132
+DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -226,6 +231,88 @@ deploy_control_is_reviewed_rolling_summary_transition() {
   done <<< "$expected"
 }
 
+# Pin the historical failed-idle bridge by every immutable Git identity. This
+# bridge-only hardening release is installed after the exact 8b4 controller is
+# fully reconciled, so the old controller admits it through the ordinary
+# control-only path without relying on this policy to install itself.
+deploy_control_is_exact_failed_idle_release_bridge() {
+  local bridge=$1 repository=${REPO:-.}
+  local actual_tree delta entry mode type object tree_path extra
+  local -a ancestry=()
+
+  [[ $bridge == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE" ]] || return 1
+  read -r -a ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#ancestry[@]} == 2 && \
+     ${ancestry[0]} == "$bridge" && \
+     ${ancestry[1]} == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || \
+    return 1
+  actual_tree=$(git -C "$repository" rev-parse \
+    "$bridge^{tree}" 2>/dev/null) || return 1
+  [[ $actual_tree == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE" ]] || \
+    return 1
+  delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" "$bridge" -- \
+    2>/dev/null) || return 1
+  [[ $delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+  entry=$(git -C "$repository" ls-tree "$bridge" -- \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) || return 1
+  read -r mode type object tree_path extra <<< "$entry"
+  [[ -z ${extra:-} && $mode == 100644 && $type == blob && \
+     $object == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB" && \
+     $tree_path == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]]
+}
+
+deploy_control_is_reviewed_failed_idle_release_bridge_transition() {
+  local current=$1 target=$2
+
+  [[ $current == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || return 1
+  deploy_control_is_exact_failed_idle_release_bridge "$target"
+}
+
+# The current-main Release B target is an exact two-parent integration: the
+# reviewed current main first and this controller-only bridge second. Requiring
+# both parents and the complete path delta keeps inherited rolling/backend work
+# intact while closing stale, rejected, wrapper, and extra-path candidates.
+deploy_control_is_reviewed_current_main_release_b_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local bridge_delta target_delta expected
+  local -a bridge_ancestry=() target_ancestry=()
+
+  read -r -a bridge_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#bridge_ancestry[@]} == 2 && \
+     ${bridge_ancestry[0]} == "$bridge" && \
+     ${bridge_ancestry[1]} == "$DEPLOY_CONTROL_RELEASE_B_CONTROLLER" ]] || \
+    return 1
+  bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_RELEASE_B_CONTROLLER" "$bridge" -- 2>/dev/null) || \
+    return 1
+  [[ $bridge_delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+
+  read -r -a target_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$target" 2>/dev/null)" || return 1
+  [[ ${#target_ancestry[@]} == 3 && \
+     ${target_ancestry[1]} == "$DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN" && \
+     ${target_ancestry[2]} == "$bridge" ]] || return 1
+  [[ $(git -C "$repository" rev-parse \
+       "$target:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) == \
+     $(git -C "$repository" rev-parse \
+       "$bridge:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) ]] || return 1
+  expected=$(printf '%s\n' \
+    .github/workflows/production-deploy.yml \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" \
+    ops/deploy/github-production-deploy-client.sh \
+    ops/deploy/github-production-deploy-client.test.sh \
+    ops/deploy/production-release-b-bridge-order.test.sh \
+    ops/ingestion/source-provider-certification.json \
+    "$DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH" | LC_ALL=C sort)
+  target_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN" "$target" -- 2>/dev/null | \
+    LC_ALL=C sort) || return 1
+  [[ $target_delta == "$expected" ]]
+}
+
 # The failed release already exists on main, so its control-only bridge is a
 # side parent from the pre-release main. GitHub must merge the reviewed PR head
 # directly into that failed release. Every intermediate parent and path delta is
@@ -238,6 +325,7 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
   local -a bridge_ancestry=() join_ancestry=() head_ancestry=()
   local -a target_ancestry=()
 
+  deploy_control_is_exact_failed_idle_release_bridge "$bridge" || return 1
   git -C "$repository" cat-file -e \
     "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE^{commit}" 2>/dev/null || return 1
   git -C "$repository" cat-file -e \
@@ -310,6 +398,14 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
 
 deploy_control_reviewed_transition_matches() {
   local bridge=$1 target=$2
+  if deploy_control_is_reviewed_current_main_release_b_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
+  if deploy_control_is_reviewed_failed_idle_release_bridge_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
   if deploy_control_daily_final_transition_matches "$bridge" "$target"; then
     return 0
   fi

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -5,8 +5,13 @@ PATH=/usr/local/bin:/usr/bin:/bin
 
 ZERO_SHA=0000000000000000000000000000000000000000
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
+RELEASE_B_CONTROLLER_SHA=8b4aeb31e855ed379349a4e4827600009e174132
+RELEASE_B_CURRENT_MAIN_SHA=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
+RELEASE_B_BRIDGE_SHA=db4537fea87a5c184a9f926867a6e6aa763ff9bd
+RELEASE_B_BRIDGE_TREE=f998252edb25e6e2411ddc351806ba8170114c61
+RELEASE_B_BRIDGE_BLOB=70a87f730ff47c1071a7855a1177fd5d1601ee5c
+RELEASE_B_BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
 DAILY_C1_BRIDGE_POLICY_SHA=944fdb6da3071f70a69c7048c9fcdf1c2552603e
-RELEASE_B_FAILED_IDLE_BRIDGE_SHA=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
 SSH_DIRECTORY=${DEPLOY_SSH_DIRECTORY:-${HOME:?HOME is required}/.ssh}
 SSH_KEY_PATH=${DEPLOY_SSH_KEY_PATH:-$SSH_DIRECTORY/social-monitor-production}
 SSH_KNOWN_HOSTS_PATH=${DEPLOY_SSH_KNOWN_HOSTS_PATH:-$SSH_DIRECTORY/known_hosts}
@@ -546,6 +551,46 @@ plan_is_fully_reconciled() {
      $PLAN_BACKEND_BASE != "$ZERO_SHA" ]]
 }
 
+plan_is_exact_release_b_bridge_transition() {
+  [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == false && \
+     $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA != "$ZERO_SHA" && \
+     $PLAN_BACKEND_BASE == "$RELEASE_B_CONTROLLER_SHA" ]]
+}
+
+verify_release_b_bridge_identity() {
+  local sha=$1 repository=${GITHUB_WORKSPACE:-.}
+  local actual_tree delta entry mode type object path extra
+  local -a ancestry=()
+
+  [[ $sha == "$RELEASE_B_BRIDGE_SHA" ]] || \
+    fail 'Release B bridge SHA is not the reviewed pin'
+  read -r -a ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$sha" 2>/dev/null)" || \
+    fail 'Release B bridge ancestry cannot be inspected'
+  [[ ${#ancestry[@]} == 2 && ${ancestry[0]} == "$sha" && \
+     ${ancestry[1]} == "$RELEASE_B_CONTROLLER_SHA" ]] || \
+    fail 'Release B bridge is not the exact controller child'
+  actual_tree=$(git -C "$repository" rev-parse "$sha^{tree}" 2>/dev/null) || \
+    fail 'Release B bridge tree cannot be inspected'
+  [[ $actual_tree == "$RELEASE_B_BRIDGE_TREE" ]] || \
+    fail 'Release B bridge tree does not match its reviewed pin'
+  delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$RELEASE_B_CONTROLLER_SHA" "$sha" -- 2>/dev/null) || \
+    fail 'Release B bridge delta cannot be inspected'
+  [[ $delta == "$RELEASE_B_BRIDGE_PATH" ]] || \
+    fail 'Release B bridge changes more than its reviewed controller policy'
+  entry=$(git -C "$repository" ls-tree "$sha" -- \
+    "$RELEASE_B_BRIDGE_PATH" 2>/dev/null) || \
+    fail 'Release B bridge policy blob cannot be inspected'
+  read -r mode type object path extra <<< "$entry"
+  [[ -z ${extra:-} && $mode == 100644 && $type == blob && \
+     $object == "$RELEASE_B_BRIDGE_BLOB" && \
+     $path == "$RELEASE_B_BRIDGE_PATH" ]] || \
+    fail 'Release B bridge policy blob does not match its reviewed pin'
+}
+
 reconcile_deploy_plan() {
   local sha=$1
   local attempt status
@@ -599,6 +644,62 @@ deploy_release() {
   }
 }
 
+prepare_release_b_bridge() {
+  local sha=$1 bridge=$2 current_main=$3 target=$4 status
+  [[ $sha == "$RELEASE_B_CONTROLLER_SHA" ]] || \
+    fail 'Release B controller SHA is not the reviewed pin'
+  [[ $current_main == "$RELEASE_B_CURRENT_MAIN_SHA" ]] || \
+    fail 'Release B current-main SHA is not the reviewed pin'
+  verify_release_b_bridge_identity "$bridge"
+
+  if capture_plan "$target"; then
+    print_plan
+    plan_is_fully_reconciled && return 0
+  else
+    status=$?
+    ((status == 1)) || fail "Release B target preflight plan failed with status $status"
+  fi
+  if capture_plan "$current_main"; then
+    print_plan
+    plan_is_fully_reconciled && return 0
+  else
+    status=$?
+    ((status == 1)) || fail "Release B current-main plan failed with status $status"
+  fi
+  if capture_plan "$bridge"; then
+    print_plan
+    plan_is_fully_reconciled && return 0
+    if plan_is_exact_release_b_bridge_transition; then
+      deploy_once "$bridge"
+      return 0
+    fi
+  else
+    status=$?
+    ((status == 1)) || \
+      fail "Release B bridge preflight plan failed with status $status"
+  fi
+  if capture_plan "$sha"; then
+    status=0
+  else
+    status=$?
+  fi
+  ((status == 0)) || \
+    fail "Release B controller plan failed with status $status"
+  print_plan
+  plan_is_fully_reconciled || deploy_once "$sha"
+  if capture_plan "$bridge"; then
+    status=0
+  else
+    status=$?
+  fi
+  ((status == 0)) || fail "Release B bridge plan failed with status $status"
+  print_plan
+  plan_is_fully_reconciled && return 0
+  plan_is_exact_release_b_bridge_transition || \
+    fail 'Release B bridge plan is not the exact fresh control-only transition'
+  deploy_once "$bridge"
+}
+
 install_daily_c1_bridge_policy() {
   local sha=$1 status
   [[ $sha == "$DAILY_C1_BRIDGE_POLICY_SHA" ]] || \
@@ -610,19 +711,6 @@ install_daily_c1_bridge_policy() {
   fi
   ((status == 0 || status == 255)) || \
     fail "daily C1 bridge policy install failed with status $status"
-}
-
-install_release_b_failed_idle_bridge() {
-  local sha=$1 status
-  [[ $sha == "$RELEASE_B_FAILED_IDLE_BRIDGE_SHA" ]] || \
-    fail 'Release B failed-idle bridge SHA is not the reviewed pin'
-  if run_remote deploy "$sha"; then
-    status=0
-  else
-    status=$?
-  fi
-  ((status == 0 || status == 255)) || \
-    fail "Release B failed-idle bridge install failed with status $status"
 }
 
 upload_frontend() {
@@ -669,17 +757,20 @@ case $action in
     validate_remote_environment
     deploy_release "$2"
     ;;
+  prepare-release-b-bridge)
+    [[ $# == 5 ]] || fail 'prepare-release-b-bridge requires controller, bridge, current-main, and target pins'
+    validate_sha "$2"
+    validate_sha "$3"
+    validate_sha "$4"
+    validate_sha "$5"
+    validate_remote_environment
+    prepare_release_b_bridge "$2" "$3" "$4" "$5"
+    ;;
   install-daily-c1-bridge-policy)
     [[ $# == 2 ]] || fail 'install-daily-c1-bridge-policy requires its pinned SHA'
     validate_sha "$2"
     validate_remote_environment
     install_daily_c1_bridge_policy "$2"
-    ;;
-  install-release-b-failed-idle-bridge)
-    [[ $# == 2 ]] || fail 'install-release-b-failed-idle-bridge requires its pinned SHA'
-    validate_sha "$2"
-    validate_remote_environment
-    install_release_b_failed_idle_bridge "$2"
     ;;
   maintenance)
     [[ $# == 3 || $# == 4 || $# == 5 || $# == 6 ]] || \

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -106,15 +106,70 @@ fake_ssh() {
     maintenance_success:"disk-report $TARGET_SHA"|maintenance_success:"project-disk-cleanup $TARGET_SHA"|maintenance_success:"reader-summary-recover-missing-days $TARGET_SHA"|maintenance_success:"reader-summary-weekly-run $TARGET_SHA"|maintenance_success:"reader-summary-production-history $TARGET_SHA 2026-08-11"|maintenance_success:"reader-summary-daily-terminal-set-receipt-v1 $TARGET_SHA"|maintenance_success:"reader-summary-daily-scan-terminal-preimage-c1 $TARGET_SHA"|maintenance_success:"reader-summary-daily-canonical-recovery-v4 $TARGET_SHA invalid-product-retry-set-v1 $TERMINAL_SET_SHA256"|maintenance_success:"reader-summary-daily-canonical-recovery-v4 $TARGET_SHA reader-summary-daily-canonical-recovery-v4 $MODEL_JOB_IDENTITY $AUTHORITY_SHA256"|maintenance_success:"reader-summary-daily-scan-terminal-repair-c1 $TARGET_SHA reader-summary-daily-scan-terminal-repair-c1 $TERMINAL_SET_SHA256"|maintenance_success:"reader-summary-daily-delivery-c1-run $TARGET_SHA reader-summary-daily-delivery-c1-run 2026-08-10"|maintenance_success:"reader-summary-daily-delivery-c1-contain $TARGET_SHA reader-summary-daily-delivery-c1-contain $TARGET_SHA")
       printf 'maintenance=%s\n' "${command%% *}"
       ;;
-    normal_success:"deploy $TARGET_SHA"|normal_success:"deploy 944fdb6da3071f70a69c7048c9fcdf1c2552603e"|normal_success:"deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA")
+    normal_success:"deploy $TARGET_SHA"|normal_success:"deploy 944fdb6da3071f70a69c7048c9fcdf1c2552603e")
       printf 'deployed=%s\n' "$TARGET_SHA"
       ;;
-    bridge_disconnect:"deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA")
-      exit 255
+    release_b_replay:"plan $TARGET_SHA")
+      print_fake_plan false false false false "$TARGET_SHA" "$TARGET_SHA"
       ;;
-    bridge_non_255:"deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA")
-      exit 42
+    release_b_current_main:"plan $TARGET_SHA")
+      print_fake_plan false false true false "$RELEASE_B_CURRENT_MAIN_SHA" \
+        "$RELEASE_B_CURRENT_MAIN_SHA"
       ;;
+    release_b_current_main:"plan $RELEASE_B_CURRENT_MAIN_SHA")
+      print_fake_plan false false false false "$RELEASE_B_CURRENT_MAIN_SHA" \
+        "$RELEASE_B_CURRENT_MAIN_SHA"
+      ;;
+    release_b_from_8b:"plan $TARGET_SHA"|release_b_bridge_disconnect:"plan $TARGET_SHA"|release_b_controller_repair:"plan $TARGET_SHA")
+      print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
+        "$RELEASE_B_CONTROLLER_SHA"
+      ;;
+    release_b_from_8b:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_bridge_disconnect:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_controller_repair:"plan $RELEASE_B_CURRENT_MAIN_SHA")
+      print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
+        "$RELEASE_B_CONTROLLER_SHA"
+      ;;
+    release_b_from_8b:"plan $RELEASE_B_BRIDGE_SHA"|release_b_bridge_disconnect:"plan $RELEASE_B_BRIDGE_SHA")
+      count=$(grep -cFx "deploy $RELEASE_B_BRIDGE_SHA" "$FAKE_SSH_LOG" || true)
+      if ((count == 0)); then
+        print_fake_plan false false true false "$RELEASE_B_CONTROLLER_SHA" \
+          "$RELEASE_B_CONTROLLER_SHA"
+      else
+        print_fake_plan false false false false "$RELEASE_B_BRIDGE_SHA" \
+          "$RELEASE_B_CONTROLLER_SHA"
+      fi
+      ;;
+    release_b_controller_repair:"plan $RELEASE_B_BRIDGE_SHA")
+      if grep -qFx "deploy $RELEASE_B_BRIDGE_SHA" "$FAKE_SSH_LOG"; then
+        print_fake_plan false false false false "$RELEASE_B_BRIDGE_SHA" \
+          "$RELEASE_B_CONTROLLER_SHA"
+      elif grep -qFx "deploy $RELEASE_B_CONTROLLER_SHA" "$FAKE_SSH_LOG"; then
+        print_fake_plan false false true false "$RELEASE_B_CONTROLLER_SHA" \
+          "$RELEASE_B_CONTROLLER_SHA"
+      else
+        print_fake_plan false true true false "$RELEASE_B_POOL_MARKER" \
+          "$RELEASE_B_BACKEND_MARKER"
+      fi
+      ;;
+    release_b_controller_repair:"plan $RELEASE_B_CONTROLLER_SHA")
+      if grep -qFx "deploy $RELEASE_B_CONTROLLER_SHA" "$FAKE_SSH_LOG"; then
+        print_fake_plan false false false false "$RELEASE_B_CONTROLLER_SHA" \
+          "$RELEASE_B_CONTROLLER_SHA"
+      else
+        print_fake_plan true true true false "$RELEASE_B_POOL_MARKER" \
+          "$RELEASE_B_BACKEND_MARKER"
+      fi
+      ;;
+    release_b_from_8b:"deploy $RELEASE_B_BRIDGE_SHA"|release_b_controller_repair:"deploy $RELEASE_B_BRIDGE_SHA")
+      printf 'deployed=%s\n' "$RELEASE_B_BRIDGE_SHA"
+      ;;
+    release_b_bridge_disconnect:"deploy $RELEASE_B_BRIDGE_SHA") exit 255 ;;
+    release_b_controller_repair:"deploy $RELEASE_B_CONTROLLER_SHA")
+      printf 'deployed=%s\n' "$RELEASE_B_CONTROLLER_SHA"
+      ;;
+    release_b_partial:"plan $TARGET_SHA")
+      printf 'frontend=false\nbackend=true\n'
+      ;;
+    release_b_rejected:"plan $TARGET_SHA"|release_b_rejected:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_rejected:"plan $RELEASE_B_BRIDGE_SHA") exit 1 ;;
     atomic_success:"deploy $TARGET_SHA")
       printf 'postgres-pool-bootstrap=%s replay=false\n' "$TARGET_SHA"
       ;;
@@ -202,7 +257,11 @@ trap 'rm -rf "$FIXTURE"' EXIT
 TARGET_SHA=1234567890abcdef1234567890abcdef12345678
 BACKEND_SHA=4f47fac7faed7dc24110f4a43e88820d776b8a40
 CURRENT_BACKEND_SHA=617e284607f3dde74c27164af2b981770b9a62ed
-RELEASE_B_FAILED_IDLE_BRIDGE_SHA=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+RELEASE_B_CONTROLLER_SHA=8b4aeb31e855ed379349a4e4827600009e174132
+RELEASE_B_CURRENT_MAIN_SHA=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
+RELEASE_B_BRIDGE_SHA=db4537fea87a5c184a9f926867a6e6aa763ff9bd
+RELEASE_B_BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
+RELEASE_B_POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
 MODEL_JOB_IDENTITY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 AUTHORITY_SHA256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 TERMINAL_SET_SHA256=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -219,7 +278,9 @@ DEPLOY_SSH_KNOWN_HOSTS_PATH=$FIXTURE/ssh/pinned-known-hosts
 DEPLOY_HOST=production.example.invalid
 DEPLOY_USER=social-monitor-deploy
 
-export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA RELEASE_B_FAILED_IDLE_BRIDGE_SHA
+export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA RELEASE_B_CONTROLLER_SHA
+export RELEASE_B_CURRENT_MAIN_SHA RELEASE_B_BRIDGE_SHA
+export RELEASE_B_BACKEND_MARKER RELEASE_B_POOL_MARKER
 export MODEL_JOB_IDENTITY AUTHORITY_SHA256 TERMINAL_SET_SHA256
 export FAKE_SSH_LOG FAKE_SSH_STATE FAKE_UPLOAD_PATH
 export DEPLOY_SSH_DIRECTORY DEPLOY_SSH_KEY_PATH DEPLOY_SSH_KNOWN_HOSTS_PATH
@@ -538,6 +599,34 @@ run_client normal_success deploy "$TARGET_SHA" >/dev/null
 assert_call_count 1 "deploy $TARGET_SHA"
 assert_call_count 1 "plan $TARGET_SHA"
 
+# Every bridge/controller mutation follows a plan and is issued at most once.
+prepare_args=(prepare-release-b-bridge "$RELEASE_B_CONTROLLER_SHA" \
+  "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" "$TARGET_SHA")
+run_client release_b_from_8b "${prepare_args[@]}" >/dev/null
+assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 2 "plan $RELEASE_B_BRIDGE_SHA"
+assert_call_count 0 "deploy $RELEASE_B_CONTROLLER_SHA"
+run_client release_b_bridge_disconnect "${prepare_args[@]}" >/dev/null
+assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 2 "plan $RELEASE_B_BRIDGE_SHA"
+run_client release_b_controller_repair "${prepare_args[@]}" >/dev/null
+assert_call_count 1 "deploy $RELEASE_B_CONTROLLER_SHA"
+assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 2 "plan $RELEASE_B_CONTROLLER_SHA"
+run_client release_b_current_main "${prepare_args[@]}" >/dev/null
+assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 1 "plan $RELEASE_B_CURRENT_MAIN_SHA"
+run_client release_b_replay "${prepare_args[@]}" >/dev/null
+assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 0 "deploy $TARGET_SHA"
+assert_fails release_b_partial "${prepare_args[@]}"
+assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_fails release_b_rejected "${prepare_args[@]}"
+assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_fails release_b_replay prepare-release-b-bridge "$TARGET_SHA" \
+  "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" "$TARGET_SHA"
+[[ ! -s $FAKE_SSH_LOG ]]
+
 run_client normal_success install-daily-c1-bridge-policy \
   944fdb6da3071f70a69c7048c9fcdf1c2552603e >/dev/null
 assert_call_count 1 \
@@ -547,25 +636,6 @@ assert_call_count 0 \
 
 assert_fails normal_success install-daily-c1-bridge-policy "$TARGET_SHA"
 assert_call_count 0 "deploy $TARGET_SHA"
-
-run_client normal_success install-release-b-failed-idle-bridge \
-  "$RELEASE_B_FAILED_IDLE_BRIDGE_SHA" >/dev/null
-assert_call_count 1 "deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
-assert_call_count 0 "plan $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
-
-run_client bridge_disconnect install-release-b-failed-idle-bridge \
-  "$RELEASE_B_FAILED_IDLE_BRIDGE_SHA" >/dev/null
-assert_call_count 1 "deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
-assert_call_count 0 "plan $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
-
-assert_fails normal_success install-release-b-failed-idle-bridge "$TARGET_SHA"
-[[ ! -s $FAKE_SSH_LOG ]]
-assert_call_count 0 "deploy $TARGET_SHA"
-
-assert_fails bridge_non_255 install-release-b-failed-idle-bridge \
-  "$RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
-assert_call_count 1 "deploy $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
-assert_call_count 0 "plan $RELEASE_B_FAILED_IDLE_BRIDGE_SHA"
 
 run_client disconnect_eventual deploy "$TARGET_SHA" >/dev/null
 assert_call_count 1 "deploy $TARGET_SHA"

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -1,169 +1,252 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 SOURCE_REPO=${PRODUCTION_RELEASE_B_TEST_SOURCE_REPO:-$PROJECT_ROOT}
 WORKFLOW=$PROJECT_ROOT/.github/workflows/production-deploy.yml
-BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
-FAILED_RELEASE=92afd97328c5412324c99be635de2c41db589d53
-BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
-INTEGRATED_RELEASE=8b4aeb31e855ed379349a4e4827600009e174132
-FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/release-b-bridge-order.XXXXXX")
+CLIENT=$PROJECT_ROOT/ops/deploy/github-production-deploy-client.sh
+BASE=8b4aeb31e855ed379349a4e4827600009e174132
+CURRENT_MAIN=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
+REJECTED=68d6910f7874be89e2d5418dede5be6129e8af3a
+REJECTED_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+BRIDGE=db4537fea87a5c184a9f926867a6e6aa763ff9bd
+BRIDGE_TREE=f998252edb25e6e2411ddc351806ba8170114c61
+BRIDGE_BLOB=70a87f730ff47c1071a7855a1177fd5d1601ee5c
+BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
+BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
+CONTROL_MARKER=3f4a561e9fd6626bbd1a1e1ca73f2ec7eb34c8f8
+FRONTEND_MARKER=eaac8ad433bc9741f493e61354b3dfe1c3161224
+POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/release-b-current-main.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
-REPO=$FIXTURE/repo
+GRAPH_REPO=$FIXTURE/graph
 
-git clone -q --shared "$SOURCE_REPO" "$REPO"
-git -C "$REPO" config user.name 'Release B Bridge Test'
-git -C "$REPO" config user.email release-b-bridge@example.invalid
-SOURCE_TIP=$(git -C "$REPO" rev-parse HEAD)
-read -r -a integrated_ancestry <<< "$(git -C "$REPO" \
-  rev-list --parents -n 1 "$INTEGRATED_RELEASE")"
-[[ ${#integrated_ancestry[@]} == 3 && \
-   ${integrated_ancestry[1]} == "$FAILED_RELEASE" ]]
-REVIEWED_HEAD=${integrated_ancestry[2]}
-[[ $(git -C "$REPO" rev-parse "$INTEGRATED_RELEASE^{tree}") == \
-   $(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}") ]]
-git -C "$REPO" merge-base --is-ancestor "$INTEGRATED_RELEASE" "$SOURCE_TIP"
-
-# The pinned side parent must be obtainable from the reviewed repository, not
-# merely present in the current object's incidental local cache.
-git -C "$REPO" fetch -q "$SOURCE_REPO" "$BRIDGE"
-[[ $(git -C "$REPO" rev-parse FETCH_HEAD) == "$BRIDGE" ]]
-for commit in "$BASE" "$FAILED_RELEASE" "$BRIDGE" "$INTEGRATED_RELEASE" \
-  "$REVIEWED_HEAD"; do
-  git -C "$REPO" cat-file -e "$commit^{commit}"
+git clone -q --shared "$SOURCE_REPO" "$GRAPH_REPO"
+git -C "$GRAPH_REPO" config user.name 'Release B Current Main Test'
+git -C "$GRAPH_REPO" config user.email release-b-current-main@example.invalid
+TARGET=$(git -C "$GRAPH_REPO" rev-parse HEAD)
+for commit in "$BASE" "$CURRENT_MAIN" "$REJECTED" "$REJECTED_BRIDGE" \
+  "$BRIDGE" "$TARGET"; do
+  git -C "$GRAPH_REPO" cat-file -e "$commit^{commit}"
 done
 
-# shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
-source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
-read -r -a head_ancestry <<< "$(git -C "$REPO" \
-  rev-list --parents -n 1 "$REVIEWED_HEAD")"
-[[ ${#head_ancestry[@]} == 2 ]]
-JOIN=${head_ancestry[1]}
-read -r -a join_ancestry <<< "$(git -C "$REPO" \
-  rev-list --parents -n 1 "$JOIN")"
-[[ ${#join_ancestry[@]} == 3 && \
-   ${join_ancestry[1]} == "$FAILED_RELEASE" && \
-   ${join_ancestry[2]} == "$BRIDGE" ]]
-read -r -a bridge_ancestry <<< "$(git -C "$REPO" \
+# The bridge is one immutable policy blob directly on the old controller.
+read -r -a bridge_parents <<< "$(git -C "$GRAPH_REPO" \
   rev-list --parents -n 1 "$BRIDGE")"
-[[ ${#bridge_ancestry[@]} == 2 && ${bridge_ancestry[1]} == "$BASE" ]]
-[[ $(git -C "$REPO" diff --name-only --no-renames "$BASE" "$BRIDGE") == \
-   ops/deploy/deploy-control-bridge-lib.sh ]]
-[[ $(git -C "$REPO" diff --name-only --no-renames \
-     "$FAILED_RELEASE" "$JOIN") == \
-   ops/deploy/deploy-control-bridge-lib.sh ]]
-expected_head_delta=$(printf '%s\n' \
-  .github/workflows/production-deploy.yml \
-  ops/deploy/production-release-b-bridge-order.test.sh \
-  ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh | LC_ALL=C sort)
-actual_head_delta=$(git -C "$REPO" diff --name-only --no-renames \
-  "$JOIN" "$REVIEWED_HEAD" | LC_ALL=C sort)
-[[ $actual_head_delta == "$expected_head_delta" ]]
-[[ $(git -C "$REPO" ls-tree "$BRIDGE" -- \
-     ops/deploy/deploy-control-bridge-lib.sh | awk '{print $1, $2}') == \
-   '100644 blob' ]]
-git -C "$REPO" merge-base --is-ancestor "$BRIDGE" "$REVIEWED_HEAD"
+[[ ${#bridge_parents[@]} == 2 && ${bridge_parents[0]} == "$BRIDGE" && \
+   ${bridge_parents[1]} == "$BASE" ]]
+[[ $(git -C "$GRAPH_REPO" rev-parse "$BRIDGE^{tree}") == "$BRIDGE_TREE" ]]
+[[ $(git -C "$GRAPH_REPO" diff --name-only --no-renames \
+     "$BASE" "$BRIDGE") == "$BRIDGE_PATH" ]]
+read -r bridge_mode bridge_type bridge_blob bridge_path bridge_extra <<< "$(
+  git -C "$GRAPH_REPO" ls-tree "$BRIDGE" -- "$BRIDGE_PATH"
+)"
+[[ -z ${bridge_extra:-} && $bridge_mode == 100644 && \
+   $bridge_type == blob && $bridge_blob == "$BRIDGE_BLOB" && \
+   $bridge_path == "$BRIDGE_PATH" ]]
 
-TARGET=$(printf 'test: simulate exact GitHub merge\n' | git -C "$REPO" \
-  commit-tree "$(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}")" \
-  -p "$FAILED_RELEASE" -p "$REVIEWED_HEAD")
-if deploy_control_reviewed_transition_matches "$BASE" "$TARGET"; then
-  echo 'failed Release B unexpectedly bypasses its required bridge' >&2
-  exit 1
-fi
-if deploy_control_reviewed_transition_matches "$BRIDGE" "$REVIEWED_HEAD"; then
-  echo 'failed-idle bridge admitted the unmerged reviewed head' >&2
-  exit 1
-fi
-deploy_control_reviewed_transition_matches "$BRIDGE" "$TARGET"
-git -C "$REPO" merge-base --is-ancestor "$FAILED_RELEASE" "$TARGET"
-git -C "$REPO" merge-base --is-ancestor "$BRIDGE" "$TARGET"
-read -r -a target_ancestry <<< "$(git -C "$REPO" \
+# The deploy target is a real current-main integration, not a wrapper around
+# the rejected sibling or the approved target's obsolete graph.
+read -r -a target_parents <<< "$(git -C "$GRAPH_REPO" \
   rev-list --parents -n 1 "$TARGET")"
-[[ ${#target_ancestry[@]} == 3 && \
-   ${target_ancestry[1]} == "$FAILED_RELEASE" && \
-   ${target_ancestry[2]} == "$REVIEWED_HEAD" ]]
-[[ $(git -C "$REPO" rev-parse "$TARGET^{tree}") == \
-   $(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}") ]]
+[[ ${#target_parents[@]} == 3 && \
+   ${target_parents[1]} == "$CURRENT_MAIN" && \
+   ${target_parents[2]} == "$BRIDGE" ]]
+git -C "$GRAPH_REPO" merge-base --is-ancestor "$CURRENT_MAIN" "$TARGET"
+git -C "$GRAPH_REPO" merge-base --is-ancestor "$BRIDGE" "$TARGET"
+if git -C "$GRAPH_REPO" merge-base --is-ancestor "$REJECTED" "$TARGET"; then
+  echo 'rejected Release B sibling is an ancestor of the candidate' >&2
+  exit 1
+fi
+[[ $(git -C "$GRAPH_REPO" rev-parse "$TARGET:$BRIDGE_PATH") == \
+   "$BRIDGE_BLOB" ]]
+expected_target_delta=$(printf '%s\n' \
+  .github/workflows/production-deploy.yml \
+  ops/deploy/deploy-control-bridge-lib.sh \
+  ops/deploy/github-production-deploy-client.sh \
+  ops/deploy/github-production-deploy-client.test.sh \
+  ops/deploy/production-release-b-bridge-order.test.sh \
+  ops/ingestion/source-provider-certification.json \
+  ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh | \
+  LC_ALL=C sort)
+actual_target_delta=$(git -C "$GRAPH_REPO" diff --name-only --no-renames \
+  "$CURRENT_MAIN" "$TARGET" | LC_ALL=C sort)
+[[ $actual_target_delta == "$expected_target_delta" ]]
 
-deploy_control_reviewed_transition_matches "$BRIDGE" "$INTEGRATED_RELEASE"
-
-git -C "$REPO" checkout -q "$TARGET"
-printf '\n# unreviewed same-path drift\n' >> \
-  "$REPO/.github/workflows/production-deploy.yml"
-git -C "$REPO" add .github/workflows/production-deploy.yml
-git -C "$REPO" commit -qm 'test: add same-path Release B drift'
-SAME_PATH_DRIFT_TARGET=$(git -C "$REPO" rev-parse HEAD)
-if deploy_control_reviewed_transition_matches \
-    "$BRIDGE" "$SAME_PATH_DRIFT_TARGET"; then
-  echo 'failed-idle bridge admitted same-allowlisted-path drift' >&2
+# Exercise the bridge acceptance policy against the real graph and negative
+# stale/rejected topologies.
+REPO=$GRAPH_REPO
+fail() { printf 'test-error: %s\n' "$*" >&2; return 1; }
+# shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
+source "$GRAPH_REPO/ops/deploy/deploy-control-bridge-lib.sh"
+deploy_control_reviewed_transition_matches "$BRIDGE" "$TARGET"
+if deploy_control_reviewed_transition_matches "$REJECTED_BRIDGE" "$REJECTED"; then
+  echo 'rejected sibling topology was admitted' >&2
+  exit 1
+fi
+stale_target=$(printf 'test: stale current-main target\n' | git -C "$GRAPH_REPO" \
+  commit-tree "$TARGET^{tree}" -p "$BASE" -p "$BRIDGE")
+if deploy_control_reviewed_transition_matches "$BRIDGE" "$stale_target"; then
+  echo 'stale current-main topology was admitted' >&2
+  exit 1
+fi
+extra_blob=$(printf 'extra target drift\n' | git -C "$GRAPH_REPO" hash-object -w --stdin)
+extra_index=$FIXTURE/extra.index
+GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" read-tree "$TARGET"
+GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" update-index \
+  --add --cacheinfo "100644,$extra_blob,unreviewed-release-b-drift"
+extra_tree=$(GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" write-tree)
+extra_target=$(printf 'test: extra path target\n' | git -C "$GRAPH_REPO" \
+  commit-tree "$extra_tree" -p "$CURRENT_MAIN" -p "$BRIDGE")
+if deploy_control_reviewed_transition_matches "$BRIDGE" "$extra_target"; then
+  echo 'extra-path current-main topology was admitted' >&2
   exit 1
 fi
 
-git -C "$REPO" checkout -q "$TARGET"
-printf 'unreviewed Release B drift\n' > "$REPO/unreviewed-release-b-drift"
-git -C "$REPO" add unreviewed-release-b-drift
-git -C "$REPO" commit -qm 'test: add unreviewed Release B drift'
-DRIFT_TARGET=$(git -C "$REPO" rev-parse HEAD)
-if deploy_control_reviewed_transition_matches "$BRIDGE" "$DRIFT_TARGET"; then
-  echo 'failed-idle bridge admitted unreviewed Release B drift' >&2
-  exit 1
-fi
+for exact_pin in \
+  "RELEASE_B_CONTROLLER_SHA=$BASE" \
+  "RELEASE_B_CURRENT_MAIN_SHA=$CURRENT_MAIN" \
+  "RELEASE_B_BRIDGE_SHA=$BRIDGE" \
+  "RELEASE_B_BRIDGE_TREE=$BRIDGE_TREE" \
+  "RELEASE_B_BRIDGE_BLOB=$BRIDGE_BLOB"; do
+  grep -Fqx "$exact_pin" "$CLIENT"
+done
+[[ $(grep -Fo "controller_release=$BASE" "$WORKFLOW" | wc -l) == 1 ]]
+[[ $(grep -Fo "current_main=$CURRENT_MAIN" "$WORKFLOW" | wc -l) == 1 ]]
+[[ $(grep -Fo "bridge_release=$BRIDGE" "$WORKFLOW" | wc -l) == 1 ]]
 
-WRONG_TOPOLOGY_TARGET=$(printf 'test: wrong GitHub parent order\n' | \
-  git -C "$REPO" commit-tree \
-  "$(git -C "$REPO" rev-parse "$REVIEWED_HEAD^{tree}")" \
-  -p "$REVIEWED_HEAD" -p "$FAILED_RELEASE")
-if deploy_control_reviewed_transition_matches \
-    "$BRIDGE" "$WRONG_TOPOLOGY_TARGET"; then
-  echo 'failed-idle bridge admitted the wrong GitHub parent topology' >&2
-  exit 1
-fi
-
-python3 - "$WORKFLOW" "$BRIDGE" <<'PY'
+python3 - "$WORKFLOW" <<'PY'
 import pathlib
 import sys
 
 workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
-bridge = sys.argv[2]
-if "bash ops/deploy/production-release-b-bridge-order.test.sh" not in workflow:
-    raise SystemExit("Release B exact-topology regression is not executed in CI")
-deploy = workflow[workflow.index("  deploy:"):workflow.index("  acceptance:")]
-bridge_step_name = "Install reviewed failed-idle bridge and reopen restricted SSH"
-fresh_step_name = "Freshly require A-complete or B-complete"
-bridge_step = deploy[
-    deploy.index(bridge_step_name):deploy.index(fresh_step_name)
+commands = [
+    'bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$GITHUB_SHA"',
+    'bash "$client" cleanup; bash "$client" configure',
+    'inspect-plan "$GITHUB_SHA"',
+    'bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"',
 ]
-commands = (
-    f"release_b_failed_idle_bridge_sha={bridge}",
-    'bash "$client" configure',
-    'bash "$client" install-release-b-failed-idle-bridge "$release_b_failed_idle_bridge_sha"',
-    'bash "$client" cleanup',
-    'bash "$client" configure',
-)
 cursor = 0
 for command in commands:
-    cursor = bridge_step.index(command, cursor) + len(command)
-fresh_step_start = deploy.index(fresh_step_name)
-fresh_step_end = deploy.index("Download immutable frontend artifact", fresh_step_start)
-fresh_step = deploy[fresh_step_start:fresh_step_end]
-for command in (
-    'inspect-plan "$GITHUB_SHA"',
-    'state "$GITHUB_SHA" TARGET',
-    'inspect-plan "$release_b2"',
-    'state "$GITHUB_SHA" B2',
-    'transition_state=target-pending',
-    'transition_state=target-complete',
-    'transition_state=A-complete',
-    'transition_state=B-complete',
-):
-    if command not in fresh_step:
-        raise SystemExit(f"fresh Release B state inspection is missing: {command}")
-for command in ('upload "$GITHUB_SHA"', 'deploy "$GITHUB_SHA"'):
-    if deploy.index(command) < fresh_step_end:
-        raise SystemExit(f"Release B target action runs before fresh state inspection: {command}")
+    cursor = workflow.index(command, cursor) + len(command)
+test_command = "          bash ops/deploy/production-release-b-bridge-order.test.sh"
+if workflow.count(test_command) != 1:
+    raise SystemExit("Release B topology regression is not executed exactly once")
+if workflow.index(test_command) < workflow.index("shellcheck -S warning -x"):
+    raise SystemExit("Release B topology regression appears only in static checks")
 PY
 
-printf 'Production Release B bridge ordering tests passed\n'
+prepare_runtime_repo() {
+  local label=$1 head=$2
+  local repo=$FIXTURE/$label/repo root=$FIXTURE/$label/root
+  git clone -q --shared "$SOURCE_REPO" "$repo"
+  git -C "$repo" checkout -q "$head"
+  install -d "$root/control/deploy-state" "$root/runtime/deploy-staging" \
+    "$root/runtime/frontend-releases" "$root/runtime/systemd"
+  printf '%s\n' "$FRONTEND_MARKER" > \
+    "$root/control/deploy-state/frontend.sha"
+  printf '%s\n' "$BACKEND_MARKER" > "$root/control/deploy-state/backend.sha"
+  printf '%s\n' "$CONTROL_MARKER" > "$root/control/deploy-state/control.sha"
+  printf '%s\n' "$POOL_MARKER" > \
+    "$root/control/deploy-state/postgres-pool-bootstrap.sha"
+}
+
+run_actual_controller() (
+  set -euo pipefail
+  local repo=$1 root=$2 target=$3 expected_head=$4 event_log=$5
+  local state=$root/control/deploy-state
+  [[ $(git -C "$repo" rev-parse HEAD) == "$expected_head" ]]
+  printf 'controller=%s target=%s\n' "$expected_head" "$target" >> "$event_log"
+  export SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
+  export SOCIAL_MONITOR_DEPLOY_ROOT=$root
+  export SOCIAL_MONITOR_DEPLOY_REPO=$repo
+  export SOCIAL_MONITOR_DEPLOY_CONTROL=$root/control
+  export SOCIAL_MONITOR_DEPLOY_STATE=$state
+  export SOCIAL_MONITOR_DEPLOY_STAGING=$root/runtime/deploy-staging
+  export SOCIAL_MONITOR_DEPLOY_RELEASES=$root/runtime/frontend-releases
+  export SOCIAL_MONITOR_DEPLOY_PROJECT=release-b-current-main-test
+  # shellcheck source=ops/deploy/social-monitor-production-deploy.sh
+  source "$repo/ops/deploy/social-monitor-production-deploy.sh"
+  [[ $DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD == "$expected_head" ]]
+  postgres_pool_atomic_legacy_state() { return 1; }
+  postgres_pool_bootstrap_installed() { return 0; }
+  reconcile_current_postgres_pool_bootstrap() { :; }
+  reconcile_completed_backend_image_rescues() { :; }
+  acquire_postgres_admission_with_daily_priority() { :; }
+  fetch_main() { :; }
+  validate_main_commit() { [[ $1 == "$target" ]]; }
+  reconcile_github_premidnight_capture_runtime_control() { printf '%s\n' "$1"; }
+  load_target_rabbitmq_quorum_backend_health() { :; }
+  load_target_reader_summary_publication_deploy_library() { :; }
+  sync_control_script() { :; }
+  deploy_release_runtime_transaction() {
+    printf 'runtime=%s backend=%s runtime_control=%s\n' \
+      "$1" "$2" "$3" >> "$event_log"
+    [[ $2 == false ]] || printf '%s\n' "$1" > "$state/backend.sha"
+  }
+  deploy_frontend() { printf '%s\n' "$1" > "$state/frontend.sha"; }
+  commit_postgres_pool_bootstrap() {
+    printf '%s\n' "$1" > "$state/postgres-pool-bootstrap.sha"
+  }
+  deploy_release "$target"
+)
+
+# The real old controller rejects the obsolete sibling after its old bridge.
+prepare_runtime_repo rejected "$BASE"
+rejected_repo=$FIXTURE/rejected/repo
+rejected_root=$FIXTURE/rejected/root
+run_actual_controller "$rejected_repo" "$rejected_root" \
+  "$REJECTED_BRIDGE" "$BASE" "$FIXTURE/rejected/events" >/dev/null
+set +e
+rejected_error=$(run_actual_controller "$rejected_repo" "$rejected_root" \
+  "$REJECTED" "$BASE" "$FIXTURE/rejected/events" 2>&1)
+rejected_status=$?
+set -e
+((rejected_status != 0))
+grep -F 'deploy control changed with backend or runtime assets; deploy the bridge release first' \
+  <<< "$rejected_error" >/dev/null
+[[ $(git -C "$rejected_repo" rev-parse HEAD) == "$BASE" ]]
+
+# Real 8b4 controller -> exact bridge -> current-main-descendant target.
+prepare_runtime_repo repaired "$BASE"
+repaired_repo=$FIXTURE/repaired/repo
+repaired_root=$FIXTURE/repaired/root
+repaired_state=$repaired_root/control/deploy-state
+repaired_events=$FIXTURE/repaired/events
+run_actual_controller "$repaired_repo" "$repaired_root" \
+  "$BASE" "$BASE" "$repaired_events" >/dev/null
+for component in frontend backend control postgres-pool-bootstrap; do
+  [[ $(<"$repaired_state/$component.sha") == "$BASE" ]]
+done
+run_actual_controller "$repaired_repo" "$repaired_root" \
+  "$BRIDGE" "$BASE" "$repaired_events" >/dev/null
+[[ $(git -C "$repaired_repo" rev-parse HEAD) == "$BRIDGE" ]]
+[[ $(<"$repaired_state/backend.sha") == "$BASE" ]]
+[[ $(<"$repaired_state/frontend.sha") == "$BASE" ]]
+run_actual_controller "$repaired_repo" "$repaired_root" \
+  "$TARGET" "$BRIDGE" "$repaired_events" >/dev/null
+[[ $(git -C "$repaired_repo" rev-parse HEAD) == "$TARGET" ]]
+[[ $(<"$repaired_state/backend.sha") == "$TARGET" ]]
+[[ $(<"$repaired_state/frontend.sha") == "$BASE" ]]
+[[ $(<"$repaired_state/control.sha") == "$TARGET" ]]
+[[ $(<"$repaired_state/postgres-pool-bootstrap.sha") == "$TARGET" ]]
+
+# If the host already reached current main, the same target is a direct
+# control-only fast-forward and does not need the side bridge installed.
+prepare_runtime_repo advanced "$CURRENT_MAIN"
+advanced_repo=$FIXTURE/advanced/repo
+advanced_root=$FIXTURE/advanced/root
+advanced_state=$advanced_root/control/deploy-state
+for component in frontend backend control postgres-pool-bootstrap; do
+  printf '%s\n' "$CURRENT_MAIN" > "$advanced_state/$component.sha"
+done
+run_actual_controller "$advanced_repo" "$advanced_root" \
+  "$TARGET" "$CURRENT_MAIN" "$FIXTURE/advanced/events" >/dev/null
+[[ $(git -C "$advanced_repo" rev-parse HEAD) == "$TARGET" ]]
+[[ $(<"$advanced_state/backend.sha") == "$CURRENT_MAIN" ]]
+[[ $(<"$advanced_state/frontend.sha") == "$CURRENT_MAIN" ]]
+[[ $(<"$advanced_state/control.sha") == "$TARGET" ]]
+
+printf 'Production Release B current-main topology tests passed\n'

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -61,7 +61,7 @@ BRIDGE_CONTROL_PATHS=(
 )
 
 assert_real_bridge_target_assets() {
-  local path entry mode type object tree_path expected_digest alternate_digest actual_digest actual_mode
+  local path entry mode type object tree_path expected_digest alternate_digest reviewed_digest actual_digest actual_mode
   local repository_root actual_path actual_real
 
   repository_root=$(readlink -f -- "$PROJECT_ROOT")
@@ -90,6 +90,7 @@ assert_real_bridge_target_assets() {
     }
     expected_digest=$(git -C "$PROJECT_ROOT" show "$BRIDGE_RELEASE_SHA:$path" | sha256sum | awk '{print $1}')
     alternate_digest=
+    reviewed_digest=
     actual_digest=$(sha256sum "$actual_real" | awk '{print $1}')
     case $path in
       ops/deploy/social-monitor-production-deploy.sh)
@@ -109,6 +110,7 @@ assert_real_bridge_target_assets() {
       ops/deploy/deploy-control-bridge-lib.sh)
         expected_digest=e6f958555966b77d02b85da8d0b9195e13a200dcb2b19c8afc010fab6d28b65d
         alternate_digest=d6f3b562e3445dce3ac3d21364793b43afa53fe56011c0b73d02fac721040cf7
+        reviewed_digest=14ab26a66e982128770947a9b66a764cd4cef6eca1bb017c13f97819ae611a7a
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then
@@ -138,7 +140,8 @@ assert_real_bridge_target_assets() {
       }
     fi
     [[ $actual_digest == "$expected_digest" ||
-       (-n $alternate_digest && $actual_digest == "$alternate_digest") ]] || {
+       (-n $alternate_digest && $actual_digest == "$alternate_digest") ||
+       (-n $reviewed_digest && $actual_digest == "$reviewed_digest") ]] || {
       printf 'current bridge asset digest drifted from V4A4: %s\n' "$path" >&2
       exit 1
     }

--- a/ops/ingestion/source-provider-certification.json
+++ b/ops/ingestion/source-provider-certification.json
@@ -277,7 +277,7 @@
       "quotaModel": "per_app",
       "itemCount": 3,
       "warningCount": 0,
-      "firstExternalId": "github-trending-page:daily:calesthio/OpenMontage:2026-06-24T12:00:00.000Z",
+      "firstExternalId": "github-trending-page:daily:scan-job-cert-github-trending-page:calesthio/OpenMontage",
       "nextCursor": "2026-06-24T12:00:00.000Z",
       "repeatedScanItemCount": 3,
       "failureKind": "unavailable",


### PR DESCRIPTION
## Summary

- restore the exact production bridge path from the last reconciled `8b4aeb31` host state to current `main`
- preserve the current-main product/runtime content byte-for-byte while adding an exactly-once bridge-aware deploy client
- keep the production workflow below the repository source-line cap and pin every action by immutable SHA

## Safety contract

- reviewed candidate: `bce12683c9309e037614f4808a0fc75caddc9864`
- ordered parents: `d7d0fc88e6a7bcd8e9929e35efd74002a7601449`, `db4537fea87a5c184a9f926867a6e6aa763ff9bd`
- bridge parent: `8b4aeb31e855ed379349a4e4827600009e174132`
- rejected deployment commit `68d6910f7874be89e2d5418dede5be6129e8af3a` is not an ancestor
- final independent `gpt-5.6-sol` xhigh review: APPROVED, 0 critical/high/medium/low findings

## Required integration

This PR is CI evidence for the exact candidate. Do not use GitHub merge, squash, rebase, or merge queue because they would create a different commit topology. After all required checks pass and `main` is still exactly `d7d0fc88`, advance `main` non-forcibly to the exact reviewed candidate SHA.

## Verification

- exact graph/tree/blob audit and `git fsck`
- source line cap: 3,619 files passed; production workflow is 999 lines
- all 15 workflow `uses:` references are immutable 40-hex pins
- shell syntax and ShellCheck on the changed deploy surface
- source certification for all seven providers
- exact release transition and component-classification checks
- focused deploy-client, bridge-order, RabbitMQ transition, and production lifecycle fixtures passed in the implementation worktree
