### PR TITLE
fix(deploy): revalidate daily runner base after build

### DIFF
--- a/ops/deploy/daily-runner-image-bootstrap-lib.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.sh
@@ -392,6 +392,7 @@ daily_runner_image_bootstrap_before_rescue() (
   local target_sha=$2
   local compose_tag state_file partial phase manifest_target
   local dockerfile_digest dockerfile_digest_after base_config base_id base_id_after
+  local base_config_after_build
   local workdir='' archive='' context='' temporary_tag='' candidate_id=''
   local base_alias_tag=''
   local identity config singleton_fd revision extra
@@ -522,7 +523,11 @@ daily_runner_image_bootstrap_before_rescue() (
     fail 'historical daily-runner image identity is unexpected'
   config=$(backend_image_rescue_image_config "$temporary_tag") || \
     fail 'historical daily-runner image config cannot be inspected'
-  [[ $config == "$base_config" ]] || \
+  base_config_after_build=$(backend_image_rescue_image_config "$base_id") || \
+    fail 'daily-runner base image config cannot be re-inspected after build'
+  [[ $base_config_after_build == "$base_config" ]] || \
+    fail 'daily-runner base image config changed during historical build'
+  [[ $config == "$base_config_after_build" ]] || \
     fail 'historical daily-runner image config is unexpected'
   if [[ $base_alias_created == true ]]; then
     daily_runner_bootstrap_remove_tag "$base_alias_tag" "$base_id" || \

--- a/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
@@ -762,13 +762,13 @@ for legacy_state in status running paused restarting dead oom-killed error \
   assert_events_exclude $'config-id\t'
 done
 
-# Configuration must be inspected by immutable ID for admission, exact
-# inheritance, and post-build revalidation, never through the mutable tag.
+# Configuration must be inspected by immutable ID for admission, immediately
+# around exact inheritance, and post-build revalidation, never by mutable tag.
 reset_case
 configure_unlabelled_base
 daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"
 [[ $(lookup_id "$COMPOSE_TAG") == "$CANDIDATE_ID" ]]
-[[ $(grep -cF -- $'config-id\t'"$BASE_ID" "$EVENTS") == 3 ]]
+[[ $(grep -cF -- $'config-id\t'"$BASE_ID" "$EVENTS") == 4 ]]
 assert_events_exclude $'config-id\tsocial-monitor-prod-intelligence-worker:latest'
 
 # Archive traversal and symlink entries never reach Docker.


### PR DESCRIPTION
Re-inspects the immutable base image immediately after the historical daily-runner build, proves its config did not change during the build, and compares the candidate only to that fresh immutable evidence. This removes dependence on an earlier shell value while keeping exact fail-closed config inheritance.\n\nThe previous merged allowlist and hosted Linux fixture remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation during image builds by detecting changes to the base image configuration.
  * Ensured built images are compared against the verified post-build base configuration.
  * Strengthened compatibility checks for unlabelled base images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->