### PR TITLE
fix(summary): replace unrenderable promotion leads

### DIFF
--- a/libs/summary/domain/policies/reader-summary-reader-facing-text-policy.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-reader-facing-text-policy.spec.ts
@@ -11,6 +11,7 @@ describe("reader summary reader-facing text policy", () => {
     expect(isUnpolishedReaderTitle("Check this out")).toBe(true);
     expect(isUnpolishedReaderTitle("Take a look!")).toBe(true);
     expect(isUnpolishedReaderTitle("Nice Work OpenAI")).toBe(true);
+    expect(isUnpolishedReaderTitle("This is awesome marketing")).toBe(true);
     expect(
       isUnpolishedReaderTitle(
         "Happy coding this weekend, Claude Code fans! https://t.co/example",

--- a/libs/summary/domain/policies/reader-summary-reader-facing-text-policy.ts
+++ b/libs/summary/domain/policies/reader-summary-reader-facing-text-policy.ts
@@ -58,6 +58,9 @@ const isLowInformationReaderTitle = (value: string): boolean => {
       normalized,
     ) ||
     /^(?:good|great|nice) work(?: [\p{L}\p{N}]+){0,3}$/u.test(normalized) ||
+    /^(?:this|that|it) is (?:awesome|amazing|great|nice)(?: marketing| work)?$/u.test(
+      normalized,
+    ) ||
     /\bmegathread\b/u.test(normalized)
   );
 };

--- a/libs/summary/domain/services/reader-post-promotion-evidence-admission.spec.ts
+++ b/libs/summary/domain/services/reader-post-promotion-evidence-admission.spec.ts
@@ -116,6 +116,60 @@ describe("admitReaderPostPromotionEvidence supplemental appendix", () => {
       "OpenAI introduced a lower-cost business plan for teams with a two-seat minimum",
     );
   });
+
+  it("replaces an unrenderable lead with the next reader-facing candidate", () => {
+    const fixture = fixtureSelection();
+    const primary = fixture.selectedEvidence[0]!;
+    const unrenderable = {
+      ...primary,
+      feedItemId: "reddit:unrenderable",
+      sourceItemId: "reddit:unrenderable",
+      providerKey: "reddit",
+      canonicalUrl: "https://reddit.com/r/openai/unrenderable",
+      title: "Nice Work OpenAI",
+      bodyPreview: "I was just vibe coding as usual and wanted to share this.",
+      score: 10,
+      promotionFacts: {
+        ...primary.promotionFacts!,
+        canonicalIdentity: "story:unrenderable",
+        metrics: { provider: "reddit", score: 500 },
+      },
+    } satisfies SummaryEvidenceItem;
+    const evidence = [unrenderable, ...fixture.selectedEvidence];
+    const projection = buildReaderPostPromotionProjection({
+      evidence,
+      clusters: [
+        {
+          ...fixture.clusters[0]!,
+          id: "cluster:unrenderable",
+          storyKey: "reddit:unrenderable",
+          representativeFeedItemId: unrenderable.feedItemId,
+          providerKeys: ["reddit"],
+          score: unrenderable.score,
+        },
+        ...fixture.clusters,
+      ],
+      sourceWindow: fixture.sourceWindow,
+      citations: evidence.map((item) => ({
+        citationId: `citation:${item.feedItemId}`,
+        feedItemId: item.feedItemId,
+        sourceItemId: item.sourceItemId,
+        providerKey: item.providerKey,
+        field: "canonicalUrl" as const,
+        canonicalUrl: item.canonicalUrl,
+      })),
+    });
+
+    expect(projection.topReads.map((item) => item.title)).toContain(
+      "Agent release reaches developers",
+    );
+    expect(projection.topReads.map((item) => item.promotionCandidateId))
+      .not.toContain(unrenderable.feedItemId);
+    expect(projection.evaluatedEvidence).toContainEqual({
+      candidateId: unrenderable.feedItemId,
+      decision: "reject",
+    });
+  });
 });
 
 const fixtureSelection = (): SummaryEvidenceSelection => {

--- a/libs/summary/domain/services/reader-post-promotion-projection.ts
+++ b/libs/summary/domain/services/reader-post-promotion-projection.ts
@@ -23,7 +23,10 @@ import { readerSummaryIndependentProviderFamily } from
   "../value-objects/reader-summary-provider-identity";
 import { compactUnique } from "../value-objects/summary-text";
 import { buildMatchedRules } from "./reader-summary-source-lineage";
-import { buildTopReadTitle } from "./reader-summary-top-read-title";
+import {
+  buildReaderPostPromotionTitle,
+  hasReaderFacingPromotionTitle,
+} from "./reader-post-promotion-title";
 import {
   buildReaderPostPromotionAttestations,
   type ReaderPostPromotionAttestationBinding,
@@ -97,7 +100,8 @@ export const buildReaderPostPromotionProjection = (params: {
       qualityScore: quality?.qualityScore ?? Number.NaN,
       relevanceScore: quality?.interestRelevanceScore ?? Number.NaN,
       integrityScore: quality?.engagementIntegrityScore ?? Number.NaN,
-      qualityValid: quality?.eligibleForSummary === true &&
+      qualityValid: hasReaderFacingPromotionTitle(item) &&
+        quality?.eligibleForSummary === true &&
         quality.eligibleForTopRead === true &&
         quality.needsLlmReview === false &&
         quality.decision !== "downrank" &&
@@ -300,13 +304,10 @@ const promotedPost = (params: {
     promotionTier: params.cardKind === "curated_top_read" ? "top" : "additional",
     promotionCandidateId: params.selected.candidate.candidateId,
     promotionCanonicalIdentity: params.selected.candidate.canonicalIdentity,
-    title: buildTopReadTitle({
-      storyTitle: lead.title,
-      storySummary:
-        [lead.bodyPreview, ...params.selected.whyImportant, ...lead.whyImportant]
-          .find((value) => value?.trim().length !== 0) ?? lead.title,
-      primaryEvidence: lead,
-      evidence: admitted,
+    title: buildReaderPostPromotionTitle({
+      lead,
+      admitted,
+      promotionReasons: params.selected.whyImportant,
     }),
     providerKey: lead.providerKey,
     providerName: lead.providerName ?? lead.providerKey,

--- a/libs/summary/domain/services/reader-post-promotion-title.ts
+++ b/libs/summary/domain/services/reader-post-promotion-title.ts
@@ -1,0 +1,26 @@
+import type { SummaryEvidenceItem } from
+  "../value-objects/summary-evidence-item";
+import { isUnpolishedReaderTitle } from
+  "../policies/reader-summary-reader-facing-text-policy";
+import { buildTopReadTitle } from "./reader-summary-top-read-title";
+
+export const buildReaderPostPromotionTitle = (params: {
+  readonly lead: SummaryEvidenceItem;
+  readonly admitted?: readonly SummaryEvidenceItem[];
+  readonly promotionReasons?: readonly string[];
+}): string => buildTopReadTitle({
+  storyTitle: params.lead.title,
+  storySummary: [
+    params.lead.bodyPreview,
+    ...(params.promotionReasons ?? []),
+    ...params.lead.whyImportant,
+  ].find((value) => value?.trim().length !== 0) ?? params.lead.title,
+  primaryEvidence: params.lead,
+  evidence: params.admitted ?? [params.lead],
+});
+
+export const hasReaderFacingPromotionTitle = (
+  item: SummaryEvidenceItem,
+): boolean => !isUnpolishedReaderTitle(
+  buildReaderPostPromotionTitle({ lead: item }),
+);

--- a/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
@@ -60,7 +60,7 @@ const authorityHashFields = [
 describe("reader summary production-day attempt identity", () => {
   it("binds retries to the current persisted artifact policy", () => {
     expect(readerSummaryProductionDayArtifactPolicyVersion).toBe(
-      "reader_summary.artifact_policy.v3",
+      "reader_summary.artifact_policy.v4",
     );
   });
 

--- a/scripts/lib/reader-summary-production-day-attempt-identity.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.ts
@@ -33,7 +33,7 @@ export type ReaderSummaryProductionDayAttemptIdentityInput = Readonly<{
 // semantics change. A production-day retry must not silently reuse an artifact
 // produced under an older publication policy.
 export const readerSummaryProductionDayArtifactPolicyVersion =
-  "reader_summary.artifact_policy.v3";
+  "reader_summary.artifact_policy.v4";
 
 export const readerSummaryProductionDayAttemptIdentity = (
   input: ReaderSummaryProductionDayAttemptIdentityInput,


### PR DESCRIPTION
## Summary

- reject promotion leads whose deterministic title can only become a technical fallback
- let the existing ranked selection fill the slot with the next reader-facing candidate
- recognize low-information marketing reactions and version production retries as artifact policy v4

## Evidence

- 44 focused tests passed
- changed-file ESLint passed
- source line-cap passed
- TypeScript 7 is incompatible with the repository baseUrl config; local pinned typecheck is blocked by pre-existing missing OpenTelemetry/generated Prisma modules, so full CI is the authoritative typecheck