### PR TITLE
perf(frontend): preload required wasm assets

### DIFF
--- a/apps/frontend/app/web/index.html
+++ b/apps/frontend/app/web/index.html
@@ -21,6 +21,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="description" content="Social Monitor">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="modulepreload" href="main.dart.mjs">
+  <link rel="preload" href="main.dart.wasm" as="fetch" type="application/wasm" crossorigin="use-credentials">
+  <link rel="preload" href="canvaskit/skwasm.wasm" as="fetch" type="application/wasm" crossorigin="use-credentials">
   <style>
     html,
     body {


### PR DESCRIPTION
## Summary
- preload the compiled Dart module and required WebAssembly payloads from the initial HTML
- preserve browser cache reuse so runtime fetches do not cause duplicate network transfers

## Evidence
- cold release build starts all three assets at ~38 ms instead of waiting for Flutter bootstrap
- server trace confirms exactly one GET per asset
- `fvm flutter build web --release --wasm --no-web-resources-cdn --dart-define=SOCIAL_MONITOR_API_BASE_URL=https://social-monitor.app`
- `fvm flutter analyze`
- `fvm flutter test app/test` (45 tests)