### PR TITLE
fix(summary): version production artifact attempts

### DIFF
--- a/libs/summary/interfaces/rest/reader-summary-promotion-board-rest.mapper.ts
+++ b/libs/summary/interfaces/rest/reader-summary-promotion-board-rest.mapper.ts
@@ -63,7 +63,7 @@ const promotionAdditionalCards = (
       additional.push(item);
       continue;
     }
-    if (item.cardKind === "supplemental_trend" && isGitHubReaderItem(item)) {
+    if (isGitHubReaderItem(item)) {
       continue;
     }
     throw new ReaderSummaryPromotionBoardMappingError();

--- a/libs/summary/interfaces/rest/reader-summary-rest.mapper.spec.ts
+++ b/libs/summary/interfaces/rest/reader-summary-rest.mapper.spec.ts
@@ -267,6 +267,21 @@ describe("readerSummaryArtifactViewFromReaderSummaryView", () => {
     expect(responseWithSupplementalAppendix.readerBrief.selectedPosts)
       .toEqual([]);
 
+    const responseWithLegacySupplementalAppendix =
+      readerSummaryArtifactViewFromReaderSummaryView({
+        ...readerSummaryView,
+        content: {
+          ...readerSummaryView.content,
+          selectedPosts: [{
+            ...supplementalCard,
+            providerKey: "github-trending-page",
+            storyClusterId: "supplemental:github-trending-page:legacy-feed",
+          }],
+        },
+      });
+    expect(responseWithLegacySupplementalAppendix.readerBrief.selectedPosts)
+      .toEqual([]);
+
     const persistedAttestation = readerSummaryView.promotionAttestations[0]!;
     for (const mutation of [
       { canonicalPayload: `${persistedAttestation.canonicalPayload} ` },

--- a/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
@@ -1,4 +1,5 @@
 import {
+  readerSummaryProductionDayArtifactPolicyVersion,
   readerSummaryProductionDayAttemptIdentity,
   readerSummaryProductionDayIdempotencyKey,
   type ReaderSummaryProductionDayAttemptIdentityInput,
@@ -57,6 +58,12 @@ const authorityHashFields = [
 ] as const;
 
 describe("reader summary production-day attempt identity", () => {
+  it("binds retries to the current persisted artifact policy", () => {
+    expect(readerSummaryProductionDayArtifactPolicyVersion).toBe(
+      "reader_summary.artifact_policy.v2",
+    );
+  });
+
   it("preserves the stable natural-day identity", () => {
     const identity = readerSummaryProductionDayAttemptIdentity(liveIdentity);
 

--- a/scripts/lib/reader-summary-production-day-attempt-identity.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.ts
@@ -29,11 +29,18 @@ export type ReaderSummaryProductionDayAttemptIdentityInput = Readonly<{
       }>;
 }>;
 
+// Bump this whenever persisted reader-summary selection or presentation
+// semantics change. A production-day retry must not silently reuse an artifact
+// produced under an older publication policy.
+export const readerSummaryProductionDayArtifactPolicyVersion =
+  "reader_summary.artifact_policy.v2";
+
 export const readerSummaryProductionDayAttemptIdentity = (
   input: ReaderSummaryProductionDayAttemptIdentityInput,
 ): string =>
   sha256(JSON.stringify({
     schemaVersion: "reader_summary.production_day_attempt.v2",
+    artifactPolicyVersion: readerSummaryProductionDayArtifactPolicyVersion,
     tenantId: requiredText(input.tenantId, "tenant"),
     workspaceId: requiredText(input.workspaceId, "workspace"),
     periodKey: requiredText(input.periodKey, "period"),


### PR DESCRIPTION
## Summary
- bind production-day idempotency to the current persisted artifact policy
- create a fresh summary job after publication semantics change
- keep the REST projection compatible with legacy GitHub supplemental cards

## Verification
- 2 focused Jest suites, 24 tests passed
- focused ESLint passed
- git diff --check passed