### PR TITLE
fix(summary): normalize ranking provider families

### DIFF
--- a/scripts/check-reader-summary-top-read-ranking.ts
+++ b/scripts/check-reader-summary-top-read-ranking.ts
@@ -23,7 +23,7 @@ import {
   presentReaderSummaryArtifact,
   readerSummaryContentForArtifact,
 } from "@social-monitor/summary/features/shared/reader-summary-artifact-presenter";
-import { readerSummaryProviderIdentity } from "@social-monitor/summary/domain/value-objects/reader-summary-provider-identity";
+import { readerSummaryIndependentProviderFamily } from "@social-monitor/summary/domain/value-objects/reader-summary-provider-identity";
 
 import {
   collectionDateOptionOrDefault,
@@ -238,7 +238,7 @@ async function buildReportFromDatabase(
     const citationProviderById = new Map(
       view.citations.map((citation) => [
         citation.citationId,
-        readerSummaryProviderIdentity(citation).providerKey,
+        rankingCitationProviderFamily(citation),
       ]),
     );
     const windowStart = dayStart(collectionDate);
@@ -553,6 +553,11 @@ const defaultAtomicReportOperations: AtomicTopReadRankingReportOperations = {
     renameSync(sourcePath, targetPath),
   removeFile: (path) => rmSync(path, { force: true }),
 };
+
+export const rankingCitationProviderFamily = (citation: {
+  readonly providerKey: string;
+  readonly canonicalUrl?: string;
+}): string => readerSummaryIndependentProviderFamily(citation);
 
 function rounded(value: number): number {
   return Number(value.toFixed(3));

--- a/scripts/lib/reader-summary-ranking-audit.spec.ts
+++ b/scripts/lib/reader-summary-ranking-audit.spec.ts
@@ -7,6 +7,7 @@ import { publicReaderSummaryMatchedRules } from "@social-monitor/summary/feature
 import {
   type AtomicTopReadRankingReportOperations,
   failTopReadRankingReport,
+  rankingCitationProviderFamily,
   writeTopReadRankingReportAtomically,
 } from "../check-reader-summary-top-read-ranking";
 
@@ -248,6 +249,15 @@ describe("reader summary ranking audit", () => {
 });
 
 describe("reader summary top-read ranking failed-report CLI", () => {
+  it("compares X citations using the independent provider family", () => {
+    expect(
+      rankingCitationProviderFamily({
+        providerKey: "x-twitter",
+        canonicalUrl: "https://x.com/example/status/123",
+      }),
+    ).toBe("x");
+  });
+
   it.each([
     { label: "neither flag", update: false, writeFailedReport: false },
     { label: "--update only", update: true, writeFailedReport: false },


### PR DESCRIPTION
## Что исправлено

- Ranking gate сравнивает citation provider с confirmed provider через общий independent-provider-family contract.
- X transport key `x-twitter` теперь корректно соответствует доменному family key `x`.
- Quality thresholds и promotion selection не меняются.

## Проверка

- focused ranking audit: 16/16 passed
- source line cap passed
- diff check passed
- local full build unavailable because shared node_modules lacks OpenTelemetry packages; CI installs lockfile dependencies cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ranking citation comparisons by grouping equivalent providers into independent provider families.
  * Ensured X citations are consistently evaluated together, including citations using alternate provider identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->