### PR TITLE
fix(summaries): reconcile rolling and daily quality gates

### DIFF
--- a/scripts/check-reader-summary-quality-dashboard.ts
+++ b/scripts/check-reader-summary-quality-dashboard.ts
@@ -48,6 +48,7 @@ import {
 } from "./lib/reader-summary-claim-quality";
 import {
   isEligiblePrimaryTopReadInput,
+  primarySummaryProviderBreadthEnough,
   primarySummaryRepresentationEnough,
   readerFacingPrimaryCandidateCount,
 } from "./lib/reader-summary-primary-source-quality";
@@ -587,12 +588,14 @@ async function buildDayReport(
       topReadCount: summary.topReadCount,
       topReadQuality,
     }),
-    summaryHasPrimarySourcesSelected: primarySources.every(
-      (source) => (summary.primarySelectedCounts[source] ?? 0) >= 1,
-    ),
-    summaryHasPrimarySourcesInTopReads: primarySources.every(
-      (source) => (summary.primaryTopReadCounts[source] ?? 0) >= 1,
-    ),
+    summaryHasPrimarySourceSelected: primarySummaryProviderBreadthEnough({
+      primarySources,
+      providerCounts: summary.primarySelectedCounts,
+    }),
+    summaryHasPrimarySourceInTopReads: primarySummaryProviderBreadthEnough({
+      primarySources,
+      providerCounts: summary.primaryTopReadCounts,
+    }),
     noTechnicalLeakage: summary.technicalLeakCount === 0,
     topReadProviderSkewControlled: topReadProviderSkewPasses(summary),
     topReadQualityPasses: Object.values(topReadQuality.gates).every(Boolean),

--- a/scripts/check-yesterday-reader-summary-artifact-quality.ts
+++ b/scripts/check-yesterday-reader-summary-artifact-quality.ts
@@ -30,6 +30,7 @@ import {
 import {
   dailyPeriodKey,
   isLocalDataSourceUnavailable,
+  visibleArtifactDoesNotPrecedeTarget,
 } from "./lib/reader-summary-quality-eval-support";
 import {
   selectedCoverageMatchesProviderBreakdown,
@@ -533,9 +534,12 @@ async function buildReport(): Promise<ArtifactQualityReport> {
       qualityGates: {
         artifactPeriodMatchesRequestedDate:
           record.periodKey === dailyPeriodKey(collectionDate),
-        latestVisibleArtifactPeriodMatchesRequestedDate:
+        latestVisibleArtifactDoesNotPrecedeRequestedDate:
           allowHistorical ||
-          latestVisible.periodKey === dailyPeriodKey(collectionDate),
+          visibleArtifactDoesNotPrecedeTarget({
+            targetPeriodStartedAt: record.periodStartedAt,
+            visiblePeriodStartedAt: latestVisible.periodStartedAt,
+          }),
         artifactStatusIsVisible:
           record.status === "COMPLETED" || record.status === "NO_SIGNAL",
         coverageSelectedMatchesPromotionAttestations:
@@ -620,6 +624,10 @@ async function buildReport(): Promise<ArtifactQualityReport> {
         promotionBoardMatchesAttestedEvidence,
         crossSourceEvidencePresent: coverage.crossSourceClusterCount > 0,
         historicalLatestVisibleGateBypassed: allowHistorical,
+        newerVisibleArtifactCoexistsWithRequestedDaily:
+          latestVisible.periodKey !== record.periodKey &&
+          new Date(latestVisible.periodStartedAt).getTime() >
+            new Date(record.periodStartedAt).getTime(),
         dirtyCollectionAllowedForInspection:
           collectionIntegrity.status === "collection_integrity_failed" &&
           allowDirtyCollection,

--- a/scripts/lib/reader-summary-primary-source-quality.spec.ts
+++ b/scripts/lib/reader-summary-primary-source-quality.spec.ts
@@ -1,11 +1,30 @@
 import type { TopRead } from "@social-monitor/summary/domain";
 
 import {
+  primarySummaryProviderBreadthEnough,
   primarySummaryRepresentationEnough,
   readerFacingPrimaryCandidateCount,
 } from "./reader-summary-primary-source-quality";
 
 describe("reader summary primary source quality", () => {
+  it("accepts one strong primary provider without forcing a weak second provider", () => {
+    expect(
+      primarySummaryProviderBreadthEnough({
+        primarySources: ["reddit", "x-twitter"],
+        providerCounts: { reddit: 6, "x-twitter": 0 },
+      }),
+    ).toBe(true);
+  });
+
+  it("still requires at least one primary provider", () => {
+    expect(
+      primarySummaryProviderBreadthEnough({
+        primarySources: ["reddit", "x-twitter"],
+        providerCounts: { "hacker-news": 8 },
+      }),
+    ).toBe(false);
+  });
+
   it("does not require a garbage second read when only one is reader-facing", () => {
     const selectedPosts = [
       topRead("Useful Reddit analysis", "Concrete operational context."),

--- a/scripts/lib/reader-summary-primary-source-quality.ts
+++ b/scripts/lib/reader-summary-primary-source-quality.ts
@@ -69,3 +69,11 @@ export const primarySummaryRepresentationEnough = (params: {
     params.selectedCount >= 5 && params.topReadCount >= requiredTopReads
   );
 };
+
+export const primarySummaryProviderBreadthEnough = (params: {
+  readonly primarySources: readonly string[];
+  readonly providerCounts: Readonly<Record<string, number>>;
+}): boolean =>
+  params.primarySources.some(
+    (source) => (params.providerCounts[source] ?? 0) >= 1,
+  );

--- a/scripts/lib/reader-summary-production-runtime-policy.spec.ts
+++ b/scripts/lib/reader-summary-production-runtime-policy.spec.ts
@@ -13,6 +13,9 @@ describe("reader summary production runtime policy", () => {
       READER_SUMMARY_PRODUCTION_RUNTIME_POLICY.summaryModelMaximumAttempts,
     ).toBe(2);
     expect(
+      READER_SUMMARY_PRODUCTION_RUNTIME_POLICY.runtimeHealthTimeoutMs,
+    ).toBeGreaterThanOrEqual(30_000);
+    expect(
       READER_SUMMARY_PRODUCTION_RUNTIME_POLICY.topicMapMaximumAttempts,
     ).toBe(2);
     expect(

--- a/scripts/lib/reader-summary-production-runtime-policy.ts
+++ b/scripts/lib/reader-summary-production-runtime-policy.ts
@@ -1,4 +1,5 @@
 export const READER_SUMMARY_PRODUCTION_RUNTIME_POLICY = {
+  runtimeHealthTimeoutMs: 30_000,
   storyRelationTimeoutMs: 900_000,
   storyRelationMaximumAttempts: 1,
   summaryModelTimeoutMs: 900_000,

--- a/scripts/lib/reader-summary-quality-eval-support.spec.ts
+++ b/scripts/lib/reader-summary-quality-eval-support.spec.ts
@@ -13,8 +13,8 @@ describe("visibleArtifactDoesNotPrecedeTarget", () => {
   it("accepts a newer rolling artifact beside an exact requested daily", () => {
     expect(
       visibleArtifactDoesNotPrecedeTarget({
-        targetPeriodStartedAt: "2026-08-27T00:00:00.000Z",
-        visiblePeriodStartedAt: "2026-08-28T00:00:00.000Z",
+        targetPeriodStartedAt: new Date("2026-08-27T00:00:00.000Z"),
+        visiblePeriodStartedAt: new Date("2026-08-28T00:00:00.000Z"),
       }),
     ).toBe(true);
   });

--- a/scripts/lib/reader-summary-quality-eval-support.spec.ts
+++ b/scripts/lib/reader-summary-quality-eval-support.spec.ts
@@ -6,7 +6,28 @@ import {
   dailyPeriodKey,
   readExactReaderSummaryArtifact,
   readLatestReaderSummaryArtifact,
+  visibleArtifactDoesNotPrecedeTarget,
 } from "./reader-summary-quality-eval-support";
+
+describe("visibleArtifactDoesNotPrecedeTarget", () => {
+  it("accepts a newer rolling artifact beside an exact requested daily", () => {
+    expect(
+      visibleArtifactDoesNotPrecedeTarget({
+        targetPeriodStartedAt: "2026-08-27T00:00:00.000Z",
+        visiblePeriodStartedAt: "2026-08-28T00:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a latest-visible artifact older than the requested daily", () => {
+    expect(
+      visibleArtifactDoesNotPrecedeTarget({
+        targetPeriodStartedAt: "2026-08-27T00:00:00.000Z",
+        visiblePeriodStartedAt: "2026-08-26T00:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("readLatestReaderSummaryArtifact", () => {
   it("reads only the latest published artifact", async () => {

--- a/scripts/lib/reader-summary-quality-eval-support.ts
+++ b/scripts/lib/reader-summary-quality-eval-support.ts
@@ -331,6 +331,16 @@ export function dailyPeriodKey(collectionDate: string): string {
   return `daily:${dayStart(collectionDate)}:${dayEnd(collectionDate)}:UTC`;
 }
 
+export function visibleArtifactDoesNotPrecedeTarget(params: {
+  readonly targetPeriodStartedAt: string;
+  readonly visiblePeriodStartedAt: string;
+}): boolean {
+  const target = Date.parse(params.targetPeriodStartedAt);
+  const visible = Date.parse(params.visiblePeriodStartedAt);
+
+  return Number.isFinite(target) && Number.isFinite(visible) && visible >= target;
+}
+
 export function readMetadataString(
   metadata: unknown,
   key: string,

--- a/scripts/lib/reader-summary-quality-eval-support.ts
+++ b/scripts/lib/reader-summary-quality-eval-support.ts
@@ -332,14 +332,17 @@ export function dailyPeriodKey(collectionDate: string): string {
 }
 
 export function visibleArtifactDoesNotPrecedeTarget(params: {
-  readonly targetPeriodStartedAt: string;
-  readonly visiblePeriodStartedAt: string;
+  readonly targetPeriodStartedAt: string | Date;
+  readonly visiblePeriodStartedAt: string | Date;
 }): boolean {
-  const target = Date.parse(params.targetPeriodStartedAt);
-  const visible = Date.parse(params.visiblePeriodStartedAt);
+  const target = dateValue(params.targetPeriodStartedAt);
+  const visible = dateValue(params.visiblePeriodStartedAt);
 
   return Number.isFinite(target) && Number.isFinite(visible) && visible >= target;
 }
+
+const dateValue = (value: string | Date): number =>
+  value instanceof Date ? value.getTime() : Date.parse(value);
 
 export function readMetadataString(
   metadata: unknown,

--- a/scripts/run-reader-summary-production-day.ts
+++ b/scripts/run-reader-summary-production-day.ts
@@ -366,6 +366,9 @@ async function main(): Promise<void> {
           DURABLE_READER_SUMMARY_MODEL: summaryModel,
           AGENT_RUNTIME_READER_SUMMARY_MODEL: "gpt-5.6-sol",
           AGENT_RUNTIME_PROVIDER: "codex",
+          AGENT_RUNTIME_GRPC_TIMEOUT_MS: String(
+            READER_SUMMARY_PRODUCTION_RUNTIME_POLICY.runtimeHealthTimeoutMs,
+          ),
           AGENT_RUNTIME_READER_SUMMARY_REASONING_EFFORT: "high",
           AGENT_RUNTIME_READER_SUMMARY_TIMEOUT_MS: String(
             READER_SUMMARY_PRODUCTION_RUNTIME_POLICY.summaryModelTimeoutMs,
@@ -753,7 +756,8 @@ async function readActualRuntimeHealth(): Promise<ProductionDayRuntimeHealth> {
     address,
     clock: new SystemClock(),
     options: {
-      timeoutMs: 5_000,
+      timeoutMs:
+        READER_SUMMARY_PRODUCTION_RUNTIME_POLICY.runtimeHealthTimeoutMs,
       serviceToken:
         process.env.AGENT_RUNTIME_SERVICE_TOKEN?.trim() || undefined,
     },


### PR DESCRIPTION
## Что исправлено
- увеличен deadline runtime health-proof с 5 до 30 секунд
- более новый rolling summary больше не блокирует точный daily artifact
- quality gate требует хотя бы один качественный primary source, не заставляя публиковать слабый X/Reddit материал

## Проверки
- 30 focused tests
- focused ESLint
- architecture boundaries
- source line cap

Production canary на предыдущем SHA воспроизвел все три причины.