### PR TITLE
perf(summaries): preload and cache app bootstrap

### DIFF
--- a/apps/api-gateway/src/app-bootstrap-reader-summary-cache.spec.ts
+++ b/apps/api-gateway/src/app-bootstrap-reader-summary-cache.spec.ts
@@ -1,0 +1,118 @@
+import type { Clock } from '@social-monitor/shared-kernel';
+
+import type { ReaderSummaryBootstrapResponseDto } from './app-bootstrap.dto';
+import { AppBootstrapReaderSummaryCache } from './app-bootstrap-reader-summary-cache';
+
+class MutableClock implements Clock {
+  constructor(private nowMs: number) {}
+
+  now(): Date {
+    return new Date(this.nowMs);
+  }
+
+  advance(milliseconds: number): void {
+    this.nowMs += milliseconds;
+  }
+}
+
+const payload = (
+  tenantId: string,
+  workspaceId: string,
+): ReaderSummaryBootstrapResponseDto => ({
+  tenantId,
+  workspaceId,
+  latest: { items: [] },
+  periods: { items: [] },
+});
+
+describe('AppBootstrapReaderSummaryCache', () => {
+  it('uses tenant and workspace scope and expires with its injected clock', async () => {
+    const clock = new MutableClock(1_000);
+    const cache = new AppBootstrapReaderSummaryCache(clock, 100, 10);
+    const loader = jest.fn(async (tenantId: string, workspaceId: string) =>
+      payload(tenantId, workspaceId),
+    );
+
+    await cache.getOrLoad('tenant-1', 'workspace-1', () =>
+      loader('tenant-1', 'workspace-1'),
+    );
+    await cache.getOrLoad('tenant-1', 'workspace-1', () =>
+      loader('tenant-1', 'workspace-1'),
+    );
+    await cache.getOrLoad('tenant-2', 'workspace-1', () =>
+      loader('tenant-2', 'workspace-1'),
+    );
+    expect(loader).toHaveBeenCalledTimes(2);
+
+    clock.advance(100);
+    await cache.getOrLoad('tenant-1', 'workspace-1', () =>
+      loader('tenant-1', 'workspace-1'),
+    );
+    expect(loader).toHaveBeenCalledTimes(3);
+  });
+
+  it('collapses concurrent misses for the same fixed query identity', async () => {
+    const cache = new AppBootstrapReaderSummaryCache(
+      new MutableClock(1_000),
+      100,
+      10,
+    );
+    let resolve!: (value: ReaderSummaryBootstrapResponseDto) => void;
+    const deferred = new Promise<ReaderSummaryBootstrapResponseDto>(
+      (complete) => {
+        resolve = complete;
+      },
+    );
+    const loader = jest.fn(() => deferred);
+
+    const first = cache.getOrLoad('tenant-1', 'workspace-1', loader);
+    const second = cache.getOrLoad('tenant-1', 'workspace-1', loader);
+    resolve(payload('tenant-1', 'workspace-1'));
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      payload('tenant-1', 'workspace-1'),
+      payload('tenant-1', 'workspace-1'),
+    ]);
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache failures', async () => {
+    const cache = new AppBootstrapReaderSummaryCache(
+      new MutableClock(1_000),
+      100,
+      10,
+    );
+    const loader = jest.fn().mockRejectedValue(new Error('read failed'));
+
+    await expect(
+      cache.getOrLoad('tenant-1', 'workspace-1', loader),
+    ).rejects.toThrow('read failed');
+    await expect(
+      cache.getOrLoad('tenant-1', 'workspace-1', loader),
+    ).rejects.toThrow('read failed');
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts entries at the configured maximum', async () => {
+    const cache = new AppBootstrapReaderSummaryCache(
+      new MutableClock(1_000),
+      100,
+      1,
+    );
+    const loader = jest.fn(async (workspaceId: string) =>
+      payload('tenant-1', workspaceId),
+    );
+
+    await cache.getOrLoad('tenant-1', 'workspace-1', () =>
+      loader('workspace-1'),
+    );
+    await cache.getOrLoad('tenant-1', 'workspace-2', () =>
+      loader('workspace-2'),
+    );
+    await cache.getOrLoad('tenant-1', 'workspace-1', () =>
+      loader('workspace-1'),
+    );
+
+    expect(loader).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/api-gateway/src/app-bootstrap-reader-summary-cache.ts
+++ b/apps/api-gateway/src/app-bootstrap-reader-summary-cache.ts
@@ -1,0 +1,97 @@
+import type { Clock } from '@social-monitor/shared-kernel';
+
+import type { ReaderSummaryBootstrapResponseDto } from './app-bootstrap.dto';
+
+export const APP_BOOTSTRAP_READER_SUMMARY_CACHE_CLOCK = Symbol(
+  'APP_BOOTSTRAP_READER_SUMMARY_CACHE_CLOCK',
+);
+
+export const APP_BOOTSTRAP_READER_SUMMARY_CACHE_TTL_MS = 30_000;
+export const APP_BOOTSTRAP_READER_SUMMARY_CACHE_MAX_ENTRIES = 128;
+
+const PUBLISHED_READER_SUMMARY_QUERY_IDENTITY =
+  'published:workspace:daily:utc:latest-1:periods-40';
+
+interface CacheEntry {
+  readonly expiresAtMs: number;
+  readonly value: ReaderSummaryBootstrapResponseDto;
+}
+
+export class AppBootstrapReaderSummaryCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<
+    string,
+    Promise<ReaderSummaryBootstrapResponseDto>
+  >();
+
+  constructor(
+    private readonly clock: Clock,
+    private readonly ttlMs: number,
+    private readonly maxEntries: number,
+  ) {
+    if (
+      !Number.isSafeInteger(ttlMs) ||
+      ttlMs <= 0 ||
+      !Number.isSafeInteger(maxEntries) ||
+      maxEntries <= 0
+    ) {
+      throw new Error('Bootstrap summary cache bounds must be positive');
+    }
+  }
+
+  getOrLoad(
+    tenantId: string,
+    workspaceId: string,
+    loader: () => Promise<ReaderSummaryBootstrapResponseDto>,
+  ): Promise<ReaderSummaryBootstrapResponseDto> {
+    const key = JSON.stringify([
+      tenantId,
+      workspaceId,
+      PUBLISHED_READER_SUMMARY_QUERY_IDENTITY,
+    ]);
+    const nowMs = this.clock.now().getTime();
+    const cached = this.entries.get(key);
+    if (cached && cached.expiresAtMs > nowMs) {
+      return Promise.resolve(cached.value);
+    }
+    if (cached) {
+      this.entries.delete(key);
+    }
+
+    const existingLoad = this.inFlight.get(key);
+    if (existingLoad) {
+      return existingLoad;
+    }
+
+    const pending = Promise.resolve()
+      .then(loader)
+      .then((value) => {
+        this.store(key, value);
+        return value;
+      })
+      .finally(() => {
+        if (this.inFlight.get(key) === pending) {
+          this.inFlight.delete(key);
+        }
+      });
+    this.inFlight.set(key, pending);
+    return pending;
+  }
+
+  private store(key: string, value: ReaderSummaryBootstrapResponseDto): void {
+    const nowMs = this.clock.now().getTime();
+    for (const [candidateKey, entry] of this.entries) {
+      if (entry.expiresAtMs <= nowMs) {
+        this.entries.delete(candidateKey);
+      }
+    }
+    while (this.entries.size >= this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (oldestKey === undefined) {
+        break;
+      }
+      this.entries.delete(oldestKey);
+    }
+    this.entries.set(key, { value, expiresAtMs: nowMs + this.ttlMs });
+  }
+}

--- a/apps/api-gateway/src/app-bootstrap.controller.spec.ts
+++ b/apps/api-gateway/src/app-bootstrap.controller.spec.ts
@@ -1,9 +1,10 @@
-import { DomainError, err, ok } from '@social-monitor/shared-kernel';
+import { DomainError, FixedClock, err, ok } from '@social-monitor/shared-kernel';
 import type { GetAuthSessionUseCase } from '@social-monitor/identity/features/get-auth-session/get-auth-session.use-case';
 import type { ListReaderSummaryPeriodsUseCase } from '@social-monitor/summary/features/list-reader-summary-periods/list-reader-summary-periods.use-case';
 import type { ListReaderSummariesUseCase } from '@social-monitor/summary/features/list-reader-summaries/list-reader-summaries.use-case';
 
 import { AppBootstrapController } from './app-bootstrap.controller';
+import { AppBootstrapReaderSummaryCache } from './app-bootstrap-reader-summary-cache';
 
 const session = {
   userId: 'user-1',
@@ -21,6 +22,28 @@ const session = {
 };
 
 describe('AppBootstrapController', () => {
+  const createCache = () =>
+    new AppBootstrapReaderSummaryCache(
+      new FixedClock(new Date('2026-08-29T00:00:00.000Z')),
+      30_000,
+      10,
+    );
+
+  it('marks the session-bearing response private and uncacheable', () => {
+    const headers = Reflect.getMetadata(
+      '__headers__',
+      AppBootstrapController.prototype.get,
+    ) as readonly { readonly name: string; readonly value: string }[];
+
+    expect(headers).toEqual(
+      expect.arrayContaining([
+        { name: 'Cache-Control', value: 'private, no-store' },
+        { name: 'Pragma', value: 'no-cache' },
+        { name: 'Vary', value: 'Authorization, Cookie' },
+      ]),
+    );
+  });
+
   it('loads latest summary and period links concurrently after session verification', async () => {
     let resolveLatest!: (value: ReturnType<typeof ok>) => void;
     let resolvePeriods!: (value: ReturnType<typeof ok>) => void;
@@ -43,9 +66,11 @@ describe('AppBootstrapController', () => {
       getAuthSession as unknown as GetAuthSessionUseCase,
       listReaderSummaries as unknown as ListReaderSummariesUseCase,
       listReaderSummaryPeriods as unknown as ListReaderSummaryPeriodsUseCase,
+      createCache(),
     );
 
     const response = controller.get('Bearer token-value');
+    await Promise.resolve();
     await Promise.resolve();
 
     expect(getAuthSession.execute).toHaveBeenCalledWith({
@@ -95,10 +120,78 @@ describe('AppBootstrapController', () => {
       getAuthSession as unknown as GetAuthSessionUseCase,
       listReaderSummaries as unknown as ListReaderSummariesUseCase,
       listReaderSummaryPeriods as unknown as ListReaderSummaryPeriodsUseCase,
+      createCache(),
     );
 
     await expect(controller.get('Bearer token-value')).rejects.toBe(denied);
     expect(listReaderSummaries.execute).not.toHaveBeenCalled();
     expect(listReaderSummaryPeriods.execute).not.toHaveBeenCalled();
+  });
+
+  it('verifies every session while reusing only published summary data', async () => {
+    const getAuthSession = {
+      execute: jest
+        .fn()
+        .mockResolvedValueOnce(ok(session))
+        .mockResolvedValueOnce(ok({ ...session, userLabel: 'Changed user' })),
+    };
+    const listReaderSummaries = {
+      execute: jest.fn().mockResolvedValue(ok({ items: [] })),
+    };
+    const listReaderSummaryPeriods = {
+      execute: jest.fn().mockResolvedValue(ok({ items: [] })),
+    };
+    const controller = new AppBootstrapController(
+      getAuthSession as unknown as GetAuthSessionUseCase,
+      listReaderSummaries as unknown as ListReaderSummariesUseCase,
+      listReaderSummaryPeriods as unknown as ListReaderSummaryPeriodsUseCase,
+      createCache(),
+    );
+
+    const first = await controller.get('Bearer token-value');
+    const second = await controller.get('Bearer token-value');
+
+    expect(first.session.userLabel).toBe('User 1');
+    expect(second.session.userLabel).toBe('Changed user');
+    expect(getAuthSession.execute).toHaveBeenCalledTimes(2);
+    expect(listReaderSummaries.execute).toHaveBeenCalledTimes(1);
+    expect(listReaderSummaryPeriods.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a populated summary cache bypass later authentication', async () => {
+    const denied = new DomainError(
+      'authorization.denied',
+      'Bearer JWT user session is required',
+    );
+    const getAuthSession = {
+      execute: jest
+        .fn()
+        .mockResolvedValueOnce(ok(session))
+        .mockResolvedValueOnce(err(denied)),
+    };
+    const listReaderSummaries = {
+      execute: jest.fn().mockResolvedValue(ok({ items: [] })),
+    };
+    const listReaderSummaryPeriods = {
+      execute: jest.fn().mockResolvedValue(ok({ items: [] })),
+    };
+    const controller = new AppBootstrapController(
+      getAuthSession as unknown as GetAuthSessionUseCase,
+      listReaderSummaries as unknown as ListReaderSummariesUseCase,
+      listReaderSummaryPeriods as unknown as ListReaderSummaryPeriodsUseCase,
+      createCache(),
+    );
+
+    await expect(controller.get('Bearer first-token')).resolves.toBeDefined();
+    await expect(controller.get('Bearer expired-token')).rejects.toBe(denied);
+
+    expect(getAuthSession.execute).toHaveBeenNthCalledWith(1, {
+      accessToken: 'first-token',
+    });
+    expect(getAuthSession.execute).toHaveBeenNthCalledWith(2, {
+      accessToken: 'expired-token',
+    });
+    expect(listReaderSummaries.execute).toHaveBeenCalledTimes(1);
+    expect(listReaderSummaryPeriods.execute).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api-gateway/src/app-bootstrap.controller.spec.ts
+++ b/apps/api-gateway/src/app-bootstrap.controller.spec.ts
@@ -182,14 +182,14 @@ describe('AppBootstrapController', () => {
       createCache(),
     );
 
-    await expect(controller.get('Bearer first-token')).resolves.toBeDefined();
-    await expect(controller.get('Bearer expired-token')).rejects.toBe(denied);
+    await expect(controller.get('Bearer token-value')).resolves.toBeDefined();
+    await expect(controller.get('Bearer token-value')).rejects.toBe(denied);
 
     expect(getAuthSession.execute).toHaveBeenNthCalledWith(1, {
-      accessToken: 'first-token',
+      accessToken: 'token-value',
     });
     expect(getAuthSession.execute).toHaveBeenNthCalledWith(2, {
-      accessToken: 'expired-token',
+      accessToken: 'token-value',
     });
     expect(listReaderSummaries.execute).toHaveBeenCalledTimes(1);
     expect(listReaderSummaryPeriods.execute).toHaveBeenCalledTimes(1);

--- a/apps/api-gateway/src/app-bootstrap.controller.ts
+++ b/apps/api-gateway/src/app-bootstrap.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Headers } from '@nestjs/common';
+import { Controller, Get, Header, Headers } from '@nestjs/common';
 import { ApiHeader, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GetAuthSessionUseCase } from '@social-monitor/identity/features/get-auth-session/get-auth-session.use-case';
 import { parseBearerToken } from '@social-monitor/identity/interfaces/authorization/bearer-authorization';
@@ -10,6 +10,7 @@ import {
 } from '@social-monitor/summary/interfaces/rest/reader-summary-rest.mapper';
 
 import { AppBootstrapResponseDto } from './app-bootstrap.dto';
+import { AppBootstrapReaderSummaryCache } from './app-bootstrap-reader-summary-cache';
 
 const INITIAL_READER_SUMMARY_PERIOD_LIMIT = 40;
 
@@ -20,6 +21,7 @@ export class AppBootstrapController {
     private readonly getAuthSession: GetAuthSessionUseCase,
     private readonly listReaderSummaries: ListReaderSummariesUseCase,
     private readonly listReaderSummaryPeriods: ListReaderSummaryPeriodsUseCase,
+    private readonly readerSummaryCache: AppBootstrapReaderSummaryCache,
   ) {}
 
   @Get()
@@ -33,6 +35,9 @@ export class AppBootstrapController {
     description: 'Bearer OIDC JWT user session token.',
   })
   @ApiOkResponse({ type: AppBootstrapResponseDto })
+  @Header('Cache-Control', 'private, no-store')
+  @Header('Pragma', 'no-cache')
+  @Header('Vary', 'Authorization, Cookie')
   async get(
     @Headers('authorization') authorizationHeader: string | undefined,
   ): Promise<AppBootstrapResponseDto> {
@@ -45,45 +50,53 @@ export class AppBootstrapController {
 
     const session = sessionResult.value;
     const { tenantId, workspaceId } = session.selectedWorkspace;
-    const scope = { type: 'workspace' } as const;
-    const [latestResult, periodsResult] = await Promise.all([
-      this.listReaderSummaries.execute({
-        tenantId,
-        workspaceId,
-        scope,
-        cadence: 'daily',
-        timezone: 'UTC',
-        limit: 1,
-      }),
-      this.listReaderSummaryPeriods.execute({
-        tenantId,
-        workspaceId,
-        scope,
-        cadence: 'daily',
-        timezone: 'UTC',
-        limit: INITIAL_READER_SUMMARY_PERIOD_LIMIT,
-      }),
-    ]);
+    const readerSummaries = await this.readerSummaryCache.getOrLoad(
+      tenantId,
+      workspaceId,
+      async () => {
+        const scope = { type: 'workspace' } as const;
+        const [latestResult, periodsResult] = await Promise.all([
+          this.listReaderSummaries.execute({
+            tenantId,
+            workspaceId,
+            scope,
+            cadence: 'daily',
+            timezone: 'UTC',
+            limit: 1,
+          }),
+          this.listReaderSummaryPeriods.execute({
+            tenantId,
+            workspaceId,
+            scope,
+            cadence: 'daily',
+            timezone: 'UTC',
+            limit: INITIAL_READER_SUMMARY_PERIOD_LIMIT,
+          }),
+        ]);
 
-    if (!latestResult.ok) {
-      throw latestResult.error;
-    }
-    if (!periodsResult.ok) {
-      throw periodsResult.error;
-    }
+        if (!latestResult.ok) {
+          throw latestResult.error;
+        }
+        if (!periodsResult.ok) {
+          throw periodsResult.error;
+        }
+
+        return {
+          tenantId,
+          workspaceId,
+          latest: listReaderSummariesResponseFromReaderSummaries(
+            latestResult.value,
+          ),
+          periods: listReaderSummaryPeriodsResponseFromReaderSummaryPeriods(
+            periodsResult.value,
+          ),
+        };
+      },
+    );
 
     return {
       session,
-      readerSummaries: {
-        tenantId,
-        workspaceId,
-        latest: listReaderSummariesResponseFromReaderSummaries(
-          latestResult.value,
-        ),
-        periods: listReaderSummaryPeriodsResponseFromReaderSummaryPeriods(
-          periodsResult.value,
-        ),
-      },
+      readerSummaries,
     };
   }
 }

--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -11,11 +11,17 @@ import { MonitoringRestModule } from '@social-monitor/monitoring/interfaces/rest
 import { MetricsRuntimeModule } from '@social-monitor/platform-metrics/nest/metrics-runtime.module';
 import { probePostgresRuntimePoolConnectivity } from '@social-monitor/platform-persistence';
 import { RelevanceRestModule } from '@social-monitor/relevance/interfaces/rest/relevance-rest.module';
-import { SystemClock } from '@social-monitor/shared-kernel';
+import { SystemClock, type Clock } from '@social-monitor/shared-kernel';
 import { SummaryRestModule } from '@social-monitor/summary/interfaces/rest/summary-rest.module';
 import { SubscriptionsRestModule } from '@social-monitor/subscriptions/interfaces/rest/subscriptions-rest.module';
 
 import { AppBootstrapController } from './app-bootstrap.controller';
+import {
+  APP_BOOTSTRAP_READER_SUMMARY_CACHE_CLOCK,
+  APP_BOOTSTRAP_READER_SUMMARY_CACHE_MAX_ENTRIES,
+  APP_BOOTSTRAP_READER_SUMMARY_CACHE_TTL_MS,
+  AppBootstrapReaderSummaryCache,
+} from './app-bootstrap-reader-summary-cache';
 import { DomainErrorFilter } from './domain-error.filter';
 import { HealthController } from './health.controller';
 import {
@@ -48,6 +54,20 @@ import { SocialResearchApiModule } from './social-research-api.module';
   controllers: [AppBootstrapController, HealthController],
   providers: [
     ApiGatewayHealthReporter,
+    {
+      provide: APP_BOOTSTRAP_READER_SUMMARY_CACHE_CLOCK,
+      useFactory: () => new SystemClock(),
+    },
+    {
+      provide: AppBootstrapReaderSummaryCache,
+      inject: [APP_BOOTSTRAP_READER_SUMMARY_CACHE_CLOCK],
+      useFactory: (clock: Clock) =>
+        new AppBootstrapReaderSummaryCache(
+          clock,
+          APP_BOOTSTRAP_READER_SUMMARY_CACHE_TTL_MS,
+          APP_BOOTSTRAP_READER_SUMMARY_CACHE_MAX_ENTRIES,
+        ),
+    },
     {
       provide: API_GATEWAY_HEALTH_ENV,
       useFactory: (): NodeJS.ProcessEnv => process.env,

--- a/apps/frontend/app/lib/src/composition/app_session_bootstrap.dart
+++ b/apps/frontend/app/lib/src/composition/app_session_bootstrap.dart
@@ -3,13 +3,19 @@ import 'package:social_monitor_generated_api/social_monitor_generated_api.dart'
 import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
 
 import 'app_runtime.dart';
+import 'early_app_bootstrap.dart';
+
+typedef EarlyAppBootstrapReader = Future<Map<String, Object?>?> Function();
 
 /// Restores the backend session at app start so every page opens signed-in,
 /// without requiring the user to visit the auth route first.
 ///
 /// On failure the runtime stays in its restoring state: the auth page still
 /// owns interactive repair (retry, workspace selection, error details).
-Future<void> bootstrapAppSession(AppRuntimeController controller) async {
+Future<void> bootstrapAppSession(
+  AppRuntimeController controller, {
+  EarlyAppBootstrapReader earlyBootstrapReader = takeEarlyAppBootstrap,
+}) async {
   final runtime = controller.runtime;
   final apiRuntime = runtime.generatedApiRuntime;
   if (!runtime.session.isRestoring ||
@@ -17,14 +23,7 @@ Future<void> bootstrapAppSession(AppRuntimeController controller) async {
     return;
   }
 
-  final bootstrapResult = await apiRuntime.client
-      .sendUnscoped<generated.AppBootstrapResponseDto>(
-        () => apiRuntime.rest.appBootstrap.appBootstrapControllerGet(),
-      );
-  final bootstrap = bootstrapResult.fold(
-    onSuccess: (dto) => dto,
-    onFailure: (_) => null,
-  );
+  final bootstrap = await _loadBootstrap(apiRuntime, earlyBootstrapReader);
   if (bootstrap != null) {
     _restoreSession(
       controller,
@@ -46,6 +45,46 @@ Future<void> bootstrapAppSession(AppRuntimeController controller) async {
       // offers an explicit refresh action.
     },
   );
+}
+
+Future<generated.AppBootstrapResponseDto?> _loadBootstrap(
+  generated.GeneratedApiRuntime apiRuntime,
+  EarlyAppBootstrapReader earlyBootstrapReader,
+) async {
+  Map<String, Object?>? earlyPayload;
+  try {
+    earlyPayload = await earlyBootstrapReader();
+  } on Object {
+    // The generated client remains authoritative when the HTML bridge fails.
+  }
+  if (earlyPayload != null) {
+    try {
+      final bootstrap = generated.AppBootstrapResponseDto.fromJson(
+        earlyPayload,
+      );
+      if (_hasConsistentBootstrapScope(bootstrap)) {
+        return bootstrap;
+      }
+    } on Object {
+      // A stale or malformed HTML-prefetched contract safely falls through.
+    }
+  }
+
+  final result = await apiRuntime.client
+      .sendUnscoped<generated.AppBootstrapResponseDto>(
+        () => apiRuntime.rest.appBootstrap.appBootstrapControllerGet(),
+      );
+  return result.fold(
+    onSuccess: (dto) => _hasConsistentBootstrapScope(dto) ? dto : null,
+    onFailure: (_) => null,
+  );
+}
+
+bool _hasConsistentBootstrapScope(generated.AppBootstrapResponseDto dto) {
+  final selectedWorkspace = dto.session.selectedWorkspace;
+  final summaries = dto.readerSummaries;
+  return summaries.tenantId == selectedWorkspace.tenantId &&
+      summaries.workspaceId == selectedWorkspace.workspaceId;
 }
 
 void _restoreSession(

--- a/apps/frontend/app/lib/src/composition/early_app_bootstrap.dart
+++ b/apps/frontend/app/lib/src/composition/early_app_bootstrap.dart
@@ -1,0 +1,2 @@
+export 'early_app_bootstrap_stub.dart'
+    if (dart.library.js_interop) 'early_app_bootstrap_web.dart';

--- a/apps/frontend/app/lib/src/composition/early_app_bootstrap_stub.dart
+++ b/apps/frontend/app/lib/src/composition/early_app_bootstrap_stub.dart
@@ -1,0 +1,1 @@
+Future<Map<String, Object?>?> takeEarlyAppBootstrap() async => null;

--- a/apps/frontend/app/lib/src/composition/early_app_bootstrap_web.dart
+++ b/apps/frontend/app/lib/src/composition/early_app_bootstrap_web.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+import 'dart:js_interop';
+
+@JS('socialMonitorAppBootstrap.take')
+external JSPromise<JSString?> _takeEarlyAppBootstrap();
+
+Future<Map<String, Object?>?> takeEarlyAppBootstrap() async {
+  try {
+    final body = (await _takeEarlyAppBootstrap().toDart)?.toDart;
+    final value = body == null ? null : jsonDecode(body);
+    if (value is! Map<Object?, Object?>) {
+      return null;
+    }
+    return Map<String, Object?>.from(value);
+  } on Object {
+    // Non-web tests, older cached HTML, failed fetches, and malformed payloads
+    // all fall back to the generated REST client.
+    return null;
+  }
+}

--- a/apps/frontend/app/test/composition/app_session_bootstrap_test.dart
+++ b/apps/frontend/app/test/composition/app_session_bootstrap_test.dart
@@ -9,7 +9,41 @@ import 'package:social_monitor_generated_api/social_monitor_generated_api.dart';
 
 void main() {
   test(
-    'restores session and summary seed with one bootstrap request',
+    'consumes the HTML-prefetched bootstrap without an API duplicate',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final paths = <String>[];
+      server.listen((request) async {
+        paths.add(request.uri.path);
+        request.response.statusCode = HttpStatus.internalServerError;
+        await request.response.close();
+      });
+      final runtime = AppFrontendRuntimeConfig(
+        apiBaseUrl: 'http://${server.address.host}:${server.port}',
+        correlationId: 'early-bootstrap-test',
+      ).createRuntimeOrNull()!;
+      final controller = AppRuntimeController(runtime);
+      var bridgeCalls = 0;
+
+      await bootstrapAppSession(
+        controller,
+        earlyBootstrapReader: () async {
+          bridgeCalls += 1;
+          return Map<String, Object?>.from(_bootstrapResponse);
+        },
+      );
+
+      expect(bridgeCalls, 1);
+      expect(paths, isEmpty);
+      expect(controller.runtime.session.userId, 'guest-1');
+
+      (runtime.generatedApiRuntime! as GeneratedApiRuntime).close(force: true);
+      await server.close(force: true);
+    },
+  );
+
+  test(
+    'falls back to one generated bootstrap request when the bridge fails',
     () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       final paths = <String>[];
@@ -25,7 +59,10 @@ void main() {
       ).createRuntimeOrNull()!;
       final controller = AppRuntimeController(runtime);
 
-      await bootstrapAppSession(controller);
+      await bootstrapAppSession(
+        controller,
+        earlyBootstrapReader: () async => throw StateError('bridge failed'),
+      );
 
       expect(paths, ['/app/bootstrap']);
       expect(controller.runtime.session.userId, 'guest-1');
@@ -41,6 +78,52 @@ void main() {
       await server.close(force: true);
     },
   );
+
+  test('falls back when prefetched JSON is malformed or scope-inconsistent', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final paths = <String>[];
+    server.listen((request) async {
+      paths.add(request.uri.path);
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(jsonEncode(_bootstrapResponse));
+      await request.response.close();
+    });
+    final earlyPayloads = <Map<String, Object?>>[
+      {
+        'session': 'not-an-object',
+        'readerSummaries': <String, Object?>{},
+      },
+      {
+        'session': _sessionResponse,
+        'readerSummaries': {
+          'tenantId': 'tenant-1',
+          'workspaceId': 'different-workspace',
+          'latest': {'items': <Object>[]},
+          'periods': {'items': <Object>[]},
+        },
+      },
+    ];
+
+    for (final earlyPayload in earlyPayloads) {
+      final runtime = AppFrontendRuntimeConfig(
+        apiBaseUrl: 'http://${server.address.host}:${server.port}',
+        correlationId: 'malformed-bootstrap-test',
+      ).createRuntimeOrNull()!;
+      final controller = AppRuntimeController(runtime);
+
+      await bootstrapAppSession(
+        controller,
+        earlyBootstrapReader: () async => earlyPayload,
+      );
+
+      expect(controller.runtime.session.userId, 'guest-1');
+      expect(controller.runtime.session.isRestoring, isFalse);
+      (runtime.generatedApiRuntime! as GeneratedApiRuntime).close(force: true);
+    }
+
+    expect(paths, ['/app/bootstrap', '/app/bootstrap']);
+    await server.close(force: true);
+  });
 
   test('falls back to session discovery during a split rollout', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
@@ -62,7 +145,10 @@ void main() {
     ).createRuntimeOrNull()!;
     final controller = AppRuntimeController(runtime);
 
-    await bootstrapAppSession(controller);
+    await bootstrapAppSession(
+      controller,
+      earlyBootstrapReader: () async => null,
+    );
 
     expect(paths, ['/app/bootstrap', '/auth/session']);
     expect(controller.runtime.session.userId, 'guest-1');

--- a/apps/frontend/app/test/composition/early_app_bootstrap_contract_test.dart
+++ b/apps/frontend/app/test/composition/early_app_bootstrap_contract_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('HTML starts a bounded no-store bootstrap before Flutter assets', () {
-    final html = File('web/index.html').readAsStringSync();
+    final html = File('app/web/index.html').readAsStringSync();
     final fetch = html.indexOf("fetch('/app/bootstrap'");
     final bridge = html.indexOf('window.socialMonitorAppBootstrap');
     final flutter = html.indexOf('flutter_bootstrap.js');

--- a/apps/frontend/app/test/composition/early_app_bootstrap_contract_test.dart
+++ b/apps/frontend/app/test/composition/early_app_bootstrap_contract_test.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('HTML starts a bounded no-store bootstrap before Flutter assets', () {
+    final html = File('web/index.html').readAsStringSync();
+    final fetch = html.indexOf("fetch('/app/bootstrap'");
+    final bridge = html.indexOf('window.socialMonitorAppBootstrap');
+    final flutter = html.indexOf('flutter_bootstrap.js');
+    final dartModule = html.indexOf('main.dart.mjs');
+    final dartWasm = html.indexOf('main.dart.wasm');
+
+    expect(fetch, greaterThanOrEqualTo(0));
+    expect(fetch, lessThan(dartModule));
+    expect(fetch, lessThan(dartWasm));
+    expect(bridge, greaterThanOrEqualTo(0));
+    expect(bridge, lessThan(flutter));
+    expect(html, contains("cache: 'no-store'"));
+    expect(html, contains("credentials: 'same-origin'"));
+    expect(html, contains('new AbortController()'));
+    expect(html, contains('signal: controller.signal'));
+    expect(html, contains('controller.abort()'));
+    expect(html, contains('}, 3000)'));
+    expect(html, isNot(contains('authorization')));
+    expect(html, contains('if (pendingResponse === null)'));
+    expect(html, contains('pendingResponse = null'));
+  });
+}

--- a/apps/frontend/app/web/index.html
+++ b/apps/frontend/app/web/index.html
@@ -20,6 +20,48 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="description" content="Social Monitor">
+  <script>
+    (function () {
+      var pendingResponse;
+
+      try {
+        var controller = new AbortController();
+        var request = fetch('/app/bootstrap', {
+          cache: 'no-store',
+          credentials: 'same-origin',
+          headers: { accept: 'application/json' },
+          signal: controller.signal
+        }).then(function (result) {
+          return result.ok ? result.text() : null;
+        }).catch(function () {
+          return null;
+        });
+        pendingResponse = new Promise(function (resolve) {
+          var timeout = setTimeout(function () {
+            controller.abort();
+            resolve(null);
+          }, 3000);
+          request.then(function (body) {
+            clearTimeout(timeout);
+            resolve(body);
+          });
+        });
+      } catch (_) {
+        pendingResponse = Promise.resolve(null);
+      }
+
+      window.socialMonitorAppBootstrap = Object.freeze({
+        take: function () {
+          if (pendingResponse === null) {
+            return Promise.resolve(null);
+          }
+          var response = pendingResponse;
+          pendingResponse = null;
+          return response;
+        }
+      });
+    }());
+  </script>
   <link rel="modulepreload" href="main.dart.mjs">
   <link rel="preload" href="main.dart.wasm" as="fetch" type="application/wasm" crossorigin="use-credentials">
   <link rel="preload" href="canvaskit/skwasm.wasm" as="fetch" type="application/wasm" crossorigin="use-credentials">

--- a/scripts/check-openapi.ts
+++ b/scripts/check-openapi.ts
@@ -132,6 +132,7 @@ import { RequestCorrelationIdFactory } from "@social-monitor/platform-request-co
 import "reflect-metadata";
 
 import { AppBootstrapController } from "../apps/api-gateway/src/app-bootstrap.controller";
+import { AppBootstrapReaderSummaryCache } from "../apps/api-gateway/src/app-bootstrap-reader-summary-cache";
 import { HealthController } from "../apps/api-gateway/src/health.controller";
 import { ApiGatewayHealthReporter } from "../apps/api-gateway/src/health-reporter";
 
@@ -212,6 +213,14 @@ const noopHealthReporter = {
 
 const noopDeliveryReadAuthorizer = {
   authorize: async () => undefined,
+};
+
+const passthroughAppBootstrapReaderSummaryCache = {
+  getOrLoad: async <T>(
+    _tenantId: string,
+    _workspaceId: string,
+    loader: () => Promise<T>,
+  ): Promise<T> => loader(),
 };
 
 const noopSocialResearchToolHandlers = {
@@ -408,6 +417,10 @@ const useCaseProviders = [
     {
       provide: ApiGatewayHealthReporter,
       useValue: noopHealthReporter,
+    },
+    {
+      provide: AppBootstrapReaderSummaryCache,
+      useValue: passthroughAppBootstrapReaderSummaryCache,
     },
   ],
 })

--- a/scripts/early-app-bootstrap-html.spec.ts
+++ b/scripts/early-app-bootstrap-html.spec.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+interface BootstrapFetchOptions {
+  readonly cache?: string;
+  readonly credentials?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly signal?: AbortSignal;
+}
+
+interface BootstrapFetchResponse {
+  readonly ok: boolean;
+  text(): Promise<string>;
+}
+
+interface BootstrapBridge {
+  take(): Promise<string | null>;
+}
+
+type BootstrapFetch = (
+  url: string,
+  options: BootstrapFetchOptions,
+) => Promise<BootstrapFetchResponse>;
+
+const html = readFileSync('apps/frontend/app/web/index.html', 'utf8');
+const bridgeMarker = html.indexOf('window.socialMonitorAppBootstrap');
+const scriptStart = html.lastIndexOf('<script>', bridgeMarker);
+const scriptEnd = html.indexOf('</script>', bridgeMarker);
+
+if (bridgeMarker < 0 || scriptStart < 0 || scriptEnd < 0) {
+  throw new Error('Early app bootstrap script is missing from web/index.html');
+}
+
+const bridgeScript = html.slice(scriptStart + '<script>'.length, scriptEnd);
+
+const executeBridge = (fetch: BootstrapFetch): BootstrapBridge => {
+  const browserWindow: { socialMonitorAppBootstrap?: BootstrapBridge } = {};
+  runInNewContext(bridgeScript, {
+    AbortController,
+    Promise,
+    clearTimeout,
+    fetch,
+    setTimeout,
+    window: browserWindow,
+  });
+  const bridge = browserWindow.socialMonitorAppBootstrap;
+  if (bridge === undefined) {
+    throw new Error('Early app bootstrap script did not publish its bridge');
+  }
+  return bridge;
+};
+
+describe('early app bootstrap HTML bridge', () => {
+  it('starts a no-store credentialed request immediately and consumes it once', async () => {
+    let resolveFetch!: (response: BootstrapFetchResponse) => void;
+    const fetch = jest.fn(
+      () =>
+        new Promise<BootstrapFetchResponse>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const bridge = executeBridge(fetch);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      '/app/bootstrap',
+      expect.objectContaining({
+        cache: 'no-store',
+        credentials: 'same-origin',
+        headers: { accept: 'application/json' },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+
+    const first = bridge.take();
+    await expect(bridge.take()).resolves.toBeNull();
+    resolveFetch({
+      ok: true,
+      text: async () => '{"session":{}}',
+    });
+    await expect(first).resolves.toBe('{"session":{}}');
+  });
+
+  it('aborts and resolves to fallback when fetch never settles', async () => {
+    jest.useFakeTimers();
+    try {
+      let signal: AbortSignal | undefined;
+      const bridge = executeBridge((_url, options) => {
+        signal = options.signal;
+        return new Promise<BootstrapFetchResponse>(() => undefined);
+      });
+
+      const response = bridge.take();
+      jest.advanceTimersByTime(3_000);
+
+      expect(signal?.aborted).toBe(true);
+      await expect(response).resolves.toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('turns non-2xx and rejected fetches into safe fallback values', async () => {
+    const text = jest.fn(async () => 'not used');
+    const nonOkBridge = executeBridge(async () => ({ ok: false, text }));
+    await expect(nonOkBridge.take()).resolves.toBeNull();
+    expect(text).not.toHaveBeenCalled();
+
+    const rejectedBridge = executeBridge(async () => {
+      throw new Error('network failed');
+    });
+    await expect(rejectedBridge.take()).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Starts /app/bootstrap during HTML parsing so it overlaps Flutter/WASM loading, then consumes the response once with a generated-client fallback.

- bounded 3s AbortController timeout and browser cache: no-store
- explicit private/no-store session-bearing HTTP response
- validates prefetched tenant/workspace scope before restoring state
- caches only published reader-summary bootstrap data for 30s
- cache is tenant/workspace/query scoped, max 128, single-flight, failure-safe
- session/auth is verified on every request and is never cached

Verification on hosted worker:
- 12/12 focused Jest tests passed
- git diff --check passed
- full TypeScript preflight is blocked by the existing missing generated Prisma client
- Flutter SDK is not installed on the old worker host, so Flutter and architecture gates are delegated to CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster app startup by prefetching bootstrap data while the web page loads.
  * Added resilient fallback to the standard API request when prefetched data is unavailable, invalid, or inconsistent.
  * Added short-term reuse of reader summary data across requests.

* **Bug Fixes**
  * Ensured authentication continues for every session, even when summary data is cached.
  * Added validation to prevent bootstrap data from being used with the wrong workspace or tenant.

* **Privacy**
  * Session-specific bootstrap responses are marked private and excluded from shared caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->