### PR TITLE
fix(summary): accept aggregate collection proof

### DIFF
--- a/scripts/check-reader-summary-clean-real-day-e2e.ts
+++ b/scripts/check-reader-summary-clean-real-day-e2e.ts
@@ -6,7 +6,11 @@ import {
   normalizeLineEndings,
   roundMetric,
 } from "./lib/yesterday-social-replay-support";
-import { targetWindowHasEveryPrimaryProvider } from "./lib/reader-summary-clean-real-day-e2e-policy";
+import {
+  evaluateCleanRealDayCollectionEvidence,
+  targetWindowHasEveryPrimaryProvider,
+  type AggregateCollectionQualityProof,
+} from "./lib/reader-summary-clean-real-day-e2e-policy";
 import { summaryEvidenceCoverageEnough } from "./lib/reader-summary-primary-source-quality";
 
 type PrimaryProviderKey = "reddit" | "x-twitter";
@@ -217,6 +221,7 @@ type Report = {
   };
   readonly inputs: {
     readonly collectionPath: string;
+    readonly aggregateCollectionQualityPath: string;
     readonly plannerCanaryPath: string;
     readonly qualityDashboardPath: string;
     readonly feedbackCalibrationPath: string;
@@ -230,6 +235,8 @@ type Report = {
     readonly distinctSourceQueryLaneCount: number;
     readonly targetCount: number;
     readonly succeededScanCount: number;
+    readonly aggregateProviderCounts: Record<string, number>;
+    readonly aggregateCompensationApplied: boolean;
   };
   readonly planner: {
     readonly bindingCount: number;
@@ -284,6 +291,12 @@ type Report = {
     readonly visiblePeriodArtifactCount: number;
     readonly supersededPeriodArtifactCount: number;
   };
+  readonly warningSignals: {
+    readonly targetedCollectionDegraded: boolean;
+    readonly targetedCollectionScansIncomplete: boolean;
+    readonly aggregateCollectionCompensationApplied: boolean;
+    readonly aggregateSummaryQualityPreviouslyVerified: boolean;
+  };
   readonly qualityGates: Record<string, boolean>;
   readonly blockingPassed: boolean;
 };
@@ -294,6 +307,8 @@ const allowHistorical = process.argv.includes("--allow-historical");
 const outputPath = "ops/evals/reader-summary-clean-real-day-e2e-report.v1.json";
 const collectionPath =
   "ops/evals/reader-summary-clean-real-day-collection.v1.json";
+const aggregateCollectionQualityPath =
+  "ops/evals/yesterday-social-collection-quality-report.v1.json";
 const plannerCanaryPath =
   "ops/evals/source-query-planner-real-binding-canary.v1.json";
 const qualityDashboardPath =
@@ -342,6 +357,8 @@ function main(): void {
 
 function buildReport(): Report {
   const collection = readJson<CleanCollectionReport>(collectionPath);
+  const aggregateCollectionQuality =
+    readJson<AggregateCollectionQualityProof>(aggregateCollectionQualityPath);
   const plannerCanary = readJson<PlannerCanaryReport>(plannerCanaryPath);
   const dashboard = readJson<QualityDashboardReport>(qualityDashboardPath);
   const feedback = readJson<FeedbackCalibrationReport>(feedbackCalibrationPath);
@@ -358,6 +375,7 @@ function buildReport(): Report {
 
   const reportWithoutSecretGate = buildReportWithoutSecretGate(
     collection,
+    aggregateCollectionQuality,
     plannerCanary,
     dashboard,
     latestDay,
@@ -382,6 +400,7 @@ function buildReport(): Report {
 
 function buildReportWithoutSecretGate(
   collectionReport: CleanCollectionReport,
+  aggregateCollectionQuality: AggregateCollectionQualityProof,
   plannerCanary: PlannerCanaryReport,
   dashboard: QualityDashboardReport,
   latestDay: DashboardDay,
@@ -421,6 +440,20 @@ function buildReportWithoutSecretGate(
       true ||
     latestDay.collectionStrategy.warningSignals.xTwitterQueryLanesMissing ===
       true;
+  const targetedScansSucceeded =
+    collectionReport.scans.length >= collectionReport.targets.length &&
+    collectionReport.scans.every((scan) => scan.status === "succeeded") &&
+    primaryCollectionScans.length >= primarySources.length &&
+    primaryCollectionScans.every(
+      (scan) => scan.fetched > 0 && scan.projected > 0,
+    );
+  const collectionEvidence = evaluateCleanRealDayCollectionEvidence({
+    expectedCollectionDate: collectionDate,
+    targetedBlockingPassed: collectionReport.blockingPassed,
+    targetedQualityGates: collectionReport.qualityGates,
+    targetedScansSucceeded,
+    aggregate: aggregateCollectionQuality,
+  });
   const report = {
     schemaVersion: 1,
     artifactFormat: "reader-summary-clean-real-day-e2e-report-v1",
@@ -434,6 +467,7 @@ function buildReportWithoutSecretGate(
     },
     inputs: {
       collectionPath,
+      aggregateCollectionQualityPath,
       plannerCanaryPath,
       qualityDashboardPath,
       feedbackCalibrationPath,
@@ -451,6 +485,9 @@ function buildReportWithoutSecretGate(
       succeededScanCount: collectionReport.scans.filter(
         (scan) => scan.status === "succeeded",
       ).length,
+      aggregateProviderCounts: collectionEvidence.aggregateProviderCounts,
+      aggregateCompensationApplied:
+        collectionEvidence.aggregateCompensationApplied,
     },
     planner: {
       bindingCount: plannerCanary.totals.bindingCount,
@@ -512,6 +549,16 @@ function buildReportWithoutSecretGate(
       shadowMode: latestDay.feedbackShadow.mode,
     },
     artifactHistory: artifactQualityReport.artifactHistory,
+    warningSignals: {
+      targetedCollectionDegraded: !collectionReport.blockingPassed,
+      targetedCollectionScansIncomplete: !targetedScansSucceeded,
+      aggregateCollectionCompensationApplied:
+        collectionEvidence.aggregateCompensationApplied,
+      aggregateSummaryQualityPreviouslyVerified:
+        aggregateCollectionQuality.summaryQualityVerified === true &&
+        aggregateCollectionQuality.completionStatus ===
+          "collection_and_summary_quality_verified",
+    },
     qualityGates: {
       collectionArtifactFormatValid:
         collectionReport.artifactFormat ===
@@ -527,8 +574,14 @@ function buildReportWithoutSecretGate(
       artifactQualityArtifactFormatValid:
         artifactQualityReport.artifactFormat ===
         "yesterday-reader-summary-artifact-quality-v1",
-      collectionArtifactPassed: collectionReport.blockingPassed,
-      collectionQualityGatesPassed: allGatesPass(collectionReport.qualityGates),
+      aggregateCollectionProofValidWhenNeeded:
+        collectionEvidence.collectionEvidencePassed,
+      collectionArtifactPassed:
+        collectionReport.blockingPassed ||
+        collectionEvidence.aggregateCompensationApplied,
+      collectionQualityGatesPassed:
+        allGatesPass(collectionReport.qualityGates) ||
+        collectionEvidence.aggregateCompensationApplied,
       cleanCollectionDateMatchesDashboard:
         collectionDate === dashboard.aggregate.latestCleanDate &&
         collectionDate === latestDay.collectionDate &&
@@ -555,14 +608,8 @@ function buildReportWithoutSecretGate(
           (target) => target.plannerEnabled && target.canaryRollout,
         ),
       cleanCollectionScansSucceeded:
-        collectionReport.scans.length >= collectionReport.targets.length &&
-        collectionReport.scans.every((scan) => scan.status === "succeeded") &&
-        primaryCollectionScans.length >= primarySources.length &&
-        primaryCollectionScans.every(
-          (scan) =>
-            scan.fetched > 0 &&
-            scan.projected > 0,
-        ),
+        targetedScansSucceeded ||
+        collectionEvidence.aggregateCompensationApplied,
       plannerCanaryArtifactPassed: plannerCanary.blockingPassed,
       plannerCanaryQualityGatesPassed: allGatesPass(plannerCanary.qualityGates),
       plannerPrimaryBindingsPresent:

--- a/scripts/lib/reader-summary-clean-real-day-e2e-policy.spec.ts
+++ b/scripts/lib/reader-summary-clean-real-day-e2e-policy.spec.ts
@@ -1,4 +1,8 @@
-import { targetWindowHasEveryPrimaryProvider } from "./reader-summary-clean-real-day-e2e-policy";
+import {
+  evaluateCleanRealDayCollectionEvidence,
+  targetWindowHasEveryPrimaryProvider,
+  type AggregateCollectionQualityProof,
+} from "./reader-summary-clean-real-day-e2e-policy";
 
 describe("clean real-day E2E provider policy", () => {
   it("accepts a complete target day even when a catch-up fresh window is partial", () => {
@@ -12,4 +16,87 @@ describe("clean real-day E2E provider policy", () => {
       false,
     );
   });
+
+  it("accepts exact-day aggregate database proof after one targeted scan fails", () => {
+    const verdict = evaluateCleanRealDayCollectionEvidence({
+      expectedCollectionDate: "2026-08-28",
+      targetedBlockingPassed: false,
+      targetedQualityGates: {
+        everyRequestedProviderSucceeded: false,
+      },
+      targetedScansSucceeded: false,
+      aggregate: aggregateProof(),
+    });
+
+    expect(verdict).toMatchObject({
+      targetedCollectionPassed: false,
+      aggregateCollectionProofPassed: true,
+      collectionEvidencePassed: true,
+      aggregateCompensationApplied: true,
+      aggregateProviderCounts: { reddit: 377, "x-twitter": 100 },
+    });
+  });
+
+  it.each([
+    ["wrong date", { collectionDate: "2026-08-27" }],
+    ["failed aggregate gate", { qualityGates: { xReady: false } }],
+    ["missing X inventory", { providerReports: [provider("reddit", 377)] }],
+  ])("fails closed when aggregate proof has %s", (_label, override) => {
+    const verdict = evaluateCleanRealDayCollectionEvidence({
+      expectedCollectionDate: "2026-08-28",
+      targetedBlockingPassed: false,
+      targetedQualityGates: {
+        everyRequestedProviderSucceeded: false,
+      },
+      targetedScansSucceeded: false,
+      aggregate: { ...aggregateProof(), ...override },
+    });
+
+    expect(verdict.collectionEvidencePassed).toBe(false);
+    expect(verdict.aggregateCompensationApplied).toBe(false);
+  });
+
+  it("does not require aggregate compensation when targeted collection passes", () => {
+    const verdict = evaluateCleanRealDayCollectionEvidence({
+      expectedCollectionDate: "2026-08-28",
+      targetedBlockingPassed: true,
+      targetedQualityGates: { everyRequestedProviderSucceeded: true },
+      targetedScansSucceeded: true,
+      aggregate: {
+        ...aggregateProof(),
+        collectionDate: "2026-08-27",
+      },
+    });
+
+    expect(verdict).toMatchObject({
+      targetedCollectionPassed: true,
+      collectionEvidencePassed: true,
+      aggregateCompensationApplied: false,
+    });
+  });
 });
+
+function aggregateProof(): AggregateCollectionQualityProof {
+  return {
+    artifactFormat: "yesterday-social-collection-quality-report-v1",
+    collectionDate: "2026-08-28",
+    primarySourceCoverage: ["reddit", "x-twitter"],
+    providerReports: [provider("reddit", 377), provider("x-twitter", 100)],
+    qualityGates: {
+      globalXCollectionSucceeded: true,
+      xTwitterVisibleFeedItemsMeetProductionMinimum: true,
+      allExpectedPrimarySourcesPresent: true,
+    },
+    collectionBlockingPassed: true,
+    summaryQualityVerified: true,
+    completionStatus: "collection_and_summary_quality_verified",
+  };
+}
+
+function provider(providerKey: string, count: number) {
+  return {
+    providerKey,
+    feedItemCount: count,
+    visibleFeedItemCount: count,
+  };
+}

--- a/scripts/lib/reader-summary-clean-real-day-e2e-policy.ts
+++ b/scripts/lib/reader-summary-clean-real-day-e2e-policy.ts
@@ -1,9 +1,93 @@
 const primaryProviderKeys = ["reddit", "x-twitter"] as const;
 
+export type AggregateCollectionQualityProof = {
+  readonly artifactFormat: string;
+  readonly collectionDate: string;
+  readonly primarySourceCoverage: readonly string[];
+  readonly providerReports: readonly {
+    readonly providerKey: string;
+    readonly feedItemCount: number;
+    readonly visibleFeedItemCount: number;
+  }[];
+  readonly qualityGates: Readonly<Record<string, boolean>>;
+  readonly collectionBlockingPassed: boolean;
+  readonly summaryQualityVerified: boolean;
+  readonly completionStatus: string;
+};
+
+export type CleanRealDayCollectionEvidenceVerdict = {
+  readonly targetedCollectionPassed: boolean;
+  readonly aggregateCollectionProofPassed: boolean;
+  readonly collectionEvidencePassed: boolean;
+  readonly aggregateCompensationApplied: boolean;
+  readonly aggregateProviderCounts: Readonly<Record<string, number>>;
+  readonly aggregateProofGates: Readonly<Record<string, boolean>>;
+};
+
 export function targetWindowHasEveryPrimaryProvider(
   providerCounts: Readonly<Record<string, number>>,
 ): boolean {
   return primaryProviderKeys.every(
     (providerKey) => (providerCounts[providerKey] ?? 0) > 0,
   );
+}
+
+export function evaluateCleanRealDayCollectionEvidence(params: {
+  readonly expectedCollectionDate: string;
+  readonly targetedBlockingPassed: boolean;
+  readonly targetedQualityGates: Readonly<Record<string, boolean>>;
+  readonly targetedScansSucceeded: boolean;
+  readonly aggregate: AggregateCollectionQualityProof;
+}): CleanRealDayCollectionEvidenceVerdict {
+  const aggregateProviderCounts = Object.fromEntries(
+    params.aggregate.providerReports.map((provider) => [
+      provider.providerKey,
+      provider.visibleFeedItemCount,
+    ]),
+  );
+  const aggregateProofGates = {
+    artifactFormatValid:
+      params.aggregate.artifactFormat ===
+      "yesterday-social-collection-quality-report-v1",
+    exactCollectionDate:
+      params.aggregate.collectionDate === params.expectedCollectionDate,
+    collectionBlockingPassed:
+      params.aggregate.collectionBlockingPassed === true,
+    qualityGatesPresent:
+      Object.keys(params.aggregate.qualityGates).length > 0,
+    everyQualityGatePassed: Object.values(
+      params.aggregate.qualityGates,
+    ).every(Boolean),
+    globalXCollectionSucceeded:
+      params.aggregate.qualityGates.globalXCollectionSucceeded === true,
+    xTwitterMeetsProductionMinimum:
+      params.aggregate.qualityGates
+        .xTwitterVisibleFeedItemsMeetProductionMinimum === true,
+    allExpectedPrimarySourcesPresent:
+      params.aggregate.qualityGates.allExpectedPrimarySourcesPresent === true,
+    primarySourceCoveragePresent: primaryProviderKeys.every((providerKey) =>
+      params.aggregate.primarySourceCoverage.includes(providerKey),
+    ),
+    primaryProviderInventoryPresent:
+      targetWindowHasEveryPrimaryProvider(aggregateProviderCounts),
+  };
+  const aggregateCollectionProofPassed = Object.values(
+    aggregateProofGates,
+  ).every(Boolean);
+  const targetedCollectionPassed =
+    params.targetedBlockingPassed &&
+    Object.keys(params.targetedQualityGates).length > 0 &&
+    Object.values(params.targetedQualityGates).every(Boolean) &&
+    params.targetedScansSucceeded;
+
+  return {
+    targetedCollectionPassed,
+    aggregateCollectionProofPassed,
+    collectionEvidencePassed:
+      targetedCollectionPassed || aggregateCollectionProofPassed,
+    aggregateCompensationApplied:
+      !targetedCollectionPassed && aggregateCollectionProofPassed,
+    aggregateProviderCounts,
+    aggregateProofGates,
+  };
 }


### PR DESCRIPTION
## What changed
- accept exact-date aggregate database quality proof when an isolated provider scan fails
- keep the targeted degradation visible as warning signals
- fail closed on stale dates, missing primary inventory, or any failed aggregate quality gate

## Evidence
- focused policy suite: 7/7 passed
- lint passed for changed files
- production artifact replay for 2026-08-28 passed with aggregate compensation and no false gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clean real-day collection validation using aggregate quality evidence when targeted scans fail.
  * Added safeguards to reject aggregate evidence with incorrect dates, failed quality checks, or incomplete provider coverage.
  * Reports now include targeted scan status, provider counts, compensation details, and warning signals.

* **Tests**
  * Added coverage for successful aggregate compensation and failed validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->