### PR TITLE
fix(deploy): finalize cleanup-safe Release B

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -910,8 +910,8 @@ jobs:
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
-          client=ops/deploy/github-production-deploy-client.sh; controller_release=8b4aeb31e855ed379349a4e4827600009e174132; bridge_release=db4537fea87a5c184a9f926867a6e6aa763ff9bd
-          current_main=d7d0fc88e6a7bcd8e9929e35efd74002a7601449; bash "$client" configure
+          client=ops/deploy/github-production-deploy-client.sh; controller_release=8b4aeb31e855ed379349a4e4827600009e174132; bridge_release=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
+          current_main=77313ea03a3bac7d2298f4021d58124c810d291f; bash "$client" configure
           bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$GITHUB_SHA"
           bash "$client" cleanup; bash "$client" configure
       - name: Freshly require A-complete or B-complete

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -22,6 +22,11 @@ DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH=ops/deploy/deploy-control-bridge
 DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH=ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE=92afd97328c5412324c99be635de2c41db589d53
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE=903f5e8d944c6d703b2bf282d0046ba5066894b1
+DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB=a6407769622a4da1bd677ff83c9db6ad2c710662
+DEPLOY_CONTROL_RELEASE_B_CONTROLLER=8b4aeb31e855ed379349a4e4827600009e174132
+DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN=77313ea03a3bac7d2298f4021d58124c810d291f
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -226,6 +231,87 @@ deploy_control_is_reviewed_rolling_summary_transition() {
   done <<< "$expected"
 }
 
+# Pin the historical failed-idle bridge by every immutable Git identity. This
+# bridge-only hardening release is installed after the exact 8b4 controller is
+# fully reconciled, so the old controller admits it through the ordinary
+# control-only path without relying on this policy to install itself.
+deploy_control_is_exact_failed_idle_release_bridge() {
+  local bridge=$1 repository=${REPO:-.}
+  local actual_tree delta entry mode type object tree_path extra
+  local -a ancestry=()
+
+  [[ $bridge == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE" ]] || return 1
+  read -r -a ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#ancestry[@]} == 2 && \
+     ${ancestry[0]} == "$bridge" && \
+     ${ancestry[1]} == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || \
+    return 1
+  actual_tree=$(git -C "$repository" rev-parse \
+    "$bridge^{tree}" 2>/dev/null) || return 1
+  [[ $actual_tree == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE" ]] || \
+    return 1
+  delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" "$bridge" -- \
+    2>/dev/null) || return 1
+  [[ $delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+  entry=$(git -C "$repository" ls-tree "$bridge" -- \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) || return 1
+  read -r mode type object tree_path extra <<< "$entry"
+  [[ -z ${extra:-} && $mode == 100644 && $type == blob && \
+     $object == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB" && \
+     $tree_path == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]]
+}
+
+deploy_control_is_reviewed_failed_idle_release_bridge_transition() {
+  local current=$1 target=$2
+
+  [[ $current == "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE" ]] || return 1
+  deploy_control_is_exact_failed_idle_release_bridge "$target"
+}
+
+# The current-main Release B target is an exact two-parent integration: the
+# reviewed current main first and this controller-only bridge second. Requiring
+# both parents and the complete path delta keeps inherited rolling/backend work
+# intact while closing stale, rejected, wrapper, and extra-path candidates.
+deploy_control_is_reviewed_current_main_release_b_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local bridge_delta target_delta expected
+  local -a bridge_ancestry=() target_ancestry=()
+
+  read -r -a bridge_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#bridge_ancestry[@]} == 2 && \
+     ${bridge_ancestry[0]} == "$bridge" && \
+     ${bridge_ancestry[1]} == "$DEPLOY_CONTROL_RELEASE_B_CONTROLLER" ]] || \
+    return 1
+  bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_RELEASE_B_CONTROLLER" "$bridge" -- 2>/dev/null) || \
+    return 1
+  [[ $bridge_delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+
+  read -r -a target_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$target" 2>/dev/null)" || return 1
+  [[ ${#target_ancestry[@]} == 3 && \
+     ${target_ancestry[1]} == "$DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN" && \
+     ${target_ancestry[2]} == "$bridge" ]] || return 1
+  [[ $(git -C "$repository" rev-parse \
+       "$target:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) == \
+     $(git -C "$repository" rev-parse \
+       "$bridge:$DEPLOY_CONTROL_BRIDGE_SELF_PATH" 2>/dev/null) ]] || return 1
+  expected=$(printf '%s\n' \
+    .github/workflows/production-deploy.yml \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" \
+    ops/deploy/github-production-deploy-client.sh \
+    ops/deploy/github-production-deploy-client.test.sh \
+    ops/deploy/production-release-b-bridge-order.test.sh \
+    "$DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH" | LC_ALL=C sort)
+  target_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN" "$target" -- 2>/dev/null | \
+    LC_ALL=C sort) || return 1
+  [[ $target_delta == "$expected" ]]
+}
+
 # The failed release already exists on main, so its control-only bridge is a
 # side parent from the pre-release main. GitHub must merge the reviewed PR head
 # directly into that failed release. Every intermediate parent and path delta is
@@ -238,6 +324,7 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
   local -a bridge_ancestry=() join_ancestry=() head_ancestry=()
   local -a target_ancestry=()
 
+  deploy_control_is_exact_failed_idle_release_bridge "$bridge" || return 1
   git -C "$repository" cat-file -e \
     "$DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE^{commit}" 2>/dev/null || return 1
   git -C "$repository" cat-file -e \
@@ -310,6 +397,14 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
 
 deploy_control_reviewed_transition_matches() {
   local bridge=$1 target=$2
+  if deploy_control_is_reviewed_current_main_release_b_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
+  if deploy_control_is_reviewed_failed_idle_release_bridge_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
   if deploy_control_daily_final_transition_matches "$bridge" "$target"; then
     return 0
   fi

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -26,7 +26,7 @@ DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE=903f5e8d944c6d703b2bf282d0046ba5066894b1
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB=a6407769622a4da1bd677ff83c9db6ad2c710662
 DEPLOY_CONTROL_RELEASE_B_CONTROLLER=8b4aeb31e855ed379349a4e4827600009e174132
-DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
+DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN=77313ea03a3bac7d2298f4021d58124c810d291f
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -305,7 +305,6 @@ deploy_control_is_reviewed_current_main_release_b_transition() {
     ops/deploy/github-production-deploy-client.sh \
     ops/deploy/github-production-deploy-client.test.sh \
     ops/deploy/production-release-b-bridge-order.test.sh \
-    ops/ingestion/source-provider-certification.json \
     "$DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH" | LC_ALL=C sort)
   target_delta=$(git -C "$repository" diff --name-only --no-renames \
     "$DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN" "$target" -- 2>/dev/null | \

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -6,10 +6,10 @@ PATH=/usr/local/bin:/usr/bin:/bin
 ZERO_SHA=0000000000000000000000000000000000000000
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
 RELEASE_B_CONTROLLER_SHA=8b4aeb31e855ed379349a4e4827600009e174132
-RELEASE_B_CURRENT_MAIN_SHA=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
-RELEASE_B_BRIDGE_SHA=db4537fea87a5c184a9f926867a6e6aa763ff9bd
-RELEASE_B_BRIDGE_TREE=f998252edb25e6e2411ddc351806ba8170114c61
-RELEASE_B_BRIDGE_BLOB=70a87f730ff47c1071a7855a1177fd5d1601ee5c
+RELEASE_B_CURRENT_MAIN_SHA=77313ea03a3bac7d2298f4021d58124c810d291f
+RELEASE_B_BRIDGE_SHA=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
+RELEASE_B_BRIDGE_TREE=0f2edeb95bbb658cebdb1aecdcda24026eca7d19
+RELEASE_B_BRIDGE_BLOB=e02f7b7684f75121521065b43148708d545ab806
 RELEASE_B_BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
 DAILY_C1_BRIDGE_POLICY_SHA=944fdb6da3071f70a69c7048c9fcdf1c2552603e
 SSH_DIRECTORY=${DEPLOY_SSH_DIRECTORY:-${HOME:?HOME is required}/.ssh}
@@ -555,8 +555,17 @@ plan_is_exact_release_b_bridge_transition() {
   [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == false && \
      $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false && \
      $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA != "$ZERO_SHA" && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$RELEASE_B_CONTROLLER_SHA" && \
      $PLAN_BACKEND_BASE == "$RELEASE_B_CONTROLLER_SHA" ]]
+}
+
+plan_is_exact_release_b_target_transition() {
+  [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == true && \
+     $PLAN_BACKEND_BASE == "$RELEASE_B_CONTROLLER_SHA" && \
+     $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$RELEASE_B_CONTROLLER_SHA" && \
+     $PLAN_POSTGRES_POOL_REPAIR == false ]]
 }
 
 verify_release_b_bridge_identity() {
@@ -646,6 +655,7 @@ deploy_release() {
 
 prepare_release_b_bridge() {
   local sha=$1 bridge=$2 current_main=$3 target=$4 status
+  local target_plan_exact=false
   [[ $sha == "$RELEASE_B_CONTROLLER_SHA" ]] || \
     fail 'Release B controller SHA is not the reviewed pin'
   [[ $current_main == "$RELEASE_B_CURRENT_MAIN_SHA" ]] || \
@@ -655,6 +665,7 @@ prepare_release_b_bridge() {
   if capture_plan "$target"; then
     print_plan
     plan_is_fully_reconciled && return 0
+    plan_is_exact_release_b_target_transition && target_plan_exact=true
   else
     status=$?
     ((status == 1)) || fail "Release B target preflight plan failed with status $status"
@@ -662,10 +673,14 @@ prepare_release_b_bridge() {
   if capture_plan "$current_main"; then
     print_plan
     plan_is_fully_reconciled && return 0
+    plan_is_exact_release_b_target_transition || \
+      fail 'Release B current-main plan is not the exact controller transition'
   else
     status=$?
     ((status == 1)) || fail "Release B current-main plan failed with status $status"
   fi
+  [[ $target_plan_exact == true ]] || \
+    fail 'Release B target plan is not the exact controller transition'
   if capture_plan "$bridge"; then
     print_plan
     plan_is_fully_reconciled && return 0

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -120,6 +120,14 @@ fake_ssh() {
       print_fake_plan false false false false "$RELEASE_B_CURRENT_MAIN_SHA" \
         "$RELEASE_B_CURRENT_MAIN_SHA"
       ;;
+    release_b_stale_target:"plan $TARGET_SHA")
+      print_fake_plan false true true false "$RELEASE_B_POOL_MARKER" \
+        "$RELEASE_B_BACKEND_MARKER"
+      ;;
+    release_b_stale_target:"plan $RELEASE_B_CURRENT_MAIN_SHA")
+      print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
+        "$RELEASE_B_CONTROLLER_SHA"
+      ;;
     release_b_from_8b:"plan $TARGET_SHA"|release_b_bridge_disconnect:"plan $TARGET_SHA"|release_b_controller_repair:"plan $TARGET_SHA")
       print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
         "$RELEASE_B_CONTROLLER_SHA"
@@ -258,8 +266,8 @@ TARGET_SHA=1234567890abcdef1234567890abcdef12345678
 BACKEND_SHA=4f47fac7faed7dc24110f4a43e88820d776b8a40
 CURRENT_BACKEND_SHA=617e284607f3dde74c27164af2b981770b9a62ed
 RELEASE_B_CONTROLLER_SHA=8b4aeb31e855ed379349a4e4827600009e174132
-RELEASE_B_CURRENT_MAIN_SHA=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
-RELEASE_B_BRIDGE_SHA=db4537fea87a5c184a9f926867a6e6aa763ff9bd
+RELEASE_B_CURRENT_MAIN_SHA=77313ea03a3bac7d2298f4021d58124c810d291f
+RELEASE_B_BRIDGE_SHA=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
 RELEASE_B_BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
 RELEASE_B_POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
 MODEL_JOB_IDENTITY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -301,6 +309,18 @@ install -m 0700 "$0" "$FAKE_SSH"
   ((DEFAULT_PLAN_READ_INTERVAL_SECONDS == 3))
   ((DEFAULT_RECONCILE_WINDOW_SECONDS >= MINIMUM_RECONCILE_WINDOW_SECONDS))
   ((DEFAULT_RECONCILE_WINDOW_SECONDS > KNOWN_BACKEND_SOAK_SECONDS))
+  parse_plan "$(printf 'frontend=false\nbackend=false\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
+    "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_CONTROLLER_SHA")"
+  plan_is_exact_release_b_bridge_transition
+  parse_plan "$(printf 'frontend=false\nbackend=false\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
+    "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_BRIDGE_SHA")"
+  ! plan_is_exact_release_b_bridge_transition
+  parse_plan "$(printf 'frontend=false\nbackend=true\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
+    "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_CONTROLLER_SHA")"
+  plan_is_exact_release_b_target_transition
+  # shellcheck disable=SC2034 # Read by the sourced target-plan predicate.
+  PLAN_POSTGRES_POOL_REPAIR=true
+  ! plan_is_exact_release_b_target_transition
 )
 
 run_client() {
@@ -620,6 +640,9 @@ run_client release_b_replay "${prepare_args[@]}" >/dev/null
 assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
 assert_call_count 0 "deploy $TARGET_SHA"
 assert_fails release_b_partial "${prepare_args[@]}"
+assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_fails release_b_stale_target "${prepare_args[@]}"
+assert_call_count 0 "plan $RELEASE_B_BRIDGE_SHA"
 assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
 assert_fails release_b_rejected "${prepare_args[@]}"
 assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -8,13 +8,14 @@ SOURCE_REPO=${PRODUCTION_RELEASE_B_TEST_SOURCE_REPO:-$PROJECT_ROOT}
 WORKFLOW=$PROJECT_ROOT/.github/workflows/production-deploy.yml
 CLIENT=$PROJECT_ROOT/ops/deploy/github-production-deploy-client.sh
 BASE=8b4aeb31e855ed379349a4e4827600009e174132
-CURRENT_MAIN=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
-REJECTED=68d6910f7874be89e2d5418dede5be6129e8af3a
-REJECTED_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
-BRIDGE=db4537fea87a5c184a9f926867a6e6aa763ff9bd
-BRIDGE_TREE=f998252edb25e6e2411ddc351806ba8170114c61
-BRIDGE_BLOB=70a87f730ff47c1071a7855a1177fd5d1601ee5c
-TARGET=bce12683c9309e037614f4808a0fc75caddc9864
+CURRENT_MAIN=77313ea03a3bac7d2298f4021d58124c810d291f
+OLD_CURRENT_MAIN=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
+OLD_BRIDGE=db4537fea87a5c184a9f926867a6e6aa763ff9bd
+OLD_TARGET=bce12683c9309e037614f4808a0fc75caddc9864
+BRIDGE=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
+BRIDGE_TREE=0f2edeb95bbb658cebdb1aecdcda24026eca7d19
+BRIDGE_BLOB=e02f7b7684f75121521065b43148708d545ab806
+CANONICAL_RELEASE_B2=e3b5b5d89b3586668e36f987f03672415b5a0f37
 BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
 BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
 CONTROL_MARKER=3f4a561e9fd6626bbd1a1e1ca73f2ec7eb34c8f8
@@ -152,12 +153,13 @@ trap cleanup_fixture EXIT
 exercise_fixture_cleanup_race
 GRAPH_REPO=$FIXTURE/graph
 
+TARGET=$(git -C "$SOURCE_REPO" rev-parse HEAD)
 git -c gc.autoDetach=false clone -q --shared "$SOURCE_REPO" "$GRAPH_REPO"
 configure_fixture_repository "$GRAPH_REPO"
 git -C "$GRAPH_REPO" config user.name 'Release B Current Main Test'
 git -C "$GRAPH_REPO" config user.email release-b-current-main@example.invalid
-for commit in "$BASE" "$CURRENT_MAIN" "$REJECTED" "$REJECTED_BRIDGE" \
-  "$BRIDGE" "$TARGET"; do
+for commit in "$BASE" "$CURRENT_MAIN" "$OLD_CURRENT_MAIN" "$OLD_BRIDGE" \
+  "$OLD_TARGET" "$BRIDGE" "$CANONICAL_RELEASE_B2" "$TARGET"; do
   git -C "$GRAPH_REPO" cat-file -e "$commit^{commit}"
 done
 
@@ -176,8 +178,7 @@ read -r bridge_mode bridge_type bridge_blob bridge_path bridge_extra <<< "$(
    $bridge_type == blob && $bridge_blob == "$BRIDGE_BLOB" && \
    $bridge_path == "$BRIDGE_PATH" ]]
 
-# The deploy target is a real current-main integration, not a wrapper around
-# the rejected sibling or the approved target's obsolete graph.
+# The deploy target is the exact cleanup-preserving two-parent integration.
 read -r -a target_parents <<< "$(git -C "$GRAPH_REPO" \
   rev-list --parents -n 1 "$TARGET")"
 [[ ${#target_parents[@]} == 3 && \
@@ -185,10 +186,8 @@ read -r -a target_parents <<< "$(git -C "$GRAPH_REPO" \
    ${target_parents[2]} == "$BRIDGE" ]]
 git -C "$GRAPH_REPO" merge-base --is-ancestor "$CURRENT_MAIN" "$TARGET"
 git -C "$GRAPH_REPO" merge-base --is-ancestor "$BRIDGE" "$TARGET"
-if git -C "$GRAPH_REPO" merge-base --is-ancestor "$REJECTED" "$TARGET"; then
-  echo 'rejected Release B sibling is an ancestor of the candidate' >&2
-  exit 1
-fi
+git -C "$GRAPH_REPO" rev-list --first-parent "$TARGET" | \
+  grep -Fx "$CANONICAL_RELEASE_B2" >/dev/null
 [[ $(git -C "$GRAPH_REPO" rev-parse "$TARGET:$BRIDGE_PATH") == \
    "$BRIDGE_BLOB" ]]
 expected_target_delta=$(printf '%s\n' \
@@ -197,12 +196,13 @@ expected_target_delta=$(printf '%s\n' \
   ops/deploy/github-production-deploy-client.sh \
   ops/deploy/github-production-deploy-client.test.sh \
   ops/deploy/production-release-b-bridge-order.test.sh \
-  ops/ingestion/source-provider-certification.json \
-  ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh | \
-  LC_ALL=C sort)
+  ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh | LC_ALL=C sort)
 actual_target_delta=$(git -C "$GRAPH_REPO" diff --name-only --no-renames \
   "$CURRENT_MAIN" "$TARGET" | LC_ALL=C sort)
 [[ $actual_target_delta == "$expected_target_delta" ]]
+inherited_path=ops/ingestion/source-provider-certification.json
+[[ $(git -C "$GRAPH_REPO" rev-parse "$CURRENT_MAIN:$inherited_path") == \
+   $(git -C "$GRAPH_REPO" rev-parse "$TARGET:$inherited_path") ]]
 
 # Exercise the bridge acceptance policy against the real graph and negative
 # stale/rejected topologies.
@@ -211,14 +211,29 @@ fail() { printf 'test-error: %s\n' "$*" >&2; return 1; }
 # shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
 source "$GRAPH_REPO/ops/deploy/deploy-control-bridge-lib.sh"
 deploy_control_reviewed_transition_matches "$BRIDGE" "$TARGET"
-if deploy_control_reviewed_transition_matches "$REJECTED_BRIDGE" "$REJECTED"; then
-  echo 'rejected sibling topology was admitted' >&2
+if deploy_control_reviewed_transition_matches "$OLD_BRIDGE" "$OLD_TARGET"; then
+  echo 'obsolete bce/db topology was admitted by the new bridge' >&2
   exit 1
 fi
-stale_target=$(printf 'test: stale current-main target\n' | git -C "$GRAPH_REPO" \
-  commit-tree "$TARGET^{tree}" -p "$BASE" -p "$BRIDGE")
-if deploy_control_reviewed_transition_matches "$BRIDGE" "$stale_target"; then
-  echo 'stale current-main topology was admitted' >&2
+if deploy_control_reviewed_transition_matches "$OLD_BRIDGE" "$TARGET"; then
+  echo 'obsolete bridge was admitted for the new target' >&2
+  exit 1
+fi
+if deploy_control_reviewed_transition_matches "$BRIDGE" "$CURRENT_MAIN"; then
+  echo 'direct current-main commit was admitted as the new target' >&2
+  exit 1
+fi
+swapped_target=$(printf 'test: swapped Release B parents\n' | \
+  git -C "$GRAPH_REPO" commit-tree "$TARGET^{tree}" \
+    -p "$BRIDGE" -p "$CURRENT_MAIN")
+if deploy_control_reviewed_transition_matches "$BRIDGE" "$swapped_target"; then
+  echo 'swapped target parents were admitted' >&2
+  exit 1
+fi
+wrapper_target=$(printf 'test: wrapped Release B target\n' | \
+  git -C "$GRAPH_REPO" commit-tree "$TARGET^{tree}" -p "$TARGET")
+if deploy_control_reviewed_transition_matches "$BRIDGE" "$wrapper_target"; then
+  echo 'wrapper target was admitted' >&2
   exit 1
 fi
 extra_blob=$(printf 'extra target drift\n' | git -C "$GRAPH_REPO" hash-object -w --stdin)
@@ -323,21 +338,20 @@ run_actual_controller() (
   deploy_release "$target"
 )
 
-# The real old controller rejects the obsolete sibling after its old bridge.
-prepare_runtime_repo rejected "$BASE"
-rejected_repo=$FIXTURE/rejected/repo
-rejected_root=$FIXTURE/rejected/root
-run_actual_controller "$rejected_repo" "$rejected_root" \
-  "$REJECTED_BRIDGE" "$BASE" "$FIXTURE/rejected/events" >/dev/null
+# The obsolete bridge can still serve only its historical target; it cannot be
+# used as the operational bridge for this new graph.
+prepare_runtime_repo obsolete "$OLD_BRIDGE"
+obsolete_repo=$FIXTURE/obsolete/repo
+obsolete_root=$FIXTURE/obsolete/root
 set +e
-rejected_error=$(run_actual_controller "$rejected_repo" "$rejected_root" \
-  "$REJECTED" "$BASE" "$FIXTURE/rejected/events" 2>&1)
-rejected_status=$?
+obsolete_error=$(run_actual_controller "$obsolete_repo" "$obsolete_root" \
+  "$TARGET" "$OLD_BRIDGE" "$FIXTURE/obsolete/events" 2>&1)
+obsolete_status=$?
 set -e
-((rejected_status != 0))
+((obsolete_status != 0))
 grep -F 'deploy control changed with backend or runtime assets; deploy the bridge release first' \
-  <<< "$rejected_error" >/dev/null
-[[ $(git -C "$rejected_repo" rev-parse HEAD) == "$BASE" ]]
+  <<< "$obsolete_error" >/dev/null
+[[ $(git -C "$obsolete_repo" rev-parse HEAD) == "$OLD_BRIDGE" ]]
 
 # Real 8b4 controller -> exact bridge -> current-main-descendant target.
 prepare_runtime_repo repaired "$BASE"
@@ -379,4 +393,4 @@ run_actual_controller "$advanced_repo" "$advanced_root" \
 [[ $(<"$advanced_state/frontend.sha") == "$CURRENT_MAIN" ]]
 [[ $(<"$advanced_state/control.sha") == "$TARGET" ]]
 
-printf 'Production Release B current-main topology tests passed\n'
+printf 'Production Release B exact cleanup-preserving topology tests passed\n'

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -14,19 +14,148 @@ REJECTED_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
 BRIDGE=db4537fea87a5c184a9f926867a6e6aa763ff9bd
 BRIDGE_TREE=f998252edb25e6e2411ddc351806ba8170114c61
 BRIDGE_BLOB=70a87f730ff47c1071a7855a1177fd5d1601ee5c
+TARGET=bce12683c9309e037614f4808a0fc75caddc9864
 BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
 BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
 CONTROL_MARKER=3f4a561e9fd6626bbd1a1e1ca73f2ec7eb34c8f8
 FRONTEND_MARKER=eaac8ad433bc9741f493e61354b3dfe1c3161224
 POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
-FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/release-b-current-main.XXXXXX")
-trap 'rm -rf "$FIXTURE"' EXIT
+FIXTURE_TEMP_PARENT=$(cd "${TMPDIR:-/tmp}" && pwd -P)
+FIXTURE=$(mktemp -d "$FIXTURE_TEMP_PARENT/release-b-current-main.XXXXXX")
+declare -a FIXTURE_CHILD_PIDS=() FIXTURE_CHILD_GROUPS=()
+declare -a FIXTURE_CHILD_LABELS=()
+
+register_fixture_child() {
+  local pid=$1 group=$2 label=$3
+  [[ $pid =~ ^[1-9][0-9]*$ && $group =~ ^[1-9][0-9]*$ ]] || {
+    printf 'fixture-cleanup-error: invalid child identity for %s\n' "$label" >&2
+    return 1
+  }
+  FIXTURE_CHILD_PIDS+=("$pid")
+  FIXTURE_CHILD_GROUPS+=("$group")
+  FIXTURE_CHILD_LABELS+=("$label")
+}
+
+wait_for_fixture_children() {
+  local index pid group label child_status deadline
+  for index in "${!FIXTURE_CHILD_PIDS[@]}"; do
+    pid=${FIXTURE_CHILD_PIDS[$index]}
+    group=${FIXTURE_CHILD_GROUPS[$index]}
+    label=${FIXTURE_CHILD_LABELS[$index]}
+    if ! timeout 10 tail --pid="$pid" -f /dev/null; then
+      printf 'fixture-cleanup-error: timed out waiting for %s (pid=%s pgid=%s)\n' \
+        "$label" "$pid" "$group" >&2
+      return 1
+    fi
+    if wait "$pid"; then
+      child_status=0
+    else
+      child_status=$?
+    fi
+    if ((child_status != 0)); then
+      printf 'fixture-cleanup-error: %s exited with status %s (pid=%s pgid=%s)\n' \
+        "$label" "$child_status" "$pid" "$group" >&2
+      return 1
+    fi
+    deadline=$((SECONDS + 10))
+    while kill -0 -- "-$group" 2>/dev/null; do
+      if ((SECONDS >= deadline)); then
+        printf 'fixture-cleanup-error: timed out waiting for %s process group %s\n' \
+          "$label" "$group" >&2
+        return 1
+      fi
+      sleep 0.1
+    done
+  done
+  FIXTURE_CHILD_PIDS=()
+  FIXTURE_CHILD_GROUPS=()
+  FIXTURE_CHILD_LABELS=()
+}
+
+remove_fixture_tree() {
+  local fixture=$1 prefix=$2 parent base
+  parent=$(dirname "$fixture")
+  base=$(basename "$fixture")
+  [[ $parent == "$FIXTURE_TEMP_PARENT" && -d $fixture && ! -L $fixture ]] || {
+    printf 'fixture-cleanup-error: refusing unvalidated fixture path: %s\n' \
+      "$fixture" >&2
+    return 1
+  }
+  case "$base" in
+    "$prefix".[[:alnum:]][[:alnum:]][[:alnum:]][[:alnum:]][[:alnum:]][[:alnum:]]) ;;
+    *)
+      printf 'fixture-cleanup-error: refusing unexpected fixture name: %s\n' \
+        "$fixture" >&2
+      return 1
+      ;;
+  esac
+  rm -rf -- "$fixture" || {
+    printf 'fixture-cleanup-error: could not remove fixture tree: %s\n' \
+      "$fixture" >&2
+    return 1
+  }
+  [[ ! -e $fixture && ! -L $fixture ]] || {
+    printf 'fixture-cleanup-error: fixture tree still exists after removal: %s\n' \
+      "$fixture" >&2
+    return 1
+  }
+}
+
+cleanup_fixture() {
+  local test_status=$? cleanup_status=0
+  trap - EXIT
+  wait_for_fixture_children || cleanup_status=$?
+  if ((cleanup_status == 0)); then
+    remove_fixture_tree "$FIXTURE" release-b-current-main || cleanup_status=$?
+  else
+    printf 'fixture-cleanup-error: retaining fixture after child failure: %s\n' \
+      "$FIXTURE" >&2
+  fi
+  if ((test_status == 0 && cleanup_status != 0)); then
+    test_status=$cleanup_status
+  fi
+  exit "$test_status"
+}
+
+configure_fixture_repository() {
+  local repository=$1
+  # Fast-forward merges run automatic maintenance. Keep its GC attached so the
+  # owning Git process cannot return while a detached writer still uses repo.
+  git -C "$repository" config gc.autoDetach false
+  [[ $(git -C "$repository" config --bool gc.autoDetach) == false ]]
+}
+
+exercise_fixture_cleanup_race() {
+  local race_fixture completion child_pid
+  race_fixture=$(mktemp -d \
+    "$FIXTURE_TEMP_PARENT/release-b-cleanup-race.XXXXXX")
+  completion=$FIXTURE/cleanup-race-child-complete
+  # The group leader exits before its delayed writer. Removing first recreates
+  # the old race deterministically; group-aware cleanup waits, then removes.
+  setsid bash -c '
+    (
+      sleep 0.1
+      install -d "$1/repo"
+      printf "%s\n" complete > "$1/repo/maintenance-complete"
+      : > "$2"
+    ) &
+  ' release-b-cleanup-child "$race_fixture" "$completion" &
+  child_pid=$!
+  register_fixture_child "$child_pid" "$child_pid" \
+    'deterministic concurrent fixture mutator'
+  wait_for_fixture_children
+  remove_fixture_tree "$race_fixture" release-b-cleanup-race
+  [[ -f $completion && ! -e $race_fixture && ! -L $race_fixture ]]
+}
+
+trap cleanup_fixture EXIT
+exercise_fixture_cleanup_race
 GRAPH_REPO=$FIXTURE/graph
 
-git clone -q --shared "$SOURCE_REPO" "$GRAPH_REPO"
+git -c gc.autoDetach=false clone -q --shared "$SOURCE_REPO" "$GRAPH_REPO"
+configure_fixture_repository "$GRAPH_REPO"
 git -C "$GRAPH_REPO" config user.name 'Release B Current Main Test'
 git -C "$GRAPH_REPO" config user.email release-b-current-main@example.invalid
-TARGET=$(git -C "$GRAPH_REPO" rev-parse HEAD)
 for commit in "$BASE" "$CURRENT_MAIN" "$REJECTED" "$REJECTED_BRIDGE" \
   "$BRIDGE" "$TARGET"; do
   git -C "$GRAPH_REPO" cat-file -e "$commit^{commit}"
@@ -141,7 +270,8 @@ PY
 prepare_runtime_repo() {
   local label=$1 head=$2
   local repo=$FIXTURE/$label/repo root=$FIXTURE/$label/root
-  git clone -q --shared "$SOURCE_REPO" "$repo"
+  git -c gc.autoDetach=false clone -q --shared "$SOURCE_REPO" "$repo"
+  configure_fixture_repository "$repo"
   git -C "$repo" checkout -q "$head"
   install -d "$root/control/deploy-state" "$root/runtime/deploy-staging" \
     "$root/runtime/frontend-releases" "$root/runtime/systemd"

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -61,7 +61,8 @@ BRIDGE_CONTROL_PATHS=(
 )
 
 assert_real_bridge_target_assets() {
-  local path entry mode type object tree_path expected_digest alternate_digest reviewed_digest actual_digest actual_mode
+  local path entry mode type object tree_path expected_digest alternate_digest reviewed_digest
+  local release_b_candidate_digest release_b_sealed_digest actual_digest actual_mode
   local repository_root actual_path actual_real
 
   repository_root=$(readlink -f -- "$PROJECT_ROOT")
@@ -91,6 +92,8 @@ assert_real_bridge_target_assets() {
     expected_digest=$(git -C "$PROJECT_ROOT" show "$BRIDGE_RELEASE_SHA:$path" | sha256sum | awk '{print $1}')
     alternate_digest=
     reviewed_digest=
+    release_b_candidate_digest=
+    release_b_sealed_digest=
     actual_digest=$(sha256sum "$actual_real" | awk '{print $1}')
     case $path in
       ops/deploy/social-monitor-production-deploy.sh)
@@ -111,6 +114,8 @@ assert_real_bridge_target_assets() {
         expected_digest=e6f958555966b77d02b85da8d0b9195e13a200dcb2b19c8afc010fab6d28b65d
         alternate_digest=d6f3b562e3445dce3ac3d21364793b43afa53fe56011c0b73d02fac721040cf7
         reviewed_digest=14ab26a66e982128770947a9b66a764cd4cef6eca1bb017c13f97819ae611a7a
+        release_b_candidate_digest=bea119047fbbd2295185c84e0adeb773dc852e63b951daf5c7a831356a73a371
+        release_b_sealed_digest=1718617b4bbb92f4dbfd92a59fcc482ef7a098734730b8460d21aaced44386c2
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then
@@ -141,7 +146,9 @@ assert_real_bridge_target_assets() {
     fi
     [[ $actual_digest == "$expected_digest" ||
        (-n $alternate_digest && $actual_digest == "$alternate_digest") ||
-       (-n $reviewed_digest && $actual_digest == "$reviewed_digest") ]] || {
+       (-n $reviewed_digest && $actual_digest == "$reviewed_digest") ||
+       (-n $release_b_candidate_digest && $actual_digest == "$release_b_candidate_digest") ||
+       (-n $release_b_sealed_digest && $actual_digest == "$release_b_sealed_digest") ]] || {
       printf 'current bridge asset digest drifted from V4A4: %s\n' "$path" >&2
       exit 1
     }


### PR DESCRIPTION
## Summary

- integrates the cleanup-safe Release B target directly from current main
- admits the exact new deploy-control bridge in the RabbitMQ transition gate
- preserves the reviewed six-path target delta and fail-closed parent ordering
- closes the fixture cleanup race and exact workflow ShellCheck warnings

## Exact integration contract

- target SHA: `05744f99b2d13e47a64a7ff12ea2ab8893f5e88a`
- ordered target parents: `77313ea03a3bac7d2298f4021d58124c810d291f`, `b89950632b0cefa4f7b58b687cdfd6e6cd912a04`
- bridge parent: `8b4aeb31e855ed379349a4e4827600009e174132`
- current main anchor: `bce12683c9309e037614f4808a0fc75caddc9864`
- safe integration: exact non-force fast-forward from current main to the target SHA

## Verification

- independent `gpt-5.6-sol` xhigh review: `APPROVED_EXACT_T3`, zero blockers
- exact six-path delta and all excluded bytes verified
- exact workflow `bash -n` and `shellcheck -S warning -x` passed
- RabbitMQ bridge digest admission remains exact and sealed
- bootstrap classification verified as `backend=true`, `control=true`, `frontend=false`
- workflow remains 999 LOC

Do not create a wrapper merge commit or deploy either parent independently. After exact-head CI succeeds, advance `main` to the exact target SHA only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Reliability**
  - Improved production deployment transitions with stricter validation of release targets and current deployment state.
  - Prevented deployments when release plans are stale, incomplete, obsolete, or inconsistent.
  - Improved handling of bridge transitions and recovery paths.

- **Bug Fixes**
  - Added safeguards against proceeding during active database pool repairs.
  - Strengthened deployment cleanup and process handling to reduce residual temporary resources.

- **Tests**
  - Expanded automated coverage for valid, invalid, stale, and already-advanced deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->