### PR TITLE
fix(deploy): make rescue cleanup replayable

### DIFF
--- a/ops/deploy/backend-image-rescue-lib.sh
+++ b/ops/deploy/backend-image-rescue-lib.sh
@@ -316,12 +316,13 @@ backend_image_rescue_remove_manifest_tag() {
   local pin_id pin_container_name status running restarting pin_image_id
   local project_label purpose_label extra
 
-  backend_image_rescue_remove_tag "$rescue_tag" && return 0
-  [[ $service == daily-runner ]] || return 1
-
-  current_rescue_id=$(backend_image_rescue_image_id "$rescue_tag") || return 1
+  if ! current_rescue_id=$(backend_image_rescue_image_id "$rescue_tag"); then
+    return 0
+  fi
   [[ $expected_image_id =~ ^sha256:[0-9a-f]{64}$ && \
      $current_rescue_id == "$expected_image_id" ]] || return 1
+  backend_image_rescue_remove_tag "$rescue_tag" && return 0
+  [[ $service == daily-runner ]] || return 1
 
   pin_name=${PROJECT}-daily-runner-image-pin
   pin_record=$(docker inspect "$pin_name" --format \
@@ -950,7 +951,7 @@ rollback_backend_and_runtime_control() {
 backend_image_rescue_cleanup() {
   local state_file=$1
   [[ -e $state_file || -L $state_file ]] || return 0
-  backend_image_rescue_validate "$state_file" || return 1
+  backend_image_rescue_validate_structure "$state_file" || return 1
   local record service policy source_kind source_ref image_id rescue_tag extra
   local phase_file
   local status=0
@@ -971,13 +972,14 @@ backend_image_rescue_reconcile_completed_state() {
   local backend_marker=$2
   local target phase
 
-  backend_image_rescue_validate "$state_file" || return 1
+  backend_image_rescue_validate_structure "$state_file" || return 1
   phase=$(backend_image_rescue_read_phase "$state_file") || return 1
   target=$(backend_image_rescue_manifest_target "$state_file") || return 1
   if [[ -n $backend_marker && $target == "$backend_marker" ]]; then
     backend_image_rescue_cleanup "$state_file" || return 1
     return 0
   fi
+  backend_image_rescue_validate "$state_file" || return 1
   case $phase in
     replacement-started)
       rollback_backend_images "$state_file" || return 1

--- a/ops/deploy/backend-image-rescue-lib.test.sh
+++ b/ops/deploy/backend-image-rescue-lib.test.sh
@@ -1024,6 +1024,18 @@ reconcile_completed_backend_image_rescues
 [[ ! -e $reconciled_state ]]
 assert_no_rescue_refs
 
+# The singleton deploy retry also completes cleanup when the exact tag was
+# already removed but the process died before deleting its ledger.
+reset_case reconcile-success-after-tag-removal
+reconciled_state=$(prepare_reconcile_state "$SHA" prepared reconciled-api)
+reconciled_tag=$(backend_image_rescue_tag "$SHA" api)
+docker image rm "$reconciled_tag" >/dev/null
+printf '%s\n' "$SHA" > "$STATE/backend.sha"
+reconcile_completed_backend_image_rescues
+[[ ! -e $reconciled_state ]]
+[[ ! -e $(backend_image_rescue_phase_file "$reconciled_state") ]]
+assert_no_rescue_refs
+
 # A completed different-release rescue whose replacement started is reconciled
 # through the normal backend rollback path before its exact tags are removed.
 reset_case reconcile-stale-replacement-started

--- a/ops/deploy/backend-image-rescue-pin-cleanup.test.sh
+++ b/ops/deploy/backend-image-rescue-pin-cleanup.test.sh
@@ -251,6 +251,18 @@ backend_image_rescue_cleanup "$success_state"
   fail 'cleanup replay called Docker'
 assert_unrelated_preserved
 
+# A release-success cleanup remains replayable when a prior process removed the
+# exact rescue tag but died before deleting the immutable ledger.
+reset_case
+write_manifest api "$IMAGE_A"
+interrupted_state=$MANIFEST_STATE_FILE
+interrupted_tag=$(backend_image_rescue_tag "$SHA" api)
+remove_ref "$interrupted_tag"
+backend_image_rescue_cleanup "$interrupted_state"
+[[ ! -e $interrupted_state ]] || \
+  fail 'interrupted cleanup retry retained the immutable ledger'
+assert_unrelated_preserved
+
 # The fallback is daily-runner-only. A conflicting API rescue does not inspect
 # or remove the retention pin.
 reset_case

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -139,6 +139,7 @@ assert_real_bridge_target_assets() {
         ;;
       ops/deploy/backend-image-rescue-lib.sh)
         expected_digest=68f13213e6d1662d943185df7cdd1c11678261e76977021f74493c4e6c643b59
+        alternate_digest=c8d363b8d64402ee77e42d62aac67ce9d4543135e328255557d2036c8ef3a398
         ;;
       ops/deploy/deploy-control-bridge-lib.sh)
         expected_digest=e6f958555966b77d02b85da8d0b9195e13a200dcb2b19c8afc010fab6d28b65d


### PR DESCRIPTION
## Summary
- make exact rescue-tag cleanup safe to replay after a process dies between tag removal and ledger deletion
- validate an existing tag identity before removing it
- let a committed backend release reconcile an already-removed rescue tag while preserving fail-closed rollback checks for other releases
- admit only the exact reviewed rescue-library digest through the sealed bridge asset test

## Production evidence
The 4f242ff deploy committed backend.sha and removed all exact rescue tags, then stopped because the remaining ledger could no longer pass full tag validation. The ledger was preserved in quarantine and the frontend-only retry completed successfully.

## Verification
- shellcheck backend-image-rescue-lib.sh
- backend-image-rescue-pin-cleanup.test.sh
- backend-image-rescue-lib.test.sh
- RabbitMQ quorum deploy bridge transition test body passes; the old-host admin rm guard blocks only its final temporary git-fixture cleanup, while CI uses the normal isolated runner cleanup path