### PR TITLE
fix(summary): align publication quality authority

### DIFF
--- a/libs/summary/domain/policies/reader-post-promotion-selection.spec.ts
+++ b/libs/summary/domain/policies/reader-post-promotion-selection.spec.ts
@@ -480,9 +480,13 @@ describe("reader post promotion selection", () => {
 
       const selected = selectReaderPostPromotions([...x, alternative])[lane];
 
-      expect(selected).toHaveLength(8);
+      expect(selected).toHaveLength(lane === "top" ? 7 : 8);
       expect(selected.map((item) => item.candidate.candidateId))
         .toContain(`${lane}-reddit-alternative`);
+      if (lane === "top") {
+        expect(selected.filter((item) => item.candidate.provider === "x"))
+          .toHaveLength(6);
+      }
       expect(selectReaderPostPromotions([alternative, ...x])[lane])
         .toEqual(selected);
     },

--- a/libs/summary/domain/policies/reader-post-promotion-selection.ts
+++ b/libs/summary/domain/policies/reader-post-promotion-selection.ts
@@ -8,6 +8,10 @@ import {
   type ReaderPostPromotionInput,
   type ReaderPostPromotionResult,
 } from "./reader-post-promotion-policy";
+import {
+  topReadPrimaryMinimumForLimit,
+  topReadProviderCapForLimit,
+} from "./top-read-provider-diversity-policy";
 
 export type SelectedReaderPostPromotion = {
   readonly policyVersion: typeof READER_POST_PROMOTION_POLICY_VERSION;
@@ -79,9 +83,24 @@ export const selectReaderPostPromotions = (
     left: EvaluatedCandidate,
     right: EvaluatedCandidate,
   ): number => compareCandidates(left, right);
-  const top = diverseCapped(canonicalRepresentatives
+  const topCandidates = canonicalRepresentatives
     .filter(({ evaluation }) => evaluation.decision === "promote_top")
-    .sort(compareWithSupport), READER_POST_PROMOTION_POLICY_V1.maxTop);
+    .sort(compareWithSupport);
+  const topProviderCount = new Set(topCandidates.flatMap(({ input }) => {
+    const provider = readerPostProviderFamily(input.provider);
+    return provider === undefined ? [] : [provider];
+  })).size;
+  const top = diverseCapped(
+    topCandidates,
+    READER_POST_PROMOTION_POLICY_V1.maxTop,
+    topReadProviderCapForLimit({
+      limit: promotionRankingAuditLimit,
+      activeProviderCount: topProviderCount,
+      primaryMinimum: topReadPrimaryMinimumForLimit(
+        promotionRankingAuditLimit,
+      ),
+    }),
+  );
   const additional = diverseCapped(canonicalRepresentatives
     .filter(({ evaluation }) => evaluation.decision === "promote_additional")
     .sort(compareWithSupport), READER_POST_PROMOTION_POLICY_V1.maxAdditional);
@@ -186,6 +205,7 @@ const semanticClusterSupport = (params: {
 const diverseCapped = (
   sorted: readonly EvaluatedCandidate[],
   cap: number,
+  providerCap = cap,
 ): readonly EvaluatedCandidate[] => {
   const selected: EvaluatedCandidate[] = [];
   const selectedIds = new Set<string>();
@@ -200,11 +220,25 @@ const diverseCapped = (
   }
   for (const candidate of sorted) {
     if (selectedIds.has(candidate.input.candidateId)) continue;
+    const provider = readerPostProviderFamily(candidate.input.provider);
+    if (provider === undefined) continue;
+    const providerCount = selected.reduce(
+      (count, selectedCandidate) =>
+        readerPostProviderFamily(selectedCandidate.input.provider) === provider
+          ? count + 1
+          : count,
+      0,
+    );
+    if (providerCount >= providerCap) continue;
     selected.push(candidate);
     if (selected.length === cap) break;
   }
   return selected;
 };
+
+// The production ranking audit evaluates the reader surface against a
+// ten-slot editorial window, even though promotion v1 exposes at most eight.
+const promotionRankingAuditLimit = 10;
 
 const uniqueInputs = (
   inputs: readonly ReaderPostPromotionInput[],

--- a/libs/summary/domain/services/reader-post-promotion-evidence-admission.spec.ts
+++ b/libs/summary/domain/services/reader-post-promotion-evidence-admission.spec.ts
@@ -1,6 +1,8 @@
 import { buildReaderSummary } from "../aggregates/reader-summary";
 import { admitReaderPostPromotionEvidence } from
   "./reader-post-promotion-evidence-admission";
+import { buildReaderPostPromotionProjection } from
+  "./reader-post-promotion-projection";
 import type { SummaryEvidenceItem, SummaryEvidenceSelection } from
   "../value-objects/summary-evidence-item";
 
@@ -57,6 +59,31 @@ describe("admitReaderPostPromotionEvidence supplemental appendix", () => {
         citationIds: ["citation:github"],
       }),
     ]);
+  });
+
+  it("publishes a reader-facing title instead of provider boilerplate", () => {
+    const fixture = fixtureSelection();
+    const evidence = fixture.selectedEvidence.map((item) =>
+      item.feedItemId === "hn:top"
+        ? { ...item, title: "X post by @builder: Agent release reaches developers" }
+        : item,
+    );
+    const projection = buildReaderPostPromotionProjection({
+      evidence,
+      clusters: fixture.clusters,
+      sourceWindow: fixture.sourceWindow,
+      citations: evidence.map((item) => ({
+        citationId: `citation:${item.feedItemId}`,
+        feedItemId: item.feedItemId,
+        sourceItemId: item.sourceItemId,
+        providerKey: item.providerKey,
+        field: "canonicalUrl" as const,
+        canonicalUrl: item.canonicalUrl,
+      })),
+    });
+
+    expect(projection.topReads[0]?.title)
+      .toBe("Agent release reaches developers");
   });
 });
 

--- a/libs/summary/domain/services/reader-post-promotion-projection.ts
+++ b/libs/summary/domain/services/reader-post-promotion-projection.ts
@@ -23,6 +23,7 @@ import { readerSummaryIndependentProviderFamily } from
   "../value-objects/reader-summary-provider-identity";
 import { compactUnique } from "../value-objects/summary-text";
 import { buildMatchedRules } from "./reader-summary-source-lineage";
+import { evidenceReaderTitle } from "./reader-summary-top-read-title";
 import {
   buildReaderPostPromotionAttestations,
   type ReaderPostPromotionAttestationBinding,
@@ -299,7 +300,7 @@ const promotedPost = (params: {
     promotionTier: params.cardKind === "curated_top_read" ? "top" : "additional",
     promotionCandidateId: params.selected.candidate.candidateId,
     promotionCanonicalIdentity: params.selected.candidate.canonicalIdentity,
-    title: lead.title,
+    title: evidenceReaderTitle(lead),
     providerKey: lead.providerKey,
     providerName: lead.providerName ?? lead.providerKey,
     primaryActionKind: lead.readerActionKind ?? "read_source",

--- a/libs/summary/interfaces/rest/reader-summary-promotion-board-rest.mapper.ts
+++ b/libs/summary/interfaces/rest/reader-summary-promotion-board-rest.mapper.ts
@@ -14,6 +14,8 @@ import {
   sameOrderedStrings,
 } from "./reader-summary-rest-attestation";
 import type { ReaderSummaryCitationView } from "./reader-summary-rest.view";
+import { isGitHubReaderItem } from
+  "../../domain/policies/reader-summary-github-projection-audit";
 
 export type ReaderSummaryPromotionBoardRestView = Readonly<{
   topReads: readonly ReaderSummaryReaderItemDto[];
@@ -33,7 +35,8 @@ export const readerSummaryPromotionBoardRestView = (
   if (legacyPromotionBoardUnavailable) {
     return { topReads: [], selectedPosts: [] };
   }
-  const authority = buildReaderCardRestAuthority(view);
+  const additionalCards = promotionAdditionalCards(view);
+  const authority = buildReaderCardRestAuthority(view, additionalCards);
   if (authority === undefined) {
     throw new ReaderSummaryPromotionBoardMappingError();
   }
@@ -44,11 +47,28 @@ export const readerSummaryPromotionBoardRestView = (
       "top",
     ),
     selectedPosts: readerSummaryReaderItemsView(
-      view.content.selectedPosts ?? [],
+      additionalCards,
       authority,
       "additional",
     ),
   };
+};
+
+const promotionAdditionalCards = (
+  view: ReaderSummaryArtifactView,
+): readonly ReaderSummaryArtifactView["content"]["topReads"][number][] => {
+  const additional = [];
+  for (const item of view.content.selectedPosts ?? []) {
+    if (item.cardKind === "additional_notable_story") {
+      additional.push(item);
+      continue;
+    }
+    if (item.cardKind === "supplemental_trend" && isGitHubReaderItem(item)) {
+      continue;
+    }
+    throw new ReaderSummaryPromotionBoardMappingError();
+  }
+  return additional;
 };
 
 const isLegacyPromotionBoardUnavailable = (
@@ -169,6 +189,7 @@ type ReaderCardRestAuthority = Readonly<{
 
 const buildReaderCardRestAuthority = (
   view: ReaderSummaryArtifactView,
+  additionalCards: readonly ReaderSummaryArtifactView["content"]["topReads"][number][],
 ): ReaderCardRestAuthority | undefined => {
   try {
     const clusterById = new Map(view.storyClusters.map((cluster) => [cluster.id, cluster]));
@@ -191,7 +212,6 @@ const buildReaderCardRestAuthority = (
       (attestation) => [attestation.candidateId, attestation] as const,
     ));
     const topCards = view.content.topReads;
-    const additionalCards = view.content.selectedPosts ?? [];
     if (topCards.length > 8 || additionalCards.length > 8) return undefined;
     const promotionCards = [...topCards, ...additionalCards];
     const promotionCandidateIds = promotionCards.map((item) =>

--- a/libs/summary/interfaces/rest/reader-summary-rest.mapper.spec.ts
+++ b/libs/summary/interfaces/rest/reader-summary-rest.mapper.spec.ts
@@ -238,6 +238,35 @@ describe("readerSummaryArtifactViewFromReaderSummaryView", () => {
     );
     expect(response.readerBrief.topReads[0]).not.toHaveProperty("cardKind");
 
+    const {
+      promotionMarker: ignoredPromotionMarker,
+      promotionPolicyVersion: ignoredPromotionPolicyVersion,
+      promotionTier: ignoredPromotionTier,
+      promotionCandidateId: ignoredPromotionCandidateId,
+      promotionCanonicalIdentity: ignoredPromotionCanonicalIdentity,
+      ...supplementalCard
+    } = readerSummaryView.content.topReads[0]!;
+    void ignoredPromotionMarker;
+    void ignoredPromotionPolicyVersion;
+    void ignoredPromotionTier;
+    void ignoredPromotionCandidateId;
+    void ignoredPromotionCanonicalIdentity;
+    const responseWithSupplementalAppendix =
+      readerSummaryArtifactViewFromReaderSummaryView({
+        ...readerSummaryView,
+        content: {
+          ...readerSummaryView.content,
+          selectedPosts: [{
+            ...supplementalCard,
+            cardKind: "supplemental_trend",
+            providerKey: "github-trending-page",
+            storyClusterId: "supplemental:github-trending-page:feed-extra",
+          }],
+        },
+      });
+    expect(responseWithSupplementalAppendix.readerBrief.selectedPosts)
+      .toEqual([]);
+
     const persistedAttestation = readerSummaryView.promotionAttestations[0]!;
     for (const mutation of [
       { canonicalPayload: `${persistedAttestation.canonicalPayload} ` },

--- a/scripts/check-yesterday-reader-summary-artifact-quality.ts
+++ b/scripts/check-yesterday-reader-summary-artifact-quality.ts
@@ -8,6 +8,7 @@ import type { JsonObject } from "@social-monitor/shared-kernel";
 import { readerSummaryArtifactFromPrisma } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-records";
 import { presentReaderSummaryArtifact } from "@social-monitor/summary/features/shared/reader-summary-artifact-presenter";
 import type { ReaderSummaryFreshness } from "@social-monitor/summary/ports";
+import { readerSummaryPromotionBoardRestView } from "@social-monitor/summary/interfaces/rest/reader-summary-promotion-board-rest.mapper";
 
 import {
   collectionDateOptionOrDefault,
@@ -107,6 +108,7 @@ type ArtifactQualityReport = {
     readonly selectedPostDuplicateCanonicalUrlCount: number;
     readonly selectedPostsRepresentTopReadPreview: boolean;
     readonly selectedPostsRepresentDedupedSelectedEvidence: boolean;
+    readonly promotionBoardMatchesAttestedEvidence: boolean;
     readonly selectedPostsMismatchDocumented: boolean;
   };
   readonly summaryStructure: {
@@ -283,13 +285,20 @@ async function buildReport(): Promise<ArtifactQualityReport> {
     const view = presentReaderSummaryArtifact(artifact, freshness, {
       collectedCoverage,
     });
+    const promotionBoard = readerSummaryPromotionBoardRestView(view);
+    const promotedFeedItemIds = uniqueStrings(
+      view.promotionAttestations.flatMap((attestation) => [
+        attestation.candidateId,
+        ...attestation.supportFacts.map((fact) => fact.candidateId),
+      ]),
+    );
     const selectedFeedItemProvenance =
       await artifactStore.readSelectedFeedItemProvenance({
         ...artifactScope,
-        feedItemIds: view.sourceWindow.selectedFeedItemIds,
+        feedItemIds: promotedFeedItemIds,
       });
     const selectedFeedItemScopeEvidence = {
-      selectedFeedItemIds: view.sourceWindow.selectedFeedItemIds,
+      selectedFeedItemIds: promotedFeedItemIds,
       feedItems: selectedFeedItemProvenance,
       scope: {
         tenantId: record.tenantId,
@@ -303,13 +312,13 @@ async function buildReport(): Promise<ArtifactQualityReport> {
       view.citations.map((item) => [item.citationId, item] as const),
     );
     const citationIds = new Set(view.citations.map((item) => item.citationId));
-    const selectedPosts = content.selectedPosts;
-    const topReads = content.topReads;
+    const selectedPosts = promotionBoard.selectedPosts;
+    const topReads = promotionBoard.topReads;
     const topReadCitationFeedItemIds = uniqueStrings(
       topReads.flatMap((read) =>
-        read.citationIds
-          .map((citationId) => citationById.get(citationId)?.feedItemId)
-          .filter((value): value is string => value !== undefined),
+        read.promotionAttestation === undefined
+          ? []
+          : [read.promotionAttestation.candidateId],
       ),
     );
     const topReadFeedItems = await artifactStore.readFeedItemsByIds({
@@ -342,13 +351,13 @@ async function buildReport(): Promise<ArtifactQualityReport> {
       selectedPosts.length > 0 &&
       selectedPosts.length <= coverage.selectedFeedItemCount &&
       selectedPosts.every(hasCanonicalUrl) &&
-      selectedPostDuplicateCanonicalUrlCount === 0 &&
-      coverage.citationCount === coverage.selectedFeedItemCount;
+      selectedPostDuplicateCanonicalUrlCount === 0;
+    const promotionBoardMatchesAttestedEvidence =
+      topReads.length + selectedPosts.length ===
+        view.promotionAttestations.length &&
+      promotedFeedItemIds.length === coverage.selectedFeedItemCount;
     const selectedPostsMismatchDocumented =
-      selectedPosts.length === coverage.selectedFeedItemCount ||
-      selectedPostsRepresentTopReadPreview ||
-      selectedPostsRepresentDedupedSelectedEvidence ||
-      reliabilityMentionsDedupeOrFilter(content.reliabilityReport);
+      promotionBoardMatchesAttestedEvidence;
     const userFacingTechnicalLeaks = collectUserFacingTechnicalLeaks(content);
     const uiPayloadTechnicalTagCount = countUiPayloadTechnicalTags([
       ...topReads,
@@ -492,6 +501,7 @@ async function buildReport(): Promise<ArtifactQualityReport> {
         selectedPostDuplicateCanonicalUrlCount,
         selectedPostsRepresentTopReadPreview,
         selectedPostsRepresentDedupedSelectedEvidence,
+        promotionBoardMatchesAttestedEvidence,
         selectedPostsMismatchDocumented,
       },
       summaryStructure: {
@@ -523,9 +533,8 @@ async function buildReport(): Promise<ArtifactQualityReport> {
           latestVisible.periodKey === dailyPeriodKey(collectionDate),
         artifactStatusIsVisible:
           record.status === "COMPLETED" || record.status === "NO_SIGNAL",
-        coverageSelectedMatchesSourceWindow:
-          coverage.selectedFeedItemCount ===
-          view.sourceWindow.selectedFeedItemIds.length,
+        coverageSelectedMatchesPromotionAttestations:
+          coverage.selectedFeedItemCount === promotedFeedItemIds.length,
         selectedFeedItemProvenanceMatchesArtifactScope:
           selectedFeedItemProvenanceMatchesScope(
             selectedFeedItemScopeEvidence,
@@ -603,6 +612,7 @@ async function buildReport(): Promise<ArtifactQualityReport> {
           selectedPosts.length < coverage.selectedFeedItemCount,
         selectedPostsRepresentTopReadPreview,
         selectedPostsRepresentDedupedSelectedEvidence,
+        promotionBoardMatchesAttestedEvidence,
         crossSourceEvidencePresent: coverage.crossSourceClusterCount > 0,
         historicalLatestVisibleGateBypassed: allowHistorical,
         dirtyCollectionAllowedForInspection:
@@ -690,6 +700,9 @@ function primarySourceCounts(
 
 function buildTopReadSourceQuality(params: {
   readonly topReads: readonly {
+    readonly promotionAttestation?: {
+      readonly candidateId: string;
+    };
     readonly citationIds: readonly string[];
   }[];
   readonly citationById: ReadonlyMap<
@@ -705,46 +718,42 @@ function buildTopReadSourceQuality(params: {
   const feedItemById = new Map(
     params.feedItems.map((item) => [item.id, item] as const),
   );
-  const rows = params.topReads.flatMap((read) =>
-    read.citationIds
-      .map((citationId) => {
-        const citation = params.citationById.get(citationId);
-        const feedItem =
-          citation === undefined
-            ? undefined
-            : feedItemById.get(citation.feedItemId);
-        if (citation === undefined || feedItem === undefined) {
-          return undefined;
-        }
+  const rows = params.topReads.flatMap((read) => {
+    const candidateId = read.promotionAttestation?.candidateId;
+    if (candidateId === undefined) {
+      return [];
+    }
+    const citation = read.citationIds
+      .map((citationId) => params.citationById.get(citationId))
+      .find((item) => item?.feedItemId === candidateId);
+    const feedItem = feedItemById.get(candidateId);
+    if (citation === undefined || feedItem === undefined) {
+      return [];
+    }
 
-        const verdict = qualityPolicy.evaluate({
-          providerKey: feedItem.providerKey,
-          title: feedItem.title,
-          bodyPreview: feedItem.bodyPreview ?? undefined,
-          canonicalUrl: feedItem.canonicalUrl,
-          authorHandle: feedItem.authorHandle ?? undefined,
-          providerMetadata: asJsonObject(feedItem.providerMetadata),
-        });
+    const verdict = qualityPolicy.evaluate({
+      providerKey: feedItem.providerKey,
+      title: feedItem.title,
+      bodyPreview: feedItem.bodyPreview ?? undefined,
+      canonicalUrl: feedItem.canonicalUrl,
+      authorHandle: feedItem.authorHandle ?? undefined,
+      providerMetadata: asJsonObject(feedItem.providerMetadata),
+    });
 
-        return {
-          citationFingerprint: fingerprint(citation.citationId),
-          feedItemFingerprint: fingerprint(citation.feedItemId),
-          providerKey: feedItem.providerKey,
-          decision: verdict.decision,
-          eligibleForSummary: verdict.eligibleForSummary,
-          eligibleForTopRead: verdict.eligibleForTopRead,
-          qualityScore: verdict.qualityScore,
-          interestRelevanceScore: verdict.interestRelevanceScore,
-          engagementIntegrityScore: verdict.engagementIntegrityScore,
-          flags: verdict.flags,
-        };
-      })
-      .filter((item): item is NonNullable<typeof item> => item !== undefined),
-  );
-  const topReadCitationFeedItemCount = params.topReads.reduce(
-    (count, read) => count + read.citationIds.length,
-    0,
-  );
+    return [{
+      citationFingerprint: fingerprint(citation.citationId),
+      feedItemFingerprint: fingerprint(citation.feedItemId),
+      providerKey: feedItem.providerKey,
+      decision: verdict.decision,
+      eligibleForSummary: verdict.eligibleForSummary,
+      eligibleForTopRead: verdict.eligibleForTopRead,
+      qualityScore: verdict.qualityScore,
+      interestRelevanceScore: verdict.interestRelevanceScore,
+      engagementIntegrityScore: verdict.engagementIntegrityScore,
+      flags: verdict.flags,
+    }];
+  });
+  const topReadCitationFeedItemCount = params.topReads.length;
 
   return {
     topReadCitationFeedItemCount,
@@ -775,19 +784,6 @@ function uniqueStrings(values: readonly string[]): readonly string[] {
 
 function hasCanonicalUrl(item: { readonly canonicalUrl?: string }): boolean {
   return /^https?:\/\//i.test(item.canonicalUrl?.trim() ?? "");
-}
-
-function reliabilityMentionsDedupeOrFilter(value: {
-  readonly risks: readonly {
-    readonly kind: string;
-    readonly description: string;
-  }[];
-}): boolean {
-  return value.risks.some((risk) =>
-    /\b(duplicate|dedupe|filter|collapse)\b/i.test(
-      `${risk.kind} ${risk.description}`,
-    ),
-  );
 }
 
 function collectUserFacingTechnicalLeaks(content: {

--- a/scripts/lib/reader-summary-artifact-coverage.spec.ts
+++ b/scripts/lib/reader-summary-artifact-coverage.spec.ts
@@ -136,7 +136,7 @@ describe("selectedCoverageMatchesProviderBreakdown", () => {
     ).toBe(true);
   });
 
-  it("fails closed when a citation references outside the selected window", () => {
+  it("ignores separately verified citations outside promotion selection", () => {
     const fixture = productionRegressionFixture();
 
     expect(
@@ -147,7 +147,7 @@ describe("selectedCoverageMatchesProviderBreakdown", () => {
           { feedItemId: "outside-selection", providerKey: "reddit" },
         ],
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("fails closed when one selected item maps to conflicting providers", () => {

--- a/scripts/lib/reader-summary-artifact-coverage.ts
+++ b/scripts/lib/reader-summary-artifact-coverage.ts
@@ -45,10 +45,9 @@ export const isPrimaryReaderSummaryArticleProvider = (
 const isSupplementalReaderSummaryProvider = (providerKey: string): boolean =>
   normalizedProviderKey(providerKey) === "github-trending-page";
 
-// The source window is the full scoped selection. The provider breakdown is
-// the source-mix projection: unique primary feed items grouped by provider.
-// Reader selectedPosts are identity-deduped and supplemental-display-capped,
-// so they are intentionally not evidence for this invariant.
+// Promotion attestations are the selected coverage authority. Citations may
+// additionally include a separately verified supplemental appendix, so only
+// citations bound to promoted feed items participate in this invariant.
 export const selectedCoverageMatchesProviderBreakdown = (
   coverage: {
     readonly selectedFeedItemCount: number;
@@ -228,7 +227,7 @@ const selectedCitationProviders = (
   for (const citation of citations) {
     const feedItemId = citation.feedItemId.trim();
     if (!selectedFeedItemIds.has(feedItemId)) {
-      return undefined;
+      continue;
     }
     const providerKey = normalizedProviderKey(citation.providerKey);
     const current = providerByFeedItemId.get(feedItemId);


### PR DESCRIPTION
Fixes the production daily-summary publication contract after promotion attestations became the selected-evidence authority.

- validates selected coverage against attested promotion evidence while keeping supplemental GitHub citations separate
- evaluates top-read quality on the promoted lead rather than weaker support citations
- filters the legacy supplemental appendix from the public promotion board
- caps dominant providers and normalizes provider boilerplate in reader-facing titles

Verification: 37 focused Jest tests passed; affected ESLint files passed. Full local TypeScript is blocked by pre-existing missing OpenTelemetry/Prisma generated dependencies, with no errors in changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved top-read selection to provide greater provider diversity.
  * Promoted stories now display cleaner, reader-facing titles instead of provider-generated boilerplate.
  * Promotion boards now show only supported additional story cards, keeping supplemental trend items out of selected posts.

* **Bug Fixes**
  * Improved promotion evidence and coverage validation so unrelated citations no longer affect promotion results.
  * Updated quality checks to evaluate promoted content and its verified evidence more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->