### PR TITLE
fix(summaries): bound reader presentation fanout

### DIFF
--- a/libs/summary/features/list-reader-summaries/list-reader-summaries.use-case.spec.ts
+++ b/libs/summary/features/list-reader-summaries/list-reader-summaries.use-case.spec.ts
@@ -232,6 +232,27 @@ describe("ListReaderSummariesUseCase", () => {
     });
   });
 
+  it("bounds presentation fan-out for small production database pools", async () => {
+    const freshness = new ConcurrentFreshnessProbe();
+    const useCase = new ListReaderSummariesUseCase(
+      new FakeReaderSummaryArtifactRepository([
+        readerSummaryArtifact({ readerSummaryId: "reader-summary-1" }),
+        readerSummaryArtifact({ readerSummaryId: "reader-summary-2" }),
+        readerSummaryArtifact({ readerSummaryId: "reader-summary-3" }),
+      ]),
+      freshness,
+    );
+
+    const result = await useCase.execute({
+      tenantId: tenant,
+      workspaceId: workspace,
+      limit: 3,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(freshness.maximumConcurrentEvaluations).toBe(1);
+  });
+
   it("does not hide required artifact repository failures", async () => {
     const repository = new FakeReaderSummaryArtifactRepository([]);
     repository.listFailure = new Error("reader summary persistence unavailable");
@@ -430,5 +451,24 @@ class FakeReaderSummaryFreshnessProbe implements ReaderSummaryFreshnessProbePort
         checkedAt: new Date("2026-06-23T08:40:00.000Z"),
       }
     );
+  }
+}
+
+class ConcurrentFreshnessProbe implements ReaderSummaryFreshnessProbePort {
+  private activeEvaluations = 0;
+  maximumConcurrentEvaluations = 0;
+
+  async evaluate(): Promise<ReaderSummaryFreshness> {
+    this.activeEvaluations += 1;
+    this.maximumConcurrentEvaluations = Math.max(
+      this.maximumConcurrentEvaluations,
+      this.activeEvaluations,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    this.activeEvaluations -= 1;
+    return {
+      status: "fresh",
+      checkedAt: new Date("2026-06-23T08:40:00.000Z"),
+    };
   }
 }

--- a/libs/summary/features/list-reader-summaries/list-reader-summaries.use-case.ts
+++ b/libs/summary/features/list-reader-summaries/list-reader-summaries.use-case.ts
@@ -65,9 +65,7 @@ export class ListReaderSummariesUseCase {
     readonly nextCursor?: string;
   }> {
     const result = await this.readerSummaries.list(query);
-    const items = await Promise.all(
-      result.items.map((readerSummary) => this.present(readerSummary)),
-    );
+    const items = await this.presentInOrder(result.items);
 
     return {
       items,
@@ -103,9 +101,7 @@ export class ListReaderSummariesUseCase {
         break;
       }
 
-      const presentedItems = await Promise.all(
-        result.items.map((readerSummary) => this.present(readerSummary)),
-      );
+      const presentedItems = await this.presentInOrder(result.items);
       for (const item of presentedItems) {
         if (matchesListReaderSummaryFilters(item, filters)) {
           items.push(item);
@@ -123,6 +119,16 @@ export class ListReaderSummariesUseCase {
       items,
       nextCursor,
     };
+  }
+
+  private async presentInOrder(
+    readerSummaries: readonly ReaderSummaryArtifact[],
+  ): Promise<readonly ReaderSummaryArtifactView[]> {
+    const items: ReaderSummaryArtifactView[] = [];
+    for (const readerSummary of readerSummaries) {
+      items.push(await this.present(readerSummary));
+    }
+    return items;
   }
 
   private async present(


### PR DESCRIPTION
## What

- serialize per-page reader summary presentation to fit the production database pool
- apply the same bound to filtered pagination
- add a regression test for maximum concurrent enrichment

## Evidence

- focused Jest: 8/8 passed
- targeted ESLint: passed
- architecture, code-quality and source-line guards: passed
- production reproduction before fix: one 25-item request passed, two concurrent requests returned 502 and restarted the API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reader summary listing reliability by processing summary freshness checks in a controlled, consistent order.
  * Prevented multiple freshness evaluations from running simultaneously when listing several summaries.
  * Preserved correct ordering while scanning and filtering summary results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->