### PR TITLE
fix(summary): validate attestations in peer context

### DIFF
--- a/libs/summary/adapters/persistence/prisma/reader-summary-artifact-promotion-immutability.spec.ts
+++ b/libs/summary/adapters/persistence/prisma/reader-summary-artifact-promotion-immutability.spec.ts
@@ -11,8 +11,99 @@ import {
 } from
   "../../../domain/services/reader-post-promotion-attestation";
 import { ReaderSummaryArtifact } from "../../../domain/entities/reader-summary-artifact";
+import { assertReaderSummaryPromotionAttestations } from
+  "../../../domain/entities/reader-summary-promotion-attestation-validation";
 
 describe("ReaderSummaryArtifact promotion immutability", () => {
+  it("validates semantic-cluster support in the persisted peer context", () => {
+    const base = readerSummaryArtifact("artifact-contextual-attestation")
+      .toSnapshot();
+    const periodStart = new Date("2026-07-05T00:00:00.000Z");
+    const periodEnd = new Date("2026-07-06T00:00:00.000Z");
+    const publishedAt = new Date("2026-07-05T08:00:00.000Z");
+    const observedAt = new Date("2026-07-05T08:05:00.000Z");
+    const cutoff = new Date("2026-07-05T09:00:00.000Z");
+    const common = {
+      clusterId: "cluster:runtime-release",
+      publishedAt,
+      observedAt,
+      periodStart,
+      periodEnd,
+      ingestionCutoff: cutoff,
+      freshnessValid: true,
+      qualityScore: 0.9,
+      relevanceScore: 0.9,
+      integrityScore: 0.9,
+      qualityValid: true,
+      safetyValid: true,
+      citationValid: true,
+      metricsState: "observed" as const,
+    };
+    const selection = selectReaderPostPromotions([{
+      ...common,
+      candidateId: "feed-context-lead",
+      provider: "reddit",
+      contentKind: "original_post",
+      canonicalIdentity: "story:runtime-release-reddit",
+      citationId: "citation-context-lead",
+      metrics: { provider: "reddit", score: 500, upvoteRatio: 0.95 },
+    }, {
+      ...common,
+      candidateId: "feed-context-support",
+      provider: "hacker-news",
+      contentKind: "story",
+      canonicalIdentity: "story:runtime-release-hn",
+      citationId: "citation-context-support",
+      metrics: { provider: "hacker_news", points: 50 },
+    }]);
+    const selected = selection.top[0]!;
+    expect(selected.support).toHaveLength(1);
+    const sourceWindow = {
+      ...base.sourceWindow,
+      selectedFeedItemIds: ["feed-context-lead", "feed-context-support"],
+      periodStartedAt: periodStart,
+      periodEndedAt: periodEnd,
+      ingestionCutoff: cutoff,
+    };
+    const attestations = buildReaderPostPromotionAttestations(selection, {
+      artifactId: base.readerSummaryId,
+      sourceWindow,
+    });
+
+    expect(() => assertReaderSummaryPromotionAttestations({
+      ...base,
+      sourceWindow,
+      citationMap: [{
+        citationId: "citation-context-lead",
+        feedItemId: "feed-context-lead",
+        sourceItemId: "source-context-lead",
+        providerKey: "reddit",
+        field: "canonicalUrl",
+      }, {
+        citationId: "citation-context-support",
+        feedItemId: "feed-context-support",
+        sourceItemId: "source-context-support",
+        providerKey: "hacker-news",
+        field: "canonicalUrl",
+      }],
+      content: {
+        ...base.content!,
+        topReads: [{
+          ...topRead(),
+          promotionMarker: "reader_post_promotion",
+          promotionPolicyVersion: "reader_post_promotion.v1",
+          promotionTier: "top",
+          promotionCandidateId: selected.candidate.candidateId,
+          promotionCanonicalIdentity: selected.candidate.canonicalIdentity,
+          citationIds: selected.citationIds,
+        }],
+        selectedPosts: [],
+      },
+      promotionAttestations: attestations,
+      promotionEvidenceFacts: [selected.candidate, ...selected.support],
+    }, attestations)).not.toThrow();
+  });
+
   it("isolates nested signed support facts from input and snapshot mutation", () => {
     const base = readerSummaryArtifact("artifact-promotion-immutability")
       .toSnapshot();

--- a/libs/summary/domain/entities/reader-summary-promotion-attestation-validation.ts
+++ b/libs/summary/domain/entities/reader-summary-promotion-attestation-validation.ts
@@ -1,8 +1,5 @@
-import {
-  readerPostPromotionTimestampMicros,
-  READER_POST_PROMOTION_POLICY_V1,
-  type ReaderPostPromotionAttestation,
-} from "../policies/reader-post-promotion-policy";
+import type { ReaderPostPromotionAttestation } from
+  "../policies/reader-post-promotion-policy";
 import { selectReaderPostPromotions } from
   "../policies/reader-post-promotion-selection";
 import {
@@ -17,6 +14,9 @@ export const assertReaderSummaryPromotionAttestations = (
   props: ReaderSummaryArtifactProps,
   attestations: readonly ReaderPostPromotionAttestation[],
 ): void => {
+  // Selection placement, semantic dedupe and provider caps depend on the peer
+  // candidate set. Recompute that persisted set once instead of re-ranking an
+  // individual attestation without its selection context.
   assertAttestationsAgainstPersistedEvidence(props, attestations);
   const candidateIds = new Set<string>();
   for (const attestation of attestations) {
@@ -39,7 +39,6 @@ export const assertReaderSummaryPromotionAttestations = (
         candidateIds.has(attestation.candidateId)) {
       throw new Error("Reader summary promotion attestation is invalid");
     }
-    assertAttestedPolicyDecision(attestation);
     candidateIds.add(attestation.candidateId);
     const components = attestation.usefulnessComponents;
     const values = [
@@ -132,105 +131,4 @@ const assertAttestationsAgainstPersistedEvidence = (
       "Reader summary promotion attestation differs from persisted evidence facts",
     );
   }
-};
-
-const assertAttestedPolicyDecision = (
-  attestation: ReaderPostPromotionAttestation,
-): void => {
-  const lead = {
-    candidateId: attestation.candidateId,
-    provider: attestation.provider,
-    contentKind: attestation.contentKind,
-    canonicalIdentity: attestation.canonicalIdentity,
-    citationId: attestation.citationId,
-    publishedAt: attestation.publishedAt,
-    observedAt: attestation.observedAt,
-    ...(attestation.exactPublishedAt === undefined ? {} : {
-      exactPublishedAt: attestation.exactPublishedAt,
-    }),
-    ...(attestation.exactObservedAt === undefined ? {} : {
-      exactObservedAt: attestation.exactObservedAt,
-    }),
-    ...(attestation.exactPeriodStart === undefined ? {} : {
-      exactPeriodStart: attestation.exactPeriodStart,
-    }),
-    ...(attestation.exactPeriodEnd === undefined ? {} : {
-      exactPeriodEnd: attestation.exactPeriodEnd,
-    }),
-    ...(attestation.exactIngestionCutoff === undefined ? {} : {
-      exactIngestionCutoff: attestation.exactIngestionCutoff,
-    }),
-    ...(attestation.checkedAt === undefined ? {} : {
-      checkedAt: attestation.checkedAt,
-    }),
-    periodStart: attestation.periodStartedAt,
-    periodEnd: attestation.periodEndedAt,
-    ingestionCutoff: attestation.ingestionCutoff,
-    freshnessValid: attestation.freshnessValid,
-    qualityScore: attestation.qualityScore,
-    relevanceScore: attestation.relevanceScore,
-    integrityScore: attestation.integrityScore,
-    qualityValid: attestation.qualityValid,
-    safetyValid: attestation.safetyValid,
-    citationValid: attestation.citationValid,
-    metricsState: attestation.metricsState,
-    ...(attestation.metrics === undefined ? {} : { metrics: attestation.metrics }),
-    ...(attestation.authorityAttestation === undefined ? {} : {
-      authorityAttestation: attestation.authorityAttestation,
-    }),
-    ...(attestation.relationTrace === undefined ? {} : {
-      relation: attestation.relationTrace,
-    }),
-  };
-  const selection = selectReaderPostPromotions([lead, ...attestation.supportFacts]);
-  const expected = attestation.placement === "top"
-    ? selection.top[0]
-    : selection.additional[0];
-  const decision = selection.decisions.find((item) =>
-    item.candidateId === attestation.candidateId,
-  );
-  const periodStart = requiredMicros(
-    attestation.exactPeriodStart ?? attestation.periodStartedAt,
-  );
-  const periodEnd = requiredMicros(
-    attestation.exactPeriodEnd ?? attestation.periodEndedAt,
-  );
-  const publishedAt = requiredMicros(
-    attestation.exactPublishedAt ?? attestation.publishedAt,
-  );
-  const duration = periodEnd - periodStart;
-  const freshness = duration <= 0n ? 0 : Math.max(0, Math.min(1,
-    Number(publishedAt - periodStart) / Number(duration),
-  ));
-  const weights = READER_POST_PROMOTION_POLICY_V1.additionalUsefulnessWeights;
-  const expectedComponents = {
-    normalizedStrength:
-      (decision?.normalizedStrength ?? Number.NaN) * weights.normalizedStrength,
-    qualityScore: attestation.qualityScore * weights.qualityScore,
-    interestRelevanceScore:
-      attestation.relevanceScore * weights.interestRelevanceScore,
-    engagementIntegrityScore:
-      attestation.integrityScore * weights.engagementIntegrityScore,
-    freshness: freshness * weights.freshness,
-  };
-  if (expected?.candidate.candidateId !== attestation.candidateId ||
-      expected.decision !== attestation.decision ||
-      decision?.reason !== attestation.reason ||
-      Object.entries(expectedComponents).some(([key, value]) =>
-        Math.abs(value - attestation.usefulnessComponents[
-          key as keyof typeof expectedComponents
-        ]) > 1e-12) ||
-      expected.providerCount !== attestation.providerCount ||
-      expected.confidence !== attestation.confidence ||
-      !sameOrderedValues(expected.citationIds, attestation.citationIds)) {
-    throw new Error("Reader summary promotion attested policy decision is invalid");
-  }
-};
-
-const requiredMicros = (value: Date | string): bigint => {
-  const micros = readerPostPromotionTimestampMicros(value);
-  if (micros === undefined) {
-    throw new Error("Reader summary promotion exact timestamp is invalid");
-  }
-  return micros;
 };

--- a/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
@@ -60,7 +60,7 @@ const authorityHashFields = [
 describe("reader summary production-day attempt identity", () => {
   it("binds retries to the current persisted artifact policy", () => {
     expect(readerSummaryProductionDayArtifactPolicyVersion).toBe(
-      "reader_summary.artifact_policy.v4",
+      "reader_summary.artifact_policy.v5",
     );
   });
 

--- a/scripts/lib/reader-summary-production-day-attempt-identity.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.ts
@@ -33,7 +33,7 @@ export type ReaderSummaryProductionDayAttemptIdentityInput = Readonly<{
 // semantics change. A production-day retry must not silently reuse an artifact
 // produced under an older publication policy.
 export const readerSummaryProductionDayArtifactPolicyVersion =
-  "reader_summary.artifact_policy.v4";
+  "reader_summary.artifact_policy.v5";
 
 export const readerSummaryProductionDayAttemptIdentity = (
   input: ReaderSummaryProductionDayAttemptIdentityInput,


### PR DESCRIPTION
## Summary

- validate promotion attestations by replaying the complete persisted peer set
- remove the contradictory isolated replay that discarded lead cluster context
- add the exact cross-provider semantic-cluster regression and version the retry as artifact policy v5

## Safety

- canonical payload and digest must still match byte-for-byte
- persisted evidence is still citation-bound and fully reselected under the promotion policy
- forged attestation mutation coverage remains green

## Evidence

- 34 focused tests passed
- regression reproduces the production semantic-cluster support shape
- changed-file ESLint and source line-cap passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of persisted reader summary promotion evidence, including semantic-cluster support.
  * Prevented older policy decisions from causing valid promotion attestations to be rejected.

* **Chores**
  * Updated the reader summary artifact policy version, ensuring production retries use distinct identities after policy changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->