### PR TITLE
fix(daily): allow Aug 26 summary recovery

### DIFF
--- a/ops/deploy/production-runtime/daily-run.sh
+++ b/ops/deploy/production-runtime/daily-run.sh
@@ -50,7 +50,7 @@ MAINTENANCE_DATE=${2:-}
 case "$DATE_FLAG" in
   --check-readiness|--today|--yesterday) ;;
   --maintenance-date)
-    [[ $# -eq 2 && $MAINTENANCE_DATE =~ ^2026-(07-(2[3-9]|3[01])|08-(0[1-9]|1[0-9]|2[0-5]))$ ]] || {
+    [[ $# -eq 2 && $MAINTENANCE_DATE =~ ^2026-(07-(2[3-9]|3[01])|08-(0[1-9]|1[0-9]|2[0-6]))$ ]] || {
       echo "historical daily production-day date is outside the reviewed recovery bound" >&2
       exit 64
     }

--- a/ops/deploy/production-runtime/daily-run.test.sh
+++ b/ops/deploy/production-runtime/daily-run.test.sh
@@ -114,7 +114,7 @@ grep -Fx -- '-n 9' "$fake_flock.calls" >/dev/null
 [[ $(wc -l <"$fake_flock.calls") -eq 1 ]]
 [[ ! -e "$work_marker" ]]
 
-for invalid in 2026-07-22 2026-08-26 not-a-date; do
+for invalid in 2026-07-22 2026-08-27 not-a-date; do
   set +e
   SOCIAL_MONITOR_DAILY_RUN_TEST_MODE=1 \
   SOCIAL_MONITOR_DAILY_RUN_TEST_ROOT="$test_root" \
@@ -133,7 +133,7 @@ SOCIAL_MONITOR_DAILY_RUN_TEST_MODE=1 \
 SOCIAL_MONITOR_DAILY_RUN_TEST_ROOT="$test_root" \
 SOCIAL_MONITOR_DAILY_RUN_TEST_FLOCK="$fake_flock" \
 SOCIAL_MONITOR_DAILY_RUN_TEST_DOCKER="$fake_docker" \
-  bash "$DAILY_RUN" --maintenance-date 2026-08-25 \
+  bash "$DAILY_RUN" --maintenance-date 2026-08-26 \
     >"$test_root/valid-bound-stdout" 2>"$test_root/valid-bound-stderr"
 status=$?
 set -e

--- a/scripts/lib/reader-summary-clean-real-day-collection-cli.spec.ts
+++ b/scripts/lib/reader-summary-clean-real-day-collection-cli.spec.ts
@@ -96,12 +96,12 @@ describe("clean real-day collection CLI", () => {
     ).toThrow("outside the daily maintenance upper bound");
   });
 
-  it("binds production history to 6101/6102 through the exact Aug20 artifact", () => {
+  it("binds production history to 6101/6102 through the exact Aug26 artifact", () => {
     const cli = withArgs(
       [
         "--update",
         "--date",
-        "2026-08-20",
+        "2026-08-26",
         "--provider-catch-up",
         "--allow-historical-provider-collection",
         "--allow-unproven-existing-window",
@@ -114,7 +114,7 @@ describe("clean real-day collection CLI", () => {
 
     expect(cli.maintenanceScope).toEqual(readerSummaryProductionHistoryScope);
     expect(cli.outputPath).toBe(
-      "/durable/production-history/reader-summary-clean-real-day-collection.2026-08-20.v1.json",
+      "/durable/production-history/reader-summary-clean-real-day-collection.2026-08-26.v1.json",
     );
     expect(cli.targetDiscoveryScopeValues).toEqual([
       readerSummaryProductionHistoryScope.tenantId,
@@ -122,13 +122,13 @@ describe("clean real-day collection CLI", () => {
     ]);
   });
 
-  it("rejects production history outside Jul23-Aug20", () => {
+  it("rejects production history outside Jul23-Aug26", () => {
     expect(() =>
       withArgs(
         [
           "--update",
           "--date",
-          "2026-08-21",
+          "2026-08-27",
           "--provider-catch-up",
           "--allow-historical-provider-collection",
           "--allow-unproven-existing-window",

--- a/scripts/lib/reader-summary-daily-maintenance-bounds.ts
+++ b/scripts/lib/reader-summary-daily-maintenance-bounds.ts
@@ -12,7 +12,7 @@ export const readerSummaryDailyJul31Aug3MaintenanceBounds: ReaderSummaryDailyMai
 export const readerSummaryProductionHistoryMaintenanceBounds: ReaderSummaryDailyMaintenanceBounds =
   Object.freeze({
     lowerInclusive: "2026-07-23",
-    upperInclusive: "2026-08-20",
+    upperInclusive: "2026-08-26",
   });
 
 export const assertReaderSummaryDailyMaintenanceBounds = (


### PR DESCRIPTION
## Summary

- extend the reviewed maintenance date bound from Aug 25 to Aug 26
- keep Aug 27 rejected by the exact boundary test
- preserve the UTC-yesterday guard and all quality gates

## Verification

- `bash ops/deploy/production-runtime/daily-run.test.sh`
- `npm run check:source-line-cap`
- `bash -n` for the runner and its focused test

The broader production classification test requires Linux Bash with `mapfile`; GitHub CI provides that environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Extended historical production-day support through August 26, 2026.
  - Updated maintenance and production-history validation to accept August 26 while continuing to reject later dates.
  - Updated related checks to reflect the expanded date range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->