### PR TITLE
fix(summaries): avoid false updating status

### DIFF
--- a/apps/frontend/features/summaries/lib/src/domain/value_objects/summary_refresh_schedule.dart
+++ b/apps/frontend/features/summaries/lib/src/domain/value_objects/summary_refresh_schedule.dart
@@ -4,6 +4,9 @@ final class SummaryRefreshSchedule {
   static const _scheduledHoursUtc = [4, 8, 12, 16, 20];
   static const scheduledMinuteUtc = 15;
 
+  /// Collection can finish shortly before its nominal publication slot.
+  static const collectionLeadTolerance = Duration(minutes: 5);
+
   static DateTime nextScheduledAt(DateTime now) {
     final utc = now.toUtc();
     for (final hour in _scheduledHoursUtc) {
@@ -27,7 +30,11 @@ final class SummaryRefreshSchedule {
   static bool isUpdateDue({
     required DateTime now,
     required DateTime collectedAt,
-  }) => collectedAt.toUtc().isBefore(latestScheduledAt(now));
+  }) {
+    final latestSlot = latestScheduledAt(now);
+    final freshnessCutoff = latestSlot.subtract(collectionLeadTolerance);
+    return collectedAt.toUtc().isBefore(freshnessCutoff);
+  }
 
   static Duration remaining({required DateTime now, required DateTime next}) {
     final value = next.toUtc().difference(now.toUtc());

--- a/apps/frontend/features/summaries/test/domain/value_objects/summary_refresh_schedule_test.dart
+++ b/apps/frontend/features/summaries/test/domain/value_objects/summary_refresh_schedule_test.dart
@@ -56,5 +56,24 @@ void main() {
         isFalse,
       );
     });
+
+    test('accepts a collection watermark shortly before its slot', () {
+      final now = DateTime.parse('2026-08-15T18:05:00.000Z');
+
+      expect(
+        SummaryRefreshSchedule.isUpdateDue(
+          now: now,
+          collectedAt: DateTime.parse('2026-08-15T16:13:00.000Z'),
+        ),
+        isFalse,
+      );
+      expect(
+        SummaryRefreshSchedule.isUpdateDue(
+          now: now,
+          collectedAt: DateTime.parse('2026-08-15T16:09:59.000Z'),
+        ),
+        isTrue,
+      );
+    });
   });
 }

--- a/apps/frontend/features/summaries/test/presentation/components/workspace_summary_refresh_status_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/workspace_summary_refresh_status_test.dart
@@ -51,4 +51,24 @@ void main() {
     expect(find.textContaining('updating now'), findsOneWidget);
     expect(refreshes, 1);
   });
+
+  testWidgets('does not report updating for a just-collected slot', (
+    tester,
+  ) async {
+    var refreshes = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WorkspaceSummaryRefreshStatus(
+          collectedAt: DateTime.parse('2026-08-15T16:13:00.000Z'),
+          clock: () => DateTime.parse('2026-08-15T18:05:00.000Z'),
+          onRefreshDue: () => refreshes += 1,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('updating now'), findsNothing);
+    expect(find.textContaining('next update in 02:10:00'), findsOneWidget);
+    expect(refreshes, 0);
+  });
 }


### PR DESCRIPTION
Treat collection watermarks up to five minutes before a rolling publication slot as fresh, so a 16:13 collection does not display updating now for the 16:15 slot. Keeps genuinely missed slots stale and adds domain plus widget regressions.