### PR TITLE
fix(deploy): make daily runner image deterministic

### DIFF
--- a/ops/deploy/daily-runner-image-bootstrap-lib.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.sh
@@ -507,7 +507,7 @@ daily_runner_image_bootstrap_before_rescue() (
     fail 'historical daily-runner archive validation failed'
 
   temporary_owned=true
-  docker build --pull=false \
+  docker build --pull=false --provenance=false \
     --file "$CONTROL/daily-runner.Dockerfile" \
     --label "org.opencontainers.image.revision=$previous_sha" \
     --tag "$temporary_tag" \

--- a/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
@@ -165,7 +165,7 @@ assert_compose_sentinel_fails_fast() {
 
 docker() {
   local source destination image_id revision
-  local tag='' label='' context='' argument=''
+  local tag='' label='' context='' argument='' provenance=''
   printf 'docker\t%s\n' "$*" >> "$EVENTS"
   case ${1:-}:${2:-} in
     container:ls)
@@ -249,6 +249,7 @@ docker() {
         shift
         case $argument in
           --pull=false) ;;
+          --provenance=false) provenance=false ;;
           --file)
             [[ ${1:-} == "$CONTROL/daily-runner.Dockerfile" ]]
             shift
@@ -265,6 +266,7 @@ docker() {
         esac
       done
       [[ $label == "org.opencontainers.image.revision=$PREVIOUS_SHA" ]]
+      [[ $provenance == false ]]
       [[ -f $context/release-content.txt ]]
       [[ $(<"$context/release-content.txt") == historical ]]
       [[ ! -e $context/target-only.txt && ! -L $context/target-only.txt ]]


### PR DESCRIPTION
## What

- disable BuildKit provenance only for the local historical daily-runner recovery image
- keep exact inherited Entrypoint/Cmd/WorkingDir/User/Healthcheck validation
- assert the deterministic build flag in the recovery fixture

## Production evidence

The default build exported an attestation manifest list despite identical inherited runtime config. The same exact historical build with `--provenance=false` produced one ordinary image ID and preserved the exact reviewed config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated historical daily-runner image builds to disable Docker provenance generation while preserving existing build behavior.
  * Added validation to ensure the required provenance setting is applied during image build checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->