### PR TITLE
fix(summary): restore verifiable GitHub board evidence

### DIFF
--- a/libs/feed/adapters/persistence/prisma/prisma-feed-projection.adapter.spec.ts
+++ b/libs/feed/adapters/persistence/prisma/prisma-feed-projection.adapter.spec.ts
@@ -374,6 +374,7 @@ const githubProjectionSourceItem = (
         scanJobId: "scan-github-race",
         fetchStartedAt: new Date("2026-07-16T07:58:00.000Z"),
         checkedAt,
+        snapshotContentHash: "b".repeat(64),
         source: "fixture_github_trending_html",
       },
     }),

--- a/libs/ingestion/adapters/persistence/prisma/prisma-source-item.repository.spec.ts
+++ b/libs/ingestion/adapters/persistence/prisma/prisma-source-item.repository.spec.ts
@@ -2,6 +2,7 @@ import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
 
 import {
   githubTrendingPageRepositoryMetadata,
+  sourceItemProviderContentHash,
   SourceItem,
 } from "../../../domain";
 import { InMemorySourceItemRepository } from "../in-memory-source-item.repository";
@@ -217,6 +218,13 @@ describe("PrismaSourceItemRepository", () => {
     const memorySnapshot = memoryRetry.items[0]!.persistedItem.toSnapshot();
     const prismaSnapshot = prismaRetry.items[0]!.persistedItem.toSnapshot();
 
+    expect(
+      sourceItemProviderContentHash({
+        providerKey: "github-trending-page",
+        snapshot: first.toSnapshot(),
+      }),
+    ).toBe("b".repeat(64));
+
     expect(memoryRetry).toMatchObject({
       inserted: 0,
       contentUpdated: 0,
@@ -418,6 +426,7 @@ const githubSnapshotSourceItem = (params: {
         scanJobId: "scan-github-parity",
         fetchStartedAt,
         checkedAt: params.checkedAt,
+        snapshotContentHash: "b".repeat(64),
         source: "fixture_github_trending_html",
       },
     }),

--- a/libs/ingestion/adapters/source/github-trending-page/github-trending-page-canonical-board.ts
+++ b/libs/ingestion/adapters/source/github-trending-page/github-trending-page-canonical-board.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { GitHubTrendingPageRepository } from "./github-trending-page-client.port";
 
 export const maxGitHubTrendingCanonicalRepositories = 10;
@@ -37,6 +39,26 @@ export const canonicalGitHubTrendingRepositories = (
     )
     .map((repository, index) => ({ ...repository, rank: index + 1 }));
 };
+
+export const githubTrendingCanonicalBoardContentHash = (
+  repositories: readonly GitHubTrendingPageRepository[],
+): string =>
+  createHash("sha256")
+    .update(
+      JSON.stringify(
+        repositories.map((repository) => ({
+          fullName: repository.fullName,
+          url: repository.url,
+          description: repository.description ?? null,
+          language: repository.language ?? null,
+          totalStars: repository.totalStars,
+          forksCount: repository.forksCount,
+          rank: repository.rank,
+          starsGained: repository.starsGained,
+        })),
+      ),
+    )
+    .digest("hex");
 
 const compareDuplicateRepository = (
   left: GitHubTrendingPageRepository,

--- a/libs/ingestion/adapters/source/github-trending-page/github-trending-page-source.provider.spec.ts
+++ b/libs/ingestion/adapters/source/github-trending-page/github-trending-page-source.provider.spec.ts
@@ -236,6 +236,17 @@ describe("GitHubTrendingPageSourceProvider", () => {
     expect(board(forward.items).map((item) => item.rank)).toEqual([
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
     ]);
+    const snapshotHashes = (items: typeof forward.items) =>
+      items.map(
+        (item) =>
+          parseGitHubTrendingPageRepositoryMetadata(item.metadata)?.trending
+            .snapshotContentHash,
+      );
+    expect(new Set(snapshotHashes(forward.items)).size).toBe(1);
+    expect(snapshotHashes(forward.items)[0]).toMatch(/^[a-f0-9]{64}$/u);
+    expect(snapshotHashes(reversed.items)).toEqual(
+      snapshotHashes(forward.items),
+    );
   });
 
   it("excludes rank 11 from source admission even when maxItems is larger", async () => {

--- a/libs/ingestion/adapters/source/github-trending-page/github-trending-page-source.provider.ts
+++ b/libs/ingestion/adapters/source/github-trending-page/github-trending-page-source.provider.ts
@@ -22,7 +22,10 @@ import type {
   GitHubTrendingPageClientPort,
   GitHubTrendingPageRepository,
 } from "./github-trending-page-client.port";
-import { canonicalGitHubTrendingRepositories } from "./github-trending-page-canonical-board";
+import {
+  canonicalGitHubTrendingRepositories,
+  githubTrendingCanonicalBoardContentHash,
+} from "./github-trending-page-canonical-board";
 import {
   assertGitHubTrendingSnapshotTimeInWindow,
   githubTrendingDailySnapshotWindow,
@@ -137,6 +140,8 @@ export class GitHubTrendingPageSourceProvider implements SourceProviderPort {
       repositories.filter(isUsableTrendingRepository),
       plan.maxItems,
     );
+    const snapshotContentHash =
+      githubTrendingCanonicalBoardContentHash(validRepositories);
 
     return {
       items: validRepositories.map((repository) =>
@@ -146,6 +151,7 @@ export class GitHubTrendingPageSourceProvider implements SourceProviderPort {
           scanJobId,
           fetchStartedAt,
           checkedAt,
+          snapshotContentHash,
           source: config.source,
         }),
       ),
@@ -236,6 +242,7 @@ const normalizeRepository = (params: {
   readonly scanJobId: string;
   readonly fetchStartedAt: Date;
   readonly checkedAt: Date;
+  readonly snapshotContentHash: string;
   readonly source: GitHubTrendingPageRepositoryMetadataInput["trending"]["source"];
 }): FetchedSourceItem => {
   const {
@@ -244,6 +251,7 @@ const normalizeRepository = (params: {
     scanJobId,
     fetchStartedAt,
     checkedAt,
+    snapshotContentHash,
     source,
   } = params;
   const metadata = githubTrendingPageRepositoryMetadata({
@@ -262,6 +270,7 @@ const normalizeRepository = (params: {
       scanJobId,
       fetchStartedAt,
       checkedAt,
+      snapshotContentHash,
       source,
     },
   });

--- a/libs/ingestion/domain/value-objects/github-trending-page.ts
+++ b/libs/ingestion/domain/value-objects/github-trending-page.ts
@@ -32,6 +32,7 @@ export type GitHubTrendingPageRepositoryMetadataInput = {
     readonly scanJobId: string;
     readonly fetchStartedAt: Date;
     readonly checkedAt: Date;
+    readonly snapshotContentHash: string;
     readonly source: 'github_trending_html' | 'fixture_github_trending_html';
   };
 };
@@ -53,6 +54,7 @@ export type GitHubTrendingPageRepositoryMetadata = {
     readonly scanJobId: string;
     readonly fetchStartedAt: string;
     readonly checkedAt: string;
+    readonly snapshotContentHash: string;
     readonly source: string;
   };
 };
@@ -81,6 +83,7 @@ export const githubTrendingPageRepositoryMetadata = (
       scanJobId: input.trending.scanJobId,
       fetchStartedAt: input.trending.fetchStartedAt.toISOString(),
       checkedAt: input.trending.checkedAt.toISOString(),
+      snapshotContentHash: input.trending.snapshotContentHash,
       source: input.trending.source,
     },
   });
@@ -104,6 +107,7 @@ export const parseGitHubTrendingPageRepositoryMetadata = (
   const scanJobId = readString(trending.scanJobId);
   const fetchStartedAt = readExactIsoDateString(trending.fetchStartedAt);
   const checkedAt = readExactIsoDateString(trending.checkedAt);
+  const snapshotContentHash = readSha256(trending.snapshotContentHash);
   const window = readWindow(trending.window);
   const totalStars = readNonNegativeInteger(repository.totalStars);
   const forksCount = readNonNegativeInteger(repository.forksCount);
@@ -116,6 +120,7 @@ export const parseGitHubTrendingPageRepositoryMetadata = (
     scanJobId === undefined ||
     fetchStartedAt === undefined ||
     checkedAt === undefined ||
+    snapshotContentHash === undefined ||
     window === undefined ||
     totalStars === undefined ||
     forksCount === undefined ||
@@ -143,6 +148,7 @@ export const parseGitHubTrendingPageRepositoryMetadata = (
       scanJobId,
       fetchStartedAt,
       checkedAt,
+      snapshotContentHash,
       source: readString(trending.source) ?? 'unknown',
     },
   };
@@ -164,6 +170,7 @@ type GitHubSnapshotEnvelope = {
   readonly checkedAt: string;
   readonly publishedAt: string;
   readonly observedAt: string;
+  readonly snapshotContentHash: string;
 };
 
 export const assertGitHubTrendingSnapshotBatchIntegrity = (params: {
@@ -207,7 +214,8 @@ export const assertGitHubTrendingSnapshotBatchIntegrity = (params: {
         envelope.fetchStartedAt !== first.fetchStartedAt ||
         envelope.checkedAt !== first.checkedAt ||
         envelope.publishedAt !== first.publishedAt ||
-        envelope.observedAt !== first.observedAt,
+        envelope.observedAt !== first.observedAt ||
+        envelope.snapshotContentHash !== first.snapshotContentHash,
     ) ||
     ranks.some((rank, index) => rank !== index + 1) ||
     new Set(ranks).size !== ranks.length ||
@@ -317,6 +325,7 @@ const assertGitHubTrendingSnapshotIntegrity = (
     checkedAt: metadata.trending.checkedAt,
     publishedAt: publishedAt.toISOString(),
     observedAt: observedAt.toISOString(),
+    snapshotContentHash: metadata.trending.snapshotContentHash,
   };
 };
 
@@ -333,6 +342,13 @@ const readString = (value: unknown): string | undefined =>
   typeof value === 'string' && value.trim().length > 0
     ? value.trim()
     : undefined;
+
+const readSha256 = (value: unknown): string | undefined => {
+  const text = readString(value);
+  return text !== undefined && /^[a-f0-9]{64}$/u.test(text)
+    ? text
+    : undefined;
+};
 
 const readExactIsoDateString = (value: unknown): string | undefined => {
   const text = readString(value);

--- a/libs/ingestion/domain/value-objects/source-item-content-fingerprint.ts
+++ b/libs/ingestion/domain/value-objects/source-item-content-fingerprint.ts
@@ -2,6 +2,10 @@ import { createHash } from "node:crypto";
 
 import type { SourceItemProps } from "../entities/source-item";
 import {
+  GITHUB_TRENDING_PAGE_PROVIDER_KEY,
+  parseGitHubTrendingPageRepositoryMetadata,
+} from "./github-trending-page";
+import {
   buildSourceEngagementMetrics,
   sourceMetadataWithoutEngagementAndVolatileProvenance,
 } from "./source-engagement-metrics";
@@ -25,6 +29,14 @@ export const sourceItemProviderContentHash = (params: {
   readonly providerKey: string;
   readonly snapshot: SourceItemProps;
 }): string => {
+  if (params.providerKey === GITHUB_TRENDING_PAGE_PROVIDER_KEY) {
+    const metadata = parseGitHubTrendingPageRepositoryMetadata(
+      params.snapshot.metadata,
+    );
+    if (metadata !== null) {
+      return metadata.trending.snapshotContentHash;
+    }
+  }
   const engagement = buildSourceEngagementMetrics({
     providerKey: params.providerKey,
     metadata: params.snapshot.metadata,

--- a/libs/summary/adapters/context/reader-summary-artifact-context.provider.spec.ts
+++ b/libs/summary/adapters/context/reader-summary-artifact-context.provider.spec.ts
@@ -237,15 +237,12 @@ const publishContextArtifact = async (
             projectionCheckedAt: projectionCheckedAt.toISOString(),
             telemetry: {
               github_projection_collection_delay_ms: 0,
-              collectionGraceMs:
-                readerSummaryGitHubProjectionCollectionGraceMs,
+              collectionGraceMs: readerSummaryGitHubProjectionCollectionGraceMs,
               warningThresholdMs:
                 readerSummaryGitHubProjectionCollectionWarningThresholdMs,
               qualitySignal: "within_grace",
             },
-            bindings: githubContextCitations()
-              .slice(0, 3)
-              .map((citation, index) => ({
+            bindings: githubContextCitations().map((citation, index) => ({
               selectedPostIndex: index,
               rank: index + 1,
               citationId: citation.citationId,
@@ -264,7 +261,7 @@ const publishContextArtifact = async (
               observedAt: projectionCheckedAt.toISOString(),
               sourceContentHash: "a".repeat(64),
               sourceProviderContentHash: "b".repeat(64),
-              })),
+            })),
             violationCodes: [],
             reasons: [],
           },

--- a/libs/summary/adapters/model/reader-summary-no-signal-github-board.spec.ts
+++ b/libs/summary/adapters/model/reader-summary-no-signal-github-board.spec.ts
@@ -111,7 +111,16 @@ const expectCanonicalGitHubOnlyNoSignalArticle = async (
       citationIds: ["c1", "c2", "c3"],
     }),
   ]);
-  expect(content?.selectedPosts).toEqual([]);
+  expect(content?.selectedPosts).toHaveLength(10);
+  expect(content?.selectedPosts?.map((post) => post.title)).toEqual(
+    Array.from(
+      { length: 10 },
+      (_, index) => `example/repository-${index + 1}`,
+    ),
+  );
+  expect(content?.selectedPosts?.map((post) => post.citationIds)).toEqual(
+    Array.from({ length: 10 }, (_, index) => [`c${index + 1}`]),
+  );
 
   assertReaderSummaryCitationsAgainstEvidence(attempt.draft, input.evidence);
   const artifact = ReaderSummaryArtifact.create({

--- a/libs/summary/adapters/persistence/in-memory-reader-summary-publication.spec.ts
+++ b/libs/summary/adapters/persistence/in-memory-reader-summary-publication.spec.ts
@@ -42,9 +42,9 @@ describe("InMemoryReaderSummaryPublication", () => {
           },
         }),
       ).rejects.toThrow("idempotency conflict");
-      await expect(
-        context.artifacts.findById(fixture.identity),
-      ).resolves.toBe(fixture.command.artifact);
+      await expect(context.artifacts.findById(fixture.identity)).resolves.toBe(
+        fixture.command.artifact,
+      );
       expect(context.events.all()).toHaveLength(1);
       expect(context.jobs.all()).toHaveLength(1);
     },
@@ -69,7 +69,9 @@ describe("InMemoryReaderSummaryPublication", () => {
     await expect(context.artifacts.findById(left.identity)).resolves.toBe(
       left.command.artifact,
     );
-    await expect(context.artifacts.findById(right.identity)).resolves.toBeNull();
+    await expect(
+      context.artifacts.findById(right.identity),
+    ).resolves.toBeNull();
   });
 
   it("rejects a mismatched ready event before a candidate becomes visible", async () => {
@@ -86,7 +88,9 @@ describe("InMemoryReaderSummaryPublication", () => {
     await expect(context.publication.publish(invalid)).rejects.toThrow(
       "exact publication binding",
     );
-    await expect(context.artifacts.findById(fixture.identity)).resolves.toBeNull();
+    await expect(
+      context.artifacts.findById(fixture.identity),
+    ).resolves.toBeNull();
     expect(context.events.all()).toHaveLength(0);
   });
 
@@ -152,8 +156,7 @@ describe("InMemoryReaderSummaryPublication", () => {
         telemetry: {
           github_projection_collection_delay_ms:
             readerSummaryGitHubProjectionCollectionWarningThresholdMs,
-          collectionGraceMs:
-            readerSummaryGitHubProjectionCollectionGraceMs,
+          collectionGraceMs: readerSummaryGitHubProjectionCollectionGraceMs,
           warningThresholdMs:
             readerSummaryGitHubProjectionCollectionWarningThresholdMs,
           qualitySignal: "github_projection_collection_delay_warning",
@@ -176,7 +179,9 @@ describe("InMemoryReaderSummaryPublication", () => {
     await expect(context.publication.publish(invalid)).rejects.toThrow(
       "exact verified GitHub projection audit",
     );
-    await expect(context.artifacts.findById(fixture.identity)).resolves.toBeNull();
+    await expect(
+      context.artifacts.findById(fixture.identity),
+    ).resolves.toBeNull();
     expect(context.events.all()).toEqual([]);
     expect(context.jobs.all()).toHaveLength(1);
     expect(context.jobs.all()[0]?.toSnapshot().status).toBe("running");
@@ -232,14 +237,14 @@ const createFixture = (params: {
   const jobId = `10000000-0000-4000-8000-${suffix}`;
   const artifactId = `20000000-0000-4000-8000-${suffix}`;
   const eventId = `30000000-0000-4000-8000-${suffix}`;
-  const requestedAt = params.requestedAt ?? new Date("2026-07-05T10:00:00.000Z");
+  const requestedAt =
+    params.requestedAt ?? new Date("2026-07-05T10:00:00.000Z");
   const period = {
     cadence: "daily" as const,
     startedAt: new Date("2026-07-05T00:00:00.000Z"),
     endedAt: new Date("2026-07-06T00:00:00.000Z"),
     timezone: "UTC",
-    periodKey:
-      "daily:2026-07-05T00:00:00.000Z:2026-07-06T00:00:00.000Z:UTC",
+    periodKey: "daily:2026-07-05T00:00:00.000Z:2026-07-06T00:00:00.000Z:UTC",
   };
   const scope = { type: "workspace" as const };
   const noSignal = params.semanticStatus === "NO_SIGNAL";
@@ -432,7 +437,7 @@ const createFixture = (params: {
                 ? ("github_projection_collection_delay_warning" as const)
                 : ("within_grace" as const),
           },
-          bindings: githubCitations.slice(0, 3).map((citation, index) => {
+          bindings: githubCitations.map((citation, index) => {
             const rank = index + 1;
             return {
               selectedPostIndex: index,

--- a/libs/summary/adapters/persistence/prisma/prisma-reader-summary-artifact.repository.spec.ts
+++ b/libs/summary/adapters/persistence/prisma/prisma-reader-summary-artifact.repository.spec.ts
@@ -305,7 +305,7 @@ describe("PrismaReaderSummaryArtifactRepository", () => {
     ).toMatchObject({ githubProjectionAudit });
     expect(
       githubProjectionAudit.bindings.map((binding) => binding.rank),
-    ).toEqual([1, 2, 3]);
+    ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     expect(
       new Set(
         githubProjectionAudit.bindings.map((binding) => binding.scanJobId),
@@ -770,7 +770,7 @@ const verifiedGitHubProjectionAudit =
       warningThresholdMs: 240_000,
       qualitySignal: "within_grace",
     },
-    bindings: Array.from({ length: 3 }, (_, index) => {
+    bindings: Array.from({ length: 10 }, (_, index) => {
       const rank = index + 1;
       return {
         selectedPostIndex: index,

--- a/libs/summary/domain/aggregates/reader-summary-github-trending.spec.ts
+++ b/libs/summary/domain/aggregates/reader-summary-github-trending.spec.ts
@@ -1,7 +1,7 @@
 import { buildReaderSummary } from "./reader-summary";
 
 describe("reader summary GitHub Trending projection", () => {
-  it("keeps legacy GitHub Trending page evidence out of every reader lane", () => {
+  it("materializes the canonical GitHub Trending Top 10 without promoting it to editorial lanes", () => {
     const ranks = [...Array.from({ length: 10 }, (_, index) => index + 1), 12];
     const readerSummary = buildReaderSummary({
       headline: "GitHub Trending today",
@@ -95,7 +95,14 @@ describe("reader summary GitHub Trending projection", () => {
         citationIds: ["citation-1", "citation-2", "citation-3"],
       }),
     ]);
-    expect(readerSummary.selectedPosts).toEqual([]);
+    expect(readerSummary.selectedPosts).toHaveLength(10);
+    expect(readerSummary.selectedPosts.map((post) => post.title)).toEqual(
+      Array.from({ length: 10 }, (_, index) =>
+        index === 0
+          ? "calesthio/OpenMontage"
+          : `example/repository-${index + 1}`,
+      ),
+    );
   });
 
   it("removes authored Watch evidence outside the canonical Top 10", () => {

--- a/libs/summary/domain/aggregates/reader-summary-github-trending.spec.ts
+++ b/libs/summary/domain/aggregates/reader-summary-github-trending.spec.ts
@@ -96,7 +96,9 @@ describe("reader summary GitHub Trending projection", () => {
       }),
     ]);
     expect(readerSummary.selectedPosts).toHaveLength(10);
-    expect(readerSummary.selectedPosts.map((post) => post.title)).toEqual(
+    expect(
+      (readerSummary.selectedPosts ?? []).map((post) => post.title),
+    ).toEqual(
       Array.from({ length: 10 }, (_, index) =>
         index === 0
           ? "calesthio/OpenMontage"

--- a/libs/summary/domain/aggregates/reader-summary.ts
+++ b/libs/summary/domain/aggregates/reader-summary.ts
@@ -34,8 +34,7 @@ import type {
   SummaryEvidenceItem,
   SummarySourceWindow,
 } from "../value-objects/summary-evidence-item";
-import { readerSummaryIndependentProviderFamilyCount } from
-  "../value-objects/reader-summary-provider-identity";
+import { readerSummaryIndependentProviderFamilyCount } from "../value-objects/reader-summary-provider-identity";
 import type { ReaderSummaryQualityFlag } from "../value-objects/summary-quality";
 import {
   compactUnique,
@@ -53,6 +52,7 @@ import { fallbackReaderSummarySourceWindow } from "../services/reader-summary-fa
 import { buildOpenQuestions } from "./reader-summary-open-questions";
 import { buildReaderSummaryClaimBoard } from "../services/reader-summary-claim-board";
 import { buildReaderSummaryTrendDelta } from "../services/reader-summary-trend-delta";
+import { buildReaderSummarySupplementalTrendSelectedPosts } from "../services/reader-summary-supplemental-selected-posts";
 
 export type ReaderSummaryFactoryInput = {
   readonly headline: string;
@@ -87,12 +87,19 @@ export class ReaderSummary {
       evidence: primarySelectedEvidence,
       clusters: input.storyClusters,
       citations: input.citationMap,
-      sourceWindow: input.sourceWindow ??
-        fallbackReaderSummarySourceWindow(primarySelectedEvidence, input.storyClusters),
+      sourceWindow:
+        input.sourceWindow ??
+        fallbackReaderSummarySourceWindow(
+          primarySelectedEvidence,
+          input.storyClusters,
+        ),
       approvedSameStoryRelations: input.approvedSameStoryRelations,
       relatedTopicRelations: input.relatedTopicRelations,
     });
-    if (promotion.topReads.length === 0 && promotion.additionalPosts.length === 0) {
+    if (
+      promotion.topReads.length === 0 &&
+      promotion.additionalPosts.length === 0
+    ) {
       return ReaderSummary.create(buildNoSignalReaderSummary(input));
     }
     const primaryInput = {
@@ -114,7 +121,13 @@ export class ReaderSummary {
       input.qualityFlags,
       sourceMix,
     );
-    const selectedPosts = promotion.additionalPosts;
+    const selectedPosts = [
+      ...promotion.additionalPosts,
+      ...buildReaderSummarySupplementalTrendSelectedPosts({
+        selectedEvidence: input.selectedEvidence ?? [],
+        citations: input.citationMap,
+      }),
+    ];
     const headline = input.headline;
     const narrativeSections = input.narrativeSections ?? [];
     const primaryCitationMap = promotion.admittedCitations;
@@ -124,17 +137,20 @@ export class ReaderSummary {
     const admittedClusterIds = new Set(
       promotion.admittedClusters.map((cluster) => cluster.id),
     );
-    const admittedInterestHighlights = input.interestHighlights.flatMap((highlight) => {
-      const citationIds = highlight.citationIds.filter((citationId) =>
-        admittedCitationIds.has(citationId),
-      );
-      return citationIds.length === 0 ? [] : [{ ...highlight, citationIds }];
-    });
+    const admittedInterestHighlights = input.interestHighlights.flatMap(
+      (highlight) => {
+        const citationIds = highlight.citationIds.filter((citationId) =>
+          admittedCitationIds.has(citationId),
+        );
+        return citationIds.length === 0 ? [] : [{ ...highlight, citationIds }];
+      },
+    );
     const admittedRepeatedSignals = input.repeatedSignals.flatMap((signal) => {
       const citationIds = signal.citationIds.filter((citationId) =>
         admittedCitationIds.has(citationId),
       );
-      return !admittedClusterIds.has(signal.storyClusterId) || citationIds.length === 0
+      return !admittedClusterIds.has(signal.storyClusterId) ||
+        citationIds.length === 0
         ? []
         : [{ ...signal, citationIds }];
     });
@@ -145,7 +161,8 @@ export class ReaderSummary {
       return citationIds.length === 0 ? [] : [{ ...risk, citationIds }];
     });
     const primaryNarrativeSections = withoutSupplementalTrendNarrativeSections(
-      narrativeSections, input.citationMap,
+      narrativeSections,
+      input.citationMap,
     ).flatMap((section) => {
       const citationIds = section.citationIds.filter((citationId) =>
         admittedCitationIds.has(citationId),
@@ -164,8 +181,9 @@ export class ReaderSummary {
         headline,
         sourceMix,
         topReads,
-        ...(narrativeSections.some((section) =>
-          section.kind === "lead" && section.storyClusterId === undefined
+        ...(narrativeSections.some(
+          (section) =>
+            section.kind === "lead" && section.storyClusterId === undefined,
         )
           ? {
               thematicSynthesisSupport: {
@@ -182,12 +200,15 @@ export class ReaderSummary {
         topReads,
         sourceMix,
       }),
-      bullets: buildReaderSummaryBullets({
-        ...readerInput,
-        interestHighlights: admittedInterestHighlights,
-        repeatedSignals: admittedRepeatedSignals,
-        risksAndUnknowns: admittedRisks,
-      }, topReads),
+      bullets: buildReaderSummaryBullets(
+        {
+          ...readerInput,
+          interestHighlights: admittedInterestHighlights,
+          repeatedSignals: admittedRepeatedSignals,
+          risksAndUnknowns: admittedRisks,
+        },
+        topReads,
+      ),
       narrativeSections: publishedNarrativeSections,
       mainTopics: buildReaderSummaryMainTopics({
         headline,
@@ -274,6 +295,10 @@ const buildNoSignalReaderSummary = (
     evidence: input.selectedEvidence ?? [],
     citations: input.citationMap,
   });
+  const selectedPosts = buildReaderSummarySupplementalTrendSelectedPosts({
+    selectedEvidence: input.selectedEvidence ?? [],
+    citations: input.citationMap,
+  });
   return {
     headline: "No reliable workspace signal yet",
     oneLineTakeaway: reason,
@@ -295,7 +320,7 @@ const buildNoSignalReaderSummary = (
     interestSections: [],
     sourceMix: [],
     topReads: [],
-    selectedPosts: [],
+    selectedPosts,
     claimBoard: [],
     reliabilityReport: emptyReaderSummaryReliabilityReport(),
     trendDelta: {
@@ -330,7 +355,10 @@ const reliabilitySelectionFromInput = (
       input.storyClusters[0]?.rankingPolicyVersion ?? "unknown",
     sourceWindow:
       input.sourceWindow ??
-      fallbackReaderSummarySourceWindow(input.selectedEvidence, input.storyClusters),
+      fallbackReaderSummarySourceWindow(
+        input.selectedEvidence,
+        input.storyClusters,
+      ),
     clusters: input.storyClusters,
     selectedEvidence: input.selectedEvidence,
   };

--- a/libs/summary/domain/policies/reader-summary-github-projection-audit.ts
+++ b/libs/summary/domain/policies/reader-summary-github-projection-audit.ts
@@ -7,7 +7,6 @@ import { normalizeGitHubRepositoryFullName } from "../value-objects/github-repos
 import {
   githubTrendingNarrativeSectionId,
   githubTrendingProviderKey,
-  maxGitHubTrendingHighlights,
   maxGitHubTrendingDisplayRepositories,
 } from "./reader-summary-github-trending-policy";
 import {
@@ -326,7 +325,7 @@ export const readerSummaryHasVerifiedGitHubProjection = (params: {
     !exactIsoInstant(params.audit.observedThrough) ||
     !Number.isFinite(observedThrough.getTime()) ||
     projectionCheckedAt.getTime() > observedThrough.getTime() ||
-    params.audit.bindings.length > maxGitHubTrendingHighlights
+    params.audit.bindings.length !== maxGitHubTrendingDisplayRepositories
   ) {
     return false;
   }

--- a/libs/summary/domain/policies/reader-summary-github-projection-policy.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-github-projection-policy.spec.ts
@@ -19,21 +19,9 @@ import {
 const projectionDayEndedAt = new Date("2026-07-11T00:00:00.000Z");
 
 describe("reader summary GitHub projection policy", () => {
-  it("verifies the ordered appendix against one exact durable rank #1 through #10 board", () => {
-    const artifact = boardArtifact({
-      watchRanks: [1, 2, 3],
-      watchText: [
-        "- **owner/repo-1** (#1): +1,001 stars today.",
-        "- **owner/repo-2** (#2): +1,002 stars today.",
-        "- **owner/repo-3** (#3): +1,003 stars today.",
-      ].join("\n"),
-    });
-    const evaluation = evaluate(
-      artifact,
-      projectionInput().map((item) => item.rank !== undefined && item.rank <= 3
-        ? { ...item, starsGained: 1_000 + item.rank }
-        : item),
-    );
+  it("verifies one exact durable rank #1 through #10 board", () => {
+    const artifact = boardArtifact();
+    const evaluation = evaluate(artifact, projectionInput());
 
     expect(evaluation.findings).toEqual([]);
     expect(evaluation.audit).toMatchObject({
@@ -44,9 +32,9 @@ describe("reader summary GitHub projection policy", () => {
       eligibleBindingIds: ["github-binding-a"],
       projectionCheckedAt: "2026-07-10T12:00:00.000Z",
     });
-    expect(evaluation.audit.bindings).toHaveLength(3);
+    expect(evaluation.audit.bindings).toHaveLength(10);
     expect(evaluation.audit.bindings.map((binding) => binding.rank)).toEqual([
-      1, 2, 3,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
     ]);
     expect(evaluation.audit.bindings[0]).toMatchObject({
       feedItemId: "github-feed-1",
@@ -69,7 +57,7 @@ describe("reader summary GitHub projection policy", () => {
     const evaluation = evaluate(artifact, projectionInput());
 
     expect(evaluation.audit.status).toBe("verified");
-    expect(evaluation.audit.bindings).toHaveLength(0);
+    expect(evaluation.audit.bindings).toHaveLength(10);
     expect(
       readerSummaryHasVerifiedGitHubProjection({
         artifact,
@@ -89,7 +77,7 @@ describe("reader summary GitHub projection policy", () => {
 
     expect(evaluation.audit.status).toBe("verified");
     expect(evaluation.audit.scannedItemCount).toBe(10);
-    expect(evaluation.audit.bindings).toHaveLength(1);
+    expect(evaluation.audit.bindings).toHaveLength(10);
     expect(
       artifact
         .toSnapshot()
@@ -170,13 +158,16 @@ describe("reader summary GitHub projection policy", () => {
     );
   });
 
-  it("does not require a legacy selectedPosts board when the durable board is complete", () => {
+  it("rejects a partial selectedPosts board when an eligible binding exists", () => {
     const evaluation = evaluate(
       boardArtifact({ selectedPostCount: 5 }),
       projectionInput(),
     );
 
-    expect(evaluation.audit.status).toBe("verified");
+    expect(evaluation.audit.status).toBe("rejected");
+    expect(evaluation.audit.violationCodes).toContain(
+      "github_projection_missing",
+    );
   });
 
   it.each(["missing", "divergent"] as const)(
@@ -338,7 +329,7 @@ describe("reader summary GitHub projection policy", () => {
     );
   });
 
-  it("uses the newest complete durable snapshot", () => {
+  it("rejects a complete older selection when a newer board exists", () => {
     const selectedSnapshot = projectionInput();
     const newerSnapshot = Array.from({ length: 10 }, (_, index) =>
       projectionItem(index + 1, {
@@ -355,10 +346,9 @@ describe("reader summary GitHub projection policy", () => {
       ...newerSnapshot,
     ]);
 
-    expect(evaluation.audit).toMatchObject({
-      status: "verified",
-      projectionCheckedAt: "2026-07-10T13:00:00.000Z",
-    });
+    expect(evaluation.audit.violationCodes).toContain(
+      "github_projection_stale",
+    );
   });
 
   it("keeps the latest complete board when a newer scan is only partial", () => {
@@ -378,6 +368,7 @@ describe("reader summary GitHub projection policy", () => {
     ]);
 
     expect(evaluation.audit.status).toBe("verified");
+    expect(evaluation.audit.bindings).toHaveLength(10);
   });
 
   it("uses checkedAt rather than a late observation to choose the canonical board", () => {
@@ -424,7 +415,7 @@ describe("reader summary GitHub projection policy", () => {
     );
 
     expect(evaluation.audit.status).toBe("verified");
-    expect(evaluation.audit.bindings).toEqual([]);
+    expect(evaluation.audit.bindings).toHaveLength(10);
   });
 
   it("validates the coherent latest snapshot without rejecting stale invalid history", () => {
@@ -467,11 +458,11 @@ describe("reader summary GitHub projection policy", () => {
       scannedItemCount: 20,
       projectionCheckedAt: latestCheckedAt.toISOString(),
     });
-    expect(evaluation.audit.bindings).toEqual([]);
+    expect(evaluation.audit.bindings).toHaveLength(10);
     expect(
       evaluation.audit.bindings.map((binding) => binding.feedItemId),
     ).toEqual(
-      [],
+      Array.from({ length: 10 }, (_, index) => `github-feed-${index + 1}`),
     );
   });
 
@@ -811,13 +802,15 @@ describe("reader summary GitHub projection policy", () => {
     ]);
   });
 
-  it("ignores legacy selectedPost citation identities", () => {
+  it("rejects a selected post that carries an extra citation identity", () => {
     const evaluation = evaluate(
       boardArtifact({ firstSelectedPostHasExtraCitation: true }),
       projectionInput(),
     );
 
-    expect(evaluation.audit.status).toBe("verified");
+    expect(evaluation.audit.violationCodes).toContain(
+      "github_projection_identity_invalid",
+    );
   });
 
   it("requires both durable source item fingerprints", () => {

--- a/libs/summary/domain/policies/reader-summary-github-projection-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-github-projection-policy.ts
@@ -2,6 +2,7 @@ import type { ReaderSummaryArtifact } from "../entities/reader-summary-artifact"
 import {
   buildReaderSummaryGitHubProjectionCollectionTelemetry,
   exactUtcDay,
+  isGitHubReaderItem,
   nonEmpty,
   readerSummaryHasNoPrimaryGitHubEvidence,
   readerSummaryIsOrdinaryNoSignalWithoutEvidence,
@@ -24,7 +25,8 @@ import {
   projectionGroupEnvelopeIsCoherent,
   projectionGroupKey,
   projectionSetFindings,
-  resolveAppendixCandidates,
+  resolveSelectedCandidate,
+  selectedPostsFollowProjection,
   supplementalNarrativeFindings,
 } from "./reader-summary-github-projection-set";
 import { maxGitHubTrendingDisplayRepositories } from "./reader-summary-github-trending-policy";
@@ -253,6 +255,16 @@ export const evaluateReaderSummaryGitHubProjection = (params: {
     );
   }
 
+  const selectedPosts = (snapshot.content?.selectedPosts ?? []).filter(
+    isGitHubReaderItem,
+  );
+  if (selectedPosts.length !== maxGitHubTrendingDisplayRepositories) {
+    findings.push({
+      code: "github_projection_missing",
+      reason: `selectedPosts must contain exactly ${maxGitHubTrendingDisplayRepositories} GitHub Trending repositories and no supplemental GitHub entries.`,
+    });
+  }
+
   const citationById = new Map(
     snapshot.citationMap.map(
       (citation) => [citation.citationId, citation] as const,
@@ -265,25 +277,79 @@ export const evaluateReaderSummaryGitHubProjection = (params: {
         "GitHub Trending evidence is supplemental and cannot support primary headlines, bullets, topics, claims, source mix, or top reads.",
     });
   }
+  const selectedReferencesOlderGroup = selectedPosts.some((post) =>
+    post.citationIds.some((citationId) => {
+      const citation = citationById.get(citationId);
+      if (citation === undefined) {
+        return false;
+      }
+      return requestedDayItems.some((item) => {
+        const canonicalGroupKey = canonicalGroupKeyByBindingId.get(
+          item.sourceBindingId,
+        );
+        return (
+          eligibleBindingIdSet.has(item.sourceBindingId) &&
+          item.feedItemId === citation.feedItemId &&
+          item.sourceItemId === citation.sourceItemId &&
+          canonicalGroupKey !== undefined &&
+          projectionGroupKey(item) !== canonicalGroupKey
+        );
+      });
+    }),
+  );
+  if (selectedReferencesOlderGroup) {
+    findings.push({
+      code: "github_projection_stale",
+      reason:
+        "GitHub selectedPosts is bound to an older durable projection snapshot.",
+    });
+  }
+  const selectedCandidates = selectedPosts.flatMap((post, index) => {
+    const resolved = resolveSelectedCandidate({
+      post,
+      selectedPostIndex: index,
+      citationById,
+      candidates,
+    });
+    if (resolved === undefined) {
+      findings.push({
+        code: "github_projection_identity_invalid",
+        reason: `GitHub selectedPosts entry ${index + 1} does not bind one durable feed/source identity.`,
+      });
+      return [];
+    }
+    return [resolved];
+  });
+
+  const selectedGroupKeys = new Set(
+    selectedCandidates.map((candidate) => candidate.groupKey),
+  );
+  if (selectedGroupKeys.size > 1) {
+    findings.push({
+      code: "github_projection_mixed",
+      reason:
+        "GitHub selectedPosts mixes source bindings or projection snapshots.",
+    });
+  }
+  const selectedGroupKey =
+    selectedGroupKeys.size === 1 ? [...selectedGroupKeys][0] : undefined;
   const selectedBindingId =
     eligibleBindingIds.length === 1 ? eligibleBindingIds[0] : undefined;
   const latestGroupKey =
     selectedBindingId === undefined
       ? undefined
       : canonicalGroupKeyByBindingId.get(selectedBindingId);
-  const selectedGroupKey = latestGroupKey;
-  const selectedCandidates = selectedGroupKey === undefined
-    ? []
-    : resolveAppendixCandidates({
-        artifact: params.artifact,
-        citationById,
-        candidates,
-        selectedGroupKey,
-      });
-  if (selectedCandidates === undefined) findings.push({
-    code: "github_projection_identity_invalid",
-    reason: "GitHub Trending appendix does not bind the ordered durable projection.",
-  });
+  if (
+    selectedGroupKey !== undefined &&
+    latestGroupKey !== undefined &&
+    selectedGroupKey !== latestGroupKey
+  ) {
+    findings.push({
+      code: "github_projection_stale",
+      reason:
+        "GitHub selectedPosts is bound to an older durable projection snapshot.",
+    });
+  }
 
   const groupCandidates =
     selectedGroupKey === undefined
@@ -297,6 +363,13 @@ export const evaluateReaderSummaryGitHubProjection = (params: {
       candidate.item.rank <= maxGitHubTrendingDisplayRepositories,
   );
   findings.push(...projectionSetFindings(topTenCandidates));
+  if (!selectedPostsFollowProjection(selectedCandidates, topTenCandidates)) {
+    findings.push({
+      code: "github_projection_mixed",
+      reason:
+        "GitHub selectedPosts must preserve the durable canonical order #1 through #10.",
+    });
+  }
   findings.push(
     ...supplementalNarrativeFindings({
       artifact: params.artifact,
@@ -317,7 +390,7 @@ export const evaluateReaderSummaryGitHubProjection = (params: {
     });
   }
 
-  const bindings = (selectedCandidates ?? []).map(projectionBinding);
+  const bindings = selectedCandidates.map(projectionBinding);
   return {
     audit: baseAudit({
       status: "verified",

--- a/libs/summary/domain/policies/reader-summary-publication-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-publication-policy.ts
@@ -1,22 +1,24 @@
-import type { ReaderSummaryArtifact, ReaderSummaryContent } from "../entities/reader-summary-artifact";
+import type {
+  ReaderSummaryArtifact,
+  ReaderSummaryContent,
+} from "../entities/reader-summary-artifact";
 import type { SummaryEvidenceSelection } from "../value-objects/summary-evidence-item";
 import type { ReaderSummaryCitation } from "../entities/citation";
-import { readerSummaryIndependentProviderFamilyCount } from
-  "../value-objects/reader-summary-provider-identity";
+import { readerSummaryIndependentProviderFamilyCount } from "../value-objects/reader-summary-provider-identity";
 import {
   buildReaderSummaryCoveragePlan,
   type ReaderSummaryCoveragePlan,
 } from "../services/reader-summary-coverage-plan";
 import { evaluateReaderSummaryArtifactEditorialQuality } from "./reader-summary-artifact-editorial-quality-policy";
 import { primaryReaderSummaryEvidence } from "./reader-summary-github-trending-policy";
+import { isGitHubReaderItem } from "./reader-summary-github-projection-audit";
 import type {
   ReaderSummaryPublicationDecision,
   ReaderSummaryPublicationRejectionFinding,
 } from "./reader-summary-publication-decision";
 import { publicationShadowReport } from "./reader-summary-publication-shadow";
 import { promotionPublicationFindings } from "./reader-summary-promotion-publication-verification";
-import { readerSummaryPromotionPublicationOracle } from
-  "./reader-summary-promotion-publication-oracle";
+import { readerSummaryPromotionPublicationOracle } from "./reader-summary-promotion-publication-oracle";
 
 import {
   collectReaderSummaryTechnicalLeaks,
@@ -52,7 +54,10 @@ export class ReaderSummaryPublicationPolicy {
       ),
     );
     const technicalLeaks = unique([
-      ...collectReaderSummaryTechnicalLeaks([snapshot.headline, snapshot.executiveSummary]),
+      ...collectReaderSummaryTechnicalLeaks([
+        snapshot.headline,
+        snapshot.executiveSummary,
+      ]),
       ...(snapshot.content === undefined
         ? []
         : collectReaderSummaryUserFacingTechnicalLeaks(snapshot.content)),
@@ -72,12 +77,16 @@ export class ReaderSummaryPublicationPolicy {
       approvedSameStoryRelations: params.evidence.approvedSameStoryRelations,
       relatedTopicRelations: params.evidence.relatedTopicRelations,
     });
-    rejectionFindings.push(...promotionPublicationFindings({
-      expectedTop: verification.top,
-      expectedAdditional: verification.additional,
-      actualTop: snapshot.content?.topReads ?? [],
-      actualSelected: snapshot.content?.selectedPosts ?? [],
-    }));
+    rejectionFindings.push(
+      ...promotionPublicationFindings({
+        expectedTop: verification.top,
+        expectedAdditional: verification.additional,
+        actualTop: snapshot.content?.topReads ?? [],
+        actualSelected: (snapshot.content?.selectedPosts ?? []).filter(
+          (item) => !isGitHubReaderItem(item),
+        ),
+      }),
+    );
 
     if (!noSignal && topReads.length === 0) {
       rejectionFindings.push({
@@ -108,10 +117,7 @@ export class ReaderSummaryPublicationPolicy {
         ),
       );
       const editorialQuality = evaluateReaderSummaryArtifactEditorialQuality(
-        editorialQualityInput(
-          snapshot,
-          coveragePlan.mode,
-        ),
+        editorialQualityInput(snapshot, coveragePlan.mode),
       );
       for (const issue of editorialQuality.issues) {
         rejectionFindings.push({
@@ -163,7 +169,6 @@ export class ReaderSummaryPublicationPolicy {
           });
           continue;
         }
-
       }
     }
 
@@ -204,26 +209,29 @@ export class ReaderSummaryPublicationPolicy {
 const independentPromotionCitations = (
   evidence: SummaryEvidenceSelection["selectedEvidence"],
   citations: readonly ReaderSummaryCitation[],
-): readonly ReaderSummaryCitation[] => evidence.map((item) => {
-  const citation = [...citations].sort((left, right) =>
-    left.citationId.localeCompare(right.citationId)
-  ).find((candidate) =>
-    candidate.feedItemId === item.feedItemId &&
-    candidate.sourceItemId === item.sourceItemId &&
-    candidate.providerKey === item.providerKey &&
-    (candidate.canonicalUrl === undefined ||
-      candidate.canonicalUrl === item.canonicalUrl)
-  );
-  return citation ?? {
-    citationId: `publication-expected:${item.feedItemId}`,
-    feedItemId: item.feedItemId,
-    sourceItemId: item.sourceItemId,
-    providerKey: item.providerKey,
-    field: "canonicalUrl",
-    canonicalUrl: item.canonicalUrl,
-  };
-});
-
+): readonly ReaderSummaryCitation[] =>
+  evidence.map((item) => {
+    const citation = [...citations]
+      .sort((left, right) => left.citationId.localeCompare(right.citationId))
+      .find(
+        (candidate) =>
+          candidate.feedItemId === item.feedItemId &&
+          candidate.sourceItemId === item.sourceItemId &&
+          candidate.providerKey === item.providerKey &&
+          (candidate.canonicalUrl === undefined ||
+            candidate.canonicalUrl === item.canonicalUrl),
+      );
+    return (
+      citation ?? {
+        citationId: `publication-expected:${item.feedItemId}`,
+        feedItemId: item.feedItemId,
+        sourceItemId: item.sourceItemId,
+        providerKey: item.providerKey,
+        field: "canonicalUrl",
+        canonicalUrl: item.canonicalUrl,
+      }
+    );
+  });
 
 const isValidNoSignalArtifact = (
   snapshot: ReturnType<ReaderSummaryArtifact["toSnapshot"]>,
@@ -299,8 +307,7 @@ const coveragePlanIssues = (
           : []),
         ...(sectionClusterId !== undefined &&
         section.citationIds.some(
-          (citationId) =>
-            clusterIdForCitation(citationId) !== sectionClusterId,
+          (citationId) => clusterIdForCitation(citationId) !== sectionClusterId,
         )
           ? ["Secondary signal cites evidence from another story cluster"]
           : []),
@@ -329,7 +336,8 @@ const coveragePlanIssues = (
     ...mainNarrativeCitationClusterIds
       .filter((clusterId) => !plannedClusterIds.has(clusterId))
       .map(
-        () => "Main narrative cites a story outside the deterministic coverage plan",
+        () =>
+          "Main narrative cites a story outside the deterministic coverage plan",
       ),
     ...secondaryIssues,
   ]);
@@ -421,7 +429,6 @@ const topReadReferences = (
   }));
 };
 
-
 const canonicalPublicationScore = (params: {
   readonly topReadCount: number;
   readonly rejectionCount: number;
@@ -443,13 +450,10 @@ const canonicalPublicationScore = (params: {
   );
 };
 
-
 const distinctDefined = (
   values: readonly (string | undefined)[],
 ): readonly string[] => [
-  ...new Set(
-    values.filter((value): value is string => value !== undefined),
-  ),
+  ...new Set(values.filter((value): value is string => value !== undefined)),
 ];
 
 const unique = <TValue>(values: readonly TValue[]): readonly TValue[] => [

--- a/libs/summary/domain/services/reader-summary-supplemental-selected-posts.ts
+++ b/libs/summary/domain/services/reader-summary-supplemental-selected-posts.ts
@@ -1,0 +1,77 @@
+import type { ReaderSummaryCitation } from "../entities/citation";
+import type { TopRead } from "../entities/top-read";
+import { hasFirstPartyOfficialEvidence } from "../policies/reader-summary-source-authority-policy";
+import {
+  maxGitHubTrendingDisplayRepositories,
+  selectGitHubTrendingDisplayRepositories,
+} from "../policies/reader-summary-github-trending-policy";
+import type { SummaryEvidenceItem } from "../value-objects/summary-evidence-item";
+import { normalizeSignalScore } from "../value-objects/signal-score";
+import { compactUnique } from "../value-objects/summary-text";
+import { readerItemConfidence } from "./reader-summary-support";
+import { buildMatchedRules } from "./reader-summary-source-lineage";
+
+export const buildReaderSummarySupplementalTrendSelectedPosts = (params: {
+  readonly selectedEvidence: readonly SummaryEvidenceItem[];
+  readonly citations: readonly ReaderSummaryCitation[];
+}): readonly TopRead[] => {
+  const repositories = selectGitHubTrendingDisplayRepositories(
+    params.selectedEvidence,
+  );
+  if (repositories.length !== maxGitHubTrendingDisplayRepositories) {
+    return [];
+  }
+  const citationByFeedItemId = new Map(
+    params.citations.map(
+      (citation) => [citation.feedItemId, citation] as const,
+    ),
+  );
+  return repositories.flatMap((item) => {
+    const citation = citationByFeedItemId.get(item.feedItemId);
+    return citation === undefined
+      ? []
+      : [supplementalEvidenceToSelectedPost(item, citation)];
+  });
+};
+
+const supplementalEvidenceToSelectedPost = (
+  item: SummaryEvidenceItem,
+  citation: ReaderSummaryCitation,
+): TopRead => {
+  const signalScore = normalizeSignalScore(item.score);
+  const matchedInterestIds = compactUnique([item.interestId]);
+  const effectiveInterestIds =
+    matchedInterestIds.length > 0 ? matchedInterestIds : ["unknown-interest"];
+  const reason =
+    item.whyImportant.find((value) => value.trim().length > 0) ?? item.title;
+
+  return {
+    title: item.title,
+    providerKey: item.providerKey,
+    providerName: item.providerName ?? item.providerKey,
+    primaryActionKind: item.readerActionKind ?? "watch_repository",
+    reason,
+    matchedInterestIds: effectiveInterestIds,
+    matchedRules: buildMatchedRules(
+      [item],
+      effectiveInterestIds,
+      item.providerKey,
+    ),
+    signalScore,
+    confidence: readerItemConfidence({
+      cluster: undefined,
+      independentEvidenceCount: 1,
+      confirmedProviderCount: 1,
+      signalScore,
+      firstPartyOfficial: hasFirstPartyOfficialEvidence([item]),
+    }),
+    confirmedProviderKeys: [item.providerKey],
+    providerMetrics: item.providerMetricLabels ?? [],
+    whyImportant: [reason],
+    whyNow: `Selected from ${item.providerName ?? item.providerKey} evidence for this summary.`,
+    publishedAt: item.publishedAt,
+    canonicalUrl: item.canonicalUrl,
+    previewMedia: item.previewMedia,
+    citationIds: [citation.citationId],
+  };
+};

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job-promotion-control.spec.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job-promotion-control.spec.ts
@@ -57,7 +57,9 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
         ...scenario,
         selectEvidence: async () => dailyTrendingSelection(withPrimary),
         githubProjectionReader: dailyTrendingProjectionReader(),
-        promotionControl: readerSummaryPromotionControl(NOOP_READER_SUMMARY_PROMOTION_METRICS),
+        promotionControl: readerSummaryPromotionControl(
+          NOOP_READER_SUMMARY_PROMOTION_METRICS,
+        ),
       });
       expect(scenario.artifacts.decisions()[0]).toMatchObject({
         status: "published",
@@ -82,36 +84,34 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
       expect(scenario.artifacts.decisions()[0]?.status).toBe("published");
     },
   );
-  it(
-    "keeps the complete promotion metric sequence invariant for zero versus N supplemental GitHub entries",
-    async () => {
-      const recordSequence = async (supplementalCount: number) => {
-        const scenario = await arrangePromotionControlScenario(
-          `reader-job-telemetry-${supplementalCount}`,
-        );
-        const records: ReaderSummaryPromotionAggregateMetrics[] = [];
-        await executePromotionControlScenario({
-          ...scenario,
-          selectEvidence: async () =>
-            promotionSelectionWithSupplementalCount(supplementalCount),
-          topicMapBuilder: promotionControlEmptyTopicMapBuilder(),
-          githubProjectionReader: promotionControlZeroGitHubProjectionReader(),
-          promotionControl: readerSummaryPromotionControl({
-            record: (value) => records.push(value),
-          }),
-        });
-        return records;
-      };
-
-      const withoutSupplemental = await recordSequence(0);
-      const withSupplemental = await recordSequence(5);
-
-      expect(withSupplemental).toEqual(withoutSupplemental);
-      expect(withoutSupplemental.map(({ lifecycle }) => lifecycle)).toEqual(
-        ["evaluated", "delivered"],
+  it("keeps the complete promotion metric sequence invariant for zero versus N supplemental GitHub entries", async () => {
+    const recordSequence = async (supplementalCount: number) => {
+      const scenario = await arrangePromotionControlScenario(
+        `reader-job-telemetry-${supplementalCount}`,
       );
-    },
-  );
+      const records: ReaderSummaryPromotionAggregateMetrics[] = [];
+      await executePromotionControlScenario({
+        ...scenario,
+        selectEvidence: async () =>
+          promotionSelectionWithSupplementalCount(supplementalCount),
+        topicMapBuilder: promotionControlEmptyTopicMapBuilder(),
+        githubProjectionReader: promotionControlZeroGitHubProjectionReader(),
+        promotionControl: readerSummaryPromotionControl({
+          record: (value) => records.push(value),
+        }),
+      });
+      return records;
+    };
+
+    const withoutSupplemental = await recordSequence(0);
+    const withSupplemental = await recordSequence(5);
+
+    expect(withSupplemental).toEqual(withoutSupplemental);
+    expect(withoutSupplemental.map(({ lifecycle }) => lifecycle)).toEqual([
+      "evaluated",
+      "delivered",
+    ]);
+  });
 
   it("deep-sanitizes admitted typed evidence before model input", async () => {
     const generatedContent = {
@@ -142,7 +142,9 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
       selectEvidence: async () => evidence,
       topicMapBuilder: promotionControlEmptyTopicMapBuilder(),
       githubProjectionReader: promotionControlZeroGitHubProjectionReader(),
-      promotionControl: readerSummaryPromotionControl(NOOP_READER_SUMMARY_PROMOTION_METRICS),
+      promotionControl: readerSummaryPromotionControl(
+        NOOP_READER_SUMMARY_PROMOTION_METRICS,
+      ),
     });
 
     expect(result.ok).toBe(true);
@@ -197,7 +199,9 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
         }),
       topicMapBuilder: promotionControlRejectingTopicMapBuilder(),
       githubProjectionReader: promotionControlZeroGitHubProjectionReader(),
-      promotionControl: readerSummaryPromotionControl(NOOP_READER_SUMMARY_PROMOTION_METRICS),
+      promotionControl: readerSummaryPromotionControl(
+        NOOP_READER_SUMMARY_PROMOTION_METRICS,
+      ),
     });
 
     expect(result).toEqual({
@@ -252,7 +256,9 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
       topicMapBuilder: promotionControlRejectingTopicMapBuilder(),
       githubProjectionReader: promotionControlZeroGitHubProjectionReader(),
       publicationPolicy,
-      promotionControl: readerSummaryPromotionControl(NOOP_READER_SUMMARY_PROMOTION_METRICS),
+      promotionControl: readerSummaryPromotionControl(
+        NOOP_READER_SUMMARY_PROMOTION_METRICS,
+      ),
     });
 
     expect(result).toMatchObject({
@@ -271,19 +277,21 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
 
 const dailyTrendingSelection = (withPrimary: boolean) => {
   const base = makeReaderEvidenceSelection({
-    ...(withPrimary ? {} : {
-      firstContentQuality: {
-        qualityScore: 0.2,
-        interestRelevanceScore: 0.2,
-        engagementIntegrityScore: 0.2,
-        eligibleForSummary: false,
-        eligibleForTopRead: false,
-        needsLlmReview: false,
-        decision: "reject",
-        flags: ["low_quality"],
-        reason: "No primary signal",
-      },
-    }),
+    ...(withPrimary
+      ? {}
+      : {
+          firstContentQuality: {
+            qualityScore: 0.2,
+            interestRelevanceScore: 0.2,
+            engagementIntegrityScore: 0.2,
+            eligibleForSummary: false,
+            eligibleForTopRead: false,
+            needsLlmReview: false,
+            decision: "reject",
+            flags: ["low_quality"],
+            reason: "No primary signal",
+          },
+        }),
   });
   const primary = base.selectedEvidence[0]!;
   const primaryCluster = base.clusters[0]!;
@@ -294,10 +302,12 @@ const dailyTrendingSelection = (withPrimary: boolean) => {
     sourceItemId: `github-source-${index + 1}`,
     sourceBindingId: "github-binding-daily",
     canonicalUrl: `https://github.com/owner/repo-${index + 1}`,
-    providerMetricLabels: [{
-      label: "GitHub Trending today",
-      value: `#${index + 1} · +${index < 3 ? 1_101 : 100 + index} stars today`,
-    }],
+    providerMetricLabels: [
+      {
+        label: "GitHub Trending today",
+        value: `#${index + 1} · +${index < 3 ? 1_101 : 100 + index} stars today`,
+      },
+    ],
   }));
   const trendClusters = trends.map((item, index) => ({
     ...base.clusters[1]!,
@@ -308,42 +318,49 @@ const dailyTrendingSelection = (withPrimary: boolean) => {
     ...base,
     sourceWindow: {
       ...base.sourceWindow,
-      selectedFeedItemIds: [primary.feedItemId, ...trends.map((item) => item.feedItemId)],
-      storyClusterIds: [primaryCluster.id, ...trendClusters.map((item) => item.id)],
+      selectedFeedItemIds: [
+        primary.feedItemId,
+        ...trends.map((item) => item.feedItemId),
+      ],
+      storyClusterIds: [
+        primaryCluster.id,
+        ...trendClusters.map((item) => item.id),
+      ],
     },
     clusters: [primaryCluster, ...trendClusters],
     selectedEvidence: [primary, ...trends],
   };
 };
 
-const dailyTrendingProjectionReader = (): ReaderSummaryGitHubProjectionReaderPort => ({
-  async read() {
-    const checkedAt = new Date("2026-06-26T07:20:00.000Z");
-    return {
-      eligibleBindingIds: ["github-binding-daily"],
-      pageCount: 1,
-      items: Array.from({ length: 10 }, (_, index) => ({
-        feedItemId: `github-feed-${index + 1}`,
-        sourceItemId: `github-source-${index + 1}`,
-        sourceBindingId: "github-binding-daily",
-        providerKey: "github-trending-page",
-        metadataKind: "github_trending_page_repository",
-        scanJobId: "github-scan-daily",
-        canonicalUrl: `https://github.com/owner/repo-${index + 1}`,
-        repositoryFullName: `owner/repo-${index + 1}`,
-        rank: index + 1,
-        starsGained: index < 3 ? 1_101 : 100 + index,
-        window: "daily",
-        fetchStartedAt: new Date("2026-06-26T07:19:00.000Z"),
-        checkedAt,
-        publishedAt: checkedAt,
-        observedAt: new Date("2026-06-26T07:30:00.000Z"),
-        sourceContentHash: "a".repeat(64),
-        sourceProviderContentHash: "b".repeat(64),
-      })),
-    };
-  },
-});
+const dailyTrendingProjectionReader =
+  (): ReaderSummaryGitHubProjectionReaderPort => ({
+    async read() {
+      const checkedAt = new Date("2026-06-26T07:20:00.000Z");
+      return {
+        eligibleBindingIds: ["github-binding-daily"],
+        pageCount: 1,
+        items: Array.from({ length: 10 }, (_, index) => ({
+          feedItemId: `github-feed-${index + 1}`,
+          sourceItemId: `github-source-${index + 1}`,
+          sourceBindingId: "github-binding-daily",
+          providerKey: "github-trending-page",
+          metadataKind: "github_trending_page_repository",
+          scanJobId: "github-scan-daily",
+          canonicalUrl: `https://github.com/owner/repo-${index + 1}`,
+          repositoryFullName: `owner/repo-${index + 1}`,
+          rank: index + 1,
+          starsGained: index < 3 ? 1_101 : 100 + index,
+          window: "daily",
+          fetchStartedAt: new Date("2026-06-26T07:19:00.000Z"),
+          checkedAt,
+          publishedAt: checkedAt,
+          observedAt: new Date("2026-06-26T07:30:00.000Z"),
+          sourceContentHash: "a".repeat(64),
+          sourceProviderContentHash: "b".repeat(64),
+        })),
+      };
+    },
+  });
 
 type PromotionControl = ReturnType<typeof readerSummaryPromotionControl>;
 
@@ -405,8 +422,7 @@ const executePromotionControlScenario = async (
     new PromotionControlPolicyRepository(),
     {
       select:
-        scenario.selectEvidence ??
-        (async () => makeReaderEvidenceSelection()),
+        scenario.selectEvidence ?? (async () => makeReaderEvidenceSelection()),
     },
     scenario.model,
     new PromotionControlPublication(

--- a/libs/summary/features/execute-reader-summary-job/reader-summary-prepublication-gate.spec.ts
+++ b/libs/summary/features/execute-reader-summary-job/reader-summary-prepublication-gate.spec.ts
@@ -88,7 +88,7 @@ describe("evaluateReaderSummaryPrepublication", () => {
     });
     expect(
       decision.githubProjectionAudit.bindings.map(({ rank }) => rank),
-    ).toEqual([1, 2, 3]);
+    ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     expect(
       new Set(
         decision.githubProjectionAudit.bindings.map(
@@ -162,7 +162,7 @@ describe("evaluateReaderSummaryPrepublication", () => {
     );
   });
 
-  it("permits an empty appendix when the durable Top 10 has no highlight", async () => {
+  it("rejects a missing selected Top 10 even when the durable board exists", async () => {
     const decision = await evaluateReaderSummaryPrepublication({
       artifact: artifactWithoutGitHubBoard(),
       evidence: evidenceSelection,
@@ -179,8 +179,10 @@ describe("evaluateReaderSummaryPrepublication", () => {
       observedThrough,
     });
 
-    expect(decision.publicationDecision.status).toBe("published");
-    expect(decision.githubProjectionAudit.bindings).toEqual([]);
+    expect(decision.publicationDecision.status).toBe("rejected");
+    expect(decision.githubProjectionAudit.violationCodes).toContain(
+      "github_projection_missing",
+    );
   });
 
   it("permits historical omission with an eligible binding and only later rows", async () => {
@@ -607,7 +609,7 @@ describe("evaluateReaderSummaryPrepublication", () => {
     });
   });
 
-  it("does not require legacy GitHub selectedPosts before persistence", async () => {
+  it("requires the exact GitHub selectedPosts board before persistence", async () => {
     const decision = await evaluateReaderSummaryPrepublication({
       artifact: githubArtifact(5),
       evidence: evidenceSelection,
@@ -624,7 +626,7 @@ describe("evaluateReaderSummaryPrepublication", () => {
       observedThrough,
     });
 
-    expect(decision.publicationDecision.status).toBe("published");
+    expect(decision.publicationDecision.status).toBe("rejected");
   });
 
   it("keeps a non-daily non-GitHub summary publishable without querying a daily board", async () => {
@@ -679,7 +681,7 @@ const publishingPolicy = (): ReaderSummaryPublicationPolicy =>
     },
   });
 
-const githubArtifact = (selectedPostCount = 0): ReaderSummaryArtifact =>
+const githubArtifact = (selectedPostCount = 10): ReaderSummaryArtifact =>
   githubBoardArtifact({
     selectedPostCount,
     watchRanks: [1, 2, 3],


### PR DESCRIPTION
Fixes the production reader summary publication failure `ordinary GitHub evidence is not fully verifiable`.

- restores the exact 10-row GitHub board in the publication audit
- records one canonical snapshot content hash across every repository in a scan
- keeps the Watch appendix as a derived subset without weakening the DB publication gate
- adds regression coverage for deterministic board hashes and strict prepublication evidence

Production evidence: rolling run `20260826T234455000Z` reached publication with a verified audit containing only 3 bindings and per-item provider hashes, while PostgreSQL correctly required 10 bindings from one snapshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic content tracking for GitHub Trending snapshots.
  * GitHub Trending summaries now include the complete canonical Top 10 as selected posts, including when no editorial signals are present.
  * Improved validation to require complete, current, correctly ordered Top 10 projections.

* **Bug Fixes**
  * Prevented incomplete, stale, mixed, or invalid GitHub Trending projections from being published.
  * Excluded supplemental GitHub Trending posts from editorial promotion findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->