### PR TITLE
fix(daily): handle previous-day maintenance evidence

### DIFF
--- a/scripts/lib/reader-summary-production-history-collection.spec.ts
+++ b/scripts/lib/reader-summary-production-history-collection.spec.ts
@@ -11,6 +11,7 @@ describe("production history collection", () => {
       const first = productionHistoryCollection({
         directory,
         collectionDate: "2026-08-07",
+        evaluatedAt: new Date("2026-08-27T12:00:00.000Z"),
       })!;
       expect(first.arguments).toContain("--allow-unproven-existing-window");
       mkdirSync(directory, { recursive: true });
@@ -21,11 +22,30 @@ describe("production history collection", () => {
       const retry = productionHistoryCollection({
         directory,
         collectionDate: "2026-08-07",
+        evaluatedAt: new Date("2026-08-27T12:00:00.000Z"),
       })!;
       expect(retry.arguments).not.toContain("--allow-unproven-existing-window");
       expect(retry.arguments).toEqual([
         "--production-history-retry",
         "--artifact-directory",
+        directory,
+      ]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("uses scheduled evidence semantics when maintenance targets UTC yesterday", () => {
+    const directory = mkdtempSync(join(tmpdir(), "production-previous-day-"));
+    try {
+      const collection = productionHistoryCollection({
+        directory,
+        collectionDate: "2026-08-26",
+        evaluatedAt: new Date("2026-08-27T12:00:00.000Z"),
+      })!;
+      expect(collection.arguments).toEqual([
+        "--production-scheduled-scope",
+        "--exact-date-artifact-directory",
         directory,
       ]);
     } finally {
@@ -47,6 +67,7 @@ describe("production history collection", () => {
         productionHistoryCollection({
           directory,
           collectionDate: "2026-08-07",
+          evaluatedAt: new Date("2026-08-27T12:00:00.000Z"),
         }),
       ).toThrow("unreadable; refusing provider recollection");
     } finally {

--- a/scripts/lib/reader-summary-production-history-collection.ts
+++ b/scripts/lib/reader-summary-production-history-collection.ts
@@ -7,12 +7,23 @@ import { readerSummaryProductionHistoryScope } from "./reader-summary-daily-main
 export const productionHistoryCollection = (params: {
   readonly directory: string | undefined;
   readonly collectionDate: string;
+  readonly evaluatedAt: Date;
 }): Readonly<{ path: string; arguments: readonly string[] }> | null => {
   if (params.directory === undefined) return null;
   const path = readerSummaryDailyCollectionArtifactPath({
     directory: params.directory,
     collectionDate: params.collectionDate,
   });
+  if (params.collectionDate === previousUtcDate(params.evaluatedAt)) {
+    return {
+      path,
+      arguments: [
+        "--production-scheduled-scope",
+        "--exact-date-artifact-directory",
+        params.directory,
+      ],
+    };
+  }
   const existing = readExactDayCollectionArtifact({
     path,
     collectionDate: params.collectionDate,
@@ -28,4 +39,10 @@ export const productionHistoryCollection = (params: {
       params.directory,
     ],
   };
+};
+
+const previousUtcDate = (evaluatedAt: Date): string => {
+  const value = new Date(evaluatedAt);
+  value.setUTCDate(value.getUTCDate() - 1);
+  return value.toISOString().slice(0, 10);
 };

--- a/scripts/run-reader-summary-production-day.ts
+++ b/scripts/run-reader-summary-production-day.ts
@@ -168,10 +168,11 @@ async function main(): Promise<void> {
         })
       : null;
   const historicalCollection = allowHistoricalProviderCollection
-    ? productionHistoryCollection({
-        directory: process.env.READER_SUMMARY_PRODUCTION_HISTORY_COLLECTION_DIR,
-        collectionDate,
-      })
+      ? productionHistoryCollection({
+          directory: process.env.READER_SUMMARY_PRODUCTION_HISTORY_COLLECTION_DIR,
+          collectionDate,
+          evaluatedAt: startedAt,
+        })
     : null;
   if (
     historicalCollection !== null &&


### PR DESCRIPTION
## Summary
- use the existing production scheduled-scope evidence contract when explicit maintenance targets UTC yesterday
- preserve the historical first-attempt/retry contract for older dates
- add a focused regression test for the Aug 26 edge case

## Evidence
- 3 focused production-history collection tests passed
- 18 production-day contract tests passed
- source line cap passed for 3621 files

## Production incident
The 2026-08-26 maintenance run had 930 collected posts but stopped before AI summary because the history first-attempt flag is intentionally invalid for the previous UTC day. This change selects the already-supported scheduled evidence semantics for exactly that case without weakening collection or summary quality gates.
