### PR TITLE
fix(summary): align promotion provider cap verification

### DIFF
--- a/libs/summary/domain/policies/reader-post-promotion-selection.ts
+++ b/libs/summary/domain/policies/reader-post-promotion-selection.ts
@@ -9,8 +9,7 @@ import {
   type ReaderPostPromotionResult,
 } from "./reader-post-promotion-policy";
 import {
-  topReadPrimaryMinimumForLimit,
-  topReadProviderCapForLimit,
+  readerPostPromotionTopProviderCap,
 } from "./top-read-provider-diversity-policy";
 
 export type SelectedReaderPostPromotion = {
@@ -93,13 +92,7 @@ export const selectReaderPostPromotions = (
   const top = diverseCapped(
     topCandidates,
     READER_POST_PROMOTION_POLICY_V1.maxTop,
-    topReadProviderCapForLimit({
-      limit: promotionRankingAuditLimit,
-      activeProviderCount: topProviderCount,
-      primaryMinimum: topReadPrimaryMinimumForLimit(
-        promotionRankingAuditLimit,
-      ),
-    }),
+    readerPostPromotionTopProviderCap(topProviderCount),
   );
   const additional = diverseCapped(canonicalRepresentatives
     .filter(({ evaluation }) => evaluation.decision === "promote_additional")
@@ -235,10 +228,6 @@ const diverseCapped = (
   }
   return selected;
 };
-
-// The production ranking audit evaluates the reader surface against a
-// ten-slot editorial window, even though promotion v1 exposes at most eight.
-const promotionRankingAuditLimit = 10;
 
 const uniqueInputs = (
   inputs: readonly ReaderPostPromotionInput[],

--- a/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.spec.ts
@@ -3,12 +3,18 @@ import type { ReaderSummaryContent } from "../entities/reader-summary-artifact";
 import { ReaderSummaryPublicationPolicy } from "./reader-summary-publication-policy";
 import { readerSummaryPromotionPublicationOracle } from
   "./reader-summary-promotion-publication-oracle";
+import { buildReaderPostPromotionProjection } from
+  "../services/reader-post-promotion-projection";
+import type { SummaryEvidenceItem } from
+  "../value-objects/summary-evidence-item";
 import {
   promotionPublicationFixture,
   exactObservedPromotionPublicationFixture,
   trustedNonOfficialSupportPublicationFixture,
   withUncheckedPublicationCards,
 } from "./reader-summary-promotion-publication-test-fixtures";
+import { dailyEvidenceSelection } from
+  "./reader-summary-publication-policy-test-fixtures";
 
 const policy = new ReaderSummaryPublicationPolicy();
 
@@ -103,6 +109,96 @@ describe("ReaderSummaryPublicationPolicy Promotion V1 oracle", () => {
     expect(result.top.map((item) => item.candidateId)).toEqual([
       evidence[1]!.feedItemId,
       evidence[0]!.feedItemId,
+    ]);
+  });
+
+  it("applies the production provider cap to independent Top verification", () => {
+    const source = dailyEvidenceSelection(50);
+    const makeCandidate = (
+      provider: "reddit" | "hacker-news" | "x-twitter",
+      index: number,
+    ): SummaryEvidenceItem => {
+      const template = provider === "hacker-news"
+        ? source.selectedEvidence[1]!
+        : source.selectedEvidence[0]!;
+      const canonicalUrl = provider === "reddit"
+        ? `https://reddit.example.test/post/${index}`
+        : provider === "hacker-news"
+          ? `https://news.example.test/item/${index}`
+          : `https://x.com/example/status/${index}`;
+      const metrics: NonNullable<
+        NonNullable<SummaryEvidenceItem["promotionFacts"]>["metrics"]
+      > = provider === "reddit"
+        ? { provider: "reddit", score: 50, upvoteRatio: 0.9 }
+        : provider === "hacker-news"
+          ? { provider: "hacker_news", points: 50 }
+          : { provider: "x", likes: 100, reposts: 50, weightedScore: 200 };
+      return {
+        ...template,
+        feedItemId: `feed-${provider}-${index}`,
+        sourceItemId: `source-${provider}-${index}`,
+        sourceBindingId: `binding-${provider}-${index}`,
+        providerKey: provider,
+        providerName: provider,
+        canonicalUrl,
+        title: `${provider} candidate ${index}`,
+        contentQuality: {
+          ...template.contentQuality!,
+          qualityScore: provider === "reddit" ? 1 :
+            provider === "hacker-news" ? 0.8 : 0.7,
+        },
+        promotionFacts: {
+          ...template.promotionFacts!,
+          contentKind: provider === "hacker-news" ? "story" : "original_post",
+          canonicalIdentity: `url:${canonicalUrl}`,
+          metrics,
+        },
+      };
+    };
+    const evidence = [
+      ...Array.from({ length: 6 }, (_, index) =>
+        makeCandidate("reddit", index)),
+      ...Array.from({ length: 3 }, (_, index) =>
+        makeCandidate("hacker-news", index)),
+      makeCandidate("x-twitter", 0),
+    ];
+    const citations = evidence.map((item, index) => ({
+      citationId: `citation-provider-cap-${index}`,
+      feedItemId: item.feedItemId,
+      sourceItemId: item.sourceItemId,
+      providerKey: item.providerKey,
+      field: "title" as const,
+      canonicalUrl: item.canonicalUrl,
+    }));
+    const sourceWindow = {
+      ...source.sourceWindow,
+      selectedFeedItemIds: evidence.map((item) => item.feedItemId),
+      storyClusterIds: [],
+    };
+    const projection = buildReaderPostPromotionProjection({
+      evidence,
+      clusters: [],
+      citations,
+      sourceWindow,
+    });
+    const oracle = readerSummaryPromotionPublicationOracle({
+      evidence,
+      citations,
+      sourceWindow,
+    });
+
+    expect(oracle.top.map((item) => item.candidateId)).toEqual(
+      projection.topReads.map((item) => item.promotionCandidateId),
+    );
+    expect(projection.topReads.map((item) => item.providerKey)).toEqual([
+      "reddit",
+      "hacker-news",
+      "x-twitter",
+      "reddit",
+      "reddit",
+      "reddit",
+      "hacker-news",
+      "hacker-news",
     ]);
   });
 

--- a/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.ts
+++ b/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.ts
@@ -10,6 +10,8 @@ import { READER_POST_PROMOTION_POLICY_V1 } from
   "./reader-post-promotion-policy-contract";
 import { readerPostPromotionTimestampMicros } from
   "./reader-post-promotion-policy";
+import { readerPostPromotionTopProviderCap } from
+  "./top-read-provider-diversity-policy";
 
 export type PromotionOracleCard = {
   readonly candidateId: string;
@@ -115,9 +117,18 @@ export const readerSummaryPromotionPublicationOracle = (params: {
     ])].sort((a, b) => a.localeCompare(b)),
   });
   const selected = [...representatives.values()];
+  const topCandidates = selected.filter((item) => item.placement === "top")
+    .sort(compareRank);
+  const topProviderCount = new Set(topCandidates.flatMap((item) => {
+    const provider = independentProviderFamily(item.item.providerKey);
+    return provider === null ? [] : [provider];
+  })).size;
   return {
-    top: diverseOracle(selected.filter((item) => item.placement === "top")
-      .sort(compareRank), READER_POST_PROMOTION_POLICY_V1.maxTop)
+    top: diverseOracle(
+      topCandidates,
+      READER_POST_PROMOTION_POLICY_V1.maxTop,
+      readerPostPromotionTopProviderCap(topProviderCount),
+    )
       .map(materialize),
     additional: diverseOracle(selected.filter((item) => item.placement === "additional")
       .sort(compareRank), READER_POST_PROMOTION_POLICY_V1.maxAdditional)
@@ -351,6 +362,7 @@ const comparePublishedMicros = (
 const diverseOracle = (
   sorted: readonly Candidate[],
   cap: number,
+  providerCap = cap,
 ): readonly Candidate[] => {
   const selected: Candidate[] = [];
   const selectedIds = new Set<string>();
@@ -365,6 +377,16 @@ const diverseOracle = (
   }
   for (const candidate of sorted) {
     if (selectedIds.has(candidate.item.feedItemId)) continue;
+    const provider = independentProviderFamily(candidate.item.providerKey);
+    if (provider === null) continue;
+    const providerCount = selected.reduce(
+      (count, selectedCandidate) =>
+        independentProviderFamily(selectedCandidate.item.providerKey) === provider
+          ? count + 1
+          : count,
+      0,
+    );
+    if (providerCount >= providerCap) continue;
     selected.push(candidate);
     if (selected.length === cap) break;
   }

--- a/libs/summary/domain/policies/top-read-provider-diversity-policy.ts
+++ b/libs/summary/domain/policies/top-read-provider-diversity-policy.ts
@@ -19,4 +19,18 @@ export const topReadProviderCapForLimit = (params: {
 export const topReadPrimaryMinimumForLimit = (limit: number): number =>
   limit >= 8 ? 2 : 1;
 
+export const readerPostPromotionTopProviderCap = (
+  activeProviderCount: number,
+): number => topReadProviderCapForLimit({
+  limit: promotionRankingAuditLimit,
+  activeProviderCount,
+  primaryMinimum: topReadPrimaryMinimumForLimit(
+    promotionRankingAuditLimit,
+  ),
+});
+
 const multiProviderDominantShare = 0.4;
+
+// Promotion V1 audits the reader surface against ten editorial slots even
+// though the published Top array exposes at most eight.
+const promotionRankingAuditLimit = 10;


### PR DESCRIPTION
## Summary
- share the immutable Promotion V1 provider-cap contract between selection and independent publication verification
- enforce the same cap in the oracle without sharing selection implementation
- add a regression covering the production 4 Reddit / 3 HN / 1 X Top layout

## Verification
- 36 focused promotion selection/publication-oracle tests passed
- source line cap passed
- `git diff --check` passed

## Production evidence
The fresh 2026-08-25 artifact was rejected only because the independent oracle omitted the provider cap and expected a different Top order. The artifact itself includes X evidence (1 Top and 3 Additional cards). This change keeps the quality gate strict while aligning it with the immutable diversity policy.
