### PR TITLE
fix(runtime): tolerate managed database admission latency

### DIFF
--- a/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
@@ -664,12 +664,16 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       'scripts/capture-durable-reader-summary-from-postgres.ts',
       'scripts/check-reader-summary-source-quality-trace.ts',
     ]) {
-      expect(readSource(path)).toContain(
-        'defaultPostgresRuntimePoolConfig',
-      );
-      expect(readSource(path)).toMatch(
-        /defaultPostgresRuntimePoolConfig\([\s\S]*?["']daily-runner["']\s*,?\s*\)/,
-      );
+      const source = readSource(path);
+      const usesDefaultBudget =
+        /defaultPostgresRuntimePoolConfig\([\s\S]*?["']daily-runner["']\s*,?\s*\)/.test(
+          source,
+        );
+      const usesValidatedRuntimeBudget =
+        /resolvePostgresRuntimePoolConfig\(\{[\s\S]*?POSTGRES_RUNTIME_PROCESS:\s*["']daily-runner["']/.test(
+          source,
+        );
+      expect(usesDefaultBudget || usesValidatedRuntimeBudget).toBe(true);
     }
   });
 

--- a/ops/deploy/production-runtime/compose.postgres-runtime.yml
+++ b/ops/deploy/production-runtime/compose.postgres-runtime.yml
@@ -22,5 +22,6 @@ services:
       POSTGRES_RUNTIME_PROCESS: daily-runner
       POSTGRES_RUNTIME_POOL_MIN: "0"
       POSTGRES_RUNTIME_POOL_MAX: "2"
+      POSTGRES_RUNTIME_POOL_CONNECTION_TIMEOUT_MS: "30000"
     deploy:
       replicas: 1

--- a/scripts/capture-durable-reader-summary-from-postgres.ts
+++ b/scripts/capture-durable-reader-summary-from-postgres.ts
@@ -4,7 +4,7 @@ import { dirname } from "node:path";
 
 import { PrismaFeedConnection } from "@social-monitor/feed/adapters/persistence/prisma/prisma-feed-connection";
 import { InMemoryMetricsRecorder } from "@social-monitor/platform-metrics";
-import { defaultPostgresRuntimePoolConfig } from "@social-monitor/platform-persistence";
+import { resolvePostgresRuntimePoolConfig } from "@social-monitor/platform-persistence";
 import { PrismaFeedItemReadRepository } from "@social-monitor/feed/adapters/persistence/prisma/prisma-feed-item-read.repository";
 import { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
 import { PrismaReaderSummaryPublication } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-publication";
@@ -255,10 +255,13 @@ async function main(): Promise<void> {
   const executionAttestations =
     new DurableReaderSummaryExecutionAttestationCapture();
 
-  const runtimePoolConfig = defaultPostgresRuntimePoolConfig(
-    databaseUrl,
-    "daily-runner",
-  );
+  const runtimePoolConfig = resolvePostgresRuntimePoolConfig({
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+    POSTGRES_RUNTIME_PROCESS: "daily-runner",
+    POSTGRES_RUNTIME_POOL_MIN: process.env.POSTGRES_RUNTIME_POOL_MIN ?? "0",
+    POSTGRES_RUNTIME_POOL_MAX: process.env.POSTGRES_RUNTIME_POOL_MAX ?? "2",
+  });
   const feedConnection = await PrismaFeedConnection.create(runtimePoolConfig);
   const summaryConnection =
     await PrismaSummaryConnection.create(runtimePoolConfig);

--- a/scripts/check-tenant-db-guards.mjs
+++ b/scripts/check-tenant-db-guards.mjs
@@ -317,6 +317,12 @@ function assertRlsMigration() {
     if (serviceBlock === undefined || !serviceBlock.includes('SYSTEM_DATABASE_URL')) {
       violations.push(`${productionRuntimeComposePath}: ${service} must use SYSTEM_DATABASE_URL`);
     }
+    if (
+      service === 'daily-runner' &&
+      !serviceBlock?.includes('POSTGRES_RUNTIME_POOL_CONNECTION_TIMEOUT_MS: "30000"')
+    ) {
+      violations.push(`${productionRuntimeComposePath}: daily-runner must tolerate 30s PostgreSQL admission latency`);
+    }
   }
   const apiBlock = productionRuntimeComposeWithSentinel.match(
     /^ {2}api:\n([\s\S]*?)(?=^ {2}[a-z_][a-z0-9_-]*:)/m,

--- a/scripts/run-reader-summary-clean-real-day-collection.ts
+++ b/scripts/run-reader-summary-clean-real-day-collection.ts
@@ -8,7 +8,7 @@ import type {
 import { Pool, type QueryResultRow } from "pg";
 import {
   acquirePrismaPgRuntimeConnection,
-  defaultPostgresRuntimePoolConfig,
+  resolvePostgresRuntimePoolConfig,
   runWithTenantDatabaseAccess,
   type PostgresRuntimePoolConfig,
   type PrismaPgRuntimeClientConstructor,
@@ -220,16 +220,19 @@ async function tryRunCollection(): Promise<
   | undefined
 > {
   const startedAt = new Date();
+  const runtimeConfig = resolvePostgresRuntimePoolConfig({
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+    POSTGRES_RUNTIME_PROCESS: "daily-runner",
+    POSTGRES_RUNTIME_POOL_MIN: process.env.POSTGRES_RUNTIME_POOL_MIN ?? "0",
+    POSTGRES_RUNTIME_POOL_MAX: process.env.POSTGRES_RUNTIME_POOL_MAX ?? "2",
+  });
   const pool = new Pool({
     connectionString: databaseUrl,
     min: 0,
     max: 1,
-    connectionTimeoutMillis: 2_000,
+    connectionTimeoutMillis: runtimeConfig.connectionTimeoutMillis,
   });
-  const runtimeConfig = defaultPostgresRuntimePoolConfig(
-    databaseUrl,
-    "daily-runner",
-  );
   let targetDiscovery:
     PrismaPgRuntimeConnectionLease<TargetDiscoveryRuntimeClient> | undefined;
   let connection: PrismaIngestionWorkerConnection | undefined;


### PR DESCRIPTION
Production rolling collection and summary capture were bypassing the configurable PostgreSQL runtime timeout and hard-coding 2s/5s. Under verified host swap pressure this caused healthy managed-DB connections to fail before publication. This change routes both phases through the validated daily-runner pool configuration and pins the reviewed production admission timeout to 30s without changing pool size or quality gates.\n\nVerified locally:\n- tenant database guardrails\n- production daily runtime contract\n- code quality guardrails\n- source/test line cap\n- diff check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL connection handling for daily processing tasks.
  * Added a 30-second connection timeout to production runtime operations.
  * Updated database guard checks to detect missing connection timeout settings.
  * Standardized connection pool settings across reader summary workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->