### PR TITLE
fix(x-collector): preserve Scweet post provenance

### DIFF
--- a/apps/x-collector/src/x_collector/scweet_adapter.py
+++ b/apps/x-collector/src/x_collector/scweet_adapter.py
@@ -889,7 +889,40 @@ def content_kind_from_scweet_record(record: Mapping[str, Any]) -> XPostContentKi
         return XPostContentKind.ORIGINAL
     if "replying_to" in record and not record.get("replying_to"):
         return XPostContentKind.ORIGINAL
-    return XPostContentKind.UNKNOWN
+    return content_kind_from_scweet_raw(record.get("raw"))
+
+
+def content_kind_from_scweet_raw(value: Any) -> XPostContentKind:
+    raw = read_mapping(value)
+    tweet = read_mapping(raw.get("tweet")) or raw
+    legacy = read_mapping(tweet.get("legacy"))
+    if not legacy:
+        return XPostContentKind.UNKNOWN
+
+    reply_fields = (
+        "in_reply_to_status_id",
+        "in_reply_to_status_id_str",
+    )
+    if any(read_string(legacy.get(field)) is not None for field in reply_fields):
+        return XPostContentKind.REPLY
+
+    quoted = tweet.get("quoted_status_result")
+    if (isinstance(quoted, Mapping) and bool(quoted)) or (
+        legacy.get("is_quote_status") is True
+    ):
+        return XPostContentKind.QUOTE
+
+    retweeted = legacy.get("retweeted_status_result")
+    if isinstance(retweeted, Mapping) and bool(retweeted):
+        return XPostContentKind.UNKNOWN
+
+    has_explicit_reply_state = any(field in legacy for field in reply_fields)
+    has_explicit_quote_state = legacy.get("is_quote_status") is False
+    return (
+        XPostContentKind.ORIGINAL
+        if has_explicit_reply_state and has_explicit_quote_state
+        else XPostContentKind.UNKNOWN
+    )
 
 
 def eligibility_metrics_state(

--- a/apps/x-collector/tests/test_promotion_provenance.py
+++ b/apps/x-collector/tests/test_promotion_provenance.py
@@ -33,6 +33,61 @@ def test_content_provenance_is_explicit_and_unknown_fails_closed() -> None:
     )
 
 
+def test_content_provenance_reads_scweet_53_raw_legacy() -> None:
+    original = {
+        "raw": {
+            "tweet": {
+                "legacy": {
+                    "in_reply_to_status_id_str": None,
+                    "is_quote_status": False,
+                },
+            },
+        },
+    }
+    reply = {
+        "raw": {
+            "legacy": {
+                "in_reply_to_status_id_str": "1956000000000000001",
+                "is_quote_status": False,
+            },
+        },
+    }
+    quote = {
+        "raw": {
+            "legacy": {
+                "in_reply_to_status_id_str": None,
+                "is_quote_status": True,
+            },
+        },
+    }
+    retweet = {
+        "raw": {
+            "legacy": {
+                "in_reply_to_status_id_str": None,
+                "is_quote_status": False,
+                "retweeted_status_result": {"result": {"rest_id": "1"}},
+            },
+        },
+    }
+
+    assert content_kind_from_scweet_record(original) is XPostContentKind.ORIGINAL
+    assert content_kind_from_scweet_record(reply) is XPostContentKind.REPLY
+    assert content_kind_from_scweet_record(quote) is XPostContentKind.QUOTE
+    assert content_kind_from_scweet_record(retweet) is XPostContentKind.UNKNOWN
+
+
+def test_content_provenance_requires_explicit_raw_originality_fields() -> None:
+    assert content_kind_from_scweet_record({"raw": {"legacy": {}}}) is (
+        XPostContentKind.UNKNOWN
+    )
+    assert content_kind_from_scweet_record({
+        "raw": {"legacy": {"in_reply_to_status_id_str": None}},
+    }) is XPostContentKind.UNKNOWN
+    assert content_kind_from_scweet_record({
+        "raw": {"legacy": {"is_quote_status": False}},
+    }) is XPostContentKind.UNKNOWN
+
+
 def test_required_metric_presence_is_not_defaulted_to_zero() -> None:
     assert eligibility_metrics_state(((None, None), (10, 10))) is (
         XEligibilityMetricsState.MISSING


### PR DESCRIPTION
## Summary
- classify original, reply, and quote posts from Scweet 5.3 raw legacy data
- keep retweets and incomplete provenance fail-closed
- add regression coverage for wrapped and direct raw payloads

## Production evidence
- all 134 X items for 2026-08-25 currently fail promotion as malformed because contentKind is absent
- the installed Scweet 5.3 result already carries the authoritative raw legacy payload

## Checks
- Python compileall
- git diff --check
- source line cap
- targeted pytest is delegated to CI because the local macOS Python environment lacks grpcio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post classification from imported content metadata.
  * More accurately identifies original posts, replies, quotes, and retweets.
  * Uses a safe fallback when provenance information is missing or ambiguous.
* **Tests**
  * Added coverage for content provenance across supported post types and incomplete metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->