### PR TITLE
perf(summaries): reduce initial reader load latency

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -693,10 +693,10 @@ jobs:
           release="$RUNNER_TEMP/social-monitor-frontend-release"
           rm -rf "$release"
           install -d -m 0755 "$release/public" "$release/admin"
-          flutter build web --release \
+          flutter build web --release --wasm --no-web-resources-cdn \
             --dart-define=SOCIAL_MONITOR_API_BASE_URL=https://social-monitor.app
           cp -R build/web/. "$release/public/"
-          flutter build web --release \
+          flutter build web --release --wasm --no-web-resources-cdn \
             --dart-define=SOCIAL_MONITOR_API_BASE_URL=https://admin.social-monitor.app
           cp -R build/web/. "$release/admin/"
           printf '%s\n' "$GITHUB_SHA" > "$release/public/release-sha.txt"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -330,3 +330,11 @@ jobs:
             features/settings features/sources features/summaries
           dart test packages/shared_kernel
           dart test packages/generated_api
+      - name: Verify production WebAssembly bundle
+        working-directory: apps/frontend/app
+        run: |
+          set -euo pipefail
+          flutter build web --release --wasm --no-web-resources-cdn \
+            --dart-define=SOCIAL_MONITOR_API_BASE_URL=https://social-monitor.app
+          test -s build/web/main.dart.wasm
+          test -s build/web/main.dart.js

--- a/apps/frontend/features/summaries/lib/src/presentation/pages/published_summary_page.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/pages/published_summary_page.dart
@@ -133,7 +133,7 @@ class _PublishedSummaryArticle extends StatelessWidget {
             isGenerating: false,
             exportSummary: summary,
             showRefreshSchedule: store.isViewingLatestDailySummary,
-            onRefreshDue: () => unawaited(store.load()),
+            onRefreshDue: () => unawaited(store.refreshIfNewer()),
             contentPadding: articlePadding,
             child: ReaderSummaryView.readOnly(
               key: const ValueKey('published-reader-summary-view'),

--- a/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
@@ -11,6 +11,8 @@ import '../../application/use_cases/open_reader_source_use_case.dart';
 import '../../domain/aggregates/reader_summary.dart';
 import '../workflows/summary_period_navigation.dart';
 
+part '../workflows/published_summary_refresh_workflow.dart';
+
 final class PublishedSummaryStore extends ChangeNotifier {
   PublishedSummaryStore({
     required WorkspaceScope scope,
@@ -335,6 +337,8 @@ final class PublishedSummaryStore extends ChangeNotifier {
       onFailure: (_) {},
     );
   }
+
+  void _notifyChanged() => notifyListeners();
 
   void _selectPeriod(SummaryPeriod period) {
     selectedPeriodPreset = summaryPeriodPresetFor(period);

--- a/apps/frontend/features/summaries/lib/src/presentation/workflows/published_summary_refresh_workflow.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/workflows/published_summary_refresh_workflow.dart
@@ -1,0 +1,72 @@
+part of '../stores/published_summary_store.dart';
+
+extension PublishedSummaryRefreshWorkflow on PublishedSummaryStore {
+  Future<void> refreshIfNewer() async {
+    if (!isViewingLatestDailySummary ||
+        state is LoadingViewState<ReaderSummary>) {
+      return;
+    }
+    final current = switch (state) {
+      ReadyViewState<ReaderSummary>(:final value) => value,
+      _ => null,
+    };
+    if (current == null) {
+      await load();
+      return;
+    }
+
+    final generation = _historyGenerationGuard.markOperationStarted();
+    final result = await _loadHistory(
+      LoadWorkspaceSummaryQuery(
+        scope: _scope,
+        period: SummaryPeriodPreset.daily.resolve(),
+      ),
+    );
+    if (!_historyGenerationGuard.isCurrent(generation)) {
+      return;
+    }
+    final snapshot = result.fold(
+      onSuccess: (value) => value,
+      onFailure: (_) => null,
+    );
+    if (snapshot == null) {
+      return;
+    }
+
+    final refreshedPeriods = mergeSummaryPeriods(
+      availablePeriods,
+      snapshot.availablePeriods,
+    );
+    final refreshedReferences = mergePublishedSummaryReferences(
+      availableSummaryReferences,
+      snapshot.availableSummaryReferences,
+    );
+    final latest = _latestReference(
+      refreshedReferences,
+      SummaryPeriodPreset.daily,
+    );
+    if (latest == null || latest.summaryId == current.id) {
+      availablePeriods = refreshedPeriods;
+      availableSummaryReferences = refreshedReferences;
+      _notifyChanged();
+      return;
+    }
+
+    availableSummaryReferences = mergePublishedSummaryReferences(
+      availableSummaryReferences,
+      [latest],
+    );
+    _selectedPeriodEndedAt = latest.period.endedAt;
+    await _loadSelectedPeriod();
+    final refreshed = switch (state) {
+      ReadyViewState<ReaderSummary>(:final value) =>
+        value.id == latest.summaryId,
+      _ => false,
+    };
+    if (refreshed) {
+      availablePeriods = refreshedPeriods;
+      availableSummaryReferences = refreshedReferences;
+      _notifyChanged();
+    }
+  }
+}

--- a/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
@@ -188,6 +188,75 @@ void main() {
     expect(store.availablePeriods, hasLength(2));
   });
 
+  test('refresh check does not reload an unchanged summary', () async {
+    final july10 = _dailySummary('summary-july-10', 2026, 7, 10);
+    final reference = PublishedSummaryReference(
+      summaryId: july10.id,
+      period: july10.period,
+    );
+    final history = Result.success(
+      WorkspaceSummarySnapshot(
+        availablePeriods: [july10.period],
+        availableSummaryReferences: [reference],
+        availablePeriodsAreComplete: true,
+      ),
+    );
+    final catalog = _PublishedSummaryCatalog(
+      publishedResult: Future.value(
+        const Result.success(WorkspaceSummarySnapshot()),
+      ),
+      publishedSummaries: {july10.id: july10},
+      historyResult: Future.value(history),
+    );
+    final store = _store(catalog);
+    addTearDown(store.dispose);
+    await store.load();
+
+    await store.refreshIfNewer();
+
+    expect(catalog.historyQueries, hasLength(2));
+    expect(catalog.publishedQueries, [july10.id]);
+    expect(_readySummary(store).id, july10.id);
+  });
+
+  test('refresh check loads a newly published summary once', () async {
+    final july10 = _dailySummary('summary-july-10', 2026, 7, 10);
+    final july11 = _dailySummary('summary-july-11', 2026, 7, 11);
+    WorkspaceSummarySnapshot historyFor(ReaderSummary summary) {
+      return WorkspaceSummarySnapshot(
+        availablePeriods: [summary.period],
+        availableSummaryReferences: [
+          PublishedSummaryReference(
+            summaryId: summary.id,
+            period: summary.period,
+          ),
+        ],
+        availablePeriodsAreComplete: true,
+      );
+    }
+
+    final catalog = _PublishedSummaryCatalog(
+      publishedResult: Future.value(
+        const Result.success(WorkspaceSummarySnapshot()),
+      ),
+      publishedSummaries: {july10.id: july10, july11.id: july11},
+      historyResult: Future.value(Result.success(historyFor(july11))),
+      historyResults: [
+        Future.value(Result.success(historyFor(july10))),
+        Future.value(Result.success(historyFor(july11))),
+      ],
+    );
+    final store = _store(catalog);
+    addTearDown(store.dispose);
+    await store.load();
+
+    await store.refreshIfNewer();
+
+    expect(catalog.historyQueries, hasLength(2));
+    expect(catalog.publishedQueries, [july10.id, july11.id]);
+    expect(_readySummary(store).id, july11.id);
+  });
+
   test('keeps the article visible while referenced detail loads', () async {
     final july9 = _dailySummary('summary-july-09', 2026, 7, 9);
     final july10 = _dailySummary('summary-july-10', 2026, 7, 10);
@@ -345,6 +414,7 @@ final class _PublishedSummaryCatalog extends Fake
   _PublishedSummaryCatalog({
     required this.publishedResult,
     required this.historyResult,
+    this.historyResults = const [],
     this.periodSummaries = const [],
     this.publishedSummaries = const {},
     this.publishedResults = const {},
@@ -352,6 +422,7 @@ final class _PublishedSummaryCatalog extends Fake
 
   final Future<Result<WorkspaceSummarySnapshot>> publishedResult;
   final Future<Result<WorkspaceSummarySnapshot>> historyResult;
+  final List<Future<Result<WorkspaceSummarySnapshot>>> historyResults;
   final List<ReaderSummary> periodSummaries;
   final Map<String, ReaderSummary> publishedSummaries;
   final Map<String, Future<Result<WorkspaceSummarySnapshot>>> publishedResults;
@@ -381,7 +452,10 @@ final class _PublishedSummaryCatalog extends Fake
     LoadWorkspaceSummaryQuery query,
   ) {
     historyQueries.add(query);
-    return historyResult;
+    final index = historyQueries.length - 1;
+    return index < historyResults.length
+        ? historyResults[index]
+        : historyResult;
   }
 
   @override

--- a/libs/summary/features/get-reader-summary/get-reader-summary.use-case.spec.ts
+++ b/libs/summary/features/get-reader-summary/get-reader-summary.use-case.spec.ts
@@ -11,6 +11,7 @@ import type {
   ListReaderSummaryArtifactsResult,
   ListReaderSummaryPeriodSummariesResult,
   ReaderSummaryArtifactRepositoryPort,
+  ReaderSummaryCollectedFeedItemCoverage,
   ReaderSummaryCoverageCounterPort,
   ReaderSummaryFreshness,
   ReaderSummaryFreshnessProbePort,
@@ -109,6 +110,65 @@ describe("GetReaderSummaryUseCase", () => {
       period,
       observedThrough: generatedAt,
     });
+  });
+
+  it("starts independent summary projections concurrently", async () => {
+    const freshnessResult = deferred<ReaderSummaryFreshness>();
+    const previewResult = deferred<ReaderSummaryContent>();
+    const coverageResult = deferred<
+      ReaderSummaryCollectedFeedItemCoverage | undefined
+    >();
+    const started: string[] = [];
+    let previewContent: ReaderSummaryContent | undefined;
+    const useCase = new GetReaderSummaryUseCase(
+      new FakeReaderSummaryArtifactRepository([
+        readerSummaryArtifact("reader-summary-1"),
+      ]),
+      {
+        evaluate() {
+          started.push("freshness");
+          return freshnessResult.promise;
+        },
+      },
+      {
+        enrich(command) {
+          started.push("preview");
+          previewContent = command.content;
+          return previewResult.promise;
+        },
+      },
+      {
+        async countCollectedFeedItems() {
+          return undefined;
+        },
+        countCollectedFeedItemCoverage() {
+          started.push("coverage");
+          return coverageResult.promise;
+        },
+      },
+    );
+
+    const execution = useCase.execute({
+      tenantId: tenant,
+      workspaceId: workspace,
+      readerSummaryId: "reader-summary-1",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const startedBeforeAnyProjectionCompleted = [...started];
+    freshnessResult.resolve({
+      status: "fresh",
+      checkedAt: new Date("2026-06-23T08:40:00.000Z"),
+    });
+    previewResult.resolve(previewContent!);
+    coverageResult.resolve(undefined);
+
+    expect((await execution).ok).toBe(true);
+    expect(startedBeforeAnyProjectionCompleted).toEqual([
+      "freshness",
+      "preview",
+      "coverage",
+    ]);
   });
 
   it("returns not found for missing reader summary artifacts", async () => {
@@ -432,7 +492,9 @@ const readerSummaryArtifact = (
     },
   });
 
-class FakeReaderSummaryArtifactRepository implements ReaderSummaryArtifactRepositoryPort {
+class FakeReaderSummaryArtifactRepository
+  implements ReaderSummaryArtifactRepositoryPort
+{
   constructor(private readonly artifacts: readonly ReaderSummaryArtifact[]) {}
 
   async save(artifact: ReaderSummaryArtifact): Promise<void> {
@@ -471,7 +533,9 @@ class FakeReaderSummaryArtifactRepository implements ReaderSummaryArtifactReposi
   }
 }
 
-class FakeReaderSummaryFreshnessProbe implements ReaderSummaryFreshnessProbePort {
+class FakeReaderSummaryFreshnessProbe
+  implements ReaderSummaryFreshnessProbePort
+{
   readonly queries: Parameters<
     ReaderSummaryFreshnessProbePort["evaluate"]
   >[0][] = [];
@@ -487,7 +551,9 @@ class FakeReaderSummaryFreshnessProbe implements ReaderSummaryFreshnessProbePort
   }
 }
 
-class FakeReaderSummaryPreviewMediaEnricher implements ReaderSummaryPreviewMediaEnricherPort {
+class FakeReaderSummaryPreviewMediaEnricher
+  implements ReaderSummaryPreviewMediaEnricherPort
+{
   async enrich(
     command: EnrichReaderSummaryPreviewMediaCommand,
   ): Promise<ReaderSummaryContent> {
@@ -506,7 +572,9 @@ class FakeReaderSummaryPreviewMediaEnricher implements ReaderSummaryPreviewMedia
   }
 }
 
-class FakeReaderSummaryCoverageCounter implements ReaderSummaryCoverageCounterPort {
+class FakeReaderSummaryCoverageCounter
+  implements ReaderSummaryCoverageCounterPort
+{
   readonly queries: Parameters<
     ReaderSummaryCoverageCounterPort["countCollectedFeedItemCoverage"]
   >[0][] = [];
@@ -541,4 +609,15 @@ class FakeReaderSummaryCoverageCounter implements ReaderSummaryCoverageCounterPo
       queryBreakdown: [],
     };
   }
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
 }

--- a/libs/summary/features/get-reader-summary/get-reader-summary.use-case.ts
+++ b/libs/summary/features/get-reader-summary/get-reader-summary.use-case.ts
@@ -55,27 +55,27 @@ export class GetReaderSummaryUseCase {
     }
 
     const snapshot = readerSummary.toSnapshot();
-    const freshness = await this.freshness.evaluate({
-      tenantId: snapshot.tenantId,
-      workspaceId: snapshot.workspaceId,
-      scope: snapshot.scope,
-      sourceWindow: snapshot.sourceWindow,
-      period: snapshot.period,
-      observedThrough: snapshot.generatedAt,
-    });
-
-    const content = await this.previewMediaEnricher.enrich({
-      artifact: readerSummary,
-      content: readerSummaryContentForArtifact(readerSummary),
-    });
-    const collectedCoverage =
-      await this.coverageCounter.countCollectedFeedItemCoverage({
+    const [freshness, content, collectedCoverage] = await Promise.all([
+      this.freshness.evaluate({
+        tenantId: snapshot.tenantId,
+        workspaceId: snapshot.workspaceId,
+        scope: snapshot.scope,
+        sourceWindow: snapshot.sourceWindow,
+        period: snapshot.period,
+        observedThrough: snapshot.generatedAt,
+      }),
+      this.previewMediaEnricher.enrich({
+        artifact: readerSummary,
+        content: readerSummaryContentForArtifact(readerSummary),
+      }),
+      this.coverageCounter.countCollectedFeedItemCoverage({
         tenantId: snapshot.tenantId,
         workspaceId: snapshot.workspaceId,
         scope: snapshot.scope,
         period: snapshot.period,
         observedThrough: snapshot.generatedAt,
-      });
+      }),
+    ]);
 
     return ok(
       presentReaderSummaryArtifact(readerSummary, freshness, {


### PR DESCRIPTION
## What changed
- avoid re-downloading the same published summary during scheduled refresh checks
- run independent summary freshness, media, and coverage projections concurrently
- build production Flutter web bundles with WebAssembly plus JavaScript fallback and self-hosted engine resources

## Verification
- focused Flutter store tests: 9 passed
- focused backend use-case tests: 6 passed
- targeted Flutter analysis: clean
- production Wasm build is enforced by PR CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published daily summaries now refresh automatically when a newer version is available.
  * Summary data loads freshness, preview media, and coverage information concurrently for faster results.

* **Bug Fixes**
  * Prevented unnecessary reloads when the latest summary has not changed.

* **Tests**
  * Added coverage for summary refresh behavior and concurrent data loading.

* **Chores**
  * Strengthened production WebAssembly build validation for public and admin web apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->