### PR TITLE
fix(deploy): validate Release B descendants before production access

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -71,8 +71,10 @@ jobs:
     timeout-minutes: 360
     environment: production
     steps:
-      - name: Check out the release commit
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with: {fetch-depth: 0}
+      - name: Verify exact Release B target locally before production contact
+        run: bash ops/deploy/github-production-deploy-client.sh verify-release-b-target "$GITHUB_SHA"
       - name: Configure restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
@@ -135,11 +137,12 @@ jobs:
       repair_anchor: ${{ steps.plan.outputs.repair_anchor }}
       transition_state: ${{ steps.plan.outputs.transition_state }}
     steps:
-      - name: Check out the release commit
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
       - name: Validate frozen three-phase graph before production SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
+      - name: Verify exact Release B target locally before production contact
+        run: bash ops/deploy/github-production-deploy-client.sh verify-release-b-target "$GITHUB_SHA"
       - name: Configure restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
@@ -732,8 +735,7 @@ jobs:
     timeout-minutes: 120
     environment: production
     steps:
-      - name: Check out frozen three-phase graph
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before production SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
@@ -899,8 +901,7 @@ jobs:
       DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
       DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
     steps:
-      - name: Check out the release commit
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before Release B SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
@@ -962,8 +963,7 @@ jobs:
     timeout-minutes: 30
     environment: production
     steps:
-      - name: Check out frozen three-phase graph
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
       - name: Validate graph and immutable manifests before acceptance SSH
         run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -910,9 +910,9 @@ jobs:
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
-          client=ops/deploy/github-production-deploy-client.sh; controller_release=8b4aeb31e855ed379349a4e4827600009e174132; bridge_release=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
+          client=ops/deploy/github-production-deploy-client.sh; controller_release=8b4aeb31e855ed379349a4e4827600009e174132; bridge_release=b89950632b0cefa4f7b58b687cdfd6e6cd912a04; bridge_target=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
           current_main=77313ea03a3bac7d2298f4021d58124c810d291f; bash "$client" configure
-          bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$GITHUB_SHA"
+          bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$bridge_target" "$GITHUB_SHA"
           bash "$client" cleanup; bash "$client" configure
       - name: Freshly require A-complete or B-complete
         id: b_state

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -11,6 +11,8 @@ RELEASE_B_BRIDGE_SHA=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
 RELEASE_B_BRIDGE_TREE=0f2edeb95bbb658cebdb1aecdcda24026eca7d19
 RELEASE_B_BRIDGE_BLOB=e02f7b7684f75121521065b43148708d545ab806
 RELEASE_B_BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
+RELEASE_B_REVIEWED_TARGET_SHA=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
+RELEASE_B_REVIEWED_TARGET_TREE=237c34068c057d2dfb5efaf9d606028cdaf18525
 DAILY_C1_BRIDGE_POLICY_SHA=944fdb6da3071f70a69c7048c9fcdf1c2552603e
 SSH_DIRECTORY=${DEPLOY_SSH_DIRECTORY:-${HOME:?HOME is required}/.ssh}
 SSH_KEY_PATH=${DEPLOY_SSH_KEY_PATH:-$SSH_DIRECTORY/social-monitor-production}
@@ -568,6 +570,15 @@ plan_is_exact_release_b_target_transition() {
      $PLAN_POSTGRES_POOL_REPAIR == false ]]
 }
 
+plan_is_exact_release_b_current_main_target_transition() {
+  [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == false && \
+     $PLAN_BACKEND_BASE == "$RELEASE_B_CURRENT_MAIN_SHA" && \
+     $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$RELEASE_B_CURRENT_MAIN_SHA" && \
+     $PLAN_POSTGRES_POOL_REPAIR == false ]]
+}
+
 verify_release_b_bridge_identity() {
   local sha=$1 repository=${GITHUB_WORKSPACE:-.}
   local actual_tree delta entry mode type object path extra
@@ -598,6 +609,56 @@ verify_release_b_bridge_identity() {
      $object == "$RELEASE_B_BRIDGE_BLOB" && \
      $path == "$RELEASE_B_BRIDGE_PATH" ]] || \
     fail 'Release B bridge policy blob does not match its reviewed pin'
+}
+
+verify_release_b_reviewed_target_identity() {
+  local sha=$1 requested_target=$2 repository=${GITHUB_WORKSPACE:-.}
+  local actual_tree delta entries first_parent_history parent
+  local -a ancestry=()
+  local requested_contains_reviewed=false
+
+  [[ $sha == "$RELEASE_B_REVIEWED_TARGET_SHA" ]] || \
+    fail 'Release B reviewed target SHA is not the reviewed pin'
+  read -r -a ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$sha" 2>/dev/null)" || \
+    fail 'Release B reviewed target ancestry cannot be inspected'
+  [[ ${#ancestry[@]} == 3 && ${ancestry[0]} == "$sha" && \
+     ${ancestry[1]} == "$RELEASE_B_CURRENT_MAIN_SHA" && \
+     ${ancestry[2]} == "$RELEASE_B_BRIDGE_SHA" ]] || \
+    fail 'Release B reviewed target does not have its exact ordered parents'
+  actual_tree=$(git -C "$repository" rev-parse "$sha^{tree}" 2>/dev/null) || \
+    fail 'Release B reviewed target tree cannot be inspected'
+  [[ $actual_tree == "$RELEASE_B_REVIEWED_TARGET_TREE" ]] || \
+    fail 'Release B reviewed target tree does not match its reviewed pin'
+  delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$RELEASE_B_CURRENT_MAIN_SHA" "$sha" -- 2>/dev/null) || \
+    fail 'Release B reviewed target delta cannot be inspected'
+  [[ $delta == $'.github/workflows/production-deploy.yml\nops/deploy/deploy-control-bridge-lib.sh\nops/deploy/github-production-deploy-client.sh\nops/deploy/github-production-deploy-client.test.sh\nops/deploy/production-release-b-bridge-order.test.sh\nops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh' ]] || \
+    fail 'Release B reviewed target changes outside its exact reviewed delta'
+  entries=$(git -C "$repository" ls-tree "$sha" -- \
+    .github/workflows/production-deploy.yml \
+    ops/deploy/deploy-control-bridge-lib.sh \
+    ops/deploy/github-production-deploy-client.sh \
+    ops/deploy/github-production-deploy-client.test.sh \
+    ops/deploy/production-release-b-bridge-order.test.sh \
+    ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh 2>/dev/null) || \
+    fail 'Release B reviewed target files cannot be inspected'
+  [[ $entries == $'100644 blob 1e85c36aaeb064df3235e8093acb6124d64d0398\t.github/workflows/production-deploy.yml\n100644 blob e02f7b7684f75121521065b43148708d545ab806\tops/deploy/deploy-control-bridge-lib.sh\n100755 blob 086a7d95d2a8125cd6c8f2dd39b05fe42e4c9482\tops/deploy/github-production-deploy-client.sh\n100755 blob 8db3980a225a8222765dfa95c4fd895bfb20712a\tops/deploy/github-production-deploy-client.test.sh\n100755 blob 47f97467223fa0e7a0b779741d676ad4f19b7bea\tops/deploy/production-release-b-bridge-order.test.sh\n100644 blob ab7e2c5cb06d85dce0d3e2427d8af7e9636b32ad\tops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh' ]] || \
+    fail 'Release B reviewed target file identities do not match their pins'
+
+  git -C "$repository" cat-file -e "$requested_target^{commit}" 2>/dev/null || \
+    fail 'Release B requested target commit cannot be inspected'
+  first_parent_history=$(git -C "$repository" rev-list --first-parent \
+    "$requested_target" 2>/dev/null) || \
+    fail 'Release B requested target first-parent history cannot be inspected'
+  while IFS= read -r parent; do
+    if [[ $parent == "$sha" ]]; then
+      requested_contains_reviewed=true
+      break
+    fi
+  done <<< "$first_parent_history"
+  [[ $requested_contains_reviewed == true ]] || \
+    fail 'Release B requested target does not first-parent-contain the reviewed target'
 }
 
 reconcile_deploy_plan() {
@@ -653,26 +714,50 @@ deploy_release() {
   }
 }
 
+deploy_release_b_reviewed_target() {
+  local target=$1 status
+  if capture_plan "$target"; then
+    status=0
+  else
+    status=$?
+  fi
+  ((status == 0)) || fail "Release B reviewed target plan failed with status $status"
+  print_plan
+  plan_is_fully_reconciled && return 0
+  { plan_is_exact_release_b_target_transition || \
+    plan_is_exact_release_b_current_main_target_transition; } || \
+    fail 'Release B reviewed target plan is not an exact admitted transition'
+  deploy_once "$target"
+}
+
 prepare_release_b_bridge() {
-  local sha=$1 bridge=$2 current_main=$3 target=$4 status
-  local target_plan_exact=false
+  local sha=$1 bridge=$2 current_main=$3 bridge_target=$4 requested_target=$5 status
+  local target_plan_exact=false current_main_target_plan_exact=false
   [[ $sha == "$RELEASE_B_CONTROLLER_SHA" ]] || \
     fail 'Release B controller SHA is not the reviewed pin'
   [[ $current_main == "$RELEASE_B_CURRENT_MAIN_SHA" ]] || \
     fail 'Release B current-main SHA is not the reviewed pin'
   verify_release_b_bridge_identity "$bridge"
+  verify_release_b_reviewed_target_identity "$bridge_target" "$requested_target"
 
-  if capture_plan "$target"; then
+  if capture_plan "$bridge_target"; then
     print_plan
     plan_is_fully_reconciled && return 0
     plan_is_exact_release_b_target_transition && target_plan_exact=true
+    plan_is_exact_release_b_current_main_target_transition && \
+      current_main_target_plan_exact=true
   else
     status=$?
     ((status == 1)) || fail "Release B target preflight plan failed with status $status"
   fi
   if capture_plan "$current_main"; then
     print_plan
-    plan_is_fully_reconciled && return 0
+    if plan_is_fully_reconciled; then
+      [[ $current_main_target_plan_exact == true ]] || \
+        fail 'Release B reviewed target is not the exact current-main transition'
+      deploy_release_b_reviewed_target "$bridge_target"
+      return 0
+    fi
     plan_is_exact_release_b_target_transition || \
       fail 'Release B current-main plan is not the exact controller transition'
   else
@@ -683,9 +768,13 @@ prepare_release_b_bridge() {
     fail 'Release B target plan is not the exact controller transition'
   if capture_plan "$bridge"; then
     print_plan
-    plan_is_fully_reconciled && return 0
+    if plan_is_fully_reconciled; then
+      deploy_release_b_reviewed_target "$bridge_target"
+      return 0
+    fi
     if plan_is_exact_release_b_bridge_transition; then
       deploy_once "$bridge"
+      deploy_release_b_reviewed_target "$bridge_target"
       return 0
     fi
   else
@@ -709,10 +798,14 @@ prepare_release_b_bridge() {
   fi
   ((status == 0)) || fail "Release B bridge plan failed with status $status"
   print_plan
-  plan_is_fully_reconciled && return 0
+  if plan_is_fully_reconciled; then
+    deploy_release_b_reviewed_target "$bridge_target"
+    return 0
+  fi
   plan_is_exact_release_b_bridge_transition || \
     fail 'Release B bridge plan is not the exact fresh control-only transition'
   deploy_once "$bridge"
+  deploy_release_b_reviewed_target "$bridge_target"
 }
 
 install_daily_c1_bridge_policy() {
@@ -773,13 +866,14 @@ case $action in
     deploy_release "$2"
     ;;
   prepare-release-b-bridge)
-    [[ $# == 5 ]] || fail 'prepare-release-b-bridge requires controller, bridge, current-main, and target pins'
+    [[ $# == 6 ]] || fail 'prepare-release-b-bridge requires controller, bridge, current-main, reviewed-target, and requested-target pins'
     validate_sha "$2"
     validate_sha "$3"
     validate_sha "$4"
     validate_sha "$5"
+    validate_sha "$6"
     validate_remote_environment
-    prepare_release_b_bridge "$2" "$3" "$4" "$5"
+    prepare_release_b_bridge "$2" "$3" "$4" "$5" "$6"
     ;;
   install-daily-c1-bridge-policy)
     [[ $# == 2 ]] || fail 'install-daily-c1-bridge-policy requires its pinned SHA'

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -14,7 +14,7 @@ RELEASE_B_BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
 RELEASE_B_REVIEWED_TARGET_SHA=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
 RELEASE_B_REVIEWED_TARGET_TREE=237c34068c057d2dfb5efaf9d606028cdaf18525
 DAILY_C1_BRIDGE_POLICY_SHA=944fdb6da3071f70a69c7048c9fcdf1c2552603e
-SSH_DIRECTORY=${DEPLOY_SSH_DIRECTORY:-${HOME:?HOME is required}/.ssh}
+SSH_DIRECTORY=${DEPLOY_SSH_DIRECTORY:-${HOME:+$HOME/.ssh}}
 SSH_KEY_PATH=${DEPLOY_SSH_KEY_PATH:-$SSH_DIRECTORY/social-monitor-production}
 SSH_KNOWN_HOSTS_PATH=${DEPLOY_SSH_KNOWN_HOSTS_PATH:-$SSH_DIRECTORY/known_hosts}
 SSH_BIN=${DEPLOY_SSH_BIN:-ssh}
@@ -85,6 +85,7 @@ validate_remote_environment() {
 }
 
 configure_ssh() {
+  [[ -n $SSH_DIRECTORY ]] || fail 'HOME or DEPLOY_SSH_DIRECTORY is required'
   [[ -n ${DEPLOY_KEY:-} ]] || fail 'DEPLOY_KEY is required'
   [[ -n ${KNOWN_HOSTS:-} ]] || fail 'KNOWN_HOSTS is required'
   install -d -m 0700 "$SSH_DIRECTORY"
@@ -852,6 +853,12 @@ case $action in
     validate_sha "$2"
     validate_remote_environment
     inspect_plan "$2"
+    ;;
+  verify-release-b-target)
+    [[ $# == 2 ]] || fail 'verify-release-b-target requires a requested target SHA'
+    validate_sha "$2"
+    verify_release_b_reviewed_target_identity \
+      "$RELEASE_B_REVIEWED_TARGET_SHA" "$2"
     ;;
   upload)
     [[ $# == 3 ]] || fail 'upload requires a target SHA and archive'

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -109,18 +109,24 @@ fake_ssh() {
     normal_success:"deploy $TARGET_SHA"|normal_success:"deploy 944fdb6da3071f70a69c7048c9fcdf1c2552603e")
       printf 'deployed=%s\n' "$TARGET_SHA"
       ;;
-    release_b_replay:"plan $TARGET_SHA")
-      print_fake_plan false false false false "$TARGET_SHA" "$TARGET_SHA"
+    release_b_replay:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
+      print_fake_plan false false false false "$RELEASE_B_REVIEWED_TARGET_SHA" \
+        "$RELEASE_B_REVIEWED_TARGET_SHA"
       ;;
-    release_b_current_main:"plan $TARGET_SHA")
-      print_fake_plan false false true false "$RELEASE_B_CURRENT_MAIN_SHA" \
-        "$RELEASE_B_CURRENT_MAIN_SHA"
+    release_b_current_main:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
+      if grep -qFx "deploy $RELEASE_B_REVIEWED_TARGET_SHA" "$FAKE_SSH_LOG"; then
+        print_fake_plan false false false false "$RELEASE_B_REVIEWED_TARGET_SHA" \
+          "$RELEASE_B_CURRENT_MAIN_SHA"
+      else
+        print_fake_plan false false true false "$RELEASE_B_CURRENT_MAIN_SHA" \
+          "$RELEASE_B_CURRENT_MAIN_SHA"
+      fi
       ;;
     release_b_current_main:"plan $RELEASE_B_CURRENT_MAIN_SHA")
       print_fake_plan false false false false "$RELEASE_B_CURRENT_MAIN_SHA" \
         "$RELEASE_B_CURRENT_MAIN_SHA"
       ;;
-    release_b_stale_target:"plan $TARGET_SHA")
+    release_b_stale_target:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
       print_fake_plan false true true false "$RELEASE_B_POOL_MARKER" \
         "$RELEASE_B_BACKEND_MARKER"
       ;;
@@ -128,9 +134,14 @@ fake_ssh() {
       print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
         "$RELEASE_B_CONTROLLER_SHA"
       ;;
-    release_b_from_8b:"plan $TARGET_SHA"|release_b_bridge_disconnect:"plan $TARGET_SHA"|release_b_controller_repair:"plan $TARGET_SHA")
-      print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
-        "$RELEASE_B_CONTROLLER_SHA"
+    release_b_from_8b:"plan $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_bridge_disconnect:"plan $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_controller_repair:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
+      if grep -qFx "deploy $RELEASE_B_REVIEWED_TARGET_SHA" "$FAKE_SSH_LOG"; then
+        print_fake_plan false false false false "$RELEASE_B_REVIEWED_TARGET_SHA" \
+          "$RELEASE_B_CONTROLLER_SHA"
+      else
+        print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
+          "$RELEASE_B_CONTROLLER_SHA"
+      fi
       ;;
     release_b_from_8b:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_bridge_disconnect:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_controller_repair:"plan $RELEASE_B_CURRENT_MAIN_SHA")
       print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
@@ -171,13 +182,16 @@ fake_ssh() {
       printf 'deployed=%s\n' "$RELEASE_B_BRIDGE_SHA"
       ;;
     release_b_bridge_disconnect:"deploy $RELEASE_B_BRIDGE_SHA") exit 255 ;;
+    release_b_from_8b:"deploy $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_bridge_disconnect:"deploy $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_controller_repair:"deploy $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_current_main:"deploy $RELEASE_B_REVIEWED_TARGET_SHA")
+      printf 'deployed=%s\n' "$RELEASE_B_REVIEWED_TARGET_SHA"
+      ;;
     release_b_controller_repair:"deploy $RELEASE_B_CONTROLLER_SHA")
       printf 'deployed=%s\n' "$RELEASE_B_CONTROLLER_SHA"
       ;;
-    release_b_partial:"plan $TARGET_SHA")
+    release_b_partial:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
       printf 'frontend=false\nbackend=true\n'
       ;;
-    release_b_rejected:"plan $TARGET_SHA"|release_b_rejected:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_rejected:"plan $RELEASE_B_BRIDGE_SHA") exit 1 ;;
+    release_b_rejected:"plan $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_rejected:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_rejected:"plan $RELEASE_B_BRIDGE_SHA") exit 1 ;;
     atomic_success:"deploy $TARGET_SHA")
       printf 'postgres-pool-bootstrap=%s replay=false\n' "$TARGET_SHA"
       ;;
@@ -262,12 +276,13 @@ MAINTENANCE_DISPATCH=$SCRIPT_DIR/github-production-maintenance-dispatch.sh
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/github-production-deploy-client-test.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
 
-TARGET_SHA=1234567890abcdef1234567890abcdef12345678
+TARGET_SHA=$(git -C "$SCRIPT_DIR/../.." rev-parse HEAD)
 BACKEND_SHA=4f47fac7faed7dc24110f4a43e88820d776b8a40
 CURRENT_BACKEND_SHA=617e284607f3dde74c27164af2b981770b9a62ed
 RELEASE_B_CONTROLLER_SHA=8b4aeb31e855ed379349a4e4827600009e174132
 RELEASE_B_CURRENT_MAIN_SHA=77313ea03a3bac7d2298f4021d58124c810d291f
 RELEASE_B_BRIDGE_SHA=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
+RELEASE_B_REVIEWED_TARGET_SHA=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
 RELEASE_B_BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
 RELEASE_B_POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
 MODEL_JOB_IDENTITY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -287,7 +302,7 @@ DEPLOY_HOST=production.example.invalid
 DEPLOY_USER=social-monitor-deploy
 
 export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA RELEASE_B_CONTROLLER_SHA
-export RELEASE_B_CURRENT_MAIN_SHA RELEASE_B_BRIDGE_SHA
+export RELEASE_B_CURRENT_MAIN_SHA RELEASE_B_BRIDGE_SHA RELEASE_B_REVIEWED_TARGET_SHA
 export RELEASE_B_BACKEND_MARKER RELEASE_B_POOL_MARKER
 export MODEL_JOB_IDENTITY AUTHORITY_SHA256 TERMINAL_SET_SHA256
 export FAKE_SSH_LOG FAKE_SSH_STATE FAKE_UPLOAD_PATH
@@ -321,6 +336,11 @@ install -m 0700 "$0" "$FAKE_SSH"
   # shellcheck disable=SC2034 # Read by the sourced target-plan predicate.
   PLAN_POSTGRES_POOL_REPAIR=true
   ! plan_is_exact_release_b_target_transition
+  # shellcheck disable=SC2034 # Read by the sourced current-main predicate.
+  PLAN_POSTGRES_POOL_REPAIR=false
+  parse_plan "$(printf 'frontend=false\nbackend=false\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
+    "$RELEASE_B_CURRENT_MAIN_SHA" "$RELEASE_B_CURRENT_MAIN_SHA")"
+  plan_is_exact_release_b_current_main_target_transition
 )
 
 run_client() {
@@ -621,23 +641,33 @@ assert_call_count 1 "plan $TARGET_SHA"
 
 # Every bridge/controller mutation follows a plan and is issued at most once.
 prepare_args=(prepare-release-b-bridge "$RELEASE_B_CONTROLLER_SHA" \
-  "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" "$TARGET_SHA")
+  "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" \
+  "$RELEASE_B_REVIEWED_TARGET_SHA" "$TARGET_SHA")
 run_client release_b_from_8b "${prepare_args[@]}" >/dev/null
 assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
 assert_call_count 2 "plan $RELEASE_B_BRIDGE_SHA"
+assert_call_count 1 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
+assert_call_count 0 "deploy $TARGET_SHA"
 assert_call_count 0 "deploy $RELEASE_B_CONTROLLER_SHA"
 run_client release_b_bridge_disconnect "${prepare_args[@]}" >/dev/null
 assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
 assert_call_count 2 "plan $RELEASE_B_BRIDGE_SHA"
+assert_call_count 1 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
+assert_call_count 0 "deploy $TARGET_SHA"
 run_client release_b_controller_repair "${prepare_args[@]}" >/dev/null
 assert_call_count 1 "deploy $RELEASE_B_CONTROLLER_SHA"
 assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 1 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
+assert_call_count 0 "deploy $TARGET_SHA"
 assert_call_count 2 "plan $RELEASE_B_CONTROLLER_SHA"
 run_client release_b_current_main "${prepare_args[@]}" >/dev/null
 assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 1 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
+assert_call_count 0 "deploy $TARGET_SHA"
 assert_call_count 1 "plan $RELEASE_B_CURRENT_MAIN_SHA"
 run_client release_b_replay "${prepare_args[@]}" >/dev/null
 assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 0 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
 assert_call_count 0 "deploy $TARGET_SHA"
 assert_fails release_b_partial "${prepare_args[@]}"
 assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
@@ -647,7 +677,13 @@ assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
 assert_fails release_b_rejected "${prepare_args[@]}"
 assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
 assert_fails release_b_replay prepare-release-b-bridge "$TARGET_SHA" \
-  "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" "$TARGET_SHA"
+  "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" \
+  "$RELEASE_B_REVIEWED_TARGET_SHA" "$TARGET_SHA"
+[[ ! -s $FAKE_SSH_LOG ]]
+assert_fails release_b_replay prepare-release-b-bridge \
+  "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_BRIDGE_SHA" \
+  "$RELEASE_B_CURRENT_MAIN_SHA" "$RELEASE_B_REVIEWED_TARGET_SHA" \
+  "$RELEASE_B_CURRENT_MAIN_SHA"
 [[ ! -s $FAKE_SSH_LOG ]]
 
 run_client normal_success install-daily-c1-bridge-policy \

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -378,6 +378,20 @@ assert_call_count() {
   }
 }
 
+# The workflow's local gate accepts the exact reviewed target and its real
+# requested descendant, but rejects current-main before any SSH call is made.
+for release_b_requested_target in \
+  "$RELEASE_B_REVIEWED_TARGET_SHA" "$TARGET_SHA"; do
+  HOME='' DEPLOY_SSH_DIRECTORY='' DEPLOY_HOST='' DEPLOY_USER='' \
+    GITHUB_WORKSPACE=$SCRIPT_DIR/../.. run_client release_b_local_identity \
+      verify-release-b-target "$release_b_requested_target"
+  [[ ! -s $FAKE_SSH_LOG ]]
+done
+HOME='' DEPLOY_SSH_DIRECTORY='' DEPLOY_HOST='' DEPLOY_USER='' \
+  GITHUB_WORKSPACE=$SCRIPT_DIR/../.. assert_fails release_b_local_identity \
+    verify-release-b-target "$RELEASE_B_CURRENT_MAIN_SHA"
+[[ ! -s $FAKE_SSH_LOG ]]
+
 DEPLOY_KEY=fake-private-key KNOWN_HOSTS=fake-known-hosts bash "$CLIENT" configure
 [[ $(stat -c '%a' "$DEPLOY_SSH_DIRECTORY") == 700 ]]
 [[ $(stat -c '%a' "$DEPLOY_SSH_KEY_PATH") == 600 ]]

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -15,6 +15,8 @@ OLD_TARGET=bce12683c9309e037614f4808a0fc75caddc9864
 BRIDGE=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
 BRIDGE_TREE=0f2edeb95bbb658cebdb1aecdcda24026eca7d19
 BRIDGE_BLOB=e02f7b7684f75121521065b43148708d545ab806
+BRIDGE_TARGET=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
+BRIDGE_TARGET_TREE=237c34068c057d2dfb5efaf9d606028cdaf18525
 CANONICAL_RELEASE_B2=e3b5b5d89b3586668e36f987f03672415b5a0f37
 BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
 BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
@@ -159,7 +161,7 @@ configure_fixture_repository "$GRAPH_REPO"
 git -C "$GRAPH_REPO" config user.name 'Release B Current Main Test'
 git -C "$GRAPH_REPO" config user.email release-b-current-main@example.invalid
 for commit in "$BASE" "$CURRENT_MAIN" "$OLD_CURRENT_MAIN" "$OLD_BRIDGE" \
-  "$OLD_TARGET" "$BRIDGE" "$CANONICAL_RELEASE_B2" "$TARGET"; do
+  "$OLD_TARGET" "$BRIDGE" "$BRIDGE_TARGET" "$CANONICAL_RELEASE_B2" "$TARGET"; do
   git -C "$GRAPH_REPO" cat-file -e "$commit^{commit}"
 done
 
@@ -178,17 +180,19 @@ read -r bridge_mode bridge_type bridge_blob bridge_path bridge_extra <<< "$(
    $bridge_type == blob && $bridge_blob == "$BRIDGE_BLOB" && \
    $bridge_path == "$BRIDGE_PATH" ]]
 
-# The deploy target is the exact cleanup-preserving two-parent integration.
+# The bridge target is the exact cleanup-preserving two-parent integration.
 read -r -a target_parents <<< "$(git -C "$GRAPH_REPO" \
-  rev-list --parents -n 1 "$TARGET")"
-[[ ${#target_parents[@]} == 3 && \
+  rev-list --parents -n 1 "$BRIDGE_TARGET")"
+[[ ${#target_parents[@]} == 3 && ${target_parents[0]} == "$BRIDGE_TARGET" && \
    ${target_parents[1]} == "$CURRENT_MAIN" && \
    ${target_parents[2]} == "$BRIDGE" ]]
-git -C "$GRAPH_REPO" merge-base --is-ancestor "$CURRENT_MAIN" "$TARGET"
-git -C "$GRAPH_REPO" merge-base --is-ancestor "$BRIDGE" "$TARGET"
-git -C "$GRAPH_REPO" rev-list --first-parent "$TARGET" | \
+[[ $(git -C "$GRAPH_REPO" rev-parse "$BRIDGE_TARGET^{tree}") == \
+   "$BRIDGE_TARGET_TREE" ]]
+git -C "$GRAPH_REPO" merge-base --is-ancestor "$CURRENT_MAIN" "$BRIDGE_TARGET"
+git -C "$GRAPH_REPO" merge-base --is-ancestor "$BRIDGE" "$BRIDGE_TARGET"
+git -C "$GRAPH_REPO" rev-list --first-parent "$BRIDGE_TARGET" | \
   grep -Fx "$CANONICAL_RELEASE_B2" >/dev/null
-[[ $(git -C "$GRAPH_REPO" rev-parse "$TARGET:$BRIDGE_PATH") == \
+[[ $(git -C "$GRAPH_REPO" rev-parse "$BRIDGE_TARGET:$BRIDGE_PATH") == \
    "$BRIDGE_BLOB" ]]
 expected_target_delta=$(printf '%s\n' \
   .github/workflows/production-deploy.yml \
@@ -198,11 +202,16 @@ expected_target_delta=$(printf '%s\n' \
   ops/deploy/production-release-b-bridge-order.test.sh \
   ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh | LC_ALL=C sort)
 actual_target_delta=$(git -C "$GRAPH_REPO" diff --name-only --no-renames \
-  "$CURRENT_MAIN" "$TARGET" | LC_ALL=C sort)
+  "$CURRENT_MAIN" "$BRIDGE_TARGET" | LC_ALL=C sort)
 [[ $actual_target_delta == "$expected_target_delta" ]]
 inherited_path=ops/ingestion/source-provider-certification.json
 [[ $(git -C "$GRAPH_REPO" rev-parse "$CURRENT_MAIN:$inherited_path") == \
-   $(git -C "$GRAPH_REPO" rev-parse "$TARGET:$inherited_path") ]]
+   $(git -C "$GRAPH_REPO" rev-parse "$BRIDGE_TARGET:$inherited_path") ]]
+
+# The requested target is distinct and must retain the reviewed target on its
+# first-parent history; its later ordinary-controller delta is not bridge policy.
+git -C "$GRAPH_REPO" rev-list --first-parent "$TARGET" | \
+  grep -Fx "$BRIDGE_TARGET" >/dev/null
 
 # Exercise the bridge acceptance policy against the real graph and negative
 # stale/rejected topologies.
@@ -210,12 +219,12 @@ REPO=$GRAPH_REPO
 fail() { printf 'test-error: %s\n' "$*" >&2; return 1; }
 # shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
 source "$GRAPH_REPO/ops/deploy/deploy-control-bridge-lib.sh"
-deploy_control_reviewed_transition_matches "$BRIDGE" "$TARGET"
+deploy_control_reviewed_transition_matches "$BRIDGE" "$BRIDGE_TARGET"
 if deploy_control_reviewed_transition_matches "$OLD_BRIDGE" "$OLD_TARGET"; then
   echo 'obsolete bce/db topology was admitted by the new bridge' >&2
   exit 1
 fi
-if deploy_control_reviewed_transition_matches "$OLD_BRIDGE" "$TARGET"; then
+if deploy_control_reviewed_transition_matches "$OLD_BRIDGE" "$BRIDGE_TARGET"; then
   echo 'obsolete bridge was admitted for the new target' >&2
   exit 1
 fi
@@ -224,21 +233,21 @@ if deploy_control_reviewed_transition_matches "$BRIDGE" "$CURRENT_MAIN"; then
   exit 1
 fi
 swapped_target=$(printf 'test: swapped Release B parents\n' | \
-  git -C "$GRAPH_REPO" commit-tree "$TARGET^{tree}" \
+  git -C "$GRAPH_REPO" commit-tree "$BRIDGE_TARGET^{tree}" \
     -p "$BRIDGE" -p "$CURRENT_MAIN")
 if deploy_control_reviewed_transition_matches "$BRIDGE" "$swapped_target"; then
   echo 'swapped target parents were admitted' >&2
   exit 1
 fi
 wrapper_target=$(printf 'test: wrapped Release B target\n' | \
-  git -C "$GRAPH_REPO" commit-tree "$TARGET^{tree}" -p "$TARGET")
+  git -C "$GRAPH_REPO" commit-tree "$BRIDGE_TARGET^{tree}" -p "$BRIDGE_TARGET")
 if deploy_control_reviewed_transition_matches "$BRIDGE" "$wrapper_target"; then
   echo 'wrapper target was admitted' >&2
   exit 1
 fi
 extra_blob=$(printf 'extra target drift\n' | git -C "$GRAPH_REPO" hash-object -w --stdin)
 extra_index=$FIXTURE/extra.index
-GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" read-tree "$TARGET"
+GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" read-tree "$BRIDGE_TARGET"
 GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" update-index \
   --add --cacheinfo "100644,$extra_blob,unreviewed-release-b-drift"
 extra_tree=$(GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" write-tree)
@@ -248,18 +257,57 @@ if deploy_control_reviewed_transition_matches "$BRIDGE" "$extra_target"; then
   echo 'extra-path current-main topology was admitted' >&2
   exit 1
 fi
+drift_blob=$(printf 'allowlisted byte drift\n' | \
+  git -C "$GRAPH_REPO" hash-object -w --stdin)
+drift_index=$FIXTURE/drift.index
+GIT_INDEX_FILE=$drift_index git -C "$GRAPH_REPO" read-tree "$BRIDGE_TARGET"
+GIT_INDEX_FILE=$drift_index git -C "$GRAPH_REPO" update-index --cacheinfo \
+  "100644,$drift_blob,.github/workflows/production-deploy.yml"
+drift_tree=$(GIT_INDEX_FILE=$drift_index git -C "$GRAPH_REPO" write-tree)
+drift_target=$(printf 'test: allowlisted target byte drift\n' | \
+  git -C "$GRAPH_REPO" commit-tree "$drift_tree" \
+    -p "$CURRENT_MAIN" -p "$BRIDGE")
+
+# The client independently pins the reviewed target and rejects requested
+# commits that contain it only through a side parent.
+DEPLOY_SSH_DIRECTORY=$FIXTURE/client-ssh
+# shellcheck source=ops/deploy/github-production-deploy-client.sh
+source "$CLIENT"
+GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
+  "$BRIDGE_TARGET" "$TARGET"
+if (GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
+    "$drift_target" "$TARGET") 2>/dev/null; then
+  echo 'allowlisted-byte drift was admitted' >&2
+  exit 1
+fi
+side_parent_target=$(printf 'test: side-parent-only requested target\n' | \
+  git -C "$GRAPH_REPO" commit-tree "$BRIDGE_TARGET^{tree}" \
+    -p "$CURRENT_MAIN" -p "$BRIDGE_TARGET")
+if (GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
+    "$BRIDGE_TARGET" "$side_parent_target") 2>/dev/null; then
+  echo 'side-parent-only requested target was admitted' >&2
+  exit 1
+fi
+if (GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
+    "$BRIDGE_TARGET" "$CURRENT_MAIN") 2>/dev/null; then
+  echo 'requested sibling of the reviewed target was admitted' >&2
+  exit 1
+fi
 
 for exact_pin in \
   "RELEASE_B_CONTROLLER_SHA=$BASE" \
   "RELEASE_B_CURRENT_MAIN_SHA=$CURRENT_MAIN" \
   "RELEASE_B_BRIDGE_SHA=$BRIDGE" \
   "RELEASE_B_BRIDGE_TREE=$BRIDGE_TREE" \
-  "RELEASE_B_BRIDGE_BLOB=$BRIDGE_BLOB"; do
+  "RELEASE_B_BRIDGE_BLOB=$BRIDGE_BLOB" \
+  "RELEASE_B_REVIEWED_TARGET_SHA=$BRIDGE_TARGET" \
+  "RELEASE_B_REVIEWED_TARGET_TREE=$BRIDGE_TARGET_TREE"; do
   grep -Fqx "$exact_pin" "$CLIENT"
 done
 [[ $(grep -Fo "controller_release=$BASE" "$WORKFLOW" | wc -l) == 1 ]]
 [[ $(grep -Fo "current_main=$CURRENT_MAIN" "$WORKFLOW" | wc -l) == 1 ]]
 [[ $(grep -Fo "bridge_release=$BRIDGE" "$WORKFLOW" | wc -l) == 1 ]]
+[[ $(grep -Fo "bridge_target=$BRIDGE_TARGET" "$WORKFLOW" | wc -l) == 1 ]]
 
 python3 - "$WORKFLOW" <<'PY'
 import pathlib
@@ -267,7 +315,7 @@ import sys
 
 workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 commands = [
-    'bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$GITHUB_SHA"',
+    'bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$bridge_target" "$GITHUB_SHA"',
     'bash "$client" cleanup; bash "$client" configure',
     'inspect-plan "$GITHUB_SHA"',
     'bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"',
@@ -353,7 +401,7 @@ grep -F 'deploy control changed with backend or runtime assets; deploy the bridg
   <<< "$obsolete_error" >/dev/null
 [[ $(git -C "$obsolete_repo" rev-parse HEAD) == "$OLD_BRIDGE" ]]
 
-# Real 8b4 controller -> exact bridge -> current-main-descendant target.
+# Real 8b4 controller -> exact bridge -> reviewed target -> requested target.
 prepare_runtime_repo repaired "$BASE"
 repaired_repo=$FIXTURE/repaired/repo
 repaired_root=$FIXTURE/repaired/root
@@ -370,9 +418,12 @@ run_actual_controller "$repaired_repo" "$repaired_root" \
 [[ $(<"$repaired_state/backend.sha") == "$BASE" ]]
 [[ $(<"$repaired_state/frontend.sha") == "$BASE" ]]
 run_actual_controller "$repaired_repo" "$repaired_root" \
-  "$TARGET" "$BRIDGE" "$repaired_events" >/dev/null
+  "$BRIDGE_TARGET" "$BRIDGE" "$repaired_events" >/dev/null
+[[ $(git -C "$repaired_repo" rev-parse HEAD) == "$BRIDGE_TARGET" ]]
+run_actual_controller "$repaired_repo" "$repaired_root" \
+  "$TARGET" "$BRIDGE_TARGET" "$repaired_events" >/dev/null
 [[ $(git -C "$repaired_repo" rev-parse HEAD) == "$TARGET" ]]
-[[ $(<"$repaired_state/backend.sha") == "$TARGET" ]]
+[[ $(<"$repaired_state/backend.sha") == "$BRIDGE_TARGET" ]]
 [[ $(<"$repaired_state/frontend.sha") == "$BASE" ]]
 [[ $(<"$repaired_state/control.sha") == "$TARGET" ]]
 [[ $(<"$repaired_state/postgres-pool-bootstrap.sha") == "$TARGET" ]]
@@ -387,7 +438,10 @@ for component in frontend backend control postgres-pool-bootstrap; do
   printf '%s\n' "$CURRENT_MAIN" > "$advanced_state/$component.sha"
 done
 run_actual_controller "$advanced_repo" "$advanced_root" \
-  "$TARGET" "$CURRENT_MAIN" "$FIXTURE/advanced/events" >/dev/null
+  "$BRIDGE_TARGET" "$CURRENT_MAIN" "$FIXTURE/advanced/events" >/dev/null
+[[ $(git -C "$advanced_repo" rev-parse HEAD) == "$BRIDGE_TARGET" ]]
+run_actual_controller "$advanced_repo" "$advanced_root" \
+  "$TARGET" "$BRIDGE_TARGET" "$FIXTURE/advanced/events" >/dev/null
 [[ $(git -C "$advanced_repo" rev-parse HEAD) == "$TARGET" ]]
 [[ $(<"$advanced_state/backend.sha") == "$CURRENT_MAIN" ]]
 [[ $(<"$advanced_state/frontend.sha") == "$CURRENT_MAIN" ]]

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -274,6 +274,8 @@ DEPLOY_SSH_DIRECTORY=$FIXTURE/client-ssh
 # shellcheck source=ops/deploy/github-production-deploy-client.sh
 source "$CLIENT"
 GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
+  "$BRIDGE_TARGET" "$BRIDGE_TARGET"
+GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
   "$BRIDGE_TARGET" "$TARGET"
 if (GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
     "$drift_target" "$TARGET") 2>/dev/null; then
@@ -314,6 +316,27 @@ import pathlib
 import sys
 
 workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+local_gate = 'run: bash ops/deploy/github-production-deploy-client.sh verify-release-b-target "$GITHUB_SHA"'
+if workflow.count(local_gate) != 2:
+    raise SystemExit("local Release B identity gate must cover both workflow roots")
+
+def job(name, next_name):
+    start = workflow.index(f"  {name}:\n")
+    end = workflow.index(f"  {next_name}:\n", start)
+    return workflow[start:end]
+
+for root_name, next_name in (("production_maintenance", "plan"),
+                             ("plan", "verify_reader_summary_publication")):
+    root = job(root_name, next_name)
+    if root.count(local_gate) != 1:
+        raise SystemExit(f"{root_name} must execute exactly one local identity gate")
+    configure = "run: bash ops/deploy/github-production-deploy-client.sh configure"
+    if root.index(local_gate) > root.index(configure):
+        raise SystemExit(f"{root_name} contacts production before identity verification")
+
+release_a = job("release_a", "deploy")
+if "      - plan\n" not in release_a:
+    raise SystemExit("Release A production mutation is not gated by the verified plan job")
 commands = [
     'bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$bridge_target" "$GITHUB_SHA"',
     'bash "$client" cleanup; bash "$client" configure',


### PR DESCRIPTION
## Summary

- separates the exact reviewed Release B bridge target from later ordinary descendants
- validates the requested SHA locally before any production SSH setup or mutation
- accepts the exact reviewed target and its first-parent descendants while rejecting stale siblings and side-parent-only ancestry
- preserves the later client-side identity verification, disconnect reconciliation, and post-deploy acceptance

## Safety evidence

- both workflow roots execute the local identity gate before restricted SSH configuration
- the gate has no HOME, SSH, secret, or remote dependency
- exact reviewed target `05744f99b2d13e47a64a7ff12ea2ab8893f5e88a` and its reviewed descendant are accepted
- stale current-main sibling `77313...` is rejected without an SSH call
- `production-release-a-transition.sh` is unchanged
- workflow remains below the source cap at 999 lines

## Verification

- focused bridge, transition, and deploy-client tests
- ShellCheck and bash syntax
- production deploy lifecycle
- source line cap
- git diff check

Independent exact-head xhigh review is running. Merge remains gated on that approval and all required GitHub checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Production Release B deployments now verify the reviewed target’s exact commit, ancestry, file changes, and content before deployment.
  * Added safeguards against stale, altered, swapped, or otherwise invalid release targets.
  * Improved handling when transitioning from the current production state.

* **Tests**
  * Expanded release validation coverage, including repaired and already-advanced production scenarios.
  * Added checks for deployment ordering and invalid target configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->