### PR TITLE
fix(deploy): accept specialized daily runner bases

### DIFF
--- a/ops/deploy/daily-runner-image-bootstrap-lib.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.sh
@@ -8,7 +8,9 @@ DAILY_RUNNER_BOOTSTRAP_MAX_ARCHIVE_MEMBERS=20000
 DAILY_RUNNER_BOOTSTRAP_MAX_EXPANDED_BYTES=1073741824
 # The dollar expression is part of the reviewed image command JSON.
 # shellcheck disable=SC2016
-DAILY_RUNNER_BOOTSTRAP_IMAGE_CONFIG='["docker-entrypoint.sh"]|["sh","-c","case \"$SERVICE\" in api) exec node dist/apps/api-gateway/src/main.js ;; agent-runtime) exec node dist/apps/agent-runtime/src/main.js ;; ingestion) exec node dist/apps/ingestion-worker/src/main.js ;; intelligence) exec node dist/apps/intelligence-worker/src/main.js ;; delivery) exec node dist/apps/delivery-service/src/main.js ;; event-relay) exec node dist/apps/event-relay/src/main.js ;; *) echo \"Unknown service: $SERVICE\" >&2; exit 64 ;; esac"]|"/app"|"node"|null'
+DAILY_RUNNER_BOOTSTRAP_LEGACY_IMAGE_CONFIG='["docker-entrypoint.sh"]|["sh","-c","case \"$SERVICE\" in api) exec node dist/apps/api-gateway/src/main.js ;; agent-runtime) exec node dist/apps/agent-runtime/src/main.js ;; ingestion) exec node dist/apps/ingestion-worker/src/main.js ;; intelligence) exec node dist/apps/intelligence-worker/src/main.js ;; delivery) exec node dist/apps/delivery-service/src/main.js ;; event-relay) exec node dist/apps/event-relay/src/main.js ;; *) echo \"Unknown service: $SERVICE\" >&2; exit 64 ;; esac"]|"/app"|"node"|null'
+DAILY_RUNNER_BOOTSTRAP_API_IMAGE_CONFIG='["/usr/local/bin/docker-entrypoint.sh"]|["/usr/local/bin/node","dist/apps/api-gateway/src/main.js"]|"/app"|"node"|null'
+DAILY_RUNNER_BOOTSTRAP_INTELLIGENCE_IMAGE_CONFIG='["/usr/local/bin/docker-entrypoint.sh"]|["/usr/local/bin/node","dist/apps/intelligence-worker/src/main.js"]|"/app"|"node"|null'
 if [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} == 1 ]]; then
   DAILY_RUNNER_BOOTSTRAP_TMP_ROOT=${SOCIAL_MONITOR_DAILY_RUNNER_BOOTSTRAP_TMP_ROOT:-/tmp}
 else
@@ -29,6 +31,24 @@ daily_runner_bootstrap_read_exact_sha() {
   } < "$path" || fail "$description is not exactly one line"
   [[ $value =~ ^[0-9a-f]{40}$ ]] || fail "$description is not a full SHA"
   printf '%s\n' "$value"
+}
+
+daily_runner_bootstrap_image_config_allowed() {
+  local config=$1
+  local service=$2
+
+  [[ $config == "$DAILY_RUNNER_BOOTSTRAP_LEGACY_IMAGE_CONFIG" ]] && return 0
+  case $service in
+    api)
+      [[ $config == "$DAILY_RUNNER_BOOTSTRAP_API_IMAGE_CONFIG" ]]
+      ;;
+    intelligence-worker)
+      [[ $config == "$DAILY_RUNNER_BOOTSTRAP_INTELLIGENCE_IMAGE_CONFIG" ]]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 daily_runner_bootstrap_verify_runtime_marker() {
@@ -281,7 +301,7 @@ daily_runner_bootstrap_base_image_id() {
   fi
   config=$(backend_image_rescue_image_config "$image_id") || \
     fail 'daily-runner base image config cannot be inspected'
-  [[ $config == "$DAILY_RUNNER_BOOTSTRAP_IMAGE_CONFIG" ]] || \
+  daily_runner_bootstrap_image_config_allowed "$config" "$base_service" || \
     fail 'daily-runner base image config is unexpected'
   printf '%s\n' "$image_id"
 }
@@ -371,7 +391,7 @@ daily_runner_image_bootstrap_before_rescue() (
   local previous_sha=$1
   local target_sha=$2
   local compose_tag state_file partial phase manifest_target
-  local dockerfile_digest dockerfile_digest_after base_id base_id_after
+  local dockerfile_digest dockerfile_digest_after base_config base_id base_id_after
   local workdir='' archive='' context='' temporary_tag='' candidate_id=''
   local base_alias_tag=''
   local identity config singleton_fd revision extra
@@ -467,6 +487,8 @@ daily_runner_image_bootstrap_before_rescue() (
     fail 'daily-runner Dockerfile could not be validated'
   base_id=$(daily_runner_bootstrap_base_image_id "$previous_sha") || \
     fail 'daily-runner base image could not be validated'
+  base_config=$(backend_image_rescue_image_config "$base_id") || \
+    fail 'daily-runner base image config cannot be re-inspected'
   base_alias_tag=$(compose_image_name intelligence-worker)
   [[ $base_alias_tag == social-monitor-prod-intelligence-worker:latest ]] || \
     fail 'daily-runner build base alias is unexpected'
@@ -500,7 +522,7 @@ daily_runner_image_bootstrap_before_rescue() (
     fail 'historical daily-runner image identity is unexpected'
   config=$(backend_image_rescue_image_config "$temporary_tag") || \
     fail 'historical daily-runner image config cannot be inspected'
-  [[ $config == "$DAILY_RUNNER_BOOTSTRAP_IMAGE_CONFIG" ]] || \
+  [[ $config == "$base_config" ]] || \
     fail 'historical daily-runner image config is unexpected'
   if [[ $base_alias_created == true ]]; then
     daily_runner_bootstrap_remove_tag "$base_alias_tag" "$base_id" || \

--- a/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
@@ -327,7 +327,7 @@ docker() {
 # shellcheck source=ops/deploy/daily-runner-image-bootstrap-lib.sh
 source "$LIBRARY"
 assert_compose_sentinel_fails_fast
-EXPECTED_CONFIG=$DAILY_RUNNER_BOOTSTRAP_IMAGE_CONFIG
+EXPECTED_CONFIG=$DAILY_RUNNER_BOOTSTRAP_LEGACY_IMAGE_CONFIG
 BASE_TAG=$(compose_image_name intelligence-worker)
 FALLBACK_BASE_TAG=$(compose_image_name api)
 COMPOSE_TAG=$(compose_image_name daily-runner)
@@ -612,6 +612,15 @@ assert_events_exclude $'docker\tcontainer ls'
 assert_events_exclude $'docker\tinspect'
 assert_events_exclude $'config-id\tsocial-monitor-prod-intelligence-worker:latest'
 
+# Current releases use dedicated service entrypoints rather than the legacy
+# SERVICE switch. The rebuilt daily-runner must inherit that exact base config.
+reset_case
+BASE_CONFIG=$DAILY_RUNNER_BOOTSTRAP_INTELLIGENCE_IMAGE_CONFIG
+BUILT_CONFIG=$BASE_CONFIG
+daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"
+[[ $(lookup_id "$COMPOSE_TAG") == "$CANDIDATE_ID" ]]
+assert_no_temporary_state
+
 # A missing intelligence-worker tag falls back to the same reviewed runtime
 # image contract under the always-on API service. This is the production
 # recovery path when an interrupted backend replacement removed only the
@@ -619,6 +628,7 @@ assert_events_exclude $'config-id\tsocial-monitor-prod-intelligence-worker:lates
 reset_case
 remove_ref "$BASE_TAG"
 set_ref "$FALLBACK_BASE_TAG" "$BASE_ID" "$PREVIOUS_SHA"
+BASE_CONFIG=$DAILY_RUNNER_BOOTSTRAP_API_IMAGE_CONFIG
 [[ $(daily_runner_bootstrap_base_image_id "$PREVIOUS_SHA") == "$BASE_ID" ]]
 grep -F $'docker\timage inspect social-monitor-prod-intelligence-worker:latest' \
   "$EVENTS" >/dev/null
@@ -629,6 +639,8 @@ assert_events_exclude $'config-id\tsocial-monitor-prod-api:latest'
 reset_case
 remove_ref "$BASE_TAG"
 set_ref "$FALLBACK_BASE_TAG" "$BASE_ID" ''
+BASE_CONFIG=$DAILY_RUNNER_BOOTSTRAP_API_IMAGE_CONFIG
+BUILT_CONFIG=$BASE_CONFIG
 configure_legacy_runtime_stable
 LEGACY_RUNTIME_SERVICE=api
 daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"
@@ -641,6 +653,8 @@ assert_no_temporary_state
 reset_case
 remove_ref "$BASE_TAG"
 set_ref "$FALLBACK_BASE_TAG" "$BASE_ID" "$PREVIOUS_SHA"
+BASE_CONFIG=$DAILY_RUNNER_BOOTSTRAP_API_IMAGE_CONFIG
+BUILT_CONFIG=$BASE_CONFIG
 BUILD_FAILURE=true
 assert_fails_with 'historical daily-runner image build failed' \
   daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"

--- a/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
@@ -762,13 +762,13 @@ for legacy_state in status running paused restarting dead oom-killed error \
   assert_events_exclude $'config-id\t'
 done
 
-# Configuration must be inspected by the immutable ID before and after the
-# historical build, never through the mutable Compose tag.
+# Configuration must be inspected by immutable ID for admission, exact
+# inheritance, and post-build revalidation, never through the mutable tag.
 reset_case
 configure_unlabelled_base
 daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"
 [[ $(lookup_id "$COMPOSE_TAG") == "$CANDIDATE_ID" ]]
-[[ $(grep -cF -- $'config-id\t'"$BASE_ID" "$EVENTS") == 2 ]]
+[[ $(grep -cF -- $'config-id\t'"$BASE_ID" "$EVENTS") == 3 ]]
 assert_events_exclude $'config-id\tsocial-monitor-prod-intelligence-worker:latest'
 
 # Archive traversal and symlink entries never reach Docker.


### PR DESCRIPTION
Fixes the production Release B bridge after backend images moved from the legacy SERVICE switch to dedicated API/intelligence entrypoints. The bootstrap now admits only the exact reviewed legacy or service-specific image configs and requires the rebuilt daily-runner to inherit the exact validated base config.\n\nEvidence:\n- focused daily-runner bootstrap suite running on the old hosted test workspace\n- local syntax/diff checks pass (macOS lacks flock for the Linux fixture)