### PR TITLE
fix(rolling): validate accumulated daily coverage

### DIFF
--- a/ops/deploy/production-runtime/rolling-summary-receipt.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.mjs
@@ -413,7 +413,7 @@ function isCompleteObservation(
     isCompleteFreshness(
       observation.freshness,
       observation.slo,
-      observation.acceptedItemCount,
+      observation.slo.evaluatedItemCount,
       collectionDate,
       collectionCompletedAt,
     )
@@ -423,8 +423,7 @@ function isCompleteObservation(
 function isCompleteSlo(slo, observation) {
   if (
     !isRecord(slo) ||
-    slo.targetItemCount !== observation.targetItemCount ||
-    slo.evaluatedItemCount !== observation.acceptedItemCount
+    slo.targetItemCount !== observation.targetItemCount
   ) {
     return false;
   }
@@ -454,10 +453,10 @@ function expectedSloReasons(observation, slo) {
   const reasons = [];
   if (observation.targetItemCount === null || observation.targetItemCount <= 0) {
     reasons.push("target_missing");
-  } else if (observation.acceptedItemCount < observation.targetItemCount) {
+  } else if (slo.evaluatedItemCount < observation.targetItemCount) {
     reasons.push("target_shortfall");
   }
-  if (observation.acceptedItemCount > 0) {
+  if (slo.evaluatedItemCount > 0) {
     if (slo.freshnessLagSeconds === undefined) {
       reasons.push("freshness_missing");
     } else if (slo.freshnessLagSeconds > slo.maxFreshnessLagSeconds) {
@@ -474,7 +473,7 @@ function expectedSloReasons(observation, slo) {
     reasons.push("partial_retryable_failure");
   }
   if (
-    observation.acceptedItemCount === 0 &&
+    slo.evaluatedItemCount === 0 &&
     ["failed", "skipped"].includes(observation.paginationStopReason)
   ) {
     reasons.push("provider_unavailable");

--- a/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
@@ -54,6 +54,43 @@ try {
   );
   runFailure("validate-collection", priorCollectionPath, date);
 
+  const accumulatedCollectionPath = join(
+    directory,
+    "collection.accumulated.json",
+  );
+  const accumulatedCollection = collectionFixture();
+  accumulatedCollection.scans[0].observability.slo.evaluatedItemCount = 25;
+  accumulatedCollection.targetWindow.providerCounts["github-trending-page"] =
+    25;
+  accumulatedCollection.targetWindow.feedItemCount += 15;
+  writeFileSync(
+    accumulatedCollectionPath,
+    JSON.stringify(accumulatedCollection),
+  );
+  run("validate-collection", accumulatedCollectionPath, date);
+
+  const deduplicatedCollectionPath = join(
+    directory,
+    "collection.deduplicated.json",
+  );
+  const deduplicatedCollection = collectionFixture();
+  deduplicatedCollection.scans[0].observability.slo.evaluatedItemCount = 5;
+  deduplicatedCollection.scans[0].observability.slo.coverageRatio = 0.5;
+  deduplicatedCollection.scans[0].observability.slo.met = false;
+  deduplicatedCollection.scans[0].observability.slo.reasons = [
+    "target_shortfall",
+  ];
+  deduplicatedCollection.scans[0].observability.slo.retryDisposition =
+    "immediate";
+  deduplicatedCollection.targetWindow.providerCounts["github-trending-page"] =
+    5;
+  deduplicatedCollection.targetWindow.feedItemCount -= 5;
+  writeFileSync(
+    deduplicatedCollectionPath,
+    JSON.stringify(deduplicatedCollection),
+  );
+  run("validate-collection", deduplicatedCollectionPath, date);
+
   for (const [label, mutate] of [
     ["schema-less", (collection) => delete collection.schemaVersion],
     ["wrong schema", (collection) => (collection.schemaVersion = 2)],


### PR DESCRIPTION
Fixes the production rolling contract mismatch after repeated same-day collection. The SLO proof is cumulative for the full daily window, while acceptedItemCount belongs only to the current pass. The validator now checks reasons and freshness against the cumulative evaluated count already bound to targetWindow. Adds regression coverage for accumulated and deduplicated rolling passes.\n\nVerified: rolling receipt tests, rolling runner tests, daily schedule wiring, review CI contract, source line cap, and the prior real production collection artifact.