### PR TITLE
fix(summaries): keep published day transitions continuous

### DIFF
--- a/apps/frontend/app/lib/src/composition/app_feature_route_builders.dart
+++ b/apps/frontend/app/lib/src/composition/app_feature_route_builders.dart
@@ -221,11 +221,6 @@ AppRouteWidgetBuilder summariesFeatureBuilder({
           generatedApiRuntime: generatedApiRuntime,
           scope: scope,
           summaryId: summaryId == null || summaryId.isEmpty ? null : summaryId,
-          onSummarySelected: (selectedSummaryId) {
-            GoRouter.of(
-              context,
-            ).go('/summaries/${Uri.encodeComponent(selectedSummaryId)}');
-          },
         );
       }
       return SummariesFeatureRoute.generatedApi(

--- a/apps/frontend/features/summaries/lib/src/domain/aggregates/reader_summary.dart
+++ b/apps/frontend/features/summaries/lib/src/domain/aggregates/reader_summary.dart
@@ -10,6 +10,7 @@ import '../entities/summary_claim.dart';
 import '../entities/summary_reliability.dart';
 import '../entities/summary_story.dart';
 import '../entities/top_read.dart';
+import '../value_objects/published_summary_reference.dart';
 import '../value_objects/reader_summary_coverage.dart';
 import '../value_objects/summary_period.dart';
 import '../value_objects/summary_quality.dart';
@@ -28,6 +29,7 @@ export '../entities/summary_story.dart';
 export '../entities/top_read.dart';
 export '../value_objects/preview_media.dart';
 export '../value_objects/provider_metric_label.dart';
+export '../value_objects/published_summary_reference.dart';
 export '../value_objects/reader_post_promotion_attestation.dart';
 export '../value_objects/reader_summary_coverage.dart';
 export '../value_objects/signal_score.dart';
@@ -39,11 +41,13 @@ final class WorkspaceSummarySnapshot {
   const WorkspaceSummarySnapshot({
     this.current,
     this.availablePeriods = const [],
+    this.availableSummaryReferences = const [],
     this.availablePeriodsAreComplete = false,
   });
 
   final ReaderSummary? current;
   final List<SummaryPeriod> availablePeriods;
+  final List<PublishedSummaryReference> availableSummaryReferences;
   final bool availablePeriodsAreComplete;
 }
 

--- a/apps/frontend/features/summaries/lib/src/domain/value_objects/published_summary_reference.dart
+++ b/apps/frontend/features/summaries/lib/src/domain/value_objects/published_summary_reference.dart
@@ -1,0 +1,11 @@
+import 'summary_period.dart';
+
+final class PublishedSummaryReference {
+  const PublishedSummaryReference({
+    required this.summaryId,
+    required this.period,
+  });
+
+  final String summaryId;
+  final SummaryPeriod period;
+}

--- a/apps/frontend/features/summaries/lib/src/infrastructure/api/summary_api_dto.dart
+++ b/apps/frontend/features/summaries/lib/src/infrastructure/api/summary_api_dto.dart
@@ -1,6 +1,7 @@
 part 'summary_reader_quality_api_dto.dart';
 part 'reader_summary_content_api_dto.dart';
 part 'reader_summary_coverage_api_dto.dart';
+part 'workspace_summary_api_dto.dart';
 
 final class SummaryCitationApiDto {
   const SummaryCitationApiDto({
@@ -351,18 +352,6 @@ final class ReaderSummaryStoryClusterAuthorityApiDto {
   final String id;
   final List<String> feedItemIds;
   final List<String> providerKeys;
-}
-
-final class WorkspaceSummaryApiDto {
-  const WorkspaceSummaryApiDto({
-    this.current,
-    this.availablePeriods = const [],
-    this.availablePeriodsAreComplete = false,
-  });
-
-  final ReaderSummaryApiDto? current;
-  final List<SummaryPeriodApiDto> availablePeriods;
-  final bool availablePeriodsAreComplete;
 }
 
 final class ReaderSummaryJobApiDto {

--- a/apps/frontend/features/summaries/lib/src/infrastructure/api/workspace_summary_api_dto.dart
+++ b/apps/frontend/features/summaries/lib/src/infrastructure/api/workspace_summary_api_dto.dart
@@ -1,0 +1,25 @@
+part of 'summary_api_dto.dart';
+
+final class WorkspaceSummaryApiDto {
+  const WorkspaceSummaryApiDto({
+    this.current,
+    this.availablePeriods = const [],
+    this.availableSummaryReferences = const [],
+    this.availablePeriodsAreComplete = false,
+  });
+
+  final ReaderSummaryApiDto? current;
+  final List<SummaryPeriodApiDto> availablePeriods;
+  final List<PublishedSummaryReferenceApiDto> availableSummaryReferences;
+  final bool availablePeriodsAreComplete;
+}
+
+final class PublishedSummaryReferenceApiDto {
+  const PublishedSummaryReferenceApiDto({
+    required this.summaryId,
+    required this.period,
+  });
+
+  final String summaryId;
+  final SummaryPeriodApiDto period;
+}

--- a/apps/frontend/features/summaries/lib/src/infrastructure/api_clients/generated_workspace_summary_reader.dart
+++ b/apps/frontend/features/summaries/lib/src/infrastructure/api_clients/generated_workspace_summary_reader.dart
@@ -75,9 +75,13 @@ final class GeneratedWorkspaceSummaryReader {
     final periodsResult = await _listPeriods(request, limit: _historyLimit);
     return periodsResult.fold(
       onSuccess: (periodsDto) {
+        final references = _availableReferencesFromPeriodSummaries(periodsDto);
         return Result.success(
           WorkspaceSummaryApiDto(
-            availablePeriods: _availablePeriodsFromPeriodSummaries(periodsDto),
+            availablePeriods: references
+                .map((reference) => reference.period)
+                .toList(growable: false),
+            availableSummaryReferences: references,
             availablePeriodsAreComplete: true,
           ),
         );
@@ -138,6 +142,14 @@ final class GeneratedWorkspaceSummaryReader {
     return WorkspaceSummaryApiDto(
       current: current,
       availablePeriods: periods,
+      availableSummaryReferences: current == null
+          ? const []
+          : [
+              PublishedSummaryReferenceApiDto(
+                summaryId: current.id,
+                period: current.period,
+              ),
+            ],
       availablePeriodsAreComplete: availablePeriodsAreComplete,
     );
   }
@@ -160,16 +172,21 @@ final class GeneratedWorkspaceSummaryReader {
     return periodsByKey.values.toList(growable: false);
   }
 
-  List<SummaryPeriodApiDto> _availablePeriodsFromPeriodSummaries(
+  List<PublishedSummaryReferenceApiDto> _availableReferencesFromPeriodSummaries(
     generated.ListReaderSummaryPeriodsResponseDto dto,
   ) {
-    final periodsByKey = <String, SummaryPeriodApiDto>{};
+    final referencesByKey = <String, PublishedSummaryReferenceApiDto>{};
     for (final item in dto.items) {
       final period = _mapper.readerSummaryPeriod(item.period);
-      periodsByKey[_periodIdentity(period)] = period;
+      referencesByKey[_periodIdentity(
+        period,
+      )] = PublishedSummaryReferenceApiDto(
+        summaryId: item.readerSummaryId,
+        period: period,
+      );
     }
 
-    return periodsByKey.values.toList(growable: false);
+    return referencesByKey.values.toList(growable: false);
   }
 
   generated.Cadence _listCadence(SummaryPeriodCadence cadence) {

--- a/apps/frontend/features/summaries/lib/src/infrastructure/repositories/generated_summary_review_catalog.dart
+++ b/apps/frontend/features/summaries/lib/src/infrastructure/repositories/generated_summary_review_catalog.dart
@@ -257,6 +257,14 @@ final class GeneratedSummaryReviewCatalog implements SummaryReviewCatalog {
           availablePeriods: dto.availablePeriods
               .map(_mapper.summaryPeriodToDomain)
               .toList(growable: false),
+          availableSummaryReferences: dto.availableSummaryReferences
+              .map(
+                (reference) => PublishedSummaryReference(
+                  summaryId: reference.summaryId,
+                  period: _mapper.summaryPeriodToDomain(reference.period),
+                ),
+              )
+              .toList(growable: false),
           availablePeriodsAreComplete: dto.availablePeriodsAreComplete,
         ),
       ),

--- a/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
@@ -45,6 +45,7 @@ final class PublishedSummaryStore extends ChangeNotifier {
   AsyncViewState<ReaderSummary> state = const InitialViewState<ReaderSummary>();
   SummaryPeriodPreset selectedPeriodPreset = SummaryPeriodPreset.daily;
   List<SummaryPeriod> availablePeriods = const [];
+  List<PublishedSummaryReference> availableSummaryReferences = const [];
   DateTime? _selectedPeriodEndedAt;
 
   SummaryPeriod get selectedPeriod =>
@@ -87,16 +88,44 @@ final class PublishedSummaryStore extends ChangeNotifier {
     notifyListeners();
 
     final requestedId = summaryId?.trim();
-    final result = requestedId != null && requestedId.isNotEmpty
-        ? await _loadPublished(
-            LoadPublishedSummaryQuery(scope: _scope, summaryId: requestedId),
-          )
-        : await _loadLatest(
-            LoadWorkspaceSummaryQuery(
-              scope: _scope,
-              period: SummaryPeriodPreset.daily.resolve(),
-            ),
-          );
+    WorkspaceSummarySnapshot? preloadedHistory;
+    Result<WorkspaceSummarySnapshot> result;
+    if (requestedId != null && requestedId.isNotEmpty) {
+      result = await _loadPublished(
+        LoadPublishedSummaryQuery(scope: _scope, summaryId: requestedId),
+      );
+    } else {
+      final historyResult = await _loadHistory(
+        LoadWorkspaceSummaryQuery(
+          scope: _scope,
+          period: SummaryPeriodPreset.daily.resolve(),
+        ),
+      );
+      if (!_generationGuard.isCurrent(generation)) {
+        return;
+      }
+      preloadedHistory = historyResult.fold(
+        onSuccess: (snapshot) => snapshot,
+        onFailure: (_) => null,
+      );
+      final latest = _latestReference(
+        preloadedHistory?.availableSummaryReferences ?? const [],
+        SummaryPeriodPreset.daily,
+      );
+      result = latest == null
+          ? await _loadLatest(
+              LoadWorkspaceSummaryQuery(
+                scope: _scope,
+                period: SummaryPeriodPreset.daily.resolve(),
+              ),
+            )
+          : await _loadPublished(
+              LoadPublishedSummaryQuery(
+                scope: _scope,
+                summaryId: latest.summaryId,
+              ),
+            );
+    }
     if (!_generationGuard.isCurrent(generation)) {
       return;
     }
@@ -107,9 +136,20 @@ final class PublishedSummaryStore extends ChangeNotifier {
         final summary = snapshot.current;
         if (summary != null) {
           _selectPeriod(summary.period);
-          availablePeriods = mergeSummaryPeriods(snapshot.availablePeriods, [
-            summary.period,
-          ]);
+          availablePeriods = mergeSummaryPeriods(
+            preloadedHistory?.availablePeriods ?? const [],
+            [...snapshot.availablePeriods, summary.period],
+          );
+          availableSummaryReferences = mergePublishedSummaryReferences(
+            preloadedHistory?.availableSummaryReferences ?? const [],
+            [
+              ...snapshot.availableSummaryReferences,
+              PublishedSummaryReference(
+                summaryId: summary.id,
+                period: summary.period,
+              ),
+            ],
+          );
         }
         return summary == null
             ? const EmptyViewState<ReaderSummary>(
@@ -125,7 +165,8 @@ final class PublishedSummaryStore extends ChangeNotifier {
     notifyListeners();
     final snapshot = loadedSnapshot;
     final current = snapshot?.current;
-    if (current != null) {
+    if (current != null &&
+        preloadedHistory?.availablePeriodsAreComplete != true) {
       await _refreshAvailablePeriods();
     }
   }
@@ -205,13 +246,21 @@ final class PublishedSummaryStore extends ChangeNotifier {
     };
     state = LoadingViewState<ReaderSummary>(previousValue: previous);
     notifyListeners();
-    final result = await _loadLatest(
-      LoadWorkspaceSummaryQuery(
-        scope: _scope,
-        period: selectedPeriod,
-        allowLatestFallback: false,
-      ),
-    );
+    final reference = _referenceForPeriod(selectedPeriod);
+    final result = reference == null
+        ? await _loadLatest(
+            LoadWorkspaceSummaryQuery(
+              scope: _scope,
+              period: selectedPeriod,
+              allowLatestFallback: false,
+            ),
+          )
+        : await _loadPublished(
+            LoadPublishedSummaryQuery(
+              scope: _scope,
+              summaryId: reference.summaryId,
+            ),
+          );
     if (!_generationGuard.isCurrent(generation)) {
       return;
     }
@@ -236,6 +285,10 @@ final class PublishedSummaryStore extends ChangeNotifier {
         availablePeriods = mergeSummaryPeriods(availablePeriods, [
           summary.period,
         ]);
+        availableSummaryReferences = mergePublishedSummaryReferences(
+          availableSummaryReferences,
+          snapshot.availableSummaryReferences,
+        );
         return ReadyViewState<ReaderSummary>(
           summary,
           isDegraded: summary.isDegraded,
@@ -273,6 +326,10 @@ final class PublishedSummaryStore extends ChangeNotifier {
           availablePeriods,
           snapshot.availablePeriods,
         );
+        availableSummaryReferences = mergePublishedSummaryReferences(
+          availableSummaryReferences,
+          snapshot.availableSummaryReferences,
+        );
         notifyListeners();
       },
       onFailure: (_) {},
@@ -282,6 +339,33 @@ final class PublishedSummaryStore extends ChangeNotifier {
   void _selectPeriod(SummaryPeriod period) {
     selectedPeriodPreset = summaryPeriodPresetFor(period);
     _selectedPeriodEndedAt = period.endedAt;
+  }
+
+  PublishedSummaryReference? _referenceForPeriod(SummaryPeriod period) {
+    for (final reference in availableSummaryReferences) {
+      if (sameSummaryPeriodWindow(reference.period, period)) {
+        return reference;
+      }
+    }
+    return null;
+  }
+
+  PublishedSummaryReference? _latestReference(
+    Iterable<PublishedSummaryReference> references,
+    SummaryPeriodPreset preset,
+  ) {
+    final matches =
+        references
+            .where(
+              (reference) =>
+                  summaryPeriodMatchesPreset(reference.period, preset),
+            )
+            .toList(growable: false)
+          ..sort(
+            (left, right) =>
+                left.period.endedAt.compareTo(right.period.endedAt),
+          );
+    return matches.isEmpty ? null : matches.last;
   }
 
   Future<void> openUrl(String canonicalUrl) async {

--- a/apps/frontend/features/summaries/lib/src/presentation/workflows/summary_period_navigation.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/workflows/summary_period_navigation.dart
@@ -64,3 +64,14 @@ List<SummaryPeriod> mergeSummaryPeriods(
   }
   return periodsByKey.values.toList(growable: false);
 }
+
+List<PublishedSummaryReference> mergePublishedSummaryReferences(
+  Iterable<PublishedSummaryReference> current,
+  Iterable<PublishedSummaryReference> incoming,
+) {
+  final referencesByKey = <String, PublishedSummaryReference>{};
+  for (final reference in [...current, ...incoming]) {
+    referencesByKey[summaryPeriodAvailabilityKey(reference.period)] = reference;
+  }
+  return referencesByKey.values.toList(growable: false);
+}

--- a/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
@@ -109,16 +109,125 @@ void main() {
 
       await store.showNextPeriod();
 
-      expect(catalog.workspaceQueries, hasLength(2));
-      expect(catalog.workspaceQueries.last.allowLatestFallback, isFalse);
-      expect(
-        _samePeriod(catalog.workspaceQueries.last.period, july10.period),
-        isTrue,
-      );
+      expect(catalog.workspaceQueries, hasLength(1));
+      expect(catalog.publishedQueries, [july10.id, july10.id]);
       expect(_readySummary(store).id, july10.id);
       expect(selectedSummaryIds, [july9.id, july10.id]);
     },
   );
+
+  test('uses lightweight period references for adjacent summaries', () async {
+    final july9 = _dailySummary('summary-july-09', 2026, 7, 9);
+    final july10 = _dailySummary('summary-july-10', 2026, 7, 10);
+    final catalog = _PublishedSummaryCatalog(
+      publishedResult: Future.value(
+        Result.success(WorkspaceSummarySnapshot(current: july10)),
+      ),
+      publishedSummaries: {july9.id: july9, july10.id: july10},
+      historyResult: Future.value(
+        Result.success(
+          WorkspaceSummarySnapshot(
+            availablePeriods: [july9.period, july10.period],
+            availableSummaryReferences: [
+              PublishedSummaryReference(
+                summaryId: july9.id,
+                period: july9.period,
+              ),
+              PublishedSummaryReference(
+                summaryId: july10.id,
+                period: july10.period,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    final store = _store(catalog, summaryId: july10.id);
+    addTearDown(store.dispose);
+    await store.load();
+
+    await store.showPreviousPeriod();
+
+    expect(catalog.workspaceQueries, isEmpty);
+    expect(catalog.publishedQueries, [july10.id, july9.id]);
+    expect(_readySummary(store).id, july9.id);
+  });
+
+  test('loads the latest summary directly from the period catalog', () async {
+    final july9 = _dailySummary('summary-july-09', 2026, 7, 9);
+    final july10 = _dailySummary('summary-july-10', 2026, 7, 10);
+    final references = [
+      PublishedSummaryReference(summaryId: july9.id, period: july9.period),
+      PublishedSummaryReference(summaryId: july10.id, period: july10.period),
+    ];
+    final catalog = _PublishedSummaryCatalog(
+      publishedResult: Future.value(
+        const Result.success(WorkspaceSummarySnapshot()),
+      ),
+      publishedSummaries: {july9.id: july9, july10.id: july10},
+      historyResult: Future.value(
+        Result.success(
+          WorkspaceSummarySnapshot(
+            availablePeriods: references
+                .map((reference) => reference.period)
+                .toList(growable: false),
+            availableSummaryReferences: references,
+            availablePeriodsAreComplete: true,
+          ),
+        ),
+      ),
+    );
+    final store = _store(catalog);
+    addTearDown(store.dispose);
+
+    await store.load();
+
+    expect(catalog.workspaceQueries, isEmpty);
+    expect(catalog.publishedQueries, [july10.id]);
+    expect(_readySummary(store).id, july10.id);
+    expect(store.availablePeriods, hasLength(2));
+  });
+
+  test('keeps the article visible while referenced detail loads', () async {
+    final july9 = _dailySummary('summary-july-09', 2026, 7, 9);
+    final july10 = _dailySummary('summary-july-10', 2026, 7, 10);
+    final deferredJuly9 = Completer<Result<WorkspaceSummarySnapshot>>();
+    final references = [
+      PublishedSummaryReference(summaryId: july9.id, period: july9.period),
+      PublishedSummaryReference(summaryId: july10.id, period: july10.period),
+    ];
+    final catalog = _PublishedSummaryCatalog(
+      publishedResult: Future.value(
+        Result.success(WorkspaceSummarySnapshot(current: july10)),
+      ),
+      publishedResults: {july9.id: deferredJuly9.future},
+      historyResult: Future.value(
+        Result.success(
+          WorkspaceSummarySnapshot(
+            availablePeriods: references
+                .map((reference) => reference.period)
+                .toList(growable: false),
+            availableSummaryReferences: references,
+          ),
+        ),
+      ),
+    );
+    final store = _store(catalog, summaryId: july10.id);
+    addTearDown(store.dispose);
+    await store.load();
+
+    final navigation = store.showPreviousPeriod();
+    await Future<void>.delayed(Duration.zero);
+
+    final loading = store.state as LoadingViewState<ReaderSummary>;
+    expect(loading.previousValue?.id, july10.id);
+
+    deferredJuly9.complete(
+      Result.success(WorkspaceSummarySnapshot(current: july9)),
+    );
+    await navigation;
+    expect(_readySummary(store).id, july9.id);
+  });
 
   test(
     'dispose prevents a deferred published result from becoming ready',
@@ -180,7 +289,7 @@ void main() {
 
 PublishedSummaryStore _store(
   _PublishedSummaryCatalog catalog, {
-  required String summaryId,
+  String? summaryId,
   void Function(String summaryId)? onSummarySelected,
 }) {
   return PublishedSummaryStore(
@@ -237,18 +346,35 @@ final class _PublishedSummaryCatalog extends Fake
     required this.publishedResult,
     required this.historyResult,
     this.periodSummaries = const [],
+    this.publishedSummaries = const {},
+    this.publishedResults = const {},
   });
 
   final Future<Result<WorkspaceSummarySnapshot>> publishedResult;
   final Future<Result<WorkspaceSummarySnapshot>> historyResult;
   final List<ReaderSummary> periodSummaries;
+  final Map<String, ReaderSummary> publishedSummaries;
+  final Map<String, Future<Result<WorkspaceSummarySnapshot>>> publishedResults;
+  final List<String> publishedQueries = [];
   final List<LoadWorkspaceSummaryQuery> workspaceQueries = [];
   final List<LoadWorkspaceSummaryQuery> historyQueries = [];
 
   @override
   Future<Result<WorkspaceSummarySnapshot>> loadPublishedSummary(
     LoadPublishedSummaryQuery query,
-  ) => publishedResult;
+  ) {
+    publishedQueries.add(query.summaryId);
+    final deferred = publishedResults[query.summaryId];
+    if (deferred != null) {
+      return deferred;
+    }
+    final summary = publishedSummaries[query.summaryId];
+    return summary == null
+        ? publishedResult
+        : Future.value(
+            Result.success(WorkspaceSummarySnapshot(current: summary)),
+          );
+  }
 
   @override
   Future<Result<WorkspaceSummarySnapshot>> loadWorkspaceSummaryHistory(


### PR DESCRIPTION
## What changed
- keep the current article visible while another published day loads
- resolve adjacent summaries through the lightweight periods catalog and direct summary ID lookup
- avoid rebuilding the public summaries route after in-page date navigation
- reuse period references for the initial latest-summary load

## Evidence
- Flutter analyze passes
- published summary store and page tests pass
- app widget tests pass
- frontend architecture boundary test passes

## Production issue reproduced
The current site clears the summary and creates a second detail request after a day is selected. This patch removes that route-level reload and the redundant exact-period list query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and loading published summaries by their specific summary and period.
  * Published summary history now includes direct references for faster access and more accurate navigation.

* **Bug Fixes**
  * Improved previous and next period navigation to reuse already loaded summaries where possible.
  * Preserved the currently displayed summary while a newly selected summary loads.
  * Improved latest-summary selection when the available history is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->