### PR TITLE
fix(summary): refresh promotion verifier artifacts

### DIFF
--- a/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.spec.ts
@@ -60,7 +60,7 @@ const authorityHashFields = [
 describe("reader summary production-day attempt identity", () => {
   it("binds retries to the current persisted artifact policy", () => {
     expect(readerSummaryProductionDayArtifactPolicyVersion).toBe(
-      "reader_summary.artifact_policy.v7",
+      "reader_summary.artifact_policy.v8",
     );
   });
 

--- a/scripts/lib/reader-summary-production-day-attempt-identity.ts
+++ b/scripts/lib/reader-summary-production-day-attempt-identity.ts
@@ -33,7 +33,7 @@ export type ReaderSummaryProductionDayAttemptIdentityInput = Readonly<{
 // semantics change. A production-day retry must not silently reuse an artifact
 // produced under an older publication policy.
 export const readerSummaryProductionDayArtifactPolicyVersion =
-  "reader_summary.artifact_policy.v7";
+  "reader_summary.artifact_policy.v8";
 
 export const readerSummaryProductionDayAttemptIdentity = (
   input: ReaderSummaryProductionDayAttemptIdentityInput,


### PR DESCRIPTION
## Summary
- advance the production-day artifact policy after the Promotion V1 verifier semantics changed
- force a fresh idempotent job instead of reusing the prior quality-rejected artifact

## Verification
- 23 attempt-identity tests passed
- source line cap passed
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the production-day reader summary artifact policy version.
  - Refreshed generated attempt identities to reflect the new policy version, improving idempotency for future summary processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->