### PR TITLE
fix(queue): reconnect after RabbitMQ channel loss

### DIFF
--- a/libs/platform/queue/src/adapters/rabbitmq/amqplib-rabbitmq-channel.spec.ts
+++ b/libs/platform/queue/src/adapters/rabbitmq/amqplib-rabbitmq-channel.spec.ts
@@ -1,0 +1,65 @@
+import { EventEmitter } from 'node:events';
+
+import type { ChannelModel, ConfirmChannel, GetMessage } from 'amqplib';
+
+import { AmqplibRabbitMqChannel } from './amqplib-rabbitmq-channel';
+
+class FakeConfirmChannel extends EventEmitter {
+  getCount = 0;
+
+  async get(): Promise<GetMessage | false> {
+    this.getCount += 1;
+    return false;
+  }
+}
+
+class FakeConnection extends EventEmitter {
+  readonly channels: FakeConfirmChannel[] = [];
+
+  async createConfirmChannel(): Promise<ConfirmChannel> {
+    const channel = new FakeConfirmChannel();
+    this.channels.push(channel);
+    return channel as unknown as ConfirmChannel;
+  }
+}
+
+describe('AmqplibRabbitMqChannel', () => {
+  it('reconnects after the broker connection emits an error', async () => {
+    const first = new FakeConnection();
+    const second = new FakeConnection();
+    const connections = [first, second];
+    const connect = jest.fn(async () =>
+      connections.shift() as unknown as ChannelModel,
+    );
+    const channel = new AmqplibRabbitMqChannel({
+      url: 'amqp://rabbitmq',
+      connect,
+    });
+
+    await channel.get('summary.jobs', { noAck: false });
+    expect(() => first.emit('error', new Error('Unexpected close'))).not.toThrow();
+    await channel.get('summary.jobs', { noAck: false });
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(first.channels[0]?.getCount).toBe(1);
+    expect(second.channels[0]?.getCount).toBe(1);
+  });
+
+  it('recreates a confirm channel after only that channel closes', async () => {
+    const connection = new FakeConnection();
+    const connect = jest.fn(async () => connection as unknown as ChannelModel);
+    const channel = new AmqplibRabbitMqChannel({
+      url: 'amqp://rabbitmq',
+      connect,
+    });
+
+    await channel.get('summary.jobs', { noAck: false });
+    const firstChannel = connection.channels[0];
+    expect(() => firstChannel?.emit('error', new Error('channel closed'))).not.toThrow();
+    await channel.get('summary.jobs', { noAck: false });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connection.channels).toHaveLength(2);
+    expect(connection.channels[1]?.getCount).toBe(1);
+  });
+});

--- a/libs/platform/queue/src/adapters/rabbitmq/amqplib-rabbitmq-channel.ts
+++ b/libs/platform/queue/src/adapters/rabbitmq/amqplib-rabbitmq-channel.ts
@@ -17,6 +17,10 @@ import type {
 export type AmqplibRabbitMqChannelOptions = {
   readonly url: string;
   readonly socketOptions?: SocketOptions;
+  readonly connect?: (
+    url: string,
+    socketOptions?: SocketOptions,
+  ) => Promise<ChannelModel>;
 };
 
 export class AmqplibRabbitMqChannel implements RabbitMqQueueChannelPort {
@@ -109,22 +113,65 @@ export class AmqplibRabbitMqChannel implements RabbitMqQueueChannelPort {
   }
 
   private async channel(): Promise<ConfirmChannel> {
-    this.channelPromise ??= this.connection().then(async (connection) => {
+    const active = this.channelPromise;
+    if (active !== undefined) {
+      return active;
+    }
+
+    const pending = this.connection().then(async (connection) => {
       const channel = await connection.createConfirmChannel();
       channel.on('return', (message) => {
         this.returnedMessages.push(toReturnedMessage(message));
       });
+      channel.on('error', () => this.invalidateChannel(pending));
+      channel.on('close', () => this.invalidateChannel(pending));
 
       return channel;
     });
+    this.channelPromise = pending;
+    void pending.catch(() => this.invalidateChannel(pending));
 
-    return this.channelPromise;
+    return pending;
   }
 
   private async connection(): Promise<ChannelModel> {
-    this.connectionPromise ??= connect(this.options.url, this.options.socketOptions);
+    const active = this.connectionPromise;
+    if (active !== undefined) {
+      return active;
+    }
 
-    return this.connectionPromise;
+    const connectToBroker = this.options.connect ?? connect;
+    const pending = connectToBroker(
+      this.options.url,
+      this.options.socketOptions,
+    ).then((connection) => {
+      connection.on('error', () => this.invalidateConnection(pending));
+      connection.on('close', () => this.invalidateConnection(pending));
+      return connection;
+    });
+    this.connectionPromise = pending;
+    void pending.catch(() => this.invalidateConnection(pending));
+
+    return pending;
+  }
+
+  private invalidateChannel(pending: Promise<ConfirmChannel>): void {
+    if (this.channelPromise !== pending) {
+      return;
+    }
+
+    this.channelPromise = undefined;
+    this.returnedMessages.length = 0;
+  }
+
+  private invalidateConnection(pending: Promise<ChannelModel>): void {
+    if (this.connectionPromise !== pending) {
+      return;
+    }
+
+    this.connectionPromise = undefined;
+    this.channelPromise = undefined;
+    this.returnedMessages.length = 0;
   }
 
   private takeReturnedMessage(


### PR DESCRIPTION
## What changed
- keep RabbitMQ connection and confirm-channel errors from crashing workers
- invalidate stale connection state so the next bounded queue tick reconnects
- cover both connection loss and channel-only closure with regression tests

## Production evidence
- intelligence-worker exited on unhandled amqplib Unexpected close while processing historical reader-summary jobs
- quorum queue retained/redelivered both commands after restart

## Verification
- focused Jest: 2 tests passed
- focused ESLint: passed
- git diff --check: passed
