### PR TITLE
fix(rolling): accept attested no-signal receipts

### DIFF
--- a/ops/deploy/production-runtime/rolling-summary-receipt.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.mjs
@@ -691,6 +691,7 @@ function isExactDailyPeriod(period, date) {
 }
 
 function isValidSummaryResult(result) {
+  const noSignal = result?.status === "no_signal";
   return (
     isRecord(result) &&
     isUuid(result.readerSummaryJobId) &&
@@ -708,9 +709,15 @@ function isValidSummaryResult(result) {
     result.topProviderKeys.every((key) => requiredProviders.includes(key)) &&
     Array.isArray(result.qualityFlags) &&
     result.qualityFlags.every(isNonemptyString) &&
-    (result.status === "completed"
-      ? result.selectedFeedItemCount > 0
-      : result.selectedFeedItemCount === 0)
+    (noSignal
+      ? result.selectedFeedItemCount === 0 &&
+        result.topReadCount === 0 &&
+        result.citationCount === 0 &&
+        result.providerCount === 0 &&
+        result.topProviderKeys.length === 0 &&
+        result.qualityFlags.includes("no_signal")
+      : result.selectedFeedItemCount > 0 &&
+        !result.qualityFlags.includes("no_signal"))
   );
 }
 
@@ -758,6 +765,7 @@ function isValidAttestationSet(attestations, result, authority) {
 
 function isValidFrontendArtifact(frontend, evidence, date) {
   const artifact = frontend?.readerSummaryArtifact;
+  const noSignal = evidence.result.status === "no_signal";
   const expectedModelVersion = [
     evidence.provenance.servingAuthority.summaryGenerator.provider,
     evidence.provenance.servingAuthority.summaryGenerator.physicalModel,
@@ -778,8 +786,12 @@ function isValidFrontendArtifact(frontend, evidence, date) {
     isExactDailyPeriod(artifact.period, date) &&
     artifact.scope?.type === "workspace" &&
     isRecord(artifact.lineage) &&
-    artifact.lineage.modelVersion === expectedModelVersion &&
-    artifact.lineage.providerVersion === "agent-runtime" &&
+    (noSignal
+      ? artifact.lineage.modelVersion === "not_invoked" &&
+        artifact.lineage.providerVersion === "deterministic" &&
+        artifact.content?.topicMap?.generatedBy === "deterministic"
+      : artifact.lineage.modelVersion === expectedModelVersion &&
+        artifact.lineage.providerVersion === "agent-runtime") &&
     isNonemptyString(artifact.lineage.schemaVersion) &&
     isRecord(artifact.content) &&
     isRecord(artifact.content.topicMap) &&

--- a/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
+++ b/ops/deploy/production-runtime/rolling-summary-receipt.test.mjs
@@ -369,6 +369,66 @@ try {
   writeFileSync(evidencePath, JSON.stringify(validEvidence));
   writeFileSync(frontendPath, JSON.stringify(validFrontend));
 
+  const noSignalEvidencePath = join(directory, "no-signal-evidence.json");
+  const noSignalFrontendPath = join(directory, "no-signal-frontend.json");
+  const noSignalReceiptPath = join(directory, "no-signal-receipt.json");
+  runFixture(
+    "no-signal-evidence",
+    noSignalEvidencePath,
+    runId,
+    date,
+    noSignalFrontendPath,
+  );
+  run(
+    "write-receipt",
+    noSignalReceiptPath,
+    noSignalEvidencePath,
+    noSignalFrontendPath,
+    collectionPath,
+    runId,
+    date,
+    "2026-08-15T00:15:00.000Z",
+    "1",
+  );
+  run("validate-receipt", noSignalReceiptPath, runId, date);
+  const noSignalReceipt = JSON.parse(
+    readFileSync(noSignalReceiptPath, "utf8"),
+  );
+  assert.equal(noSignalReceipt.summary.status, "no_signal");
+  assert.equal(noSignalReceipt.summary.selectedFeedItemCount, 0);
+  for (const [label, mutate] of [
+    ["no-signal-citations", (value) => (value.summary.citationCount = 1)],
+    ["no-signal-provider", (value) => (value.summary.providerCount = 1)],
+    ["no-signal-flag", (value) => (value.summary.qualityFlags = [])],
+  ]) {
+    const invalid = JSON.parse(JSON.stringify(noSignalReceipt));
+    mutate(invalid);
+    const invalidPath = join(directory, `${label}.json`);
+    writeFileSync(invalidPath, JSON.stringify(invalid));
+    runFailure("validate-receipt", invalidPath, runId, date);
+  }
+
+  const invalidNoSignalFrontend = JSON.parse(
+    readFileSync(noSignalFrontendPath, "utf8"),
+  );
+  invalidNoSignalFrontend.readerSummaryArtifact.lineage.modelVersion =
+    "codex:gpt-5.6-sol:xhigh";
+  writeFileSync(
+    noSignalFrontendPath,
+    JSON.stringify(invalidNoSignalFrontend),
+  );
+  runFailure(
+    "write-receipt",
+    join(directory, "invalid-no-signal-lineage.json"),
+    noSignalEvidencePath,
+    noSignalFrontendPath,
+    collectionPath,
+    runId,
+    date,
+    "2026-08-15T00:15:00.000Z",
+    "1",
+  );
+
   const degradedReceiptPath = join(directory, "degraded-receipt.json");
   run(
     "write-receipt",

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-artifact.mjs
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-artifact.mjs
@@ -78,19 +78,22 @@ if (kind === "collection") {
     qualityGates: qualityGates(degraded),
     blockingPassed: !degraded,
   });
-} else if (kind === "evidence") {
+} else if (kind === "evidence" || kind === "no-signal-evidence") {
   const frontendPath = degradedValue;
+  const noSignal = kind === "no-signal-evidence";
   const result = {
     readerSummaryJobId: "11111111-1111-4111-8111-111111111111",
     readerSummaryId: "22222222-2222-4222-8222-222222222222",
-    status: "completed",
-    headline: "Fixture rolling summary",
-    selectedFeedItemCount: 10,
-    topReadCount: 2,
-    citationCount: 12,
-    providerCount: 1,
-    topProviderKeys: ["reddit"],
-    qualityFlags: [],
+    status: noSignal ? "no_signal" : "completed",
+    headline: noSignal
+      ? "No reliable workspace signal yet"
+      : "Fixture rolling summary",
+    selectedFeedItemCount: noSignal ? 0 : 10,
+    topReadCount: noSignal ? 0 : 2,
+    citationCount: noSignal ? 0 : 12,
+    providerCount: noSignal ? 0 : 1,
+    topProviderKeys: noSignal ? [] : ["reddit"],
+    qualityFlags: noSignal ? ["no_signal"] : [],
   };
   const authority = {
     summaryGenerator: {
@@ -117,29 +120,38 @@ if (kind === "collection") {
       launcherSha256: "d".repeat(64),
     },
   };
-  const executionAttestations = [
-    {
-      taskRole: "summary",
-      attempt: "primary",
-      normalizedOutputSha256: "b".repeat(64),
-      attestation: {
-        schemaVersion: 1,
-        requestId: `fixture-${runId}`,
-        purpose: "social_monitor.reader_summary.generate",
-        canonicalRequestSha256: "c".repeat(64),
-        provider: "codex",
-        model: "gpt-5.6-sol",
-        reasoningEffort: "xhigh",
-        runtimeEngine: "subscription-runtime-cli",
-        runtimePackageVersion: "fixture-runtime-1",
-        launcherSha256: "d".repeat(64),
-        selectedOutputKind: "structured_output",
-        selectedOutputSha256: "e".repeat(64),
-      },
-    },
-  ];
+  const executionAttestations = noSignal
+    ? []
+    : [
+        {
+          taskRole: "summary",
+          attempt: "primary",
+          normalizedOutputSha256: "b".repeat(64),
+          attestation: {
+            schemaVersion: 1,
+            requestId: `fixture-${runId}`,
+            purpose: "social_monitor.reader_summary.generate",
+            canonicalRequestSha256: "c".repeat(64),
+            provider: "codex",
+            model: "gpt-5.6-sol",
+            reasoningEffort: "xhigh",
+            runtimeEngine: "subscription-runtime-cli",
+            runtimePackageVersion: "fixture-runtime-1",
+            launcherSha256: "d".repeat(64),
+            selectedOutputKind: "structured_output",
+            selectedOutputSha256: "e".repeat(64),
+          },
+        },
+      ];
   const period = dailyPeriod(collectionDate);
-  const content = { narrative: "fixture", topicMap: { nodes: [], edges: [] } };
+  const content = {
+    narrative: "fixture",
+    topicMap: {
+      nodes: [],
+      edges: [],
+      ...(noSignal ? { generatedBy: "deterministic" } : {}),
+    },
+  };
   const redaction = {
     secretsIncluded: false,
     rawProviderPayloadIncluded: false,
@@ -195,11 +207,13 @@ if (kind === "collection") {
         period,
         scope: { type: "workspace" },
         lineage: {
-          modelVersion: "codex:gpt-5.6-sol:xhigh",
+          modelVersion: noSignal
+            ? "not_invoked"
+            : "codex:gpt-5.6-sol:xhigh",
           rulesVersion: "fixture-rules",
           promptVersion: "fixture-prompt",
           schemaVersion: "reader_summary.artifact.v1",
-          providerVersion: "agent-runtime",
+          providerVersion: noSignal ? "deterministic" : "agent-runtime",
           evalDatasetVersion: "fixture-eval",
           rankingPolicyVersion: "fixture-ranking",
         },


### PR DESCRIPTION
## Что исправлено

- валидный опубликованный no_signal больше не превращает плановый rolling run в false failure
- deterministic/not_invoked lineage проверяется отдельно от AI-generated summary
- no_signal остаётся строгим: 0 selected/top reads/citations/providers и обязательный quality flag

## Проверка

- rolling-summary-receipt tests
- rolling-run tests
- ESLint по изменённым файлам
- source line cap
- exact production no_signal evidence/frontend/collection artifacts -> SUCCESS receipt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of rolling summary receipts when no signal is available.
  * No-signal results now require zero counts, appropriate quality indicators, and deterministic processing details.
  * Completed results are validated for positive content counts and proper quality status.
  * Invalid citation, provider, quality, or processing metadata is rejected.

* **Tests**
  * Added coverage for valid and intentionally corrupted no-signal receipts and artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->