### PR TITLE
fix(summary): align source quality trace with promotion inputs

### DIFF
--- a/scripts/check-reader-summary-source-quality-trace.ts
+++ b/scripts/check-reader-summary-source-quality-trace.ts
@@ -7,7 +7,11 @@ import { defaultPostgresRuntimePoolConfig } from "@social-monitor/platform-persi
 import { PrismaFeedConnection } from "../libs/feed/adapters/persistence/prisma/prisma-feed-connection";
 import { PrismaFeedItemReadRepository } from "../libs/feed/adapters/persistence/prisma/prisma-feed-item-read.repository";
 import { InMemoryUserRelevanceProfileRepository } from "../libs/relevance/adapters/persistence/in-memory-user-relevance-profile.repository";
-import { SourceContentQualityPolicy } from "../libs/relevance/domain";
+import {
+  SourceContentQualityPolicy,
+  SourceContentSafetyPolicy,
+} from "../libs/relevance/domain";
+import { promotionSafeProviderMetadata } from "../libs/relevance/features/rank-feed-items/rank-feed-item-projection";
 import { hasReaderSummaryEvidenceHardBlock } from "../libs/summary/domain/policies/reader-summary-evidence-eligibility-policy";
 import { RankFeedItemsUseCase } from "../libs/relevance/features/rank-feed-items/rank-feed-items.use-case";
 import { readerSummaryArtifactFromPrisma } from "../libs/summary/adapters/persistence/prisma/prisma-reader-summary-records";
@@ -532,19 +536,29 @@ function buildLaneTrace(params: {
   readonly topReadFeedItemIds: ReadonlySet<string>;
 }): LaneTrace {
   const qualityPolicy = new SourceContentQualityPolicy();
+  const safetyPolicy = new SourceContentSafetyPolicy();
   const descriptor = laneDescriptor(
     params.providerKey,
     params.items[0]?.providerMetadata,
   );
   const itemTraces = params.items.map((item) => {
     const ranked = params.rankedById.get(item.id);
-    const verdict = qualityPolicy.evaluate({
+    const safety = safetyPolicy.evaluate({
       providerKey: item.providerKey,
       title: item.title,
       bodyPreview: item.bodyPreview ?? undefined,
       canonicalUrl: item.canonicalUrl,
+    });
+    const verdict = qualityPolicy.evaluate({
+      providerKey: item.providerKey,
+      title: safety.sanitizedTitle,
+      bodyPreview: safety.sanitizedBodyPreview,
+      canonicalUrl: safety.sanitizedCanonicalUrl ?? item.canonicalUrl,
       authorHandle: item.authorHandle ?? undefined,
-      providerMetadata: asJsonObject(item.providerMetadata),
+      providerMetadata: promotionSafeProviderMetadata(
+        item.providerKey,
+        asJsonObject(item.providerMetadata),
+      ),
     });
     const selected = params.selectedFeedItemIds.has(item.id);
     const topRead = params.topReadFeedItemIds.has(item.id);


### PR DESCRIPTION
## What changed
- evaluate source-quality trace with the same sanitized source fields used by promotion
- canonicalize provider metadata before applying content-quality policy
- keep every existing blocking quality gate unchanged

## Evidence
- production diagnostic for 2026-08-25 changed from 3 false gates to all source-quality gates passing
- focused relevance/safety tests: 5/5
- ESLint for changed script: passed
- source line cap: passed
- local full build remains unavailable because the shared node_modules is missing existing OpenTelemetry packages; clean CI is the build authority