### PR TITLE
fix(summary): publish canonical no-signal updates

### DIFF
--- a/libs/summary/domain/policies/reader-summary-github-projection-no-signal.ts
+++ b/libs/summary/domain/policies/reader-summary-github-projection-no-signal.ts
@@ -1,0 +1,32 @@
+import type { ReaderSummaryGitHubProjectionEvaluation } from "./reader-summary-github-projection-audit";
+
+export const ordinaryNoSignalGitHubProjectionEvaluation = (params: {
+  readonly requestedUtcDay: string;
+  readonly pageCount: number;
+}): ReaderSummaryGitHubProjectionEvaluation => {
+  const validPageCount =
+    Number.isSafeInteger(params.pageCount) && params.pageCount >= 1;
+  const findings = validPageCount
+    ? []
+    : [
+        {
+          code: "github_projection_unavailable" as const,
+          reason:
+            "Durable GitHub binding eligibility was not completely read before no-signal publication.",
+        },
+      ];
+  return {
+    audit: {
+      schemaVersion: "reader_summary.github_projection.v1",
+      status: validPageCount ? "not_required" : "rejected",
+      requestedUtcDay: params.requestedUtcDay,
+      pageCount: params.pageCount,
+      scannedItemCount: 0,
+      eligibleBindingIds: [],
+      bindings: [],
+      violationCodes: findings.map((finding) => finding.code),
+      reasons: findings.map((finding) => finding.reason),
+    },
+    findings,
+  };
+};

--- a/libs/summary/domain/policies/reader-summary-github-projection-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-github-projection-policy.ts
@@ -30,6 +30,7 @@ import {
   supplementalNarrativeFindings,
 } from "./reader-summary-github-projection-set";
 import { maxGitHubTrendingDisplayRepositories } from "./reader-summary-github-trending-policy";
+import { ordinaryNoSignalGitHubProjectionEvaluation } from "./reader-summary-github-projection-no-signal";
 
 export { githubProjectionItemTouchesDay } from "./reader-summary-github-projection-candidates";
 
@@ -118,11 +119,9 @@ export const evaluateReaderSummaryGitHubProjection = (params: {
     snapshot.period.endedAt,
     snapshot.period.timezone,
   );
-  const eligibleBindingIds = [
-    ...unique(
-      params.eligibleBindingIds.filter((bindingId) => nonEmpty(bindingId)),
-    ),
-  ].sort();
+  const eligibleBindingIds = unique(
+    params.eligibleBindingIds.filter((bindingId) => nonEmpty(bindingId)),
+  ).sort();
   if (day === undefined) {
     return rejectedEvaluation({
       artifact: params.artifact,
@@ -136,6 +135,12 @@ export const evaluateReaderSummaryGitHubProjection = (params: {
             "GitHub Top 10 publication requires one exact UTC calendar day.",
         },
       ],
+    });
+  }
+  if (ordinaryNoSignal) {
+    return ordinaryNoSignalGitHubProjectionEvaluation({
+      requestedUtcDay: day.day,
+      pageCount: params.pageCount,
     });
   }
 
@@ -475,7 +480,7 @@ const baseAudit = (params: {
   reasons: params.reasons ?? [],
 });
 
-const unique = <TValue>(values: readonly TValue[]): readonly TValue[] => [
+const unique = <TValue>(values: readonly TValue[]): TValue[] => [
   ...new Set(values),
 ];
 

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job-promotion-control.spec.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job-promotion-control.spec.ts
@@ -69,18 +69,22 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
         value: { status: withPrimary ? "completed" : "no_signal" },
       });
       const published = scenario.artifacts.all()[0]?.toSnapshot();
-      expect(published?.content?.narrativeSections).toContainEqual(
-        expect.objectContaining({
-          id: "github-trending",
-          citationIds: withPrimary
-            ? ["github-citation-1", "github-citation-2", "github-citation-3"]
-            : [
-                "supplemental:1:github-feed-1",
-                "supplemental:2:github-feed-2",
-                "supplemental:3:github-feed-3",
-              ],
-        }),
-      );
+      if (withPrimary) {
+        expect(published?.content?.narrativeSections).toContainEqual(
+          expect.objectContaining({
+            id: "github-trending",
+            citationIds: [
+              "github-citation-1",
+              "github-citation-2",
+              "github-citation-3",
+            ],
+          }),
+        );
+      } else {
+        expect(published?.citationMap).toEqual([]);
+        expect(published?.content?.narrativeSections).toEqual([]);
+        expect(published?.content?.selectedPosts).toEqual([]);
+      }
       expect(scenario.artifacts.decisions()[0]?.status).toBe("published");
     },
   );

--- a/libs/summary/features/execute-reader-summary-job/reader-summary-promotion-no-signal.ts
+++ b/libs/summary/features/execute-reader-summary-job/reader-summary-promotion-no-signal.ts
@@ -20,14 +20,7 @@ export const buildPromotionNoSignalArtifact = (params: {
   readonly noSignalReason?: string;
 }): ReaderSummaryArtifact => {
   const noSignalReason = params.noSignalReason ?? defaultNoSignalReason;
-  const citationMap = params.evidence.selectedEvidence.map((item, index) => ({
-    citationId: `supplemental:${index + 1}:${item.feedItemId}`,
-    feedItemId: item.feedItemId,
-    sourceItemId: item.sourceItemId,
-    providerKey: item.providerKey,
-    field: "canonicalUrl" as const,
-    canonicalUrl: item.canonicalUrl,
-  }));
+  const citationMap = [] as const;
   const content = buildReaderSummary({
     headline: "No reliable workspace signal yet",
     executiveSummary: noSignalReason,
@@ -38,7 +31,7 @@ export const buildPromotionNoSignalArtifact = (params: {
     citationMap,
     storyClusters: params.evidence.clusters,
     sourceWindow: params.evidence.sourceWindow,
-    selectedEvidence: params.evidence.selectedEvidence,
+    selectedEvidence: [],
     qualityFlags: ["no_signal"],
     noSignalReason,
   });


### PR DESCRIPTION
Fix the production rolling-summary failure discovered by the exact-head E2E.

- publish Promotion V1 no-signal artifacts without claim citations
- record GitHub projection as not-required for ordinary no-signal output
- retain exact GitHub Top-10 evidence for completed summaries

Evidence: 58 focused tests passed; source line-cap passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of artifacts without valid evidence or page-count signals.
  * No-signal summaries now publish without citations, narrative sections, or selected posts.
  * GitHub projection is marked unavailable when required page information is invalid.

* **Tests**
  * Updated daily Trends promotion checks to verify results with and without primary evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->