### PR TITLE
fix(summaries): reconcile published daily cursor gaps

### DIFF
--- a/ops/deploy/production-runtime/daily-run.sh
+++ b/ops/deploy/production-runtime/daily-run.sh
@@ -270,8 +270,25 @@ fi
     exit 0
   fi
   if [ "$historical_mode" = false ]; then
+    gap_verified=false
+    if [ -n "$cursor_date" ]; then
+      expected_next=$(node -e '\''
+        const value = new Date(`${process.argv[1]}T00:00:00.000Z`);
+        value.setUTCDate(value.getUTCDate() + 1);
+        process.stdout.write(value.toISOString().slice(0, 10));
+      '\'' -- "$cursor_date")
+      if [ "$expected_next" != "$requested_date" ]; then
+        node scripts/run-with-timeout.mjs \
+          --timeout-ms 180000 \
+          --node-options --max-old-space-size=768 \
+          -- ./node_modules/.bin/ts-node -r tsconfig-paths/register \
+          scripts/check-reader-summary-production-day-publication-gap.ts \
+          --after-date "$cursor_date" --target-date "$requested_date"
+        gap_verified=true
+      fi
+    fi
     node -e '\''
-    const [previous, expected] = process.argv.slice(1);
+    const [previous, expected, gapVerified] = process.argv.slice(1);
     const validDate = (value) =>
       typeof value === "string" &&
       /^\d{4}-\d{2}-\d{2}$/.test(value) &&
@@ -282,10 +299,12 @@ fi
     if (previous === "") process.exit(0);
     const next = new Date(`${previous}T00:00:00.000Z`);
     next.setUTCDate(next.getUTCDate() + 1);
-    if (next.toISOString().slice(0, 10) !== expected) {
+    if (next.toISOString().slice(0, 10) !== expected && gapVerified !== "true") {
       throw new Error("requested daily state transition is not consecutive");
     }
-    '\'' -- "$cursor_date" "$requested_date"
+    '\'' -- "$cursor_date" "$requested_date" "$gap_verified"
+  else
+    gap_verified=false
   fi
   export READER_SUMMARY_DAILY_RUN_EXPECTED_DATE=$requested_date
   rm -f \
@@ -450,7 +469,7 @@ fi
       --state-dir "$public_dir")
   fi
   transition=$(node -e '\''
-    const [previous, expected, historicalMode] = process.argv.slice(1);
+    const [previous, expected, historicalMode, gapVerified] = process.argv.slice(1);
     const next = (date) => {
       const value = new Date(`${date}T00:00:00.000Z`);
       value.setUTCDate(value.getUTCDate() + 1);
@@ -460,8 +479,9 @@ fi
     else if (previous === expected) process.stdout.write("replay");
     else if (historicalMode === "true" && expected < previous) process.stdout.write("historical");
     else if (next(previous) === expected) process.stdout.write("advance");
+    else if (gapVerified === "true" && previous < expected) process.stdout.write("advance_verified_gap");
     else throw new Error("daily production-day state transition is not consecutive");
-  '\'' -- "$previous_state_date" "$expected_date" "$historical_mode")
+  '\'' -- "$previous_state_date" "$expected_date" "$historical_mode" "$gap_verified")
 
   if [ "$transition" = replay ]; then
     cmp -s "$staged_state" "$public_dir/latest-state.v1.json" || {

--- a/ops/deploy/production-runtime/daily-run.test.sh
+++ b/ops/deploy/production-runtime/daily-run.test.sh
@@ -28,6 +28,9 @@ grep -F 'scripts/verify-reader-summary-production-day-publication.mjs' \
   "$DAILY_RUN" >/dev/null
 grep -F 'scripts/verify-reader-summary-production-day-state.mjs' \
   "$DAILY_RUN" >/dev/null
+grep -F 'scripts/check-reader-summary-production-day-publication-gap.ts' \
+  "$DAILY_RUN" >/dev/null
+grep -F 'advance_verified_gap' "$DAILY_RUN" >/dev/null
 grep -F 'latest-state.v1.json' "$DAILY_RUN" >/dev/null
 grep -F 'DURABLE_READER_SUMMARY_PUBLICATION_RECOVERY_DIR=' \
   "$DAILY_RUN" >/dev/null

--- a/scripts/check-reader-summary-production-day-publication-gap.spec.ts
+++ b/scripts/check-reader-summary-production-day-publication-gap.spec.ts
@@ -1,0 +1,27 @@
+import { publicationGapDates } from "./check-reader-summary-production-day-publication-gap";
+
+describe("production-day publication cursor gap", () => {
+  it("returns every intervening UTC date and excludes both endpoints", () => {
+    expect(publicationGapDates("2026-08-14", "2026-08-18")).toEqual([
+      "2026-08-15",
+      "2026-08-16",
+      "2026-08-17",
+    ]);
+  });
+
+  it("accepts an ordinary consecutive transition without a database gap", () => {
+    expect(publicationGapDates("2026-08-27", "2026-08-28")).toEqual([]);
+  });
+
+  it("fails closed for malformed or non-forward transitions", () => {
+    expect(() => publicationGapDates("not-a-date", "2026-08-28")).toThrow(
+      "publication cursor date is invalid",
+    );
+    expect(() => publicationGapDates("2026-08-28", "2026-08-28")).toThrow(
+      "must follow the current cursor",
+    );
+    expect(() => publicationGapDates("2026-08-29", "2026-08-28")).toThrow(
+      "must follow the current cursor",
+    );
+  });
+});

--- a/scripts/check-reader-summary-production-day-publication-gap.ts
+++ b/scripts/check-reader-summary-production-day-publication-gap.ts
@@ -1,0 +1,97 @@
+import { Pool } from "pg";
+
+import { readCurrentPublicArtifactSnapshot } from "./lib/reader-summary-current-publication-bindings";
+import { readerSummaryProductionDayScope } from "./lib/reader-summary-production-day-scope";
+import { yesterdaySocialQualityDatabaseUrl } from "./lib/yesterday-social-replay-support";
+
+export function publicationGapDates(
+  afterDate: string,
+  targetDate: string,
+): readonly string[] {
+  assertUtcDate(afterDate, "publication cursor date");
+  assertUtcDate(targetDate, "requested publication date");
+  if (afterDate >= targetDate) {
+    throw new Error("Publication gap target must follow the current cursor");
+  }
+
+  const dates: string[] = [];
+  const cursor = new Date(`${afterDate}T00:00:00.000Z`);
+  cursor.setUTCDate(cursor.getUTCDate() + 1);
+  while (cursor.toISOString().slice(0, 10) < targetDate) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return dates;
+}
+
+export async function verifyPublishedProductionDayGap(params: {
+  readonly afterDate: string;
+  readonly targetDate: string;
+  readonly databaseUrl: string;
+}): Promise<readonly string[]> {
+  const dates = publicationGapDates(params.afterDate, params.targetDate);
+  if (dates.length === 0) return dates;
+
+  const pool = new Pool({
+    connectionString: params.databaseUrl,
+    min: 0,
+    max: 1,
+    connectionTimeoutMillis: 20_000,
+    options: "-c social_monitor.system_access=true",
+  });
+  try {
+    for (const collectionDate of dates) {
+      await readCurrentPublicArtifactSnapshot({
+        pool,
+        databaseUrl: params.databaseUrl,
+        scope: {
+          ...readerSummaryProductionDayScope,
+          scopeType: "workspace",
+          scopeKey: "workspace",
+        },
+        collectionDates: [collectionDate],
+      });
+    }
+  } finally {
+    await pool.end().catch(() => undefined);
+  }
+  return dates;
+}
+
+async function main(): Promise<void> {
+  const afterDate = readOption("--after-date");
+  const targetDate = readOption("--target-date");
+  const dates = await verifyPublishedProductionDayGap({
+    afterDate,
+    targetDate,
+    databaseUrl: yesterdaySocialQualityDatabaseUrl(),
+  });
+  console.log(
+    `Verified completed exact production publications for cursor gap ${afterDate}..${targetDate} (${dates.length} dates)`,
+  );
+}
+
+function readOption(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index < 0 ? undefined : process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function assertUtcDate(value: string, label: string): void {
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/u.test(value) ||
+    new Date(`${value}T00:00:00.000Z`).toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+}
+
+if (require.main === module) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-reader-summary-production-day-publication-gap.ts
+++ b/scripts/check-reader-summary-production-day-publication-gap.ts
@@ -1,6 +1,15 @@
-import { Pool } from "pg";
+import {
+  acquirePrismaPgRuntimeConnection,
+  defaultPostgresRuntimePoolConfig,
+  runWithSystemDatabaseAccess,
+  type PrismaPgRuntimeClientConstructor,
+} from "@social-monitor/platform-persistence";
+import { loadPrismaRuntimeClient } from "@social-monitor/platform-persistence/prisma-runtime-client";
 
-import { readCurrentPublicArtifactSnapshot } from "./lib/reader-summary-current-publication-bindings";
+import {
+  buildCurrentPublicArtifactSnapshot,
+  currentPublicArtifactBindingsQuery,
+} from "./lib/reader-summary-current-publication-bindings";
 import { readerSummaryProductionDayScope } from "./lib/reader-summary-production-day-scope";
 import { yesterdaySocialQualityDatabaseUrl } from "./lib/yesterday-social-replay-support";
 
@@ -32,31 +41,77 @@ export async function verifyPublishedProductionDayGap(params: {
   const dates = publicationGapDates(params.afterDate, params.targetDate);
   if (dates.length === 0) return dates;
 
-  const pool = new Pool({
-    connectionString: params.databaseUrl,
-    min: 0,
-    max: 1,
-    connectionTimeoutMillis: 20_000,
-    options: "-c social_monitor.system_access=true",
-  });
+  const PrismaClient =
+    loadPrismaRuntimeClient<
+      PrismaPgRuntimeClientConstructor<PublicationGapRuntimeClient>
+    >();
+  const connection = await acquirePrismaPgRuntimeConnection(
+    defaultPostgresRuntimePoolConfig(params.databaseUrl, "daily-runner"),
+    PrismaClient,
+  );
   try {
-    for (const collectionDate of dates) {
-      await readCurrentPublicArtifactSnapshot({
-        pool,
-        databaseUrl: params.databaseUrl,
-        scope: {
-          ...readerSummaryProductionDayScope,
-          scopeType: "workspace",
-          scopeKey: "workspace",
-        },
-        collectionDates: [collectionDate],
-      });
-    }
+    await runWithSystemDatabaseAccess(
+      "verify published daily summary cursor gap",
+      () =>
+        connection.client.$transaction(
+          async (transaction) => {
+            await transaction.$executeRawUnsafe(
+              "SET LOCAL statement_timeout = '60s'",
+            );
+            for (const collectionDate of dates) {
+              const rows = await transaction.$queryRawUnsafe<
+                Parameters<typeof buildCurrentPublicArtifactSnapshot>[0]["rows"]
+              >(
+                currentPublicArtifactBindingsQuery,
+                readerSummaryProductionDayScope.tenantId,
+                readerSummaryProductionDayScope.workspaceId,
+                "workspace",
+                [collectionDate],
+              );
+              buildCurrentPublicArtifactSnapshot({
+                rows,
+                databaseUrl: params.databaseUrl,
+                scope: {
+                  ...readerSummaryProductionDayScope,
+                  scopeType: "workspace",
+                  scopeKey: "workspace",
+                },
+                collectionDates: [collectionDate],
+              });
+            }
+          },
+          {
+            isolationLevel: "RepeatableRead",
+            maxWait: 30_000,
+            timeout: 180_000,
+          },
+        ),
+    );
   } finally {
-    await pool.end().catch(() => undefined);
+    await connection.close().catch(() => undefined);
   }
   return dates;
 }
+
+type PublicationGapTransactionClient = {
+  $executeRawUnsafe(
+    query: string,
+    ...values: readonly unknown[]
+  ): Promise<number>;
+  $queryRawUnsafe<T>(query: string, ...values: readonly unknown[]): Promise<T>;
+};
+
+type PublicationGapRuntimeClient = PublicationGapTransactionClient & {
+  $disconnect(): Promise<void>;
+  $transaction<T>(
+    operation: (client: PublicationGapTransactionClient) => Promise<T>,
+    options: {
+      readonly isolationLevel: "RepeatableRead";
+      readonly maxWait: number;
+      readonly timeout: number;
+    },
+  ): Promise<T>;
+};
 
 async function main(): Promise<void> {
   const afterDate = readOption("--after-date");


### PR DESCRIPTION
## What
- verify every skipped UTC day against the exact current production publication binding
- allow the daily file cursor to advance across already-published dates only after that fail-closed PostgreSQL proof
- retain ordinary consecutive and historical recovery behavior

## Why
Production DB has completed exact daily summaries for Aug 15-28, while the immutable file cursor remained at Aug 14. Without reconciliation, the next scheduled daily run rejects the valid forward transition before collection.

## Verification
- focused Jest: 3/3
- daily V6 schedule wiring test
- architecture boundaries
- code quality guardrails
- source line cap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Production processing can now safely advance across missed publication days after verifying that all intervening daily summaries are available.
  - Added validation for publication gaps, including date sequencing and completed summary artifacts.

- **Bug Fixes**
  - Prevents invalid or unverified cursor transitions during production-day processing.

- **Tests**
  - Added coverage for consecutive dates, multi-day gaps, malformed dates, and invalid transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->