### PR TITLE
fix(rolling): allow repeated summary citations

### DIFF
--- a/ops/deploy/production-runtime/rolling-summary-receipt.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.mjs
@@ -701,7 +701,6 @@ function isValidSummaryResult(result) {
     isNonnegativeInteger(result.topReadCount) &&
     result.topReadCount <= result.selectedFeedItemCount &&
     isNonnegativeInteger(result.citationCount) &&
-    result.citationCount <= result.selectedFeedItemCount &&
     isNonnegativeInteger(result.providerCount) &&
     Array.isArray(result.topProviderKeys) &&
     result.topProviderKeys.length === result.providerCount &&

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-artifact.mjs
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-artifact.mjs
@@ -87,7 +87,7 @@ if (kind === "collection") {
     headline: "Fixture rolling summary",
     selectedFeedItemCount: 10,
     topReadCount: 2,
-    citationCount: 10,
+    citationCount: 12,
     providerCount: 1,
     topProviderKeys: ["reddit"],
     qualityFlags: [],


### PR DESCRIPTION
Fix the final rolling receipt boundary when a valid summary cites the same selected post more than once.

Evidence:
- real production artifact: 16 unique selected posts, 26 valid citations
- focused receipt test passes with 10 selected posts and 12 citations
- rolling-run degraded collection to publication test passes
- real production evidence/frontend/collection artifacts now produce a valid SUCCESS receipt locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rolling summary validation to accept valid evidence results when the citation count exceeds the number of selected feed items.
  * Updated validation scenarios to reflect the broader range of supported citation counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->