### PR TITLE
perf(summaries): parallelize initial reader load

### DIFF
--- a/apps/frontend/app/web/index.html
+++ b/apps/frontend/app/web/index.html
@@ -20,6 +20,7 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="description" content="Social Monitor">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <style>
     html,
     body {

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_brief_surface.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_brief_surface.dart
@@ -133,7 +133,9 @@ class _ReaderSummaryBriefSurfaceState extends State<ReaderSummaryBriefSurface> {
                 ),
                 if (!content.topicMap.isEmpty) ...[
                   const SizedBox(height: AppSpacing.md),
-                  ReaderSummaryTopicMapPanel(topicMap: content.topicMap),
+                  ReaderSummaryDeferredTopicMapPanel(
+                    topicMap: content.topicMap,
+                  ),
                 ],
                 const SizedBox(height: AppSpacing.md),
                 _SourceFilterChips(

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_topic_map_panel.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_topic_map_panel.dart
@@ -2,6 +2,73 @@ part of 'reader_summary_brief_surface.dart';
 
 enum ReaderSummaryTopicMapRenderer { graphView, flutterGraphView }
 
+class ReaderSummaryDeferredTopicMapPanel extends StatefulWidget {
+  const ReaderSummaryDeferredTopicMapPanel({super.key, required this.topicMap});
+
+  final ReaderSummaryTopicMap topicMap;
+
+  @override
+  State<ReaderSummaryDeferredTopicMapPanel> createState() =>
+      _ReaderSummaryDeferredTopicMapPanelState();
+}
+
+class _ReaderSummaryDeferredTopicMapPanelState
+    extends State<ReaderSummaryDeferredTopicMapPanel> {
+  bool _isReady = false;
+  Timer? _deferredRender;
+
+  @override
+  void initState() {
+    super.initState();
+    _showAfterFirstFrame();
+  }
+
+  @override
+  void didUpdateWidget(covariant ReaderSummaryDeferredTopicMapPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.topicMap != widget.topicMap) {
+      _isReady = false;
+      _showAfterFirstFrame();
+    }
+  }
+
+  void _showAfterFirstFrame() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _deferredRender?.cancel();
+      _deferredRender = Timer(const Duration(milliseconds: 16), () {
+        if (mounted && !_isReady) {
+          setState(() => _isReady = true);
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _deferredRender?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isReady) {
+      return ReaderSummaryTopicMapPanel(topicMap: widget.topicMap);
+    }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth.isFinite
+            ? constraints.maxWidth
+            : 640.0;
+        return SizedBox(
+          key: const ValueKey('deferred-topic-map-placeholder'),
+          width: width,
+          height: width < 420 ? 360 : 420,
+        );
+      },
+    );
+  }
+}
+
 class ReaderSummaryTopicMapPanel extends StatelessWidget {
   const ReaderSummaryTopicMapPanel({
     super.key,

--- a/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/stores/published_summary_store.dart
@@ -14,6 +14,7 @@ import '../../domain/aggregates/reader_summary.dart';
 import '../workflows/summary_period_navigation.dart';
 
 part '../workflows/published_summary_refresh_workflow.dart';
+part '../workflows/published_summary_initial_load_workflow.dart';
 part '../workflows/published_summary_navigation_workflow.dart';
 
 final class PublishedSummaryStore extends ChangeNotifier {
@@ -97,61 +98,43 @@ final class PublishedSummaryStore extends ChangeNotifier {
     notifyListeners();
 
     final requestedId = summaryId?.trim();
-    WorkspaceSummarySnapshot? preloadedHistory;
-    Result<WorkspaceSummarySnapshot> result;
-    if (requestedId != null && requestedId.isNotEmpty) {
-      result = await _loadPublished(
-        LoadPublishedSummaryQuery(scope: _scope, summaryId: requestedId),
-      );
-    } else {
-      final historyResult = await _loadHistory(
-        LoadWorkspaceSummaryQuery(
-          scope: _scope,
-          period: SummaryPeriodPreset.daily.resolve(),
-        ),
-      );
-      if (!_generationGuard.isCurrent(generation)) {
-        return;
-      }
-      preloadedHistory = historyResult.fold(
-        onSuccess: (snapshot) => snapshot,
-        onFailure: (_) => null,
-      );
-      final latest = _latestReference(
-        preloadedHistory?.availableSummaryReferences ?? const [],
-        SummaryPeriodPreset.daily,
-      );
-      result = latest == null
-          ? await _loadLatest(
-              LoadWorkspaceSummaryQuery(
-                scope: _scope,
-                period: SummaryPeriodPreset.daily.resolve(),
-              ),
-            )
-          : await _loadPublished(
-              LoadPublishedSummaryQuery(
-                scope: _scope,
-                summaryId: latest.summaryId,
-              ),
-            );
+    if (requestedId == null || requestedId.isEmpty) {
+      await _loadInitialSummaryAndHistory(generation);
+      return;
     }
+
+    final result = await _loadPublished(
+      LoadPublishedSummaryQuery(scope: _scope, summaryId: requestedId),
+    );
     if (!_generationGuard.isCurrent(generation)) {
       return;
     }
-    WorkspaceSummarySnapshot? loadedSnapshot;
+
+    final current = _publishInitialResult(result);
+    if (current != null) {
+      await _refreshAvailablePeriods();
+    }
+    _prefetchAdjacentSummaries();
+  }
+
+  ReaderSummary? _publishInitialResult(
+    Result<WorkspaceSummarySnapshot> result, {
+    WorkspaceSummarySnapshot? history,
+  }) {
+    ReaderSummary? current;
     state = result.fold(
       onSuccess: (snapshot) {
-        loadedSnapshot = snapshot;
         final summary = snapshot.current;
         if (summary != null) {
+          current = summary;
           _rememberSummary(summary);
           _selectPeriod(summary.period);
           availablePeriods = mergeSummaryPeriods(
-            preloadedHistory?.availablePeriods ?? const [],
+            history?.availablePeriods ?? const [],
             [...snapshot.availablePeriods, summary.period],
           );
           availableSummaryReferences = mergePublishedSummaryReferences(
-            preloadedHistory?.availableSummaryReferences ?? const [],
+            history?.availableSummaryReferences ?? const [],
             [
               ...snapshot.availableSummaryReferences,
               PublishedSummaryReference(
@@ -173,13 +156,7 @@ final class PublishedSummaryStore extends ChangeNotifier {
       onFailure: (failure) => FailureViewState<ReaderSummary>(failure: failure),
     );
     notifyListeners();
-    final snapshot = loadedSnapshot;
-    final current = snapshot?.current;
-    if (current != null &&
-        preloadedHistory?.availablePeriodsAreComplete != true) {
-      await _refreshAvailablePeriods();
-    }
-    _prefetchAdjacentSummaries();
+    return current;
   }
 
   SummaryPeriod? _adjacentAvailablePeriod(int offset) {

--- a/apps/frontend/features/summaries/lib/src/presentation/workflows/published_summary_initial_load_workflow.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/workflows/published_summary_initial_load_workflow.dart
@@ -1,0 +1,70 @@
+part of '../stores/published_summary_store.dart';
+
+extension PublishedSummaryInitialLoadWorkflow on PublishedSummaryStore {
+  Future<void> _loadInitialSummaryAndHistory(int generation) async {
+    final query = LoadWorkspaceSummaryQuery(
+      scope: _scope,
+      period: SummaryPeriodPreset.daily.resolve(),
+    );
+    final latestFuture = _loadLatest(query);
+    final historyFuture = _loadHistory(query);
+
+    final latestResult = await latestFuture;
+    if (!_generationGuard.isCurrent(generation)) {
+      return;
+    }
+
+    final latestSnapshot = latestResult.fold(
+      onSuccess: (snapshot) => snapshot,
+      onFailure: (_) => null,
+    );
+    var current = latestSnapshot?.current;
+    if (current != null) {
+      _publishInitialResult(latestResult);
+    }
+
+    final historyResult = await historyFuture;
+    if (!_generationGuard.isCurrent(generation)) {
+      return;
+    }
+    final history = historyResult.fold(
+      onSuccess: (snapshot) => snapshot,
+      onFailure: (_) => null,
+    );
+
+    final latestReference = _latestReference(
+      history?.availableSummaryReferences ?? const [],
+      SummaryPeriodPreset.daily,
+    );
+    if (current == null ||
+        (latestReference != null && latestReference.summaryId != current.id)) {
+      final fallbackResult = latestReference == null
+          ? latestResult
+          : await _loadPublished(
+              LoadPublishedSummaryQuery(
+                scope: _scope,
+                summaryId: latestReference.summaryId,
+              ),
+            );
+      if (!_generationGuard.isCurrent(generation)) {
+        return;
+      }
+      current = _publishInitialResult(fallbackResult, history: history);
+    } else if (history != null) {
+      availablePeriods = mergeSummaryPeriods(
+        availablePeriods,
+        history.availablePeriods,
+      );
+      availableSummaryReferences = mergePublishedSummaryReferences(
+        availableSummaryReferences,
+        history.availableSummaryReferences,
+      );
+      _notifyChanged();
+    }
+
+    if (current != null && history?.availablePeriodsAreComplete != true) {
+      await _refreshAvailablePeriods();
+    }
+    _prefetchAdjacentSummaries();
+  }
+}

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_brief_surface_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_brief_surface_test.dart
@@ -112,6 +112,7 @@ void main() {
         ),
       ),
     );
+    await tester.pump(const Duration(milliseconds: 17));
 
     final topicMap = find.byType(
       ReaderSummaryTopicMapPanel,

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_deferred_topic_map_panel_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_deferred_topic_map_panel_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_monitor_design_system/social_monitor_design_system.dart';
+import 'package:social_monitor_summaries/src/infrastructure/mappers/summary_mapper.dart';
+import 'package:social_monitor_summaries/src/presentation/components/reader_summary_brief_surface.dart';
+
+import '../../support/summaries_test_fixtures.dart';
+
+void main() {
+  testWidgets('defers the topic graph until after the first summary frame', (
+    tester,
+  ) async {
+    final summary = const SummaryMapper().readerSummaryToDomain(
+      readerSummaryApiDto(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark(),
+        home: Scaffold(
+          body: ReaderSummaryDeferredTopicMapPanel(
+            topicMap: summary.content.topicMap,
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const ValueKey('deferred-topic-map-placeholder')),
+      findsOneWidget,
+    );
+    expect(find.byType(ReaderSummaryTopicMapPanel), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 17));
+
+    expect(
+      find.byKey(const ValueKey('deferred-topic-map-placeholder')),
+      findsNothing,
+    );
+    expect(find.byType(ReaderSummaryTopicMapPanel), findsOneWidget);
+  });
+}

--- a/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_initial_load_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_initial_load_test.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
+import 'package:social_monitor_summaries/src/application/contracts/reader_source_launcher.dart';
+import 'package:social_monitor_summaries/src/application/contracts/summary_review_catalog.dart';
+import 'package:social_monitor_summaries/src/application/queries/load_published_summary_query.dart';
+import 'package:social_monitor_summaries/src/application/queries/load_workspace_summary_query.dart';
+import 'package:social_monitor_summaries/src/application/use_cases/load_published_summary_use_case.dart';
+import 'package:social_monitor_summaries/src/application/use_cases/load_workspace_summary_history_use_case.dart';
+import 'package:social_monitor_summaries/src/application/use_cases/load_workspace_summary_use_case.dart';
+import 'package:social_monitor_summaries/src/application/use_cases/open_reader_source_use_case.dart';
+import 'package:social_monitor_summaries/src/domain/aggregates/reader_summary.dart';
+import 'package:social_monitor_summaries/src/infrastructure/mappers/summary_mapper.dart';
+import 'package:social_monitor_summaries/src/presentation/stores/published_summary_store.dart';
+
+import '../../support/summaries_test_fixtures.dart';
+
+void main() {
+  test('publishes latest while the period catalog is still loading', () async {
+    final summary = _dailySummary('summary-july-10', 2026, 7, 10);
+    final latest = Completer<Result<WorkspaceSummarySnapshot>>();
+    final history = Completer<Result<WorkspaceSummarySnapshot>>();
+    final catalog = _InitialLoadCatalog(
+      latestResult: latest.future,
+      historyResult: history.future,
+    );
+    final store = _store(catalog);
+    addTearDown(store.dispose);
+
+    final load = store.load();
+    await _waitUntil(
+      () =>
+          catalog.latestQueries.isNotEmpty && catalog.historyQueries.isNotEmpty,
+    );
+
+    latest.complete(Result.success(WorkspaceSummarySnapshot(current: summary)));
+    await _waitUntil(() => store.state is ReadyViewState<ReaderSummary>);
+
+    expect(_readySummary(store).id, summary.id);
+    expect(catalog.publishedQueries, isEmpty);
+
+    history.complete(
+      Result.success(
+        WorkspaceSummarySnapshot(
+          availablePeriods: [summary.period],
+          availableSummaryReferences: [
+            PublishedSummaryReference(
+              summaryId: summary.id,
+              period: summary.period,
+            ),
+          ],
+          availablePeriodsAreComplete: true,
+        ),
+      ),
+    );
+    await load;
+
+    expect(catalog.latestQueries, hasLength(1));
+    expect(catalog.historyQueries, hasLength(1));
+    expect(_readySummary(store).id, summary.id);
+  });
+
+  test(
+    'falls back to the latest period reference when direct load fails',
+    () async {
+      final summary = _dailySummary('summary-july-10', 2026, 7, 10);
+      final reference = PublishedSummaryReference(
+        summaryId: summary.id,
+        period: summary.period,
+      );
+      final catalog = _InitialLoadCatalog(
+        latestResult: Future.value(
+          const Result.failure(
+            UnexpectedFailure(message: 'Latest endpoint unavailable'),
+          ),
+        ),
+        historyResult: Future.value(
+          Result.success(
+            WorkspaceSummarySnapshot(
+              availablePeriods: [summary.period],
+              availableSummaryReferences: [reference],
+              availablePeriodsAreComplete: true,
+            ),
+          ),
+        ),
+        publishedSummaries: {summary.id: summary},
+      );
+      final store = _store(catalog);
+      addTearDown(store.dispose);
+
+      await store.load();
+
+      expect(catalog.latestQueries, hasLength(1));
+      expect(catalog.historyQueries, hasLength(1));
+      expect(catalog.publishedQueries, [summary.id]);
+      expect(_readySummary(store).id, summary.id);
+    },
+  );
+
+  test(
+    'adopts a newer period discovered during parallel history load',
+    () async {
+      final previous = _dailySummary('summary-july-09', 2026, 7, 9);
+      final current = _dailySummary('summary-july-10', 2026, 7, 10);
+      final reference = PublishedSummaryReference(
+        summaryId: current.id,
+        period: current.period,
+      );
+      final catalog = _InitialLoadCatalog(
+        latestResult: Future.value(
+          Result.success(WorkspaceSummarySnapshot(current: previous)),
+        ),
+        historyResult: Future.value(
+          Result.success(
+            WorkspaceSummarySnapshot(
+              availablePeriods: [previous.period, current.period],
+              availableSummaryReferences: [reference],
+              availablePeriodsAreComplete: true,
+            ),
+          ),
+        ),
+        publishedSummaries: {current.id: current},
+      );
+      final store = _store(catalog);
+      addTearDown(store.dispose);
+
+      await store.load();
+
+      expect(catalog.publishedQueries, [current.id]);
+      expect(_readySummary(store).id, current.id);
+    },
+  );
+}
+
+PublishedSummaryStore _store(_InitialLoadCatalog catalog) {
+  return PublishedSummaryStore(
+    scope: summaryWorkspaceScope,
+    loadLatest: LoadWorkspaceSummaryUseCase(catalog),
+    loadHistory: LoadWorkspaceSummaryHistoryUseCase(catalog),
+    loadPublished: LoadPublishedSummaryUseCase(catalog),
+    openReaderSource: const OpenReaderSourceUseCase(_SourceLauncher()),
+  );
+}
+
+ReaderSummary _dailySummary(String id, int year, int month, int day) {
+  final startedAt = DateTime.utc(year, month, day);
+  return const SummaryMapper().readerSummaryToDomain(
+    readerSummaryApiDto(
+      id: id,
+      period: summaryPeriodApiDto(
+        startedAt: startedAt,
+        endedAt: startedAt.add(const Duration(days: 1)),
+        periodKey: null,
+      ),
+    ),
+  );
+}
+
+ReaderSummary _readySummary(PublishedSummaryStore store) {
+  return (store.state as ReadyViewState<ReaderSummary>).value;
+}
+
+Future<void> _waitUntil(bool Function() predicate) async {
+  for (var attempt = 0; attempt < 20 && !predicate(); attempt += 1) {
+    await Future<void>.delayed(Duration.zero);
+  }
+  expect(predicate(), isTrue, reason: 'Expected asynchronous state change');
+}
+
+final class _InitialLoadCatalog extends Fake implements SummaryReviewCatalog {
+  _InitialLoadCatalog({
+    required this.latestResult,
+    required this.historyResult,
+    this.publishedSummaries = const {},
+  });
+
+  final Future<Result<WorkspaceSummarySnapshot>> latestResult;
+  final Future<Result<WorkspaceSummarySnapshot>> historyResult;
+  final Map<String, ReaderSummary> publishedSummaries;
+  final List<LoadWorkspaceSummaryQuery> latestQueries = [];
+  final List<LoadWorkspaceSummaryQuery> historyQueries = [];
+  final List<String> publishedQueries = [];
+
+  @override
+  Future<Result<WorkspaceSummarySnapshot>> loadWorkspaceSummary(
+    LoadWorkspaceSummaryQuery query,
+  ) {
+    latestQueries.add(query);
+    return latestResult;
+  }
+
+  @override
+  Future<Result<WorkspaceSummarySnapshot>> loadWorkspaceSummaryHistory(
+    LoadWorkspaceSummaryQuery query,
+  ) {
+    historyQueries.add(query);
+    return historyResult;
+  }
+
+  @override
+  Future<Result<WorkspaceSummarySnapshot>> loadPublishedSummary(
+    LoadPublishedSummaryQuery query,
+  ) async {
+    publishedQueries.add(query.summaryId);
+    return Result.success(
+      WorkspaceSummarySnapshot(current: publishedSummaries[query.summaryId]),
+    );
+  }
+}
+
+final class _SourceLauncher implements ReaderSourceLauncher {
+  const _SourceLauncher();
+
+  @override
+  Future<Result<Unit>> open(Uri uri) async => const Result.success(Unit.value);
+}

--- a/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/stores/published_summary_store_period_navigation_test.dart
@@ -153,7 +153,7 @@ void main() {
     expect(_readySummary(store).id, july9.id);
   });
 
-  test('loads the latest summary directly from the period catalog', () async {
+  test('falls back to the latest summary in the period catalog', () async {
     final july9 = _dailySummary('summary-july-09', 2026, 7, 9);
     final july10 = _dailySummary('summary-july-10', 2026, 7, 10);
     final references = [
@@ -182,7 +182,7 @@ void main() {
 
     await store.load();
 
-    expect(catalog.workspaceQueries, isEmpty);
+    expect(catalog.workspaceQueries, hasLength(1));
     expect(catalog.publishedQueries, [july10.id, july9.id]);
     expect(_readySummary(store).id, july10.id);
     expect(store.availablePeriods, hasLength(2));


### PR DESCRIPTION
## Summary
- load the latest published summary and period catalog in parallel
- preserve the catalog fallback and newer-publication race handling
- defer the topic graph until after the first summary frame
- preconnect the external font origin

## Evidence
- real API trace starts latest and periods together
- current summary rendered in about 2.4 seconds in the local production build measurement
- desktop and 390px visual checks pass without overflow
- flutter analyze passes
- 21 frontend architecture tests pass
- 295 summaries tests pass
- 45 app tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Topic maps now load shortly after the summary view appears, improving initial rendering responsiveness.
  - Added an early connection setup for Google Fonts to help text and interface styling load more efficiently.

- **Bug Fixes**
  - Improved initial summary loading and fallback behavior when the latest summary or period data is unavailable.
  - Summary history, available periods, and nearby summaries now update more reliably during initial loading and navigation.

- **Tests**
  - Added coverage for deferred topic-map rendering and summary loading, fallback, and period-navigation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->