### PR TITLE
fix(summary): constrain optional narrative citations

### DIFF
--- a/libs/summary/adapters/model/openai-responses-reader-summary-narrative-coverage.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-narrative-coverage.ts
@@ -1,6 +1,7 @@
 import type {
   ReaderSummaryCitation,
   ReaderSummaryCoverageMode,
+  ReaderSummaryNarrativeSection,
 } from "../../domain";
 import type { ReaderSummaryModelInput } from "../../ports";
 
@@ -9,6 +10,7 @@ export type ReaderSummaryNarrativeCoverage = {
   readonly leadClusterId: string | undefined;
   readonly leadCitationIds: ReadonlySet<string>;
   readonly allowedLeadCitationIds: ReadonlySet<string>;
+  readonly allowedNarrativeCitationIds: ReadonlySet<string>;
   readonly secondaryCitationIds: ReadonlyMap<string, ReadonlySet<string>>;
 };
 
@@ -35,6 +37,10 @@ export const buildReaderSummaryNarrativeCoverage = (
       citationIdsFor(item.feedItemIds),
     ]),
   );
+  const allowedNarrativeCitationIds = new Set([
+    ...leadCitationIds,
+    ...[...secondaryCitationIds.values()].flatMap((ids) => [...ids]),
+  ]);
 
   return {
     mode: plan.mode,
@@ -42,11 +48,9 @@ export const buildReaderSummaryNarrativeCoverage = (
     leadCitationIds,
     allowedLeadCitationIds:
       plan.mode === "daily_synthesis"
-        ? new Set([
-            ...leadCitationIds,
-            ...[...secondaryCitationIds.values()].flatMap((ids) => [...ids]),
-          ])
+        ? allowedNarrativeCitationIds
         : leadCitationIds,
+    allowedNarrativeCitationIds,
     secondaryCitationIds,
   };
 };
@@ -72,3 +76,23 @@ export const isValidReaderSummaryNarrativeLead = (
     )
   );
 };
+
+export const buildReaderSummaryNarrativeCitationGuard =
+  (
+    coverage: ReaderSummaryNarrativeCoverage,
+    eligibleWatchCitationIds: ReadonlySet<string>,
+  ): ((
+    kind: ReaderSummaryNarrativeSection["kind"] | undefined,
+    citationIds: readonly string[],
+  ) => boolean) =>
+  (kind, citationIds) => {
+    if (kind === "watch") {
+      return citationIds.every((id) => eligibleWatchCitationIds.has(id));
+    }
+    if (kind === "main_signal" || kind === "why_it_matters") {
+      return citationIds.every((id) =>
+        coverage.allowedNarrativeCitationIds.has(id),
+      );
+    }
+    return true;
+  };

--- a/libs/summary/adapters/model/openai-responses-reader-summary-narrative.spec.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-narrative.spec.ts
@@ -41,6 +41,25 @@ describe("normalizeOpenAiReaderSummaryNarrative", () => {
     ]);
   });
 
+  it("drops optional narrative sections that cite outside the coverage plan", () => {
+    const result = normalize([
+      section("lead", "lead", "c1"),
+      {
+        ...section("main_signal", "unplanned", "c4"),
+        citationIds: ["c2", "c4"],
+      },
+      section("secondary_signal", "security", "c2"),
+      section("secondary_signal", "database", "c3"),
+    ]);
+
+    expect(result.some((item) => item.kind === "main_signal")).toBe(false);
+    expect(result.map((item) => item.kind)).toEqual([
+      "lead",
+      "secondary_signal",
+      "secondary_signal",
+    ]);
+  });
+
   it("binds a lead section to the planned cluster when the model omits it", () => {
     const result = normalize([
       {

--- a/libs/summary/adapters/model/openai-responses-reader-summary-narrative.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-narrative.ts
@@ -16,6 +16,7 @@ import {
   requiredStringArray,
 } from "./openai-responses-reader-summary-json";
 import {
+  buildReaderSummaryNarrativeCitationGuard,
   buildReaderSummaryNarrativeCoverage,
   isValidReaderSummaryNarrativeLead,
   type ReaderSummaryNarrativeCoverage,
@@ -23,7 +24,6 @@ import {
 
 const narrativeKinds = new Set(readerSummaryNarrativeSectionKinds);
 const maxNarrativeSections = 7;
-const maxSecondarySections = 3;
 
 export const normalizeOpenAiReaderSummaryNarrative = (params: {
   readonly rawSections: unknown;
@@ -58,6 +58,10 @@ export const normalizeOpenAiReaderSummaryNarrative = (params: {
   const eligibleWatchCitationIds = watchEligibleCitationIds(
     params.input,
     params.citationMap,
+  );
+  const citationsAllowed = buildReaderSummaryNarrativeCitationGuard(
+    coverage,
+    eligibleWatchCitationIds,
   );
   const sections = rawSections
     .slice(0, maxNarrativeSections)
@@ -114,10 +118,7 @@ export const normalizeOpenAiReaderSummaryNarrative = (params: {
       ) {
         return [];
       }
-      if (
-        kind === "watch" &&
-        !citationIds.every((id) => eligibleWatchCitationIds.has(id))
-      ) {
+      if (!citationsAllowed(kind, citationIds)) {
         return [];
       }
       if (
@@ -415,10 +416,7 @@ const assertNarrativeCoverage = (
   const secondarySections = sections.filter(
     (section) => section.kind === "secondary_signal",
   );
-  const plannedClusterIds = [...plannedSecondaryCitations.keys()].slice(
-    0,
-    maxSecondarySections,
-  );
+  const plannedClusterIds = [...plannedSecondaryCitations.keys()].slice(0, 3);
   const actualClusterIds = secondarySections
     .map((section) => section.storyClusterId)
     .filter((clusterId): clusterId is string => clusterId !== undefined);


### PR DESCRIPTION
## Summary
- constrain optional main narrative citations to the deterministic coverage plan
- drop only invalid optional sections while preserving lead, secondary signals, and eligible watch content
- add regression coverage for a mixed planned/unplanned citation section

## Validation
- focused Jest: 34 tests passed
- source line-cap: passed
- git diff check: passed
- full local typecheck is blocked by pre-existing missing OpenTelemetry/generated Prisma modules in the shared dependency tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved narrative summary validation to reject optional sections containing citations outside the approved coverage.
  * Ensured only fully supported narrative sections are included in generated summaries.

* **Tests**
  * Added coverage confirming unsupported citations are filtered from narrative summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->