### PR TITLE
fix(summary): refresh X provenance artifacts

### DIFF
--- a/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
@@ -60,7 +60,7 @@ const authorityHashFields = [
 describe("reader summary production-day attempt identity", () => {
   it("binds retries to the current persisted artifact policy", () => {
     expect(readerSummaryProductionDayArtifactPolicyVersion).toBe(
-      "reader_summary.artifact_policy.v6",
+      "reader_summary.artifact_policy.v7",
     );
   });
 

--- a/scripts/lib/reader-summary-production-day-attempt-identity.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.ts
@@ -33,7 +33,7 @@ export type ReaderSummaryProductionDayAttemptIdentityInput = Readonly<{
 // semantics change. A production-day retry must not silently reuse an artifact
 // produced under an older publication policy.
 export const readerSummaryProductionDayArtifactPolicyVersion =
-  "reader_summary.artifact_policy.v6";
+  "reader_summary.artifact_policy.v7";
 
 export const readerSummaryProductionDayAttemptIdentity = (
   input: ReaderSummaryProductionDayAttemptIdentityInput,


### PR DESCRIPTION
## Summary
- bump the persisted daily artifact policy after X provenance semantics changed
- force retries to create a fresh model artifact instead of reusing the pre-fix completed summary

## Evidence
- 23 focused identity tests passed
- source/test line cap passed

## Production proof
After PR #185 deployed, Aug 25 now has 84 original X posts with explicit contentKind. The first retry still reused pre-fix artifact f958d3e2, so this policy bump is required for the new evidence set to reach the model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the persisted artifact policy version to the latest version, ensuring newly generated records use the correct policy identifier.
- **Tests**
  - Updated validation checks to confirm the latest artifact policy version is persisted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->