### PR TITLE
fix(deploy): satisfy production client shellcheck

### DIFF
--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -314,7 +314,7 @@ install -m 0700 "$0" "$FAKE_SSH"
   plan_is_exact_release_b_bridge_transition
   parse_plan "$(printf 'frontend=false\nbackend=false\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
     "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_BRIDGE_SHA")"
-  ! plan_is_exact_release_b_bridge_transition
+  plan_is_exact_release_b_bridge_transition && exit 1
   parse_plan "$(printf 'frontend=false\nbackend=true\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
     "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_CONTROLLER_SHA")"
   plan_is_exact_release_b_target_transition


### PR DESCRIPTION
## Summary

- fix the exact SC2251 failure that stopped production verification before deploy
- preserve the negative assertion semantics under `set -e`
- keep the Release B graph, bridge digests, workflow and runtime behavior unchanged

## Evidence

- `bash -n ops/deploy/github-production-deploy-client.test.sh`
- `shellcheck ops/deploy/github-production-deploy-client.test.sh`
- `bash ops/deploy/github-production-deploy-client.test.sh`
- independent exact-SHA xhigh review: `APPROVED_EXACT_246BB`, zero blockers

The failed production run did not enter reconcile or deploy. Frontend verification and the mandatory reader-summary publication boundary both passed on the parent SHA.
