### PR TITLE
fix(summary): align promotion quality authority

### DIFF
--- a/libs/summary/domain/policies/reader-summary-reader-facing-text-policy.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-reader-facing-text-policy.spec.ts
@@ -10,6 +10,7 @@ describe("reader summary reader-facing text policy", () => {
   it("rejects low-information teaser titles", () => {
     expect(isUnpolishedReaderTitle("Check this out")).toBe(true);
     expect(isUnpolishedReaderTitle("Take a look!")).toBe(true);
+    expect(isUnpolishedReaderTitle("Nice Work OpenAI")).toBe(true);
     expect(
       isUnpolishedReaderTitle(
         "Happy coding this weekend, Claude Code fans! https://t.co/example",

--- a/libs/summary/domain/policies/reader-summary-reader-facing-text-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-reader-facing-text-policy.ts
@@ -57,6 +57,7 @@ const isLowInformationReaderTitle = (value: string): boolean => {
     /^(?:happy|good) (?:coding|building|shipping)(?: this weekend)?(?: [\p{L}\p{N} ]+ fans)?$/u.test(
       normalized,
     ) ||
+    /^(?:good|great|nice) work(?: [\p{L}\p{N}]+){0,3}$/u.test(normalized) ||
     /\bmegathread\b/u.test(normalized)
   );
 };

--- a/libs/summary/domain/services/reader-post-promotion-evidence-admission.spec.ts
+++ b/libs/summary/domain/services/reader-post-promotion-evidence-admission.spec.ts
@@ -85,6 +85,37 @@ describe("admitReaderPostPromotionEvidence supplemental appendix", () => {
     expect(projection.topReads[0]?.title)
       .toBe("Agent release reaches developers");
   });
+
+  it("derives a reader-facing promotion title from the source body", () => {
+    const fixture = fixtureSelection();
+    const evidence = fixture.selectedEvidence.map((item) =>
+      item.feedItemId === "hn:top"
+        ? {
+            ...item,
+            title: "Nice Work OpenAI",
+            bodyPreview:
+              "OpenAI introduced a lower-cost business plan for teams with a two-seat minimum.",
+          }
+        : item,
+    );
+    const projection = buildReaderPostPromotionProjection({
+      evidence,
+      clusters: fixture.clusters,
+      sourceWindow: fixture.sourceWindow,
+      citations: evidence.map((item) => ({
+        citationId: `citation:${item.feedItemId}`,
+        feedItemId: item.feedItemId,
+        sourceItemId: item.sourceItemId,
+        providerKey: item.providerKey,
+        field: "canonicalUrl" as const,
+        canonicalUrl: item.canonicalUrl,
+      })),
+    });
+
+    expect(projection.topReads[0]?.title).toBe(
+      "OpenAI introduced a lower-cost business plan for teams with a two-seat minimum",
+    );
+  });
 });
 
 const fixtureSelection = (): SummaryEvidenceSelection => {

--- a/libs/summary/domain/services/reader-post-promotion-projection.ts
+++ b/libs/summary/domain/services/reader-post-promotion-projection.ts
@@ -302,7 +302,9 @@ const promotedPost = (params: {
     promotionCanonicalIdentity: params.selected.candidate.canonicalIdentity,
     title: buildTopReadTitle({
       storyTitle: lead.title,
-      storySummary: promotionStorySummary(lead, params.selected),
+      storySummary:
+        [lead.bodyPreview, ...params.selected.whyImportant, ...lead.whyImportant]
+          .find((value) => value?.trim().length !== 0) ?? lead.title,
       primaryEvidence: lead,
       evidence: admitted,
     }),
@@ -340,13 +342,6 @@ const promotedPost = (params: {
     citationIds: params.selected.citationIds,
   };
 };
-
-const promotionStorySummary = (
-  lead: SummaryEvidenceItem,
-  selected: SelectedReaderPostPromotion,
-): string =>
-  [lead.bodyPreview, ...selected.whyImportant, ...lead.whyImportant]
-    .find((value) => value?.trim().length !== 0) ?? lead.title;
 
 const promotionRelations = (params: {
   readonly evidenceById: ReadonlyMap<string, SummaryEvidenceItem>;

--- a/libs/summary/domain/services/reader-post-promotion-projection.ts
+++ b/libs/summary/domain/services/reader-post-promotion-projection.ts
@@ -23,7 +23,7 @@ import { readerSummaryIndependentProviderFamily } from
   "../value-objects/reader-summary-provider-identity";
 import { compactUnique } from "../value-objects/summary-text";
 import { buildMatchedRules } from "./reader-summary-source-lineage";
-import { evidenceReaderTitle } from "./reader-summary-top-read-title";
+import { buildTopReadTitle } from "./reader-summary-top-read-title";
 import {
   buildReaderPostPromotionAttestations,
   type ReaderPostPromotionAttestationBinding,
@@ -300,7 +300,12 @@ const promotedPost = (params: {
     promotionTier: params.cardKind === "curated_top_read" ? "top" : "additional",
     promotionCandidateId: params.selected.candidate.candidateId,
     promotionCanonicalIdentity: params.selected.candidate.canonicalIdentity,
-    title: evidenceReaderTitle(lead),
+    title: buildTopReadTitle({
+      storyTitle: lead.title,
+      storySummary: promotionStorySummary(lead, params.selected),
+      primaryEvidence: lead,
+      evidence: admitted,
+    }),
     providerKey: lead.providerKey,
     providerName: lead.providerName ?? lead.providerKey,
     primaryActionKind: lead.readerActionKind ?? "read_source",
@@ -335,6 +340,13 @@ const promotedPost = (params: {
     citationIds: params.selected.citationIds,
   };
 };
+
+const promotionStorySummary = (
+  lead: SummaryEvidenceItem,
+  selected: SelectedReaderPostPromotion,
+): string =>
+  [lead.bodyPreview, ...selected.whyImportant, ...lead.whyImportant]
+    .find((value) => value?.trim().length !== 0) ?? lead.title;
 
 const promotionRelations = (params: {
   readonly evidenceById: ReadonlyMap<string, SummaryEvidenceItem>;

--- a/libs/summary/domain/services/reader-summary-top-read-title.spec.ts
+++ b/libs/summary/domain/services/reader-summary-top-read-title.spec.ts
@@ -74,6 +74,47 @@ describe("reader summary top read title", () => {
     expect(title).toBe("Claude Code users question another access extension");
   });
 
+  it.each([
+    {
+      sourceTitle: "Nice Work OpenAI",
+      summary:
+        "OpenAI introduced a lower-cost business plan for teams with a two-seat minimum.",
+      expected:
+        "OpenAI introduced a lower-cost business plan for teams with a two-seat minimum",
+    },
+    {
+      sourceTitle: "I am unsure what I gave my copilot to make it hallucinate?",
+      summary:
+        "GitHub Copilot hallucinated a nonexistent package while proposing a dependency change.",
+      expected:
+        "GitHub Copilot hallucinated a nonexistent package while proposing a dependency change",
+    },
+    {
+      sourceTitle:
+        "New $100 Business Plan (2 seat minimum). They finally did it. My team just switched over. This is why 5h limits are back.",
+      summary:
+        "OpenAI's new business plan costs $100 and requires at least two seats.",
+      expected:
+        "OpenAI's new business plan costs $100 and requires at least two seats",
+    },
+  ])(
+    "derives a concrete title from evidence text for an unpolished source hook",
+    ({ sourceTitle, summary, expected }) => {
+      const title = buildTopReadTitle({
+        storyTitle: sourceTitle,
+        storySummary: summary,
+        primaryEvidence: evidence({
+          providerKey: "reddit",
+          title: sourceTitle,
+          bodyPreview: summary,
+        }),
+        evidence: [],
+      });
+
+      expect(title).toBe(expected);
+    },
+  );
+
   it("repairs an obvious agreement error in a native English title", () => {
     const title = buildTopReadTitle({
       storyTitle: "AI research productivity study",

--- a/scripts/check-yesterday-reader-summary-artifact-quality.ts
+++ b/scripts/check-yesterday-reader-summary-artifact-quality.ts
@@ -3,7 +3,11 @@ import { dirname } from "node:path";
 
 import { Pool } from "pg";
 
-import { SourceContentQualityPolicy } from "@social-monitor/relevance/domain";
+import {
+  SourceContentQualityPolicy,
+  SourceContentSafetyPolicy,
+} from "@social-monitor/relevance/domain";
+import { promotionSafeProviderMetadata } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-item-projection";
 import type { JsonObject } from "@social-monitor/shared-kernel";
 import { readerSummaryArtifactFromPrisma } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-records";
 import { presentReaderSummaryArtifact } from "@social-monitor/summary/features/shared/reader-summary-artifact-presenter";
@@ -176,6 +180,7 @@ const databaseUrl = yesterdaySocialQualityDatabaseUrl();
 const primarySources = ["reddit", "x-twitter"] as const;
 const badGamingFalsePositiveNeedle =
   "game industry is making me incredibly depressed";
+const promotionSourceTextSafetyCap = 256_000;
 
 void main();
 
@@ -715,6 +720,7 @@ function buildTopReadSourceQuality(params: {
   readonly feedItems: readonly TopReadFeedItemQualityRow[];
 }): ArtifactQualityReport["sourceQuality"] {
   const qualityPolicy = new SourceContentQualityPolicy();
+  const safetyPolicy = new SourceContentSafetyPolicy();
   const feedItemById = new Map(
     params.feedItems.map((item) => [item.id, item] as const),
   );
@@ -731,13 +737,22 @@ function buildTopReadSourceQuality(params: {
       return [];
     }
 
-    const verdict = qualityPolicy.evaluate({
+    const safety = safetyPolicy.evaluate({
       providerKey: feedItem.providerKey,
       title: feedItem.title,
-      bodyPreview: feedItem.bodyPreview ?? undefined,
+      bodyPreview: feedItem.sourceBody.slice(0, promotionSourceTextSafetyCap),
       canonicalUrl: feedItem.canonicalUrl,
+    });
+    const verdict = qualityPolicy.evaluate({
+      providerKey: feedItem.providerKey,
+      title: safety.sanitizedTitle,
+      bodyPreview: safety.sanitizedBodyPreview,
+      canonicalUrl: safety.sanitizedCanonicalUrl ?? feedItem.canonicalUrl,
       authorHandle: feedItem.authorHandle ?? undefined,
-      providerMetadata: asJsonObject(feedItem.providerMetadata),
+      providerMetadata: promotionSafeProviderMetadata(
+        feedItem.providerKey,
+        asJsonObject(feedItem.providerMetadata),
+      ),
     });
 
     return [{

--- a/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
@@ -60,7 +60,7 @@ const authorityHashFields = [
 describe("reader summary production-day attempt identity", () => {
   it("binds retries to the current persisted artifact policy", () => {
     expect(readerSummaryProductionDayArtifactPolicyVersion).toBe(
-      "reader_summary.artifact_policy.v2",
+      "reader_summary.artifact_policy.v3",
     );
   });
 

--- a/scripts/lib/reader-summary-production-day-attempt-identity.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.ts
@@ -33,7 +33,7 @@ export type ReaderSummaryProductionDayAttemptIdentityInput = Readonly<{
 // semantics change. A production-day retry must not silently reuse an artifact
 // produced under an older publication policy.
 export const readerSummaryProductionDayArtifactPolicyVersion =
-  "reader_summary.artifact_policy.v2";
+  "reader_summary.artifact_policy.v3";
 
 export const readerSummaryProductionDayAttemptIdentity = (
   input: ReaderSummaryProductionDayAttemptIdentityInput,

--- a/scripts/lib/yesterday-reader-summary-artifact-quality-store.spec.ts
+++ b/scripts/lib/yesterday-reader-summary-artifact-quality-store.spec.ts
@@ -209,6 +209,7 @@ describe("YesterdayReaderSummaryArtifactQualityStore", () => {
         authorHandle: "example-author",
         title: "Example title",
         bodyPreview: "Example preview",
+        sourceBody: "Full original source body",
         providerMetadata: { score: 42 },
       },
     ];
@@ -221,11 +222,16 @@ describe("YesterdayReaderSummaryArtifactQualityStore", () => {
     ).resolves.toEqual(rows);
 
     const sql = querySql(query);
-    expect(sql).toContain('id::text as "id"');
-    expect(sql).toContain('provider_key as "providerKey"');
-    expect(sql).toContain("tenant_id = $1::uuid");
-    expect(sql).toContain("workspace_id = $2::uuid");
-    expect(sql).toContain("id = any($3::uuid[])");
+    expect(sql).toContain('fi.id::text as "id"');
+    expect(sql).toContain('fi.provider_key as "providerKey"');
+    expect(sql).toContain('si.body as "sourceBody"');
+    expect(sql).toContain("join source_items si");
+    expect(sql).toContain("si.id = fi.source_item_id");
+    expect(sql).toContain("si.tenant_id = fi.tenant_id");
+    expect(sql).toContain("si.workspace_id = fi.workspace_id");
+    expect(sql).toContain("fi.tenant_id = $1::uuid");
+    expect(sql).toContain("fi.workspace_id = $2::uuid");
+    expect(sql).toContain("fi.id = any($3::uuid[])");
     expect(query.mock.calls[0]?.[1]).toEqual([
       tenantId,
       workspaceId,

--- a/scripts/lib/yesterday-reader-summary-artifact-quality-store.ts
+++ b/scripts/lib/yesterday-reader-summary-artifact-quality-store.ts
@@ -36,6 +36,7 @@ export type TopReadFeedItemQualityRow = {
   readonly authorHandle: string | null;
   readonly title: string;
   readonly bodyPreview: string | null;
+  readonly sourceBody: string;
   readonly providerMetadata: unknown;
 };
 
@@ -295,17 +296,22 @@ export class YesterdayReaderSummaryArtifactQualityStore {
     const result = await this.pool.query<TopReadFeedItemQualityRow>(
       `
         select
-          id::text as "id",
-          provider_key as "providerKey",
-          canonical_url as "canonicalUrl",
-          author_handle as "authorHandle",
-          title,
-          body_preview as "bodyPreview",
-          provider_metadata as "providerMetadata"
-        from feed_items
-        where tenant_id = $1::uuid
-          and workspace_id = $2::uuid
-          and id = any($3::uuid[])
+          fi.id::text as "id",
+          fi.provider_key as "providerKey",
+          fi.canonical_url as "canonicalUrl",
+          fi.author_handle as "authorHandle",
+          fi.title,
+          fi.body_preview as "bodyPreview",
+          si.body as "sourceBody",
+          fi.provider_metadata as "providerMetadata"
+        from feed_items fi
+        join source_items si
+          on si.id = fi.source_item_id
+         and si.tenant_id = fi.tenant_id
+         and si.workspace_id = fi.workspace_id
+        where fi.tenant_id = $1::uuid
+          and fi.workspace_id = $2::uuid
+          and fi.id = any($3::uuid[])
       `,
       [params.tenantId, params.workspaceId, params.feedItemIds],
     );


### PR DESCRIPTION
## Summary
- make the final publication quality gate evaluate the same authoritative full source text and safety-normalized metadata as promotion selection
- normalize promoted reader titles from grounded source content instead of exposing conversational hooks
- bump the production-day artifact policy to v3 so retries cannot reuse stale summaries

## Evidence
- 52 focused tests passed
- changed-file ESLint passed
- git diff check passed
- repository TypeScript check is blocked by pre-existing missing OpenTelemetry/generated Prisma modules in this worktree; changed TypeScript was compiled by Jest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved top-read titles by generating clearer, more descriptive reader-facing summaries from source content.
  * Reduced low-information titles such as “Nice Work OpenAI.”
  * Enhanced source-quality checks by sanitizing content before evaluation.
  * Improved source content retrieval for more accurate quality assessment.

* **Bug Fixes**
  * Corrected promotion titles that were derived from raw provider titles instead of source content.

* **Tests**
  * Added coverage for title quality, promotion title derivation, source-content handling, and updated artifact policy validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->