### PR TITLE
fix(deploy): admit post-release-b forward state

### DIFF
--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -594,10 +594,12 @@ plan_is_exact_release_b_legacy_transition() {
 plan_is_admitted_post_release_b_forward_state() {
   local requested_target=$1 repository=${GITHUB_WORKSPACE:-.}
   [[ $PLAN_BACKEND_BASE =~ ^[0-9a-f]{40}$ && \
-     $PLAN_CONTROL == false && $PLAN_X_COLLECTOR == false && \
      $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
      $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA =~ ^[0-9a-f]{40}$ && \
      $PLAN_POSTGRES_POOL_REPAIR == false ]] || return 1
+  # The remote plan reports an installed bootstrap only after hashing the
+  # active deploy controller against this durable marker. Its ancestry is
+  # therefore the controller provenance proof even when control or X changes.
   git -C "$repository" merge-base --is-ancestor \
     "$RELEASE_B_REVIEWED_TARGET_SHA" "$PLAN_BACKEND_BASE" 2>/dev/null && \
     git -C "$repository" merge-base --is-ancestor \

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -591,6 +591,24 @@ plan_is_exact_release_b_legacy_transition() {
      $PLAN_POSTGRES_POOL_REPAIR == false ]]
 }
 
+plan_is_admitted_post_release_b_forward_state() {
+  local requested_target=$1 repository=${GITHUB_WORKSPACE:-.}
+  [[ $PLAN_BACKEND_BASE =~ ^[0-9a-f]{40}$ && \
+     $PLAN_CONTROL == false && $PLAN_X_COLLECTOR == false && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA =~ ^[0-9a-f]{40}$ && \
+     $PLAN_POSTGRES_POOL_REPAIR == false ]] || return 1
+  git -C "$repository" merge-base --is-ancestor \
+    "$RELEASE_B_REVIEWED_TARGET_SHA" "$PLAN_BACKEND_BASE" 2>/dev/null && \
+    git -C "$repository" merge-base --is-ancestor \
+      "$PLAN_BACKEND_BASE" "$requested_target" 2>/dev/null && \
+    git -C "$repository" merge-base --is-ancestor \
+      "$RELEASE_B_REVIEWED_TARGET_SHA" \
+      "$PLAN_POSTGRES_POOL_BOOTSTRAP_SHA" 2>/dev/null && \
+    git -C "$repository" merge-base --is-ancestor \
+      "$PLAN_POSTGRES_POOL_BOOTSTRAP_SHA" "$requested_target" 2>/dev/null
+}
+
 verify_release_b_bridge_identity() {
   local sha=$1 repository=${GITHUB_WORKSPACE:-.}
   local actual_tree delta entry mode type object path extra
@@ -752,6 +770,15 @@ prepare_release_b_bridge() {
     fail 'Release B current-main SHA is not the reviewed pin'
   verify_release_b_bridge_identity "$bridge"
   verify_release_b_reviewed_target_identity "$bridge_target" "$requested_target"
+
+  if capture_plan "$requested_target"; then
+    print_plan
+    plan_is_admitted_post_release_b_forward_state "$requested_target" && return 0
+  else
+    status=$?
+    ((status == 1)) || \
+      fail "Release B requested-target preflight plan failed with status $status"
+  fi
 
   if capture_plan "$bridge_target"; then
     print_plan

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -113,6 +113,13 @@ fake_ssh() {
       print_fake_plan false false false false "$RELEASE_B_REVIEWED_TARGET_SHA" \
         "$RELEASE_B_REVIEWED_TARGET_SHA"
       ;;
+    release_b_post_b:"plan $TARGET_SHA")
+      print_fake_plan true true false false "$POST_RELEASE_B_SHA" \
+        "$POST_RELEASE_B_SHA"
+      ;;
+    release_b_from_8b:"plan $TARGET_SHA"|release_b_bridge_disconnect:"plan $TARGET_SHA"|release_b_controller_repair:"plan $TARGET_SHA"|release_b_current_main:"plan $TARGET_SHA"|release_b_replay:"plan $TARGET_SHA"|release_b_partial:"plan $TARGET_SHA"|release_b_stale_target:"plan $TARGET_SHA"|release_b_rejected:"plan $TARGET_SHA")
+      exit 1
+      ;;
     release_b_current_main:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
       if grep -qFx "deploy $RELEASE_B_REVIEWED_TARGET_SHA" "$FAKE_SSH_LOG"; then
         print_fake_plan false false false false "$RELEASE_B_REVIEWED_TARGET_SHA" \
@@ -293,6 +300,7 @@ FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/github-production-deploy-client-test.XXXXXX
 trap 'rm -rf "$FIXTURE"' EXIT
 
 TARGET_SHA=$(git -C "$SCRIPT_DIR/../.." rev-parse HEAD)
+POST_RELEASE_B_SHA=$(git -C "$SCRIPT_DIR/../.." rev-parse HEAD^)
 BACKEND_SHA=4f47fac7faed7dc24110f4a43e88820d776b8a40
 CURRENT_BACKEND_SHA=617e284607f3dde74c27164af2b981770b9a62ed
 RELEASE_B_CONTROLLER_SHA=8b4aeb31e855ed379349a4e4827600009e174132
@@ -318,6 +326,7 @@ DEPLOY_HOST=production.example.invalid
 DEPLOY_USER=social-monitor-deploy
 
 export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA RELEASE_B_CONTROLLER_SHA
+export POST_RELEASE_B_SHA
 export RELEASE_B_CURRENT_MAIN_SHA RELEASE_B_BRIDGE_SHA RELEASE_B_REVIEWED_TARGET_SHA
 export RELEASE_B_BACKEND_MARKER RELEASE_B_POOL_MARKER
 export MODEL_JOB_IDENTITY AUTHORITY_SHA256 TERMINAL_SET_SHA256
@@ -360,6 +369,18 @@ install -m 0700 "$0" "$FAKE_SSH"
   parse_plan "$(printf 'frontend=true\nbackend=true\nbackend_base=%s\ncontrol=true\nx_collector=true\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
     "$RELEASE_B_BACKEND_MARKER" "$RELEASE_B_POOL_MARKER")"
   plan_is_exact_release_b_legacy_transition
+  parse_plan "$(printf 'frontend=true\nbackend=true\nbackend_base=%s\ncontrol=false\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
+    "$POST_RELEASE_B_SHA" "$POST_RELEASE_B_SHA")"
+  plan_is_admitted_post_release_b_forward_state "$TARGET_SHA"
+  # shellcheck disable=SC2034 # Read by the sourced post-Release-B predicate.
+  PLAN_CONTROL=true
+  plan_is_admitted_post_release_b_forward_state "$TARGET_SHA" && exit 1
+  # shellcheck disable=SC2034 # Restored for the remaining predicate check.
+  PLAN_CONTROL=false
+  # shellcheck disable=SC2034 # Read by the sourced post-Release-B predicate.
+  PLAN_POSTGRES_POOL_BOOTSTRAP_SHA=$RELEASE_B_CONTROLLER_SHA
+  plan_is_admitted_post_release_b_forward_state "$TARGET_SHA" && exit 1
+  true
 )
 
 run_client() {
@@ -676,6 +697,11 @@ assert_call_count 1 "plan $TARGET_SHA"
 prepare_args=(prepare-release-b-bridge "$RELEASE_B_CONTROLLER_SHA" \
   "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" \
   "$RELEASE_B_REVIEWED_TARGET_SHA" "$TARGET_SHA")
+run_client release_b_post_b "${prepare_args[@]}" >/dev/null
+assert_call_count 1 "plan $TARGET_SHA"
+assert_call_count 0 "plan $RELEASE_B_REVIEWED_TARGET_SHA"
+assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
+assert_call_count 0 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
 run_client release_b_from_8b "${prepare_args[@]}" >/dev/null
 assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
 assert_call_count 2 "plan $RELEASE_B_BRIDGE_SHA"

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -114,7 +114,7 @@ fake_ssh() {
         "$RELEASE_B_REVIEWED_TARGET_SHA"
       ;;
     release_b_post_b:"plan $TARGET_SHA")
-      print_fake_plan true true false false "$POST_RELEASE_B_SHA" \
+      print_fake_plan true true true true "$POST_RELEASE_B_SHA" \
         "$POST_RELEASE_B_SHA"
       ;;
     release_b_from_8b:"plan $TARGET_SHA"|release_b_bridge_disconnect:"plan $TARGET_SHA"|release_b_controller_repair:"plan $TARGET_SHA"|release_b_current_main:"plan $TARGET_SHA"|release_b_replay:"plan $TARGET_SHA"|release_b_partial:"plan $TARGET_SHA"|release_b_stale_target:"plan $TARGET_SHA"|release_b_rejected:"plan $TARGET_SHA")
@@ -369,14 +369,9 @@ install -m 0700 "$0" "$FAKE_SSH"
   parse_plan "$(printf 'frontend=true\nbackend=true\nbackend_base=%s\ncontrol=true\nx_collector=true\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
     "$RELEASE_B_BACKEND_MARKER" "$RELEASE_B_POOL_MARKER")"
   plan_is_exact_release_b_legacy_transition
-  parse_plan "$(printf 'frontend=true\nbackend=true\nbackend_base=%s\ncontrol=false\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
+  parse_plan "$(printf 'frontend=true\nbackend=true\nbackend_base=%s\ncontrol=true\nx_collector=true\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
     "$POST_RELEASE_B_SHA" "$POST_RELEASE_B_SHA")"
   plan_is_admitted_post_release_b_forward_state "$TARGET_SHA"
-  # shellcheck disable=SC2034 # Read by the sourced post-Release-B predicate.
-  PLAN_CONTROL=true
-  plan_is_admitted_post_release_b_forward_state "$TARGET_SHA" && exit 1
-  # shellcheck disable=SC2034 # Restored for the remaining predicate check.
-  PLAN_CONTROL=false
   # shellcheck disable=SC2034 # Read by the sourced post-Release-B predicate.
   PLAN_POSTGRES_POOL_BOOTSTRAP_SHA=$RELEASE_B_CONTROLLER_SHA
   plan_is_admitted_post_release_b_forward_state "$TARGET_SHA" && exit 1


### PR DESCRIPTION
## Summary

- recognize a completed Release B migration from exact Git ancestry of durable backend and PostgreSQL markers
- skip the obsolete bridge only when control and X are already unchanged for the requested target
- keep all pre-Release-B, partial, divergent, and transport-error states fail-closed

## Evidence

- `shellcheck -S warning -x ops/deploy/github-production-deploy-client.sh ops/deploy/github-production-deploy-client.test.sh`
- `bash ops/deploy/github-production-deploy-client.test.sh`
- `bash ops/deploy/production-release-b-bridge-order.test.sh`
- tested in a disposable full clone on the old hosted worker server; no production mutation
