### PR TITLE
fix(deploy): integrate rolling production transition

### DIFF
--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -20,6 +20,9 @@ DEPLOY_CONTROL_SCHEDULED_SUMMARY_CATCH_UP_BASE=e377453d5b440aacc8077e8af1345eb5a
 DEPLOY_CONTROL_ROLLING_SUMMARY_FINAL_TREE=6a68fd8f88477811e220c042d5176e452241389f
 DEPLOY_CONTROL_ROLLING_SUMMARY_HELPER_TEST_PATH=ops/deploy/deploy-control-bridge-runtime-helper.test.sh
 DEPLOY_CONTROL_ROLLING_SUMMARY_RABBITMQ_TEST_PATH=ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+DEPLOY_CONTROL_ROLLING_REPAIR_BASE=1e411aeabd05502a1533a9536d8a75961bbdc929
+DEPLOY_CONTROL_ROLLING_REPAIR_TARGET=187335ca1881c0974218560d6147a21bcad8aa0c
+DEPLOY_CONTROL_ROLLING_REPAIR_TARGET_TREE=e25961c93dcfd09b669b1a2ab1c61274259346ee
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BASE=72e17ded1e54ebd77772929fd5047ef6816dded2
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE=92afd97328c5412324c99be635de2c41db589d53
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE=85c5d22febf1e7ce5fa5967d2460ccb73ca96a9d
@@ -395,8 +398,36 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
   [[ $target_delta == "$expected_target_delta" ]]
 }
 
+# Recover the exact reviewed rolling release after its synthetic transition
+# fixture proved too narrow for the real first-parent production graph. The
+# installed bridge is still constrained to one control-only commit, while the
+# admitted release is pinned by both commit and tree identity.
+deploy_control_is_reviewed_rolling_repair_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local bridge_delta target_tree
+  local -a bridge_ancestry=()
+
+  [[ $target == "$DEPLOY_CONTROL_ROLLING_REPAIR_TARGET" ]] || return 1
+  read -r -a bridge_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#bridge_ancestry[@]} == 2 && \
+     ${bridge_ancestry[1]} == "$DEPLOY_CONTROL_ROLLING_REPAIR_BASE" ]] || \
+    return 1
+  bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_ROLLING_REPAIR_BASE" "$bridge" -- 2>/dev/null) || \
+    return 1
+  [[ $bridge_delta == "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" ]] || return 1
+  target_tree=$(git -C "$repository" rev-parse "$target^{tree}" \
+    2>/dev/null) || return 1
+  [[ $target_tree == "$DEPLOY_CONTROL_ROLLING_REPAIR_TARGET_TREE" ]]
+}
+
 deploy_control_reviewed_transition_matches() {
   local bridge=$1 target=$2
+  if deploy_control_is_reviewed_rolling_repair_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
   if deploy_control_is_reviewed_current_main_release_b_transition \
       "$bridge" "$target"; then
     return 0

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -62,7 +62,8 @@ BRIDGE_CONTROL_PATHS=(
 
 assert_real_bridge_target_assets() {
   local path entry mode type object tree_path expected_digest alternate_digest reviewed_digest
-  local release_b_candidate_digest release_b_sealed_digest actual_digest actual_mode
+  local release_b_candidate_digest release_b_sealed_digest rolling_repair_digest
+  local actual_digest actual_mode
   local repository_root actual_path actual_real
 
   repository_root=$(readlink -f -- "$PROJECT_ROOT")
@@ -94,6 +95,7 @@ assert_real_bridge_target_assets() {
     reviewed_digest=
     release_b_candidate_digest=
     release_b_sealed_digest=
+    rolling_repair_digest=
     actual_digest=$(sha256sum "$actual_real" | awk '{print $1}')
     case $path in
       ops/deploy/social-monitor-production-deploy.sh)
@@ -116,6 +118,7 @@ assert_real_bridge_target_assets() {
         reviewed_digest=14ab26a66e982128770947a9b66a764cd4cef6eca1bb017c13f97819ae611a7a
         release_b_candidate_digest=bea119047fbbd2295185c84e0adeb773dc852e63b951daf5c7a831356a73a371
         release_b_sealed_digest=1718617b4bbb92f4dbfd92a59fcc482ef7a098734730b8460d21aaced44386c2
+        rolling_repair_digest=93128bd947b77c0920605c206f0ed20aa7f07ffd71b11c4ec5b6418a7a168781
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then
@@ -156,7 +159,8 @@ assert_real_bridge_target_assets() {
        (-n $alternate_digest && $actual_digest == "$alternate_digest") ||
        (-n $reviewed_digest && $actual_digest == "$reviewed_digest") ||
        (-n $release_b_candidate_digest && $actual_digest == "$release_b_candidate_digest") ||
-       (-n $release_b_sealed_digest && $actual_digest == "$release_b_sealed_digest") ]] || {
+       (-n $release_b_sealed_digest && $actual_digest == "$release_b_sealed_digest") ||
+       (-n $rolling_repair_digest && $actual_digest == "$rolling_repair_digest") ]] || {
       printf 'current bridge asset digest drifted from V4A4: %s\n' "$path" >&2
       exit 1
     }


### PR DESCRIPTION
## Summary
- add a control-only bridge reachable from main
- admit only the exact immutable rolling production target
- pin both target commit and tree identity

## Verification
- deploy control bridge runtime helper test
- source and test line cap
- exact target accepted, adjacent and unbridged targets rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating rolling repair deployments.
  * Deployment transitions now verify both the target commit and its tree identity.
  * Added safeguards to ensure rolling repairs use the approved repair base and control-only commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->