### PR TITLE
fix(summaries): stabilize navigation and daily delivery

### DIFF
--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_section_sliver.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_top_posts_section_sliver.dart
@@ -53,7 +53,20 @@ class _ReaderSummaryTopPostsSectionSliverState
   @override
   Widget build(BuildContext context) {
     if (_projection.isEmpty) {
-      return const SliverToBoxAdapter(child: SizedBox.shrink());
+      if (!_hasSummaryEvidence(widget.summary)) {
+        return const SliverToBoxAdapter(child: SizedBox.shrink());
+      }
+      return SliverMainAxisGroup(
+        slivers: [
+          const SliverToBoxAdapter(child: SizedBox(height: AppSpacing.md + 2)),
+          SliverPadding(
+            padding: widget.contentPadding,
+            sliver: const SliverToBoxAdapter(
+              child: _UnavailableTopPostsNotice(),
+            ),
+          ),
+        ],
+      );
     }
     return SliverMainAxisGroup(
       slivers: [
@@ -76,6 +89,36 @@ class _ReaderSummaryTopPostsSectionSliverState
       ],
     );
   }
+}
+
+bool _hasSummaryEvidence(ReaderSummary summary) =>
+    summary.citations.isNotEmpty ||
+    (summary.coverage?.selectedFeedItemCount ?? 0) > 0;
+
+class _UnavailableTopPostsNotice extends StatelessWidget {
+  const _UnavailableTopPostsNotice();
+
+  @override
+  Widget build(BuildContext context) => Column(
+    key: const ValueKey('reader-summary-top-posts-unavailable'),
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      Text(
+        'Top posts',
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w800,
+          letterSpacing: 0,
+        ),
+      ),
+      const SizedBox(height: AppSpacing.sm),
+      const AppInlineProblem(
+        title: 'Verified Top posts unavailable',
+        message:
+            'This summary still has its narrative and citations, but no posts '
+            'have the verification required for the Top posts board.',
+      ),
+    ],
+  );
 }
 
 int _selectedPostCount(ReaderSummary summary) {

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_view.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_view.dart
@@ -99,6 +99,10 @@ class ReaderSummaryView extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          if (isRefreshing) ...[
+            const _ReaderSummaryRefreshStatus(),
+            const SizedBox(height: AppSpacing.sm),
+          ],
           _ExecutiveBoardCard(
             summary: summary,
             citationsById: citationsById,
@@ -136,6 +140,25 @@ class ReaderSummaryView extends StatelessWidget {
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+class _ReaderSummaryRefreshStatus extends StatelessWidget {
+  const _ReaderSummaryRefreshStatus();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      liveRegion: true,
+      label: 'Updating selected summary',
+      child: const Align(
+        alignment: Alignment.centerRight,
+        child: AppStatusBadge(
+          key: ValueKey('reader-summary-refreshing'),
+          label: 'Refreshing',
+        ),
       ),
     );
   }

--- a/apps/frontend/features/summaries/lib/src/presentation/stores/summaries_review_store.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/summaries_review_store.dart
@@ -143,7 +143,9 @@ final class SummariesReviewStore extends ChangeNotifier {
           previousValue?.current,
         _ => null,
       };
-      if (latest != null) {
+      if (latest != null &&
+          summaryPeriodPresetFor(latest.period) ==
+              selectedSummaryPeriodPreset) {
         return latest.period;
       }
     }

--- a/apps/frontend/features/summaries/lib/src/presentation/stores/summaries_review_store.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/summaries_review_store.dart
@@ -97,7 +97,6 @@ final class SummariesReviewStore extends ChangeNotifier {
   final OperationGenerationGuard _postRatingGenerationGuard;
   final OperationGenerationGuard _topicRecommendationGenerationGuard;
   final Duration _workspaceSummaryLoadTimeout;
-
   WorkspaceScope _scope;
   final String _userId;
   SummaryId? _selectedSummaryId;
@@ -134,7 +133,6 @@ final class SummariesReviewStore extends ChangeNotifier {
       const InitialViewState<ReaderSummaryTopicRecommendationQueue>();
 
   WorkspaceScope get scope => _scope;
-
   SummaryPeriod get selectedSummaryPeriod {
     if (_selectedSummaryPeriodEndedAt == null) {
       final latest = switch (workspaceSummaryState) {

--- a/apps/frontend/features/summaries/lib/src/presentation/stores/summaries_review_store_period_helpers.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/summaries_review_store_period_helpers.dart
@@ -21,6 +21,32 @@ List<SummaryPeriod> _snapshotSummaryPeriods(WorkspaceSummarySnapshot snapshot) {
   return periodsByKey.values.toList(growable: false);
 }
 
+List<SummaryPeriod> _mergeSummarySnapshotPeriods(
+  WorkspaceSummarySnapshot? previous,
+  WorkspaceSummarySnapshot next,
+) {
+  return mergeSummaryPeriods(
+    previous == null ? const [] : _snapshotSummaryPeriods(previous),
+    _snapshotSummaryPeriods(next),
+  );
+}
+
+WorkspaceSummarySnapshot? _summarySnapshotForSelectedPreset(
+  WorkspaceSummarySnapshot? snapshot,
+  SummaryPeriodPreset preset,
+) {
+  final current = snapshot?.current;
+  if (snapshot == null ||
+      current == null ||
+      summaryPeriodPresetFor(current.period) == preset) {
+    return snapshot;
+  }
+  return WorkspaceSummarySnapshot(
+    availablePeriods: _snapshotSummaryPeriods(snapshot),
+    availablePeriodsAreComplete: snapshot.availablePeriodsAreComplete,
+  );
+}
+
 bool _sameSummaryPeriodWindow(SummaryPeriod left, SummaryPeriod right) {
   return sameSummaryPeriodWindow(left, right);
 }

--- a/apps/frontend/features/summaries/lib/src/presentation/stores/summaries_review_store_workspace_summary_workflow.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/summaries_review_store_workspace_summary_workflow.dart
@@ -215,7 +215,6 @@ extension SummariesReviewStoreWorkspaceSummaryWorkflow on SummariesReviewStore {
   Future<void> _reloadSelectedWorkspaceSummaryPeriod() async {
     _summaryGenerationGuard.invalidate();
     _postRatingGenerationGuard.invalidate();
-    workspaceSummaryState = const InitialViewState<WorkspaceSummarySnapshot>();
     postRatingState = const InitialViewState<Map<String, PostRating>>();
     summaryJobState = const InitialViewState<ReaderSummaryJobSnapshot>();
     _notifyStateChanged();
@@ -228,12 +227,16 @@ Future<void> _loadWorkspaceSummaryForStore(
   SummariesReviewStore store,
   int generation,
 ) async {
-  final previous = switch (store.workspaceSummaryState) {
+  final previousSnapshot = switch (store.workspaceSummaryState) {
     ReadyViewState<WorkspaceSummarySnapshot>(:final value) => value,
     LoadingViewState<WorkspaceSummarySnapshot>(:final previousValue) =>
       previousValue,
     _ => null,
   };
+  final previous = _summarySnapshotForSelectedPreset(
+    previousSnapshot,
+    store.selectedSummaryPeriodPreset,
+  );
   store.workspaceSummaryState = LoadingViewState<WorkspaceSummarySnapshot>(
     previousValue: previous,
   );
@@ -273,21 +276,26 @@ Future<void> _loadWorkspaceSummaryForStore(
 
   store.workspaceSummaryState = result.fold(
     onSuccess: (snapshot) {
-      final current = snapshot.current;
+      final mergedSnapshot = WorkspaceSummarySnapshot(
+        current: snapshot.current,
+        availablePeriods: _mergeSummarySnapshotPeriods(previous, snapshot),
+        availablePeriodsAreComplete: snapshot.availablePeriodsAreComplete,
+      );
+      final current = mergedSnapshot.current;
       if (current == null) {
-        return ReadyViewState<WorkspaceSummarySnapshot>(snapshot);
+        return ReadyViewState<WorkspaceSummarySnapshot>(mergedSnapshot);
       }
       if (_periodMatchesPreset(
             current.period,
             store.selectedSummaryPeriodPreset,
           ) &&
-          !_snapshotSummaryPeriods(snapshot).any(
+          !_snapshotSummaryPeriods(mergedSnapshot).any(
             (period) =>
                 _sameSummaryPeriodWindow(period, store.selectedSummaryPeriod),
           )) {
         store._selectedSummaryPeriodEndedAt = current.period.endedAt;
       }
-      return ReadyViewState<WorkspaceSummarySnapshot>(snapshot);
+      return ReadyViewState<WorkspaceSummarySnapshot>(mergedSnapshot);
     },
     onFailure: (failure) =>
         FailureViewState<WorkspaceSummarySnapshot>(failure: failure),

--- a/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/summaries_feature_page_test.dart
@@ -33,6 +33,31 @@ import '../../support/summaries_test_fixtures.dart';
 part 'summaries_feature_page_test_support.dart';
 
 void main() {
+  testWidgets('explains why a legacy summary has no verified Top posts', (
+    tester,
+  ) async {
+    final store = _store(
+      [githubTrendingSummaryApiDto()],
+      workspaceSummary: readerSummaryApiDto(
+        content: readerSummaryContentApiDto(
+          topReads: const [],
+          selectedPosts: const [],
+        ),
+      ),
+    );
+
+    await _pumpSizedFeature(tester, store: store, size: const Size(1280, 820));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('reader-summary-top-posts-unavailable')),
+      500,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    expect(find.text('Top posts'), findsOneWidget);
+    expect(find.text('Verified Top posts unavailable'), findsOneWidget);
+  });
+
   testWidgets('does not render legacy supplemental cards', (tester) async {
     final store = _store([
       githubTrendingSummaryApiDto(),
@@ -378,6 +403,10 @@ void main() {
     expect(find.textContaining('GitHub daily radar'), findsOneWidget);
     expect(
       find.byKey(const ValueKey('workspace-summary-toolbar-generate')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('reader-summary-refreshing')),
       findsOneWidget,
     );
   });

--- a/apps/frontend/features/summaries/test/presentation/stores/summaries_review_store_period_navigation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/summaries_review_store_period_navigation_test.dart
@@ -23,8 +23,8 @@ import 'package:social_monitor_summaries/src/infrastructure/repositories/generat
 import 'package:social_monitor_summaries/src/presentation/stores/summaries_review_store.dart';
 import 'package:social_monitor_summaries/src/presentation/workflows/summaries_review_store_dependencies.dart';
 
-import '../../support/summaries_test_fixtures.dart';
 import '../../support/deferred_summary_review_catalog.dart';
+import '../../support/summaries_test_fixtures.dart';
 
 void main() {
   test('does not navigate to periods without a workspace summary', () async {

--- a/apps/frontend/features/summaries/test/presentation/stores/summaries_review_store_period_navigation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/summaries_review_store_period_navigation_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
 import 'package:social_monitor_summaries/src/application/contracts/reader_source_launcher.dart';
+import 'package:social_monitor_summaries/src/application/contracts/summary_review_catalog.dart';
 import 'package:social_monitor_summaries/src/application/use_cases/decide_topic_recommendation_use_case.dart';
 import 'package:social_monitor_summaries/src/application/use_cases/list_summaries_use_case.dart';
 import 'package:social_monitor_summaries/src/application/use_cases/load_post_ratings_use_case.dart';
@@ -17,11 +18,13 @@ import 'package:social_monitor_summaries/src/application/use_cases/submit_reader
 import 'package:social_monitor_summaries/src/application/use_cases/submit_summary_feedback_use_case.dart';
 import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.dart';
 import 'package:social_monitor_summaries/src/infrastructure/api_clients/in_memory_summaries_api_client.dart';
+import 'package:social_monitor_summaries/src/infrastructure/mappers/summary_mapper.dart';
 import 'package:social_monitor_summaries/src/infrastructure/repositories/generated_summary_review_catalog.dart';
 import 'package:social_monitor_summaries/src/presentation/stores/summaries_review_store.dart';
 import 'package:social_monitor_summaries/src/presentation/workflows/summaries_review_store_dependencies.dart';
 
 import '../../support/summaries_test_fixtures.dart';
+import '../../support/deferred_summary_review_catalog.dart';
 
 void main() {
   test('does not navigate to periods without a workspace summary', () async {
@@ -227,10 +230,107 @@ void main() {
       expect(store.isSelectedSummaryPeriodCurrent, isTrue);
     },
   );
+
+  test('keeps the previous summary visible while another day loads', () async {
+    final catalog = DeferredSummaryReviewCatalog(
+      const [],
+      deferWorkspaceSummary: true,
+    );
+    final store = _storeWithCatalog(catalog);
+    final selectedDate = DateTime(2026, 7, 5);
+    final selectedPeriod = SummaryPeriodPreset.daily.resolveForCalendarDate(
+      selectedDate,
+    );
+    final previous = WorkspaceSummarySnapshot(
+      current: const SummaryMapper().readerSummaryToDomain(
+        readerSummaryApiDto(title: 'Previous day summary'),
+      ),
+      availablePeriods: [selectedPeriod],
+    );
+    final next = WorkspaceSummarySnapshot(
+      current: const SummaryMapper().readerSummaryToDomain(
+        readerSummaryApiDto(
+          id: 'readerSummary-next',
+          title: 'Selected day summary',
+          period: summaryPeriodApiDto(
+            startedAt: selectedPeriod.startedAt,
+            endedAt: selectedPeriod.endedAt,
+            periodKey: null,
+          ),
+        ),
+      ),
+    );
+
+    final initialLoad = store.loadWorkspaceSummary();
+    await Future<void>.delayed(Duration.zero);
+    catalog.pendingWorkspaceSummarys.single.complete(Result.success(previous));
+    await initialLoad;
+
+    final navigation = store.selectWorkspaceSummaryCalendarDate(selectedDate);
+    await Future<void>.delayed(Duration.zero);
+
+    final loading =
+        store.workspaceSummaryState
+            as LoadingViewState<WorkspaceSummarySnapshot>;
+    expect(loading.previousValue?.current?.title, 'Previous day summary');
+    expect(store.availableWorkspaceSummaryPeriods, hasLength(2));
+    expect(catalog.pendingWorkspaceSummarys, hasLength(2));
+
+    catalog.pendingWorkspaceSummarys.last.complete(Result.success(next));
+    await navigation;
+
+    final ready =
+        store.workspaceSummaryState as ReadyViewState<WorkspaceSummarySnapshot>;
+    expect(ready.value.current?.title, 'Selected day summary');
+    expect(store.availableWorkspaceSummaryPeriods, hasLength(2));
+  });
+
+  test('does not inherit a daily window when switching to weekly', () async {
+    final catalog = DeferredSummaryReviewCatalog(
+      const [],
+      deferWorkspaceSummary: true,
+    );
+    final store = _storeWithCatalog(catalog);
+    final dailySnapshot = WorkspaceSummarySnapshot(
+      current: const SummaryMapper().readerSummaryToDomain(
+        readerSummaryApiDto(title: 'Daily summary'),
+      ),
+    );
+
+    final initialLoad = store.loadWorkspaceSummary();
+    await Future<void>.delayed(Duration.zero);
+    catalog.pendingWorkspaceSummarys.single.complete(
+      Result.success(dailySnapshot),
+    );
+    await initialLoad;
+
+    final navigation = store.selectWorkspaceSummaryPeriod(
+      SummaryPeriodPreset.weekly,
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      catalog.workspaceSummaryQueries.last.period.cadence,
+      SummaryPeriodCadence.weekly,
+    );
+    final loading =
+        store.workspaceSummaryState
+            as LoadingViewState<WorkspaceSummarySnapshot>;
+    expect(loading.previousValue?.current, isNull);
+
+    catalog.pendingWorkspaceSummarys.last.complete(
+      const Result.success(WorkspaceSummarySnapshot()),
+    );
+    await navigation;
+  });
 }
 
 SummariesReviewStore _store(InMemorySummariesApiClient apiClient) {
   final catalog = GeneratedSummaryReviewCatalog(apiClient: apiClient);
+  return _storeWithCatalog(catalog);
+}
+
+SummariesReviewStore _storeWithCatalog(SummaryReviewCatalog catalog) {
   return SummariesReviewStore(
     dependencies: SummariesReviewStoreDependencies(
       listSummaries: ListSummariesUseCase(catalog),

--- a/apps/frontend/features/summaries/test/support/deferred_summary_review_catalog.dart
+++ b/apps/frontend/features/summaries/test/support/deferred_summary_review_catalog.dart
@@ -40,6 +40,7 @@ final class DeferredSummaryReviewCatalog implements SummaryReviewCatalog {
   final pendingDetails = <PendingSummaryDetailRequest>[];
   final pendingWorkspaceSummarys =
       <Completer<Result<WorkspaceSummarySnapshot>>>[];
+  final workspaceSummaryQueries = <LoadWorkspaceSummaryQuery>[];
   var summaryListLoadCount = 0;
   var workspaceSummaryLoadCount = 0;
   var workspaceSummaryHistoryLoadCount = 0;
@@ -107,6 +108,7 @@ final class DeferredSummaryReviewCatalog implements SummaryReviewCatalog {
     LoadWorkspaceSummaryQuery query,
   ) {
     workspaceSummaryLoadCount += 1;
+    workspaceSummaryQueries.add(query);
     if (hangWorkspaceSummary) {
       return Completer<Result<WorkspaceSummarySnapshot>>().future;
     }

--- a/libs/feed/adapters/persistence/prisma/prisma-feed-client.ts
+++ b/libs/feed/adapters/persistence/prisma/prisma-feed-client.ts
@@ -154,10 +154,21 @@ export type PrismaFeedClient = {
         readonly sourceItemId?: string;
         readonly status: "VISIBLE";
         readonly observedAt?: {
+          readonly gte?: Date;
+          readonly gt?: Date;
           readonly lte?: Date;
           readonly lt?: Date;
         };
+        readonly publishedAt?: {
+          readonly gte?: Date;
+          readonly lt?: Date;
+        };
+        readonly providerKey?: string;
       };
+      readonly orderBy?: readonly [
+        { readonly observedAt: "desc" },
+        { readonly id: "desc" },
+      ];
     }): Promise<PrismaFeedItemRecord | null>;
   };
   readonly feedSignalBaselineSample: {

--- a/libs/feed/adapters/persistence/prisma/prisma-feed-item-read.repository.ts
+++ b/libs/feed/adapters/persistence/prisma/prisma-feed-item-read.repository.ts
@@ -78,7 +78,7 @@ export class PrismaFeedItemReadRepository implements
     query: FindLatestFeedItemSignalQuery,
   ): Promise<FeedItem | null> {
     const record = await this.prisma.feedItem.findFirst({
-      where: commonWhere(query),
+      where: latestSignalWhere(query),
       orderBy: [{ observedAt: "desc" }, { id: "desc" }],
     });
     if (record === null) return null;
@@ -397,6 +397,26 @@ const promotionWhere = (
 const commonWhere = (
   query: ListFeedItemSignalCandidatesQuery,
 ): Parameters<PrismaFeedClient["feedItem"]["findMany"]>[0]["where"] => ({
+  tenantId: query.tenantId,
+  workspaceId: query.workspaceId,
+  status: "VISIBLE",
+  interestId: query.interestId,
+  observedAt: dateRange({
+    gte: query.observedAtOrAfter,
+    gt: query.observedAfter,
+    lte: query.observedAtOrBefore,
+    lt: query.observedBefore,
+  }),
+  publishedAt: dateRange({
+    gte: query.publishedAtOrAfter,
+    lt: query.publishedBefore,
+  }),
+  providerKey: query.providerKey,
+});
+
+const latestSignalWhere = (
+  query: FindLatestFeedItemSignalQuery,
+): Parameters<PrismaFeedClient["feedItem"]["findFirst"]>[0]["where"] => ({
   tenantId: query.tenantId,
   workspaceId: query.workspaceId,
   status: "VISIBLE",

--- a/libs/feed/adapters/persistence/prisma/prisma-feed-item-read.repository.ts
+++ b/libs/feed/adapters/persistence/prisma/prisma-feed-item-read.repository.ts
@@ -11,6 +11,7 @@ import {
   PROMOTION_ELIGIBLE_ITEM_CEILING,
   PROMOTION_PHYSICAL_ROW_CEILING,
   type FeedItemReadRepositoryPort,
+  type FindLatestFeedItemSignalQuery,
   type ListFeedItemsQuery,
   type ListFeedItemsResult,
   type ListFeedItemSignalCandidatesQuery,
@@ -71,6 +72,18 @@ export class PrismaFeedItemReadRepository implements
     });
     return records.map(feedItemFromPrisma)
       .filter((item) => matchesFeedItemReadFilters(item, query));
+  }
+
+  async findLatestSignalCandidate(
+    query: FindLatestFeedItemSignalQuery,
+  ): Promise<FeedItem | null> {
+    const record = await this.prisma.feedItem.findFirst({
+      where: commonWhere(query),
+      orderBy: [{ observedAt: "desc" }, { id: "desc" }],
+    });
+    if (record === null) return null;
+    const item = feedItemFromPrisma(record);
+    return matchesFeedItemReadFilters(item, query) ? item : null;
   }
 
   async readPromotionSnapshot(

--- a/libs/feed/ports/feed-item-read-repository.port.ts
+++ b/libs/feed/ports/feed-item-read-repository.port.ts
@@ -41,6 +41,14 @@ export type ListFeedItemSignalCandidatesQuery = Omit<
   "limit" | "cursor"
 >;
 
+export type FindLatestFeedItemSignalQuery = Omit<
+  ListFeedItemSignalCandidatesQuery,
+  | "searchQuery"
+  | "repositoryTrendWindow"
+  | "repositoryLanguage"
+  | "repositoryTopic"
+>;
+
 export type ReadPromotionFeedItemSnapshotQuery = {
   readonly tenantId: TenantId;
   readonly workspaceId: WorkspaceId;
@@ -119,6 +127,10 @@ export interface FeedItemReadRepositoryPort {
   listSignalCandidates?(
     query: ListFeedItemSignalCandidatesQuery,
   ): Promise<readonly FeedItem[]>;
+  /** Returns the newest matching signal without hydrating the bounded cohort. */
+  findLatestSignalCandidate?(
+    query: FindLatestFeedItemSignalQuery,
+  ): Promise<FeedItem | null>;
   readPromotionSnapshot?(
     query: ReadPromotionFeedItemSnapshotQuery,
   ): Promise<PromotionFeedItemSnapshotResult>;

--- a/libs/summary/adapters/evidence/feed-reader-summary-coverage.counter.spec.ts
+++ b/libs/summary/adapters/evidence/feed-reader-summary-coverage.counter.spec.ts
@@ -417,7 +417,7 @@ class FakeFeedItems implements FeedItemReadRepositoryPort {
 
 class SignalCandidateFeedItems implements FeedItemReadRepositoryPort {
   readonly candidateQueries: ListFeedItemSignalCandidatesQuery[] = [];
-  var listCalls = 0;
+  listCalls = 0;
 
   constructor(private readonly items: readonly FeedItem[]) {}
 

--- a/libs/summary/adapters/evidence/feed-reader-summary-coverage.counter.spec.ts
+++ b/libs/summary/adapters/evidence/feed-reader-summary-coverage.counter.spec.ts
@@ -3,6 +3,7 @@ import type {
   FeedItemReadRepositoryPort,
   ListFeedItemsQuery,
   ListFeedItemsResult,
+  ListFeedItemSignalCandidatesQuery,
 } from "@social-monitor/feed/ports";
 import {
   type JsonObject,
@@ -40,6 +41,33 @@ describe("FeedReaderSummaryCoverageCounter", () => {
     ]);
     expect(feedItems.queries[0]?.observedAfter).toBeUndefined();
     expect(feedItems.queries[0]?.observedBefore).toBeUndefined();
+  });
+
+  it("uses one bounded candidate scan when the repository supports it", async () => {
+    const feedItems = new SignalCandidateFeedItems([
+      fakeFeedItem("reddit", 0),
+      fakeFeedItem("rss", 1),
+      fakeFeedItem("github-trending-page", 2),
+    ]);
+    const counter = new FeedReaderSummaryCoverageCounter(feedItems);
+
+    const result = await counter.countCollectedFeedItems({
+      tenantId: tenant,
+      workspaceId: workspace,
+      scope: { type: "workspace" },
+      period,
+    });
+
+    expect(result).toBe(2);
+    expect(feedItems.listCalls).toBe(0);
+    expect(feedItems.candidateQueries).toEqual([
+      expect.objectContaining({
+        tenantId: tenant,
+        workspaceId: workspace,
+        publishedAtOrAfter: period.startedAt,
+        publishedBefore: period.endedAt,
+      }),
+    ]);
   });
 
   it("freezes coverage at the artifact observation cutoff", async () => {
@@ -386,6 +414,45 @@ class FakeFeedItems implements FeedItemReadRepositoryPort {
     return null;
   }
 }
+
+class SignalCandidateFeedItems implements FeedItemReadRepositoryPort {
+  readonly candidateQueries: ListFeedItemSignalCandidatesQuery[] = [];
+  var listCalls = 0;
+
+  constructor(private readonly items: readonly FeedItem[]) {}
+
+  async list(query: ListFeedItemsQuery): Promise<ListFeedItemsResult> {
+    this.listCalls += 1;
+    return { items: this.items.slice(0, query.limit) };
+  }
+
+  async listSignalCandidates(
+    query: ListFeedItemSignalCandidatesQuery,
+  ): Promise<readonly FeedItem[]> {
+    this.candidateQueries.push(query);
+    return this.items;
+  }
+
+  async findById(): Promise<FeedItem | null> {
+    return null;
+  }
+}
+
+const fakeFeedItem = (providerKey: string, index: number): FeedItem =>
+  FeedItem.publish({
+    id: `candidate-feed-${index}`,
+    tenantId: tenant,
+    workspaceId: workspace,
+    interestId: "interest-ai",
+    sourceItemId: `candidate-source-${index}`,
+    sourceBindingId: `candidate-binding-${providerKey}`,
+    providerKey,
+    canonicalUrl: `https://example.test/candidate/${index}`,
+    title: `${providerKey} candidate`,
+    bodyPreview: "Summary coverage candidate.",
+    publishedAt: period.startedAt,
+    observedAt: period.startedAt,
+  });
 
 type FakeFeedItemInput = {
   readonly providerKey: string;

--- a/libs/summary/adapters/evidence/feed-reader-summary-coverage.counter.ts
+++ b/libs/summary/adapters/evidence/feed-reader-summary-coverage.counter.ts
@@ -1,4 +1,8 @@
-import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import type { FeedItem } from "@social-monitor/feed/domain";
+import type {
+  FeedItemReadRepositoryPort,
+  ListFeedItemSignalCandidatesQuery,
+} from "@social-monitor/feed/ports";
 
 import type {
   CountReaderSummaryCollectedFeedItemsQuery,
@@ -34,82 +38,28 @@ export class FeedReaderSummaryCoverageCounter implements ReaderSummaryCoverageCo
     query: CountReaderSummaryCollectedFeedItemsQuery,
   ): Promise<ReaderSummaryCollectedFeedItemCoverage | undefined> {
     let cursor: string | undefined;
-    let total = 0;
-    const totals = emptyCoverageCounts();
-    const providerCounts = new Map<string, CoverageBucket>();
-    const topicCounts = new Map<string, CoverageBucket>();
-    const queryCounts = new Map<string, CoverageBucket>();
+    const accumulator = emptyCoverageAccumulator();
     const collectionHealthPromise =
       this.collectionHealth.readProviderCollectionHealth(query);
+    const candidateReader = this.feedItems.listSignalCandidates;
+    const feedQuery = coverageFeedItemQuery(query);
+
+    if (candidateReader !== undefined) {
+      const items = await candidateReader.call(this.feedItems, feedQuery);
+      recordCoverageItems(items, accumulator);
+      return coverageResult(accumulator, await collectionHealthPromise);
+    }
 
     for (let page = 0; page < MAX_PAGES; page += 1) {
       const result = await this.feedItems.list({
-        tenantId: query.tenantId,
-        workspaceId: query.workspaceId,
-        interestId:
-          query.scope.type === "interest" ? query.scope.interestId : undefined,
-        publishedAtOrAfter: query.period.startedAt,
-        publishedBefore: query.period.endedAt,
-        observedAtOrBefore: query.observedThrough,
+        ...feedQuery,
         limit: PAGE_LIMIT,
         cursor,
       });
-      for (const item of result.items) {
-        const snapshot = item.toSnapshot();
-        const providerKey = snapshot.providerKey;
-        if (!isDefaultReaderSummaryEvidenceProvider(providerKey)) {
-          continue;
-        }
-        const stats = statsForFeedItemMetadata(snapshot.providerMetadata);
-
-        total += 1;
-        incrementBucket(totals, stats);
-        incrementNamedBucket(providerCounts, providerKey, stats);
-        incrementNamedBucket(topicCounts, snapshot.interestId, stats, {
-          label: stats.topicLabel,
-        });
-        for (const searchQuery of stats.searchQueries) {
-          incrementNamedBucket(queryCounts, searchQuery, stats);
-        }
-      }
+      recordCoverageItems(result.items, accumulator);
 
       if (result.nextCursor === undefined) {
-        return {
-          collectedFeedItemCount: total,
-          lowRelevanceFeedItemCount: totals.lowRelevanceFeedItemCount,
-          mutedFeedItemCount: totals.mutedFeedItemCount,
-          userRatedFeedItemCount: totals.userRatedFeedItemCount,
-          providerBreakdown: mergeProviderCollectionHealth(
-            coverageRows(providerCounts).map(
-              ([
-                providerKey,
-                bucket,
-              ]): ReaderSummaryCollectedProviderCoverage => ({
-                providerKey,
-                ...bucket,
-              }),
-            ),
-            await collectionHealthPromise,
-          ),
-          topicBreakdown: coverageRows(topicCounts).map(
-            ([topicKey, bucket]): ReaderSummaryCollectedTopicCoverage => ({
-              topicKey,
-              ...(bucket.label === undefined
-                ? {}
-                : { topicLabel: bucket.label }),
-              collectedFeedItemCount: bucket.collectedFeedItemCount,
-              lowRelevanceFeedItemCount: bucket.lowRelevanceFeedItemCount,
-              mutedFeedItemCount: bucket.mutedFeedItemCount,
-              userRatedFeedItemCount: bucket.userRatedFeedItemCount,
-            }),
-          ),
-          queryBreakdown: coverageRows(queryCounts).map(
-            ([queryText, bucket]): ReaderSummaryCollectedQueryCoverage => ({
-              query: queryText,
-              ...bucket,
-            }),
-          ),
-        };
+        return coverageResult(accumulator, await collectionHealthPromise);
       }
 
       if (result.nextCursor === cursor) {
@@ -124,6 +74,14 @@ export class FeedReaderSummaryCoverageCounter implements ReaderSummaryCoverageCo
 
 type FeedItemCollectionStats = ReturnType<typeof statsForFeedItemMetadata>;
 
+type CoverageAccumulator = {
+  total: number;
+  readonly totals: CoverageBucket;
+  readonly providerCounts: Map<string, CoverageBucket>;
+  readonly topicCounts: Map<string, CoverageBucket>;
+  readonly queryCounts: Map<string, CoverageBucket>;
+};
+
 type CoverageBucket = {
   collectedFeedItemCount: number;
   lowRelevanceFeedItemCount: number;
@@ -137,6 +95,89 @@ const emptyCoverageCounts = (): CoverageBucket => ({
   lowRelevanceFeedItemCount: 0,
   mutedFeedItemCount: 0,
   userRatedFeedItemCount: 0,
+});
+
+const emptyCoverageAccumulator = (): CoverageAccumulator => ({
+  total: 0,
+  totals: emptyCoverageCounts(),
+  providerCounts: new Map(),
+  topicCounts: new Map(),
+  queryCounts: new Map(),
+});
+
+const coverageFeedItemQuery = (
+  query: CountReaderSummaryCollectedFeedItemsQuery,
+): ListFeedItemSignalCandidatesQuery => ({
+  tenantId: query.tenantId,
+  workspaceId: query.workspaceId,
+  interestId:
+    query.scope.type === "interest" ? query.scope.interestId : undefined,
+  publishedAtOrAfter: query.period.startedAt,
+  publishedBefore: query.period.endedAt,
+  observedAtOrBefore: query.observedThrough,
+});
+
+const recordCoverageItems = (
+  items: readonly FeedItem[],
+  accumulator: CoverageAccumulator,
+): void => {
+  for (const item of items) {
+    const snapshot = item.toSnapshot();
+    const providerKey = snapshot.providerKey;
+    if (!isDefaultReaderSummaryEvidenceProvider(providerKey)) {
+      continue;
+    }
+    const stats = statsForFeedItemMetadata(snapshot.providerMetadata);
+
+    accumulator.total += 1;
+    incrementBucket(accumulator.totals, stats);
+    incrementNamedBucket(accumulator.providerCounts, providerKey, stats);
+    incrementNamedBucket(
+      accumulator.topicCounts,
+      snapshot.interestId,
+      stats,
+      { label: stats.topicLabel },
+    );
+    for (const searchQuery of stats.searchQueries) {
+      incrementNamedBucket(accumulator.queryCounts, searchQuery, stats);
+    }
+  }
+};
+
+const coverageResult = (
+  accumulator: CoverageAccumulator,
+  collectionHealth: readonly ReaderSummaryProviderCollectionHealth[],
+): ReaderSummaryCollectedFeedItemCoverage => ({
+  collectedFeedItemCount: accumulator.total,
+  lowRelevanceFeedItemCount:
+    accumulator.totals.lowRelevanceFeedItemCount,
+  mutedFeedItemCount: accumulator.totals.mutedFeedItemCount,
+  userRatedFeedItemCount: accumulator.totals.userRatedFeedItemCount,
+  providerBreakdown: mergeProviderCollectionHealth(
+    coverageRows(accumulator.providerCounts).map(
+      ([providerKey, bucket]): ReaderSummaryCollectedProviderCoverage => ({
+        providerKey,
+        ...bucket,
+      }),
+    ),
+    collectionHealth,
+  ),
+  topicBreakdown: coverageRows(accumulator.topicCounts).map(
+    ([topicKey, bucket]): ReaderSummaryCollectedTopicCoverage => ({
+      topicKey,
+      ...(bucket.label === undefined ? {} : { topicLabel: bucket.label }),
+      collectedFeedItemCount: bucket.collectedFeedItemCount,
+      lowRelevanceFeedItemCount: bucket.lowRelevanceFeedItemCount,
+      mutedFeedItemCount: bucket.mutedFeedItemCount,
+      userRatedFeedItemCount: bucket.userRatedFeedItemCount,
+    }),
+  ),
+  queryBreakdown: coverageRows(accumulator.queryCounts).map(
+    ([queryText, bucket]): ReaderSummaryCollectedQueryCoverage => ({
+      query: queryText,
+      ...bucket,
+    }),
+  ),
 });
 
 const incrementNamedBucket = (

--- a/libs/summary/adapters/evidence/feed-reader-summary-freshness.probe.spec.ts
+++ b/libs/summary/adapters/evidence/feed-reader-summary-freshness.probe.spec.ts
@@ -1,5 +1,6 @@
 import type {
   FeedItemReadRepositoryPort,
+  FindLatestFeedItemSignalQuery,
   ListFeedItemsQuery,
   ListFeedItemsResult,
 } from "@social-monitor/feed/ports";
@@ -51,6 +52,47 @@ describe("FeedReaderSummaryFreshnessProbe", () => {
       }),
     ]);
   });
+
+  it("uses the direct newest-signal query when the adapter supports it", async () => {
+    const feedItems = new FastRecordingFeedItems();
+    const observedThrough = new Date("2026-07-13T08:52:00.000Z");
+    const period = {
+      cadence: "daily" as const,
+      startedAt: new Date("2026-07-12T00:00:00.000Z"),
+      endedAt: new Date("2026-07-13T00:00:00.000Z"),
+      timezone: "UTC",
+      periodKey:
+        "daily:2026-07-12T00:00:00.000Z:2026-07-13T00:00:00.000Z:UTC",
+    };
+
+    const result = await new FeedReaderSummaryFreshnessProbe(
+      feedItems,
+      new FixedClock(new Date("2026-07-13T09:30:00.000Z")),
+    ).evaluate({
+      tenantId: tenantId("tenant-reader-freshness"),
+      workspaceId: workspaceId("workspace-reader-freshness"),
+      scope: { type: "workspace" },
+      period,
+      observedThrough,
+      sourceWindow: {
+        windowId: "window-reader-freshness",
+        startedAt: new Date("2026-07-12T00:10:00.000Z"),
+        endedAt: new Date("2026-07-12T23:50:00.000Z"),
+        selectedFeedItemIds: [],
+        storyClusterIds: [],
+      },
+    });
+
+    expect(result.status).toBe("fresh");
+    expect(feedItems.listCalls).toBe(0);
+    expect(feedItems.signalQueries).toEqual([
+      expect.objectContaining({
+        publishedAtOrAfter: period.startedAt,
+        publishedBefore: period.endedAt,
+        observedAfter: observedThrough,
+      }),
+    ]);
+  });
 });
 
 class RecordingFeedItems implements FeedItemReadRepositoryPort {
@@ -59,6 +101,27 @@ class RecordingFeedItems implements FeedItemReadRepositoryPort {
   async list(query: ListFeedItemsQuery): Promise<ListFeedItemsResult> {
     this.queries.push(query);
     return { items: [], nextCursor: undefined };
+  }
+
+  async findById() {
+    return null;
+  }
+}
+
+class FastRecordingFeedItems implements FeedItemReadRepositoryPort {
+  readonly signalQueries: FindLatestFeedItemSignalQuery[] = [];
+  listCalls = 0;
+
+  async list(): Promise<ListFeedItemsResult> {
+    this.listCalls += 1;
+    return { items: [], nextCursor: undefined };
+  }
+
+  async findLatestSignalCandidate(
+    query: FindLatestFeedItemSignalQuery,
+  ) {
+    this.signalQueries.push(query);
+    return null;
   }
 
   async findById() {

--- a/libs/summary/adapters/evidence/feed-reader-summary-freshness.probe.ts
+++ b/libs/summary/adapters/evidence/feed-reader-summary-freshness.probe.ts
@@ -15,7 +15,7 @@ export class FeedReaderSummaryFreshnessProbe implements ReaderSummaryFreshnessPr
   async evaluate(
     params: Parameters<ReaderSummaryFreshnessProbePort["evaluate"]>[0],
   ): Promise<ReaderSummaryFreshness> {
-    const result = await this.feedItems.list({
+    const query = {
       tenantId: params.tenantId,
       workspaceId: params.workspaceId,
       interestId:
@@ -23,9 +23,10 @@ export class FeedReaderSummaryFreshnessProbe implements ReaderSummaryFreshnessPr
       publishedAtOrAfter: params.period?.startedAt,
       publishedBefore: params.period?.endedAt,
       observedAfter: params.observedThrough ?? params.sourceWindow.endedAt,
-      limit: 1,
-    });
-    const newest = result.items[0];
+    };
+    const newest = this.feedItems.findLatestSignalCandidate === undefined
+      ? (await this.feedItems.list({ ...query, limit: 1 })).items[0]
+      : await this.feedItems.findLatestSignalCandidate(query) ?? undefined;
     const checkedAt = this.clock.now();
 
     if (newest === undefined) {

--- a/libs/summary/adapters/persistence/prisma/reader-summary-artifact-promotion-immutability.spec.ts
+++ b/libs/summary/adapters/persistence/prisma/reader-summary-artifact-promotion-immutability.spec.ts
@@ -15,6 +15,30 @@ import { assertReaderSummaryPromotionAttestations } from
   "../../../domain/entities/reader-summary-promotion-attestation-validation";
 
 describe("ReaderSummaryArtifact promotion immutability", () => {
+  it("rehydrates a pre-rollout V1 attestation with legacy peer facts", () => {
+    const fixture = legacyPeerContextFixture(
+      new Date("2026-08-27T13:48:17.317Z"),
+    );
+
+    expect(() => assertReaderSummaryPromotionAttestations(
+      fixture.props,
+      fixture.attestations,
+    )).not.toThrow();
+  });
+
+  it("does not allow legacy peer verification after its rollout boundary", () => {
+    const fixture = legacyPeerContextFixture(
+      new Date("2026-08-27T21:11:02.430Z"),
+    );
+
+    expect(() => assertReaderSummaryPromotionAttestations(
+      fixture.props,
+      fixture.attestations,
+    )).toThrow(
+      "Reader summary promotion attestation differs from persisted evidence facts",
+    );
+  });
+
   it("validates semantic-cluster support in the persisted peer context", () => {
     const base = readerSummaryArtifact("artifact-contextual-attestation")
       .toSnapshot();
@@ -388,6 +412,94 @@ describe("ReaderSummaryArtifact promotion immutability", () => {
     }
   });
 });
+
+const legacyPeerContextFixture = (generatedAt: Date) => {
+  const base = readerSummaryArtifact("artifact-legacy-peer-context")
+    .toSnapshot();
+  const periodStart = new Date("2026-08-26T00:00:00.000Z");
+  const periodEnd = new Date("2026-08-27T00:00:00.000Z");
+  const cutoff = new Date("2026-08-27T00:00:00.000Z");
+  const lead = {
+    candidateId: "feed-legacy-lead",
+    provider: "reddit",
+    contentKind: "original_post" as const,
+    canonicalIdentity: "story:legacy-lead",
+    citationId: "citation-legacy-lead",
+    publishedAt: new Date("2026-08-26T08:00:00.000Z"),
+    observedAt: new Date("2026-08-26T08:05:00.000Z"),
+    periodStart,
+    periodEnd,
+    ingestionCutoff: cutoff,
+    freshnessValid: true,
+    qualityScore: 0.9,
+    relevanceScore: 0.9,
+    integrityScore: 0.9,
+    qualityValid: true,
+    safetyValid: true,
+    citationValid: true,
+    metricsState: "observed" as const,
+    metrics: { provider: "reddit" as const, score: 500, upvoteRatio: 0.95 },
+  };
+  const peer = {
+    ...lead,
+    candidateId: "feed-peer-added-before-contextual-verification",
+    provider: "hacker-news",
+    contentKind: "story" as const,
+    canonicalIdentity: "story:legacy-peer",
+    citationId: "citation-legacy-peer",
+    metrics: { provider: "hacker_news" as const, points: 100 },
+  };
+  const selection = selectReaderPostPromotions([lead]);
+  const sourceWindow = {
+    ...base.sourceWindow,
+    selectedFeedItemIds: [lead.candidateId, peer.candidateId],
+    periodStartedAt: periodStart,
+    periodEndedAt: periodEnd,
+    ingestionCutoff: cutoff,
+  };
+  const attestations = buildReaderPostPromotionAttestations(selection, {
+    artifactId: base.readerSummaryId,
+    sourceWindow,
+  });
+  const selected = selection.top[0]!;
+
+  return {
+    attestations,
+    props: {
+      ...base,
+      generatedAt,
+      sourceWindow,
+      citationMap: [{
+        citationId: lead.citationId,
+        feedItemId: lead.candidateId,
+        sourceItemId: "source-legacy-lead",
+        providerKey: lead.provider,
+        field: "canonicalUrl" as const,
+      }, {
+        citationId: peer.citationId,
+        feedItemId: peer.candidateId,
+        sourceItemId: "source-legacy-peer",
+        providerKey: peer.provider,
+        field: "canonicalUrl" as const,
+      }],
+      content: {
+        ...base.content!,
+        topReads: [{
+          ...topRead(),
+          promotionMarker: "reader_post_promotion" as const,
+          promotionPolicyVersion: "reader_post_promotion.v1" as const,
+          promotionTier: "top" as const,
+          promotionCandidateId: selected.candidate.candidateId,
+          promotionCanonicalIdentity: selected.candidate.canonicalIdentity,
+          citationIds: selected.citationIds,
+        }],
+        selectedPosts: [],
+      },
+      promotionAttestations: attestations,
+      promotionEvidenceFacts: [lead, peer],
+    },
+  };
+};
 
 const nestedRecord = (
   value: Record<string, unknown>,

--- a/libs/summary/domain/entities/reader-summary-promotion-attestation-validation.ts
+++ b/libs/summary/domain/entities/reader-summary-promotion-attestation-validation.ts
@@ -147,11 +147,12 @@ const assertAttestationsAgainstPersistedEvidence = (
 };
 
 const assertLegacyAttestationsAgainstPersistedEvidence = (
-  generatedAt: Date,
+  generatedAt: Date | undefined,
   evidenceFacts: readonly ReaderPostPromotionInput[],
   attestations: readonly ReaderPostPromotionAttestation[],
 ): void => {
-  if (generatedAt.getTime() >= PEER_CONTEXT_PROMOTION_ROLLOUT_AT.getTime()) {
+  if (generatedAt === undefined ||
+      generatedAt.getTime() >= PEER_CONTEXT_PROMOTION_ROLLOUT_AT.getTime()) {
     throw new Error(
       "Reader summary promotion attestation differs from persisted evidence facts",
     );

--- a/libs/summary/domain/entities/reader-summary-promotion-attestation-validation.ts
+++ b/libs/summary/domain/entities/reader-summary-promotion-attestation-validation.ts
@@ -1,14 +1,25 @@
-import type { ReaderPostPromotionAttestation } from
-  "../policies/reader-post-promotion-policy";
+import {
+  readerPostPromotionTimestampMicros,
+  READER_POST_PROMOTION_POLICY_V1,
+  type ReaderPostPromotionAttestation,
+  type ReaderPostPromotionInput,
+} from "../policies/reader-post-promotion-policy";
 import { selectReaderPostPromotions } from
   "../policies/reader-post-promotion-selection";
 import {
   buildReaderPostPromotionAttestations,
+  canonicalPromotionPayload,
   verifyReaderPostPromotionAttestationDigest,
 } from "../services/reader-post-promotion-attestation";
 import type { ReaderSummaryArtifactProps } from "./reader-summary-artifact";
 import { sameOrderedValues } from
   "./reader-summary-artifact-validation-values";
+
+// Promotion V1 changed from per-attestation verification to peer-context
+// verification without changing its persisted version. Keep the exact legacy
+// verifier only for artifacts generated before that rollout boundary.
+const PEER_CONTEXT_PROMOTION_ROLLOUT_AT =
+  new Date("2026-08-27T20:00:00.000Z");
 
 export const assertReaderSummaryPromotionAttestations = (
   props: ReaderSummaryArtifactProps,
@@ -127,8 +138,178 @@ const assertAttestationsAgainstPersistedEvidence = (
     item.canonicalPayload !== attestations[index]?.canonicalPayload ||
     item.digest !== attestations[index]?.digest
   )) {
+    assertLegacyAttestationsAgainstPersistedEvidence(
+      props.generatedAt,
+      evidenceFacts,
+      attestations,
+    );
+  }
+};
+
+const assertLegacyAttestationsAgainstPersistedEvidence = (
+  generatedAt: Date,
+  evidenceFacts: readonly ReaderPostPromotionInput[],
+  attestations: readonly ReaderPostPromotionAttestation[],
+): void => {
+  if (generatedAt.getTime() >= PEER_CONTEXT_PROMOTION_ROLLOUT_AT.getTime()) {
     throw new Error(
       "Reader summary promotion attestation differs from persisted evidence facts",
     );
   }
+  const evidenceByCandidateId = new Map(
+    evidenceFacts.map((fact) => [fact.candidateId, fact] as const),
+  );
+  try {
+    for (const attestation of attestations) {
+      const lead = promotionInputFromAttestation(attestation);
+      const persistedLead = evidenceByCandidateId.get(lead.candidateId);
+      if (
+        persistedLead === undefined ||
+        !attestedInputMatchesPersistedFact(lead, persistedLead) ||
+        attestation.supportFacts.some((support) => {
+          const persistedSupport = evidenceByCandidateId.get(
+            support.candidateId,
+          );
+          return persistedSupport === undefined ||
+            canonicalPromotionPayload(persistedSupport) !==
+              canonicalPromotionPayload(support);
+        })
+      ) {
+        throw new Error("Legacy promotion evidence is not persistently bound");
+      }
+      assertLegacyAttestedPolicyDecision(attestation, lead);
+    }
+  } catch {
+    throw new Error(
+      "Reader summary promotion attestation differs from persisted evidence facts",
+    );
+  }
+};
+
+const attestedInputMatchesPersistedFact = (
+  attested: ReaderPostPromotionInput,
+  persisted: ReaderPostPromotionInput,
+): boolean => {
+  const comparablePersisted = Object.fromEntries(
+    Object.keys(attested).map((key) => [
+      key,
+      persisted[key as keyof ReaderPostPromotionInput],
+    ]).filter(([, value]) => value !== undefined),
+  );
+  return canonicalPromotionPayload(attested) ===
+    canonicalPromotionPayload(comparablePersisted);
+};
+
+const promotionInputFromAttestation = (
+  attestation: ReaderPostPromotionAttestation,
+): ReaderPostPromotionInput => ({
+  candidateId: attestation.candidateId,
+  provider: attestation.provider,
+  contentKind: attestation.contentKind,
+  canonicalIdentity: attestation.canonicalIdentity,
+  citationId: attestation.citationId,
+  publishedAt: attestation.publishedAt,
+  observedAt: attestation.observedAt,
+  ...(attestation.exactPublishedAt === undefined ? {} : {
+    exactPublishedAt: attestation.exactPublishedAt,
+  }),
+  ...(attestation.exactObservedAt === undefined ? {} : {
+    exactObservedAt: attestation.exactObservedAt,
+  }),
+  ...(attestation.exactPeriodStart === undefined ? {} : {
+    exactPeriodStart: attestation.exactPeriodStart,
+  }),
+  ...(attestation.exactPeriodEnd === undefined ? {} : {
+    exactPeriodEnd: attestation.exactPeriodEnd,
+  }),
+  ...(attestation.exactIngestionCutoff === undefined ? {} : {
+    exactIngestionCutoff: attestation.exactIngestionCutoff,
+  }),
+  ...(attestation.checkedAt === undefined ? {} : {
+    checkedAt: attestation.checkedAt,
+  }),
+  periodStart: attestation.periodStartedAt,
+  periodEnd: attestation.periodEndedAt,
+  ingestionCutoff: attestation.ingestionCutoff,
+  freshnessValid: attestation.freshnessValid,
+  qualityScore: attestation.qualityScore,
+  relevanceScore: attestation.relevanceScore,
+  integrityScore: attestation.integrityScore,
+  qualityValid: attestation.qualityValid,
+  safetyValid: attestation.safetyValid,
+  citationValid: attestation.citationValid,
+  metricsState: attestation.metricsState,
+  ...(attestation.metrics === undefined ? {} : {
+    metrics: attestation.metrics,
+  }),
+  ...(attestation.authorityAttestation === undefined ? {} : {
+    authorityAttestation: attestation.authorityAttestation,
+  }),
+  ...(attestation.relationTrace === undefined ? {} : {
+    relation: attestation.relationTrace,
+  }),
+});
+
+const assertLegacyAttestedPolicyDecision = (
+  attestation: ReaderPostPromotionAttestation,
+  lead: ReaderPostPromotionInput,
+): void => {
+  const selection = selectReaderPostPromotions([
+    lead,
+    ...attestation.supportFacts,
+  ]);
+  const expected = attestation.placement === "top"
+    ? selection.top[0]
+    : selection.additional[0];
+  const decision = selection.decisions.find((item) =>
+    item.candidateId === attestation.candidateId
+  );
+  const periodStart = requiredMicros(
+    attestation.exactPeriodStart ?? attestation.periodStartedAt,
+  );
+  const periodEnd = requiredMicros(
+    attestation.exactPeriodEnd ?? attestation.periodEndedAt,
+  );
+  const publishedAt = requiredMicros(
+    attestation.exactPublishedAt ?? attestation.publishedAt,
+  );
+  const duration = periodEnd - periodStart;
+  const freshness = duration <= 0n ? 0 : Math.max(0, Math.min(
+    1,
+    Number(publishedAt - periodStart) / Number(duration),
+  ));
+  const weights = READER_POST_PROMOTION_POLICY_V1.additionalUsefulnessWeights;
+  const expectedComponents = {
+    normalizedStrength:
+      (decision?.normalizedStrength ?? Number.NaN) * weights.normalizedStrength,
+    qualityScore: attestation.qualityScore * weights.qualityScore,
+    interestRelevanceScore:
+      attestation.relevanceScore * weights.interestRelevanceScore,
+    engagementIntegrityScore:
+      attestation.integrityScore * weights.engagementIntegrityScore,
+    freshness: freshness * weights.freshness,
+  };
+  if (
+    expected?.candidate.candidateId !== attestation.candidateId ||
+    expected.decision !== attestation.decision ||
+    decision?.reason !== attestation.reason ||
+    Object.entries(expectedComponents).some(([key, value]) =>
+      Math.abs(value - attestation.usefulnessComponents[
+        key as keyof typeof expectedComponents
+      ]) > 1e-12
+    ) ||
+    expected.providerCount !== attestation.providerCount ||
+    expected.confidence !== attestation.confidence ||
+    !sameOrderedValues(expected.citationIds, attestation.citationIds)
+  ) {
+    throw new Error("Reader summary legacy promotion decision is invalid");
+  }
+};
+
+const requiredMicros = (value: Date | string): bigint => {
+  const micros = readerPostPromotionTimestampMicros(value);
+  if (micros === undefined) {
+    throw new Error("Reader summary promotion exact timestamp is invalid");
+  }
+  return micros;
 };

--- a/ops/deploy/production-runtime/daily-run.sh
+++ b/ops/deploy/production-runtime/daily-run.sh
@@ -63,13 +63,6 @@ case "$DATE_FLAG" in
   *) echo "usage: $0 [--check-readiness|--today|--yesterday|--maintenance-date YYYY-MM-DD]" >&2; exit 64 ;;
 esac
 
-# The rolling pipeline is the production owner for scheduled collection,
-# summary generation and publication. Keep the reviewed midnight timer as its
-# sixth four-hour trigger while retaining explicit maintenance modes below.
-if [[ $DATE_FLAG == --yesterday && $DAILY_TEST_MODE != 1 ]]; then
-  exec "$ROOT/control/rolling-run.sh"
-fi
-
 [[ $POSTGRES_ADMISSION_WAIT_SECONDS =~ \
    ^([0-9]+([.][0-9]+)?|[.][0-9]+)$ ]] || {
   echo "daily production-day admission wait is invalid" >&2

--- a/ops/deploy/production-runtime/daily-run.test.sh
+++ b/ops/deploy/production-runtime/daily-run.test.sh
@@ -48,9 +48,7 @@ grep -F 'historicalMode === "true" && expected < previous' "$DAILY_RUN" >/dev/nu
 grep -F 'if [ "$transition" = historical ]; then' "$DAILY_RUN" >/dev/null
 grep -F -- '--dated-state "$requested_state"' "$DAILY_RUN" >/dev/null
 grep -F 'DATE_FLAG=${1:---yesterday}' "$DAILY_RUN" >/dev/null
-grep -F 'if [[ $DATE_FLAG == --yesterday && $DAILY_TEST_MODE != 1 ]]; then' \
-  "$DAILY_RUN" >/dev/null
-grep -F 'exec "$ROOT/control/rolling-run.sh"' "$DAILY_RUN" >/dev/null
+! grep -F 'exec "$ROOT/control/rolling-run.sh"' "$DAILY_RUN" >/dev/null
 ! grep -Eq 'READER_SUMMARY.*(MAINTENANCE|HISTORICAL).*DATE_FLAG' "$DAILY_RUN"
 
 if grep -Eq \

--- a/ops/deploy/production-runtime/daily-runtime-contract.test.sh
+++ b/ops/deploy/production-runtime/daily-runtime-contract.test.sh
@@ -17,9 +17,7 @@ grep -F '"$FLOCK_COMMAND" -w "$POSTGRES_ADMISSION_WAIT_SECONDS" 8' \
   "$DAILY_RUN" >/dev/null
 grep -Fx 'ExecStart=/var/data/social-monitor/control/daily-run.sh --yesterday' \
   "$DAILY_SERVICE" >/dev/null
-grep -F 'if [[ $DATE_FLAG == --yesterday && $DAILY_TEST_MODE != 1 ]]; then' \
-  "$DAILY_RUN" >/dev/null
-grep -F 'exec "$ROOT/control/rolling-run.sh"' "$DAILY_RUN" >/dev/null
+! grep -F 'exec "$ROOT/control/rolling-run.sh"' "$DAILY_RUN" >/dev/null
 grep -Fx 'Unit=social-monitor-daily.service' "$DAILY_TIMER" >/dev/null
 grep -Fx 'Restart=no' "$DAILY_SERVICE" >/dev/null
 

--- a/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
+++ b/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
@@ -28,7 +28,7 @@ BEGIN
        SELECT 1
        FROM pg_index
        WHERE indexrelid =
-         'public.scan_jobs_reader_summary_window_latest_idx'::regclass
+         to_regclass('public.scan_jobs_reader_summary_window_latest_idx')
          AND indrelid = 'public.scan_jobs'::regclass
          AND indisvalid AND indisready AND indislive
      ) THEN

--- a/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
+++ b/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
@@ -18,6 +18,27 @@ FROM (
 WHERE owner.table_owner = session_user
    OR owner.table_owner = 'social_monitor_public_schema_owner';
 
+-- A cancelled concurrent build can leave a same-name catalog entry that
+-- IF NOT EXISTS would otherwise accept as usable. Fail closed so the operator
+-- can drop that invalid index concurrently before retrying this migration.
+DO $$
+BEGIN
+  IF to_regclass('public.scan_jobs_reader_summary_window_latest_idx') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_index
+       WHERE indexrelid =
+         'public.scan_jobs_reader_summary_window_latest_idx'::regclass
+         AND indrelid = 'public.scan_jobs'::regclass
+         AND indisvalid AND indisready AND indislive
+     ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'scan_jobs reader-summary index is invalid; drop it concurrently before retry';
+  END IF;
+END
+$$;
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS
   "scan_jobs_reader_summary_window_latest_idx"
 ON "scan_jobs" (

--- a/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
+++ b/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
@@ -1,0 +1,42 @@
+-- @social-monitor-forward-migration
+-- Online-only migration. PostgreSQL forbids CREATE INDEX CONCURRENTLY inside
+-- a transaction block, so this file intentionally has no BEGIN/COMMIT.
+SET statement_timeout = '30s';
+SELECT pg_advisory_lock(hashtextextended(
+  'social-monitor:20260828133000_reader_summary_collection_health_window_index',
+  0
+));
+
+SET lock_timeout = '2s';
+SET statement_timeout = '15min';
+
+SELECT set_config('role', owner.table_owner, false)
+FROM (
+  SELECT pg_get_userbyid(relowner) AS table_owner
+  FROM pg_class WHERE oid = 'public.scan_jobs'::regclass
+) AS owner
+WHERE owner.table_owner = session_user
+   OR owner.table_owner = 'social_monitor_public_schema_owner';
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  "scan_jobs_reader_summary_window_latest_idx"
+ON "scan_jobs" (
+  "tenant_id",
+  "workspace_id",
+  ("execution_metadata"->>'targetPublishedWindowStartedAt'),
+  ("execution_metadata"->>'targetPublishedWindowEndedAt'),
+  "source_binding_id",
+  "completed_at" DESC NULLS LAST,
+  "requested_at" DESC,
+  "id" DESC
+)
+WHERE "execution_metadata" IS NOT NULL
+  AND "status" IN ('SUCCEEDED', 'FAILED');
+
+RESET ROLE;
+RESET statement_timeout;
+RESET lock_timeout;
+SELECT pg_advisory_unlock(hashtextextended(
+  'social-monitor:20260828133000_reader_summary_collection_health_window_index',
+  0
+));

--- a/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
+++ b/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
@@ -18,28 +18,13 @@ FROM (
 WHERE owner.table_owner = session_user
    OR owner.table_owner = 'social_monitor_public_schema_owner';
 
--- A cancelled concurrent build can leave a same-name catalog entry that
--- IF NOT EXISTS would otherwise accept as usable. Fail closed so the operator
--- can drop that invalid index concurrently before retrying this migration.
-DO $$
-BEGIN
-  IF to_regclass('public.scan_jobs_reader_summary_window_latest_idx') IS NOT NULL
-     AND NOT EXISTS (
-       SELECT 1
-       FROM pg_index
-       WHERE indexrelid =
-         to_regclass('public.scan_jobs_reader_summary_window_latest_idx')
-         AND indrelid = 'public.scan_jobs'::regclass
-         AND indisvalid AND indisready AND indislive
-     ) THEN
-    RAISE EXCEPTION USING
-      ERRCODE = '55000',
-      MESSAGE = 'scan_jobs reader-summary index is invalid; drop it concurrently before retry';
-  END IF;
-END
-$$;
+-- A cancelled concurrent build can leave a same-name invalid catalog entry.
+-- Rebuild this new performance index on retry instead of accepting that entry.
+-- Both statements remain transaction-free as required by PostgreSQL.
+DROP INDEX CONCURRENTLY IF EXISTS
+  "scan_jobs_reader_summary_window_latest_idx";
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   "scan_jobs_reader_summary_window_latest_idx"
 ON "scan_jobs" (
   "tenant_id",

--- a/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
+++ b/prisma/migrations/20260828133000_reader_summary_collection_health_window_index/migration.sql
@@ -18,13 +18,7 @@ FROM (
 WHERE owner.table_owner = session_user
    OR owner.table_owner = 'social_monitor_public_schema_owner';
 
--- A cancelled concurrent build can leave a same-name invalid catalog entry.
--- Rebuild this new performance index on retry instead of accepting that entry.
--- Both statements remain transaction-free as required by PostgreSQL.
-DROP INDEX CONCURRENTLY IF EXISTS
-  "scan_jobs_reader_summary_window_latest_idx";
-
-CREATE INDEX CONCURRENTLY
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
   "scan_jobs_reader_summary_window_latest_idx"
 ON "scan_jobs" (
   "tenant_id",
@@ -38,6 +32,18 @@ ON "scan_jobs" (
 )
 WHERE "execution_metadata" IS NOT NULL
   AND "status" IN ('SUCCEEDED', 'FAILED');
+
+-- IF NOT EXISTS can encounter a catalog entry left by a cancelled concurrent
+-- build. Keep the migration non-transactional, but fail it when that entry is
+-- not a live, ready and valid index so deployment cannot report false success.
+SELECT 1 / COUNT(*) AS valid_health_index
+FROM pg_index
+WHERE indexrelid =
+    'public.scan_jobs_reader_summary_window_latest_idx'::regclass
+  AND indrelid = 'public.scan_jobs'::regclass
+  AND indisvalid
+  AND indisready
+  AND indislive;
 
 RESET ROLE;
 RESET statement_timeout;


### PR DESCRIPTION
## Что исправлено
- плавная навигация по датам без исчезновения текущего summary
- явное состояние для legacy-дней без проверенного Top posts board
- совместимое чтение pre-rollout promotion attestations, из-за которого не открывался 26 августа
- устранены повторные полные сканы coverage/freshness и добавлен production-индекс
- nightly timer снова запускает канонический yesterday pipeline

## Проверено локально
- focused Flutter store/page tests: 20 passed
- daily/rolling shell contract tests: passed
- source line cap: passed
- git diff check: passed

Hosted validation и CI запускаются на exact head bb3c7817.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible “Refreshing” status indicator with accessibility announcements while summaries update.
  - Added an “Verified Top posts unavailable” notice when summary evidence exists but top posts cannot be displayed.

- **Bug Fixes**
  - Summary content now remains visible while switching periods or refreshing.
  - Daily production runs now handle “yesterday” directly, improving date-specific execution reliability.
  - Fixed period navigation so switching between daily and weekly summaries uses the correct time window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->