### PR TITLE
chore(deploy): pin transition review authority

### DIFF
--- a/ops/deploy/production-transition-review.allowed_signers
+++ b/ops/deploy/production-transition-review.allowed_signers
@@ -1,0 +1,1 @@
+production-transition-review namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHJzqdb3PC26RzrJlMzx6SPOGglfink6OkkvkObqfeM

--- a/ops/deploy/production-transition-review.anchor
+++ b/ops/deploy/production-transition-review.anchor
@@ -1,0 +1,7 @@
+version=social-monitor-production-transition-review-anchor-v1
+anchor-path=ops/deploy/production-transition-review.anchor
+allowed-signers-path=ops/deploy/production-transition-review.allowed_signers
+principal=production-transition-review
+namespace=git
+key-type=ssh-ed25519
+fingerprint=SHA256:RQ/JZlrtmTgY4lNHhyzQnxI4IjQZ47Xt/Pu00ppuUaA


### PR DESCRIPTION
Adds the inert trust authority required before the production transition can be authenticated.

Scope:
- add the strict transition review anchor contract
- add the matching namespaced allowed-signers authority

Evidence:
- exact parent is current main c63f938f
- fingerprint was recomputed from the checked-in public key
- independent gpt-5.6-sol xhigh review passed
- diff check passed

This PR does not enable transition execution, sign a release, deploy product code, or contain a private key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SSH signing verification configuration for production transition reviews.
  * Registered the approved signing key and verification anchor for related deployment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->