### PR TITLE
fix(summaries): admit bound historical publication dates

### DIFF
--- a/scripts/lib/reader-summary-current-publication-bindings.spec.ts
+++ b/scripts/lib/reader-summary-current-publication-bindings.spec.ts
@@ -130,6 +130,7 @@ describe("current public reader-summary bindings", () => {
 
     const wrongRequestedDate = cloneRows(rows);
     wrongRequestedDate[0]!.exactProof.requestedUtcDate = "2026-07-15";
+    wrongRequestedDate[0]!.publicationRequestedUtcDate = "2026-07-15";
     wrongRequestedDate[0]!.proofSha256 = canonicalJsonSha256(
       wrongRequestedDate[0]!.exactProof,
     );
@@ -206,6 +207,26 @@ describe("current public reader-summary bindings", () => {
         expectedManifest,
       }),
     ).toThrow("drifted from target manifest");
+  });
+
+  it("accepts an exact historical publication requested after its target day", () => {
+    const rows = cloneRows(fixtureRows());
+    const historical = rows[0]!;
+    const requestedAt = "2026-07-21T00:01:00.000Z";
+    historical.publicationRequestedUtcDate = historical.collectionDate;
+    historical.publicationRequestedAt = new Date(requestedAt);
+    historical.exactProof.requestedUtcDate = historical.collectionDate;
+    historical.exactProof.requestedAt = requestedAt;
+    historical.proofSha256 = canonicalJsonSha256(historical.exactProof);
+
+    expect(() =>
+      buildCurrentPublicArtifactSnapshot({
+        rows,
+        databaseUrl: databaseUrl(),
+        scope: scope(),
+        collectionDates: dates(),
+      }),
+    ).not.toThrow();
   });
 
   it("rejects a different database and slots replaced after capture", () => {

--- a/scripts/lib/reader-summary-current-publication-bindings.ts
+++ b/scripts/lib/reader-summary-current-publication-bindings.ts
@@ -314,6 +314,10 @@ function assertExactProofBinding(
   collectionDate: string,
 ): void {
   const proof = row.exactProof;
+  const publicationRequestedAt = exactTimestamp(
+    row.publicationRequestedAt,
+    "Current publication requestedAt",
+  );
   if (
     !isRecord(proof) ||
     !hasExactKeys(proof, [
@@ -351,16 +355,12 @@ function assertExactProofBinding(
     proof.period.startedAt !== `${collectionDate}T00:00:00.000Z` ||
     proof.period.endedAt !== nextUtcDate(collectionDate) ||
     proof.requestedUtcDate !== row.publicationRequestedUtcDate ||
-    proof.requestedUtcDate !==
-      exactTimestamp(
-        row.publicationRequestedAt,
-        "Current publication requestedAt",
-      ).slice(0, 10) ||
-    proof.requestedAt !==
-      exactTimestamp(
-        row.publicationRequestedAt,
-        "Current publication requestedAt",
-      ) ||
+    !matchesSupportedRequestedUtcDate({
+      requestedUtcDate: proof.requestedUtcDate,
+      requestedAt: publicationRequestedAt,
+      collectionDate,
+    }) ||
+    proof.requestedAt !== publicationRequestedAt ||
     proof.readerSummaryJobId !== row.publicationReaderSummaryJobId ||
     proof.readerSummaryArtifactId !== target.artifactId ||
     proof.reportSha256 !== target.reportSha256 ||
@@ -370,6 +370,20 @@ function assertExactProofBinding(
   ) {
     throw new Error(`Current publication exact proof drifted for ${collectionDate}`);
   }
+}
+
+function matchesSupportedRequestedUtcDate(input: {
+  readonly requestedUtcDate: unknown;
+  readonly requestedAt: string;
+  readonly collectionDate: string;
+}): boolean {
+  if (input.requestedUtcDate === input.requestedAt.slice(0, 10)) {
+    return true;
+  }
+  return (
+    input.requestedUtcDate === input.collectionDate &&
+    input.requestedAt >= nextUtcDate(input.collectionDate)
+  );
 }
 
 function assertPersistedReportHash(


### PR DESCRIPTION
## What
- accept cryptographically bound historical summary requests whose target day predates execution
- keep exact publication column, timestamp, scope, report and proof hash checks fail-closed
- cover valid backfill and unrelated-date rejection

## Evidence
- 10 focused tests passed
- TypeScript build typecheck passed
- focused ESLint passed
- architecture and source line-cap gates passed
- read-only production diagnostic: 2026-08-17,20,25,26 differ only because requestedUtcDate is the historical target while requestedAt is the later execution time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of historical publication records when request timestamps cross UTC date boundaries.
  - Prevented valid exact publication records from being incorrectly rejected due to date mismatches.
  - Strengthened validation for publication request dates and collection dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->