### PR TITLE
fix(summaries): stop redundant x readiness waits

### DIFF
--- a/scripts/lib/production-collection-quality-policy.spec.ts
+++ b/scripts/lib/production-collection-quality-policy.spec.ts
@@ -14,6 +14,7 @@ import {
   productionCollectionThresholds,
   providerMeetsProductionBlockingPolicy,
   recalculateProductionBlockingPolicyGates,
+  xTargetWindowAlreadyMeetsProductionPolicy,
 } from "./production-collection-quality-policy";
 
 describe("production collection quality policy", () => {
@@ -315,7 +316,46 @@ describe("production collection quality policy", () => {
     ).toBe(true);
   });
 
-  it("still blocks unavailable, stale, rate-limited or insufficient inventories", () => {
+  it("accepts a rate-limited X pass when the exact-day inventory is already sufficient", () => {
+    expect(
+      providerMeetsProductionBlockingPolicy({
+        providerKey: "x-twitter",
+        status: "succeeded",
+        observability: observation({
+          target: 100,
+          collected: 35,
+          evaluated: 137,
+          coverageRatio: 1,
+          reasons: ["rate_limited"],
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("spends no delayed X retry budget for a sufficient fresh exact-day inventory", () => {
+    const input = {
+      visibleItemCount: 137,
+      targetItemCount: 100,
+      newestPublishedAt: "2026-08-27T23:58:00.000Z",
+      targetWindowEndedAt: new Date("2026-08-28T00:00:00.000Z"),
+    };
+
+    expect(xTargetWindowAlreadyMeetsProductionPolicy(input)).toBe(true);
+    expect(
+      xTargetWindowAlreadyMeetsProductionPolicy({
+        ...input,
+        visibleItemCount: 19,
+      }),
+    ).toBe(false);
+    expect(
+      xTargetWindowAlreadyMeetsProductionPolicy({
+        ...input,
+        newestPublishedAt: "2026-08-27T17:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+
+  it("still blocks unavailable, stale or insufficient inventories", () => {
     expect(
       providerMeetsProductionBlockingPolicy({
         providerKey: "x-twitter",

--- a/scripts/lib/production-collection-quality-policy.ts
+++ b/scripts/lib/production-collection-quality-policy.ts
@@ -247,7 +247,11 @@ export const providerMeetsProductionBlockingPolicy = (
     return (
       observation.slo.evaluatedItemCount >=
         productionCollectionThresholds.xTwitterVisibleFeedItems &&
-      meetsBoundedInventoryPolicy(observation, 0.8)
+      observation.slo.coverageRatio >= 0.8 &&
+      observation.slo.reasons.every(
+        (reason) =>
+          reason === "target_shortfall" || reason === "rate_limited",
+      )
     );
   }
 
@@ -260,6 +264,41 @@ const meetsBoundedInventoryPolicy = (
 ): boolean =>
   observation.slo.coverageRatio >= minimumCoverageRatio &&
   observation.slo.reasons.every((reason) => reason === "target_shortfall");
+
+export const xTargetWindowAlreadyMeetsProductionPolicy = (params: {
+  readonly visibleItemCount: number;
+  readonly targetItemCount: number | undefined;
+  readonly newestPublishedAt: string | undefined;
+  readonly targetWindowEndedAt: Date;
+  readonly maxFreshnessLagSeconds?: number;
+}): boolean => {
+  const targetItemCount = params.targetItemCount;
+  const newestPublishedAt =
+    params.newestPublishedAt === undefined
+      ? undefined
+      : new Date(params.newestPublishedAt);
+  const freshnessLagSeconds =
+    newestPublishedAt === undefined ||
+    !Number.isFinite(newestPublishedAt.getTime())
+      ? Number.POSITIVE_INFINITY
+      : Math.max(
+          0,
+          Math.round(
+            (params.targetWindowEndedAt.getTime() -
+              newestPublishedAt.getTime()) /
+              1000,
+          ),
+        );
+
+  return (
+    targetItemCount !== undefined &&
+    targetItemCount > 0 &&
+    params.visibleItemCount >=
+      productionCollectionThresholds.xTwitterVisibleFeedItems &&
+    params.visibleItemCount / targetItemCount >= 0.8 &&
+    freshnessLagSeconds <= (params.maxFreshnessLagSeconds ?? 21_600)
+  );
+};
 
 const nonGitHubDailyProviderKeys = [
   "hacker-news",

--- a/scripts/run-reader-summary-clean-real-day-collection.ts
+++ b/scripts/run-reader-summary-clean-real-day-collection.ts
@@ -60,6 +60,7 @@ import {
 } from "./lib/clean-real-day-provider-acquisition";
 import { requireScanPolicyTargets } from "./lib/clean-real-day-scan-policy-targets";
 import {
+  configuredProviderCollectionTargetItemCount,
   providerCollectionFreshnessReferenceAt,
   withProviderCollectionWindowProof,
 } from "./lib/provider-collection-observability";
@@ -67,6 +68,7 @@ import {
   explicitGitHubUnavailableIsTransparentPartialDailyInput,
   providerMeetsProductionBlockingPolicy,
   recalculateProductionBlockingPolicyGates,
+  xTargetWindowAlreadyMeetsProductionPolicy,
 } from "./lib/production-collection-quality-policy";
 import { PrismaGitHubTrendingDurableSnapshotReader } from "./lib/github-trending-durable-snapshot-reuse";
 
@@ -301,8 +303,24 @@ async function tryRunCollection(): Promise<
     const targets = allTargets.filter((target) =>
       providerKeys.includes(target.providerKey),
     );
+    const xTarget = targets.find(
+      (target) => target.providerKey === "x-twitter",
+    );
+    const xTargetWindowAlreadyReady =
+      xTarget !== undefined &&
+      xTargetWindowAlreadyMeetsProductionPolicy({
+        visibleItemCount: databaseWindow.providerCounts["x-twitter"] ?? 0,
+        targetItemCount: configuredProviderCollectionTargetItemCount(
+          xTarget.config,
+        ),
+        newestPublishedAt:
+          databaseWindow.newestItemAtByProvider["x-twitter"],
+        targetWindowEndedAt: new Date(targetPublishedWindow.endExclusive),
+      });
     const spendXReadinessBudget =
-      waitForXReadiness && catchUpCanSpendXReadinessBudget(plan);
+      waitForXReadiness &&
+      !xTargetWindowAlreadyReady &&
+      catchUpCanSpendXReadinessBudget(plan);
     const scanResults = await executeCleanRealDayProviderAcquisition({
       targets,
       connection,


### PR DESCRIPTION
## Summary
- stop delayed X retries when fresh exact-day inventory already satisfies the production floor
- accept a partial rate-limited X pass when cumulative exact-day coverage remains sufficient
- keep stale, unavailable and insufficient X inventories blocking

## Verification
- 29 focused tests passed
- repository lint passed
- source line-cap passed
- local project typecheck is blocked only by pre-existing missing generated/OpenTelemetry dependencies; CI installs exact dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection readiness checks for rate-limited X inventories.
  * Scans are now accepted when they already contain enough fresh, exact-day items.
  * Prevented unnecessary readiness delays and retry-budget consumption when collection targets are already satisfied.
  * Insufficient or stale inventories continue to be blocked until they meet production quality requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->