### PR TITLE
perf(summaries): prefetch adjacent daily reports

### DIFF
--- a/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
 
@@ -12,6 +14,7 @@ import '../../domain/aggregates/reader_summary.dart';
 import '../workflows/summary_period_navigation.dart';
 
 part '../workflows/published_summary_refresh_workflow.dart';
+part '../workflows/published_summary_navigation_workflow.dart';
 
 final class PublishedSummaryStore extends ChangeNotifier {
   PublishedSummaryStore({
@@ -42,7 +45,11 @@ final class PublishedSummaryStore extends ChangeNotifier {
   final void Function(String summaryId)? _onSummarySelected;
   final OperationGenerationGuard _generationGuard;
   final OperationGenerationGuard _historyGenerationGuard;
+  final OperationGenerationGuard _prefetchGenerationGuard =
+      OperationGenerationGuard();
   final String? summaryId;
+  final Map<String, ReaderSummary> _summaryCache = {};
+  final Map<String, Future<void>> _summaryPrefetches = {};
 
   AsyncViewState<ReaderSummary> state = const InitialViewState<ReaderSummary>();
   SummaryPeriodPreset selectedPeriodPreset = SummaryPeriodPreset.daily;
@@ -137,6 +144,7 @@ final class PublishedSummaryStore extends ChangeNotifier {
         loadedSnapshot = snapshot;
         final summary = snapshot.current;
         if (summary != null) {
+          _rememberSummary(summary);
           _selectPeriod(summary.period);
           availablePeriods = mergeSummaryPeriods(
             preloadedHistory?.availablePeriods ?? const [],
@@ -171,61 +179,7 @@ final class PublishedSummaryStore extends ChangeNotifier {
         preloadedHistory?.availablePeriodsAreComplete != true) {
       await _refreshAvailablePeriods();
     }
-  }
-
-  Future<void> selectPeriodPreset(SummaryPeriodPreset preset) async {
-    if (preset == selectedPeriodPreset) {
-      return;
-    }
-    final previousPreset = selectedPeriodPreset;
-    final previousPeriodEndedAt = _selectedPeriodEndedAt;
-    selectedPeriodPreset = preset;
-    _selectedPeriodEndedAt = null;
-    notifyListeners();
-    await _refreshAvailablePeriods();
-    final periods = availablePeriodsForPreset;
-    if (periods.isEmpty) {
-      selectedPeriodPreset = previousPreset;
-      _selectedPeriodEndedAt = previousPeriodEndedAt;
-      notifyListeners();
-      return;
-    }
-    _selectedPeriodEndedAt = periods.last.endedAt;
-    await _loadSelectedPeriod();
-  }
-
-  Future<void> showPreviousPeriod() => _showAdjacentPeriod(-1);
-
-  Future<void> showNextPeriod() => _showAdjacentPeriod(1);
-
-  Future<void> showCurrentPeriod() async {
-    final periods = availablePeriodsForPreset;
-    if (periods.isEmpty) {
-      return;
-    }
-    _selectedPeriodEndedAt = periods.last.endedAt;
-    await _loadSelectedPeriod();
-  }
-
-  Future<void> selectCalendarDate(DateTime date) async {
-    final requested = selectedPeriodPreset.resolveForCalendarDate(date);
-    final available = availablePeriodsForPreset.where(
-      (period) => sameSummaryPeriodWindow(period, requested),
-    );
-    if (available.isEmpty) {
-      return;
-    }
-    _selectedPeriodEndedAt = available.first.endedAt;
-    await _loadSelectedPeriod();
-  }
-
-  Future<void> _showAdjacentPeriod(int offset) async {
-    final adjacent = _adjacentAvailablePeriod(offset);
-    if (adjacent == null) {
-      return;
-    }
-    _selectedPeriodEndedAt = adjacent.endedAt;
-    await _loadSelectedPeriod();
+    _prefetchAdjacentSummaries();
   }
 
   SummaryPeriod? _adjacentAvailablePeriod(int offset) {
@@ -237,105 +191,6 @@ final class PublishedSummaryStore extends ChangeNotifier {
     return index < 0 || nextIndex < 0 || nextIndex >= periods.length
         ? null
         : periods[nextIndex];
-  }
-
-  Future<void> _loadSelectedPeriod() async {
-    final generation = _generationGuard.markOperationStarted();
-    final previous = switch (state) {
-      ReadyViewState<ReaderSummary>(:final value) => value,
-      LoadingViewState<ReaderSummary>(:final previousValue) => previousValue,
-      _ => null,
-    };
-    state = LoadingViewState<ReaderSummary>(previousValue: previous);
-    notifyListeners();
-    final reference = _referenceForPeriod(selectedPeriod);
-    final result = reference == null
-        ? await _loadLatest(
-            LoadWorkspaceSummaryQuery(
-              scope: _scope,
-              period: selectedPeriod,
-              allowLatestFallback: false,
-            ),
-          )
-        : await _loadPublished(
-            LoadPublishedSummaryQuery(
-              scope: _scope,
-              summaryId: reference.summaryId,
-            ),
-          );
-    if (!_generationGuard.isCurrent(generation)) {
-      return;
-    }
-    ReaderSummary? selectedSummary;
-    state = result.fold(
-      onSuccess: (snapshot) {
-        final summary = snapshot.current;
-        if (summary == null) {
-          if (previous != null) {
-            _selectPeriod(previous.period);
-            return ReadyViewState<ReaderSummary>(
-              previous,
-              isDegraded: previous.isDegraded,
-            );
-          }
-          return const EmptyViewState<ReaderSummary>(
-            reason: 'No published summary exists for this period.',
-          );
-        }
-        selectedSummary = summary;
-        _selectPeriod(summary.period);
-        availablePeriods = mergeSummaryPeriods(availablePeriods, [
-          summary.period,
-        ]);
-        availableSummaryReferences = mergePublishedSummaryReferences(
-          availableSummaryReferences,
-          snapshot.availableSummaryReferences,
-        );
-        return ReadyViewState<ReaderSummary>(
-          summary,
-          isDegraded: summary.isDegraded,
-        );
-      },
-      onFailure: (failure) {
-        if (previous != null) {
-          _selectPeriod(previous.period);
-          return ReadyViewState<ReaderSummary>(
-            previous,
-            isDegraded: previous.isDegraded,
-          );
-        }
-        return FailureViewState<ReaderSummary>(failure: failure);
-      },
-    );
-    notifyListeners();
-    final selected = selectedSummary;
-    if (selected != null && selected.id != previous?.id) {
-      _onSummarySelected?.call(selected.id);
-    }
-  }
-
-  Future<void> _refreshAvailablePeriods() async {
-    final generation = _historyGenerationGuard.markOperationStarted();
-    final result = await _loadHistory(
-      LoadWorkspaceSummaryQuery(scope: _scope, period: selectedPeriod),
-    );
-    if (!_historyGenerationGuard.isCurrent(generation)) {
-      return;
-    }
-    result.fold(
-      onSuccess: (snapshot) {
-        availablePeriods = mergeSummaryPeriods(
-          availablePeriods,
-          snapshot.availablePeriods,
-        );
-        availableSummaryReferences = mergePublishedSummaryReferences(
-          availableSummaryReferences,
-          snapshot.availableSummaryReferences,
-        );
-        notifyListeners();
-      },
-      onFailure: (_) {},
-    );
   }
 
   void _notifyChanged() => notifyListeners();
@@ -395,6 +250,9 @@ final class PublishedSummaryStore extends ChangeNotifier {
   void dispose() {
     _generationGuard.invalidate();
     _historyGenerationGuard.invalidate();
+    _prefetchGenerationGuard.invalidate();
+    _summaryCache.clear();
+    _summaryPrefetches.clear();
     super.dispose();
   }
 }

--- a/apps/frontend/features/summaries/lib/src/presentation/workflows/published_summary_navigation_workflow.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/workflows/published_summary_navigation_workflow.dart
@@ -1,0 +1,262 @@
+part of '../stores/published_summary_store.dart';
+
+const _publishedSummaryCacheLimit = 7;
+
+extension PublishedSummaryNavigationWorkflow on PublishedSummaryStore {
+  Future<void> selectPeriodPreset(SummaryPeriodPreset preset) async {
+    if (preset == selectedPeriodPreset) {
+      return;
+    }
+    final previousPreset = selectedPeriodPreset;
+    final previousPeriodEndedAt = _selectedPeriodEndedAt;
+    selectedPeriodPreset = preset;
+    _selectedPeriodEndedAt = null;
+    _notifyChanged();
+    await _refreshAvailablePeriods();
+    final periods = availablePeriodsForPreset;
+    if (periods.isEmpty) {
+      selectedPeriodPreset = previousPreset;
+      _selectedPeriodEndedAt = previousPeriodEndedAt;
+      _notifyChanged();
+      return;
+    }
+    _selectedPeriodEndedAt = periods.last.endedAt;
+    await _loadSelectedPeriod();
+  }
+
+  Future<void> showPreviousPeriod() => _showAdjacentPeriod(-1);
+
+  Future<void> showNextPeriod() => _showAdjacentPeriod(1);
+
+  Future<void> showCurrentPeriod() async {
+    final periods = availablePeriodsForPreset;
+    if (periods.isEmpty) {
+      return;
+    }
+    _selectedPeriodEndedAt = periods.last.endedAt;
+    await _loadSelectedPeriod();
+  }
+
+  Future<void> selectCalendarDate(DateTime date) async {
+    final requested = selectedPeriodPreset.resolveForCalendarDate(date);
+    final available = availablePeriodsForPreset.where(
+      (period) => sameSummaryPeriodWindow(period, requested),
+    );
+    if (available.isEmpty) {
+      return;
+    }
+    _selectedPeriodEndedAt = available.first.endedAt;
+    await _loadSelectedPeriod();
+  }
+
+  Future<void> _showAdjacentPeriod(int offset) async {
+    final adjacent = _adjacentAvailablePeriod(offset);
+    if (adjacent == null) {
+      return;
+    }
+    _selectedPeriodEndedAt = adjacent.endedAt;
+    await _loadSelectedPeriod();
+  }
+
+  Future<void> _loadSelectedPeriod() async {
+    final generation = _generationGuard.markOperationStarted();
+    final previous = switch (state) {
+      ReadyViewState<ReaderSummary>(:final value) => value,
+      LoadingViewState<ReaderSummary>(:final previousValue) => previousValue,
+      _ => null,
+    };
+    final reference = _referenceForPeriod(selectedPeriod);
+    var cached = _cachedSummary(reference);
+    if (cached != null) {
+      _publishSelectedSummary(cached, previous: previous);
+      return;
+    }
+
+    state = LoadingViewState<ReaderSummary>(previousValue: previous);
+    _notifyChanged();
+    final prefetch = reference == null
+        ? null
+        : _summaryPrefetches[reference.summaryId];
+    if (prefetch != null) {
+      await prefetch;
+      if (!_generationGuard.isCurrent(generation)) {
+        return;
+      }
+      cached = _cachedSummary(reference);
+      if (cached != null) {
+        _publishSelectedSummary(cached, previous: previous);
+        return;
+      }
+    }
+
+    final result = reference == null
+        ? await _loadLatest(
+            LoadWorkspaceSummaryQuery(
+              scope: _scope,
+              period: selectedPeriod,
+              allowLatestFallback: false,
+            ),
+          )
+        : await _loadPublished(
+            LoadPublishedSummaryQuery(
+              scope: _scope,
+              summaryId: reference.summaryId,
+            ),
+          );
+    if (!_generationGuard.isCurrent(generation)) {
+      return;
+    }
+    ReaderSummary? selectedSummary;
+    state = result.fold(
+      onSuccess: (snapshot) {
+        final summary = snapshot.current;
+        if (summary == null) {
+          return _fallbackState(previous);
+        }
+        selectedSummary = summary;
+        _rememberSummary(summary);
+        _selectPeriod(summary.period);
+        availablePeriods = mergeSummaryPeriods(availablePeriods, [
+          summary.period,
+        ]);
+        availableSummaryReferences = mergePublishedSummaryReferences(
+          availableSummaryReferences,
+          snapshot.availableSummaryReferences,
+        );
+        return ReadyViewState<ReaderSummary>(
+          summary,
+          isDegraded: summary.isDegraded,
+        );
+      },
+      onFailure: (failure) => previous == null
+          ? FailureViewState<ReaderSummary>(failure: failure)
+          : _fallbackState(previous),
+    );
+    _notifyChanged();
+    final selected = selectedSummary;
+    if (selected != null && selected.id != previous?.id) {
+      _onSummarySelected?.call(selected.id);
+    }
+    _prefetchAdjacentSummaries();
+  }
+
+  AsyncViewState<ReaderSummary> _fallbackState(ReaderSummary? previous) {
+    if (previous == null) {
+      return const EmptyViewState<ReaderSummary>(
+        reason: 'No published summary exists for this period.',
+      );
+    }
+    _selectPeriod(previous.period);
+    return ReadyViewState<ReaderSummary>(
+      previous,
+      isDegraded: previous.isDegraded,
+    );
+  }
+
+  void _publishSelectedSummary(
+    ReaderSummary summary, {
+    required ReaderSummary? previous,
+  }) {
+    _selectPeriod(summary.period);
+    state = ReadyViewState<ReaderSummary>(
+      summary,
+      isDegraded: summary.isDegraded,
+    );
+    _notifyChanged();
+    if (summary.id != previous?.id) {
+      _onSummarySelected?.call(summary.id);
+    }
+    _prefetchAdjacentSummaries();
+  }
+
+  Future<void> _refreshAvailablePeriods() async {
+    final generation = _historyGenerationGuard.markOperationStarted();
+    final result = await _loadHistory(
+      LoadWorkspaceSummaryQuery(scope: _scope, period: selectedPeriod),
+    );
+    if (!_historyGenerationGuard.isCurrent(generation)) {
+      return;
+    }
+    result.fold(
+      onSuccess: (snapshot) {
+        availablePeriods = mergeSummaryPeriods(
+          availablePeriods,
+          snapshot.availablePeriods,
+        );
+        availableSummaryReferences = mergePublishedSummaryReferences(
+          availableSummaryReferences,
+          snapshot.availableSummaryReferences,
+        );
+        _notifyChanged();
+        _prefetchAdjacentSummaries();
+      },
+      onFailure: (_) {},
+    );
+  }
+
+  void _rememberSummary(ReaderSummary summary) {
+    _summaryCache.remove(summary.id);
+    _summaryCache[summary.id] = summary;
+    while (_summaryCache.length > _publishedSummaryCacheLimit) {
+      _summaryCache.remove(_summaryCache.keys.first);
+    }
+  }
+
+  ReaderSummary? _cachedSummary(PublishedSummaryReference? reference) {
+    if (reference == null) {
+      return null;
+    }
+    final cached = _summaryCache.remove(reference.summaryId);
+    if (cached != null) {
+      _summaryCache[reference.summaryId] = cached;
+    }
+    return cached;
+  }
+
+  void _prefetchAdjacentSummaries() {
+    for (final offset in const [-1, 1]) {
+      final period = _adjacentAvailablePeriod(offset);
+      final reference = period == null ? null : _referenceForPeriod(period);
+      if (reference != null) {
+        unawaited(_prefetchSummary(reference));
+      }
+    }
+  }
+
+  Future<void> _prefetchSummary(PublishedSummaryReference reference) async {
+    if (_summaryCache.containsKey(reference.summaryId) ||
+        _summaryPrefetches.containsKey(reference.summaryId)) {
+      return;
+    }
+    final generation = _prefetchGenerationGuard.generation;
+    late final Future<void> operation;
+    operation = () async {
+      final result = await _loadPublished(
+        LoadPublishedSummaryQuery(
+          scope: _scope,
+          summaryId: reference.summaryId,
+        ),
+      );
+      if (!_prefetchGenerationGuard.isCurrent(generation)) {
+        return;
+      }
+      result.fold(
+        onSuccess: (snapshot) {
+          final summary = snapshot.current;
+          if (summary != null && summary.id == reference.summaryId) {
+            _rememberSummary(summary);
+          }
+        },
+        onFailure: (_) {},
+      );
+    }();
+    _summaryPrefetches[reference.summaryId] = operation;
+    try {
+      await operation;
+    } finally {
+      if (identical(_summaryPrefetches[reference.summaryId], operation)) {
+        unawaited(_summaryPrefetches.remove(reference.summaryId));
+      }
+    }
+  }
+}

--- a/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_navigation_cache_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_navigation_cache_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
+import 'package:social_monitor_summaries/src/application/contracts/reader_source_launcher.dart';
+import 'package:social_monitor_summaries/src/application/contracts/summary_review_catalog.dart';
+import 'package:social_monitor_summaries/src/application/queries/load_published_summary_query.dart';
+import 'package:social_monitor_summaries/src/application/queries/load_workspace_summary_query.dart';
+import 'package:social_monitor_summaries/src/application/use_cases/load_published_summary_use_case.dart';
+import 'package:social_monitor_summaries/src/application/use_cases/load_workspace_summary_history_use_case.dart';
+import 'package:social_monitor_summaries/src/application/use_cases/load_workspace_summary_use_case.dart';
+import 'package:social_monitor_summaries/src/application/use_cases/open_reader_source_use_case.dart';
+import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.dart';
+import 'package:social_monitor_summaries/src/infrastructure/mappers/summary_mapper.dart';
+import 'package:social_monitor_summaries/src/presentation/stores/published_summary_store.dart';
+
+import '../../support/summaries_test_fixtures.dart';
+
+void main() {
+  test('prefetches adjacent days and switches without loading again', () async {
+    final previous = _dailySummary('summary-july-09', 2026, 7, 9);
+    final current = _dailySummary('summary-july-10', 2026, 7, 10);
+    final catalog = _NavigationCacheCatalog([previous, current]);
+    final selectedIds = <String>[];
+    final store = _store(catalog, selectedIds.add);
+    addTearDown(store.dispose);
+
+    await store.load();
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(catalog.requestsFor(current.id), 1);
+    expect(catalog.requestsFor(previous.id), 1);
+
+    final loadingStates = <AsyncViewState<ReaderSummary>>[];
+    store.addListener(() {
+      if (store.state is LoadingViewState<ReaderSummary>) {
+        loadingStates.add(store.state);
+      }
+    });
+
+    await store.showPreviousPeriod();
+    await store.showNextPeriod();
+
+    expect(loadingStates, isEmpty);
+    expect(catalog.requestsFor(previous.id), 1);
+    expect(catalog.requestsFor(current.id), 1);
+    expect(selectedIds, [previous.id, current.id]);
+    expect(_readySummary(store).id, current.id);
+  });
+
+  test('retries normally when an adjacent prefetch fails', () async {
+    final previous = _dailySummary('summary-july-09', 2026, 7, 9);
+    final current = _dailySummary('summary-july-10', 2026, 7, 10);
+    final catalog = _NavigationCacheCatalog([
+      previous,
+      current,
+    ], failFirstRequestFor: previous.id);
+    final store = _store(catalog, (_) {});
+    addTearDown(store.dispose);
+
+    await store.load();
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    await store.showPreviousPeriod();
+
+    expect(catalog.requestsFor(previous.id), 2);
+    expect(_readySummary(store).id, previous.id);
+  });
+}
+
+PublishedSummaryStore _store(
+  _NavigationCacheCatalog catalog,
+  void Function(String summaryId) onSummarySelected,
+) {
+  return PublishedSummaryStore(
+    scope: summaryWorkspaceScope,
+    loadLatest: LoadWorkspaceSummaryUseCase(catalog),
+    loadHistory: LoadWorkspaceSummaryHistoryUseCase(catalog),
+    loadPublished: LoadPublishedSummaryUseCase(catalog),
+    openReaderSource: const OpenReaderSourceUseCase(_SourceLauncher()),
+    onSummarySelected: onSummarySelected,
+  );
+}
+
+ReaderSummary _dailySummary(String id, int year, int month, int day) {
+  final startedAt = DateTime.utc(year, month, day);
+  return const SummaryMapper().readerSummaryToDomain(
+    readerSummaryApiDto(
+      id: id,
+      period: summaryPeriodApiDto(
+        startedAt: startedAt,
+        endedAt: startedAt.add(const Duration(days: 1)),
+        periodKey: null,
+      ),
+    ),
+  );
+}
+
+ReaderSummary _readySummary(PublishedSummaryStore store) {
+  return (store.state as ReadyViewState<ReaderSummary>).value;
+}
+
+final class _NavigationCacheCatalog extends Fake
+    implements SummaryReviewCatalog {
+  _NavigationCacheCatalog(
+    List<ReaderSummary> summaries, {
+    this.failFirstRequestFor,
+  }) : _summaries = {for (final summary in summaries) summary.id: summary},
+       _references = [
+         for (final summary in summaries)
+           PublishedSummaryReference(
+             summaryId: summary.id,
+             period: summary.period,
+           ),
+       ];
+
+  final Map<String, ReaderSummary> _summaries;
+  final List<PublishedSummaryReference> _references;
+  final String? failFirstRequestFor;
+  final List<String> publishedQueries = [];
+
+  int requestsFor(String summaryId) =>
+      publishedQueries.where((id) => id == summaryId).length;
+
+  @override
+  Future<Result<WorkspaceSummarySnapshot>> loadPublishedSummary(
+    LoadPublishedSummaryQuery query,
+  ) async {
+    publishedQueries.add(query.summaryId);
+    if (query.summaryId == failFirstRequestFor &&
+        requestsFor(query.summaryId) == 1) {
+      return const Result.failure(
+        UnexpectedFailure(message: 'Temporary prefetch failure'),
+      );
+    }
+    return Result.success(
+      WorkspaceSummarySnapshot(current: _summaries[query.summaryId]),
+    );
+  }
+
+  @override
+  Future<Result<WorkspaceSummarySnapshot>> loadWorkspaceSummaryHistory(
+    LoadWorkspaceSummaryQuery query,
+  ) async => Result.success(
+    WorkspaceSummarySnapshot(
+      availablePeriods: _references
+          .map((reference) => reference.period)
+          .toList(growable: false),
+      availableSummaryReferences: _references,
+      availablePeriodsAreComplete: true,
+    ),
+  );
+
+  @override
+  Future<Result<WorkspaceSummarySnapshot>> loadWorkspaceSummary(
+    LoadWorkspaceSummaryQuery query,
+  ) async => const Result.success(WorkspaceSummarySnapshot());
+}
+
+final class _SourceLauncher implements ReaderSourceLauncher {
+  const _SourceLauncher();
+
+  @override
+  Future<Result<Unit>> open(Uri uri) async => const Result.success(Unit.value);
+}

--- a/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
@@ -110,7 +110,7 @@ void main() {
       await store.showNextPeriod();
 
       expect(catalog.workspaceQueries, hasLength(1));
-      expect(catalog.publishedQueries, [july10.id, july10.id]);
+      expect(catalog.publishedQueries, [july10.id]);
       expect(_readySummary(store).id, july10.id);
       expect(selectedSummaryIds, [july9.id, july10.id]);
     },
@@ -183,7 +183,7 @@ void main() {
     await store.load();
 
     expect(catalog.workspaceQueries, isEmpty);
-    expect(catalog.publishedQueries, [july10.id]);
+    expect(catalog.publishedQueries, [july10.id, july9.id]);
     expect(_readySummary(store).id, july10.id);
     expect(store.availablePeriods, hasLength(2));
   });


### PR DESCRIPTION
Speeds up daily summary navigation by keeping a bounded workspace-scoped in-memory cache and prefetching adjacent published summaries. Cached switches avoid the loading state and duplicate detail requests; failed prefetches fall back to the normal request path.\n\nChecks:\n- fvm flutter analyze\n- focused published summary navigation tests\n- frontend architecture boundaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster navigation between published summary periods through in-memory caching and background prefetching.
  * Added controls to select preset periods, move to previous or next periods, return to the current period, and choose a date from the calendar.
  * Improved loading states and recovery when a summary temporarily fails to load.

* **Bug Fixes**
  * Prevented duplicate summary requests during period navigation.
  * Improved handling of adjacent and latest available summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->