### PR TITLE
perf(bootstrap): refresh published summaries in background

### DIFF
--- a/apps/api-gateway/src/app-bootstrap-reader-summary-cache.spec.ts
+++ b/apps/api-gateway/src/app-bootstrap-reader-summary-cache.spec.ts
@@ -28,7 +28,7 @@ const payload = (
 describe('AppBootstrapReaderSummaryCache', () => {
   it('uses tenant and workspace scope and expires with its injected clock', async () => {
     const clock = new MutableClock(1_000);
-    const cache = new AppBootstrapReaderSummaryCache(clock, 100, 10);
+    const cache = new AppBootstrapReaderSummaryCache(clock, 100, 1_000, 10);
     const loader = jest.fn(async (tenantId: string, workspaceId: string) =>
       payload(tenantId, workspaceId),
     );
@@ -48,13 +48,61 @@ describe('AppBootstrapReaderSummaryCache', () => {
     await cache.getOrLoad('tenant-1', 'workspace-1', () =>
       loader('tenant-1', 'workspace-1'),
     );
+    await Promise.resolve();
     expect(loader).toHaveBeenCalledTimes(3);
+  });
+
+  it('serves bounded stale data while a single refresh runs', async () => {
+    const clock = new MutableClock(1_000);
+    const cache = new AppBootstrapReaderSummaryCache(clock, 100, 1_000, 10);
+    const initial = payload('tenant-1', 'workspace-1');
+    const refreshed = payload('tenant-1', 'workspace-refreshed');
+    await cache.getOrLoad('tenant-1', 'workspace-1', async () => initial);
+    clock.advance(100);
+
+    let resolve!: (value: ReaderSummaryBootstrapResponseDto) => void;
+    const refresh = new Promise<ReaderSummaryBootstrapResponseDto>(
+      (complete) => {
+        resolve = complete;
+      },
+    );
+    const loader = jest.fn(() => refresh);
+
+    await expect(
+      cache.getOrLoad('tenant-1', 'workspace-1', loader),
+    ).resolves.toEqual(initial);
+    await expect(
+      cache.getOrLoad('tenant-1', 'workspace-1', loader),
+    ).resolves.toEqual(initial);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    resolve(refreshed);
+    await refresh;
+    await Promise.resolve();
+    await expect(
+      cache.getOrLoad('tenant-1', 'workspace-1', loader),
+    ).resolves.toEqual(refreshed);
+  });
+
+  it('blocks for a new value after the stale bound expires', async () => {
+    const clock = new MutableClock(1_000);
+    const cache = new AppBootstrapReaderSummaryCache(clock, 100, 1_000, 10);
+    await cache.getOrLoad('tenant-1', 'workspace-1', async () =>
+      payload('tenant-1', 'workspace-1'),
+    );
+    clock.advance(1_100);
+
+    const refreshed = payload('tenant-1', 'workspace-refreshed');
+    await expect(
+      cache.getOrLoad('tenant-1', 'workspace-1', async () => refreshed),
+    ).resolves.toEqual(refreshed);
   });
 
   it('collapses concurrent misses for the same fixed query identity', async () => {
     const cache = new AppBootstrapReaderSummaryCache(
       new MutableClock(1_000),
       100,
+      1_000,
       10,
     );
     let resolve!: (value: ReaderSummaryBootstrapResponseDto) => void;
@@ -80,6 +128,7 @@ describe('AppBootstrapReaderSummaryCache', () => {
     const cache = new AppBootstrapReaderSummaryCache(
       new MutableClock(1_000),
       100,
+      1_000,
       10,
     );
     const loader = jest.fn().mockRejectedValue(new Error('read failed'));
@@ -97,6 +146,7 @@ describe('AppBootstrapReaderSummaryCache', () => {
     const cache = new AppBootstrapReaderSummaryCache(
       new MutableClock(1_000),
       100,
+      1_000,
       1,
     );
     const loader = jest.fn(async (workspaceId: string) =>

--- a/apps/api-gateway/src/app-bootstrap-reader-summary-cache.ts
+++ b/apps/api-gateway/src/app-bootstrap-reader-summary-cache.ts
@@ -7,13 +7,15 @@ export const APP_BOOTSTRAP_READER_SUMMARY_CACHE_CLOCK = Symbol(
 );
 
 export const APP_BOOTSTRAP_READER_SUMMARY_CACHE_TTL_MS = 30_000;
+export const APP_BOOTSTRAP_READER_SUMMARY_CACHE_STALE_MS = 5 * 60_000;
 export const APP_BOOTSTRAP_READER_SUMMARY_CACHE_MAX_ENTRIES = 128;
 
 const PUBLISHED_READER_SUMMARY_QUERY_IDENTITY =
   'published:workspace:daily:utc:latest-1:periods-40';
 
 interface CacheEntry {
-  readonly expiresAtMs: number;
+  readonly freshUntilMs: number;
+  readonly staleUntilMs: number;
   readonly value: ReaderSummaryBootstrapResponseDto;
 }
 
@@ -27,11 +29,14 @@ export class AppBootstrapReaderSummaryCache {
   constructor(
     private readonly clock: Clock,
     private readonly ttlMs: number,
+    private readonly staleMs: number,
     private readonly maxEntries: number,
   ) {
     if (
       !Number.isSafeInteger(ttlMs) ||
       ttlMs <= 0 ||
+      !Number.isSafeInteger(staleMs) ||
+      staleMs <= 0 ||
       !Number.isSafeInteger(maxEntries) ||
       maxEntries <= 0
     ) {
@@ -51,13 +56,24 @@ export class AppBootstrapReaderSummaryCache {
     ]);
     const nowMs = this.clock.now().getTime();
     const cached = this.entries.get(key);
-    if (cached && cached.expiresAtMs > nowMs) {
+    if (cached && cached.freshUntilMs > nowMs) {
       return Promise.resolve(cached.value);
     }
-    if (cached) {
+    if (cached && cached.staleUntilMs > nowMs) {
+      void this.load(key, loader).catch(() => undefined);
+      return Promise.resolve(cached.value);
+    }
+    if (cached !== undefined) {
       this.entries.delete(key);
     }
 
+    return this.load(key, loader);
+  }
+
+  private load(
+    key: string,
+    loader: () => Promise<ReaderSummaryBootstrapResponseDto>,
+  ): Promise<ReaderSummaryBootstrapResponseDto> {
     const existingLoad = this.inFlight.get(key);
     if (existingLoad) {
       return existingLoad;
@@ -81,7 +97,7 @@ export class AppBootstrapReaderSummaryCache {
   private store(key: string, value: ReaderSummaryBootstrapResponseDto): void {
     const nowMs = this.clock.now().getTime();
     for (const [candidateKey, entry] of this.entries) {
-      if (entry.expiresAtMs <= nowMs) {
+      if (entry.staleUntilMs <= nowMs) {
         this.entries.delete(candidateKey);
       }
     }
@@ -92,6 +108,10 @@ export class AppBootstrapReaderSummaryCache {
       }
       this.entries.delete(oldestKey);
     }
-    this.entries.set(key, { value, expiresAtMs: nowMs + this.ttlMs });
+    this.entries.set(key, {
+      value,
+      freshUntilMs: nowMs + this.ttlMs,
+      staleUntilMs: nowMs + this.ttlMs + this.staleMs,
+    });
   }
 }

--- a/apps/api-gateway/src/app-bootstrap.controller.spec.ts
+++ b/apps/api-gateway/src/app-bootstrap.controller.spec.ts
@@ -26,6 +26,7 @@ describe('AppBootstrapController', () => {
     new AppBootstrapReaderSummaryCache(
       new FixedClock(new Date('2026-08-29T00:00:00.000Z')),
       30_000,
+      300_000,
       10,
     );
 

--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -19,6 +19,7 @@ import { AppBootstrapController } from './app-bootstrap.controller';
 import {
   APP_BOOTSTRAP_READER_SUMMARY_CACHE_CLOCK,
   APP_BOOTSTRAP_READER_SUMMARY_CACHE_MAX_ENTRIES,
+  APP_BOOTSTRAP_READER_SUMMARY_CACHE_STALE_MS,
   APP_BOOTSTRAP_READER_SUMMARY_CACHE_TTL_MS,
   AppBootstrapReaderSummaryCache,
 } from './app-bootstrap-reader-summary-cache';
@@ -65,6 +66,7 @@ import { SocialResearchApiModule } from './social-research-api.module';
         new AppBootstrapReaderSummaryCache(
           clock,
           APP_BOOTSTRAP_READER_SUMMARY_CACHE_TTL_MS,
+          APP_BOOTSTRAP_READER_SUMMARY_CACHE_STALE_MS,
           APP_BOOTSTRAP_READER_SUMMARY_CACHE_MAX_ENTRIES,
         ),
     },

--- a/apps/frontend/app/test/composition/early_app_bootstrap_contract_test.dart
+++ b/apps/frontend/app/test/composition/early_app_bootstrap_contract_test.dart
@@ -21,7 +21,7 @@ void main() {
     expect(html, contains('new AbortController()'));
     expect(html, contains('signal: controller.signal'));
     expect(html, contains('controller.abort()'));
-    expect(html, contains('}, 3000)'));
+    expect(html, contains('}, 12000)'));
     expect(html, isNot(contains('authorization')));
     expect(html, contains('if (pendingResponse === null)'));
     expect(html, contains('pendingResponse = null'));

--- a/apps/frontend/app/web/index.html
+++ b/apps/frontend/app/web/index.html
@@ -40,7 +40,7 @@
           var timeout = setTimeout(function () {
             controller.abort();
             resolve(null);
-          }, 3000);
+          }, 12000);
           request.then(function (body) {
             clearTimeout(timeout);
             resolve(body);

--- a/scripts/early-app-bootstrap-html.spec.ts
+++ b/scripts/early-app-bootstrap-html.spec.ts
@@ -92,7 +92,7 @@ describe('early app bootstrap HTML bridge', () => {
       });
 
       const response = bridge.take();
-      jest.advanceTimersByTime(3_000);
+      jest.advanceTimersByTime(12_000);
 
       expect(signal?.aborted).toBe(true);
       await expect(response).resolves.toBeNull();


### PR DESCRIPTION
## Summary
- serve the last published reader-summary immediately after the 30-second fresh window
- refresh the scoped cache once in the background with single-flight deduplication
- bound stale serving to five minutes, then block for authoritative data
- keep the HTML preload alive for 12 seconds so a loaded host does not abort it and issue a duplicate bootstrap request
- preserve tenant/workspace isolation, max-entry bounds and no-store response headers

## Production motivation
After the initial cache deployment, warm bootstrap requests took 0.32-0.77s, while the first request after TTL expiry took 6.84s. Chrome proved the 3-second HTML timeout aborted the preload and Flutter retried it, delaying data until 10.39s. This keeps refresh off the first-user path and preserves the single early request without making stale data or the preload unbounded.

## Verification
- 11/11 focused cache and controller tests pass
- production TypeScript build passes
- focused Flutter HTML bootstrap contract test passes