### PR TITLE
fix(summary): regenerate X provenance artifacts

### DIFF
--- a/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
@@ -60,7 +60,7 @@ const authorityHashFields = [
 describe("reader summary production-day attempt identity", () => {
   it("binds retries to the current persisted artifact policy", () => {
     expect(readerSummaryProductionDayArtifactPolicyVersion).toBe(
-      "reader_summary.artifact_policy.v5",
+      "reader_summary.artifact_policy.v6",
     );
   });
 

--- a/scripts/lib/reader-summary-production-day-attempt-identity.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.ts
@@ -33,7 +33,7 @@ export type ReaderSummaryProductionDayAttemptIdentityInput = Readonly<{
 // semantics change. A production-day retry must not silently reuse an artifact
 // produced under an older publication policy.
 export const readerSummaryProductionDayArtifactPolicyVersion =
-  "reader_summary.artifact_policy.v5";
+  "reader_summary.artifact_policy.v6";
 
 export const readerSummaryProductionDayAttemptIdentity = (
   input: ReaderSummaryProductionDayAttemptIdentityInput,


### PR DESCRIPTION
## Что исправлено

- повышена версия production artifact policy после изменения X promotion provenance
- повторный maintenance-run создаёт новый идемпотентный summary job вместо reuse старого X-less artifact
- старые job/artifact остаются неизменными для аудита

## Production evidence

- после PR #183 существующие X feed items обновились и quality trace видит promotion-eligible X candidates
- production capture всё ещё переиспользовал job 377bdf25-b994-42c2-a3b6-defb03a5bc69 с providers=reddit,hacker-news
- dashboard остановил публикацию, поэтому ослабления gate нет

## Проверки

- 23 targeted tests passed
- architecture boundaries OK
- code quality guardrails OK
- source/test line cap OK