### PR TITLE
fix(deploy): retry daily runner config settle

### DIFF
--- a/ops/deploy/daily-runner-image-bootstrap-lib.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.sh
@@ -6,6 +6,7 @@
 DAILY_RUNNER_BOOTSTRAP_DOCKERFILE_SHA256=8ec51a5215f00c9b7c09a664ed908c4358698974cd864fbeeddf90b91110fd93
 DAILY_RUNNER_BOOTSTRAP_MAX_ARCHIVE_MEMBERS=20000
 DAILY_RUNNER_BOOTSTRAP_MAX_EXPANDED_BYTES=1073741824
+DAILY_RUNNER_BOOTSTRAP_CONFIG_INSPECT_ATTEMPTS=5
 # The dollar expression is part of the reviewed image command JSON.
 # shellcheck disable=SC2016
 DAILY_RUNNER_BOOTSTRAP_LEGACY_IMAGE_CONFIG='["docker-entrypoint.sh"]|["sh","-c","case \"$SERVICE\" in api) exec node dist/apps/api-gateway/src/main.js ;; agent-runtime) exec node dist/apps/agent-runtime/src/main.js ;; ingestion) exec node dist/apps/ingestion-worker/src/main.js ;; intelligence) exec node dist/apps/intelligence-worker/src/main.js ;; delivery) exec node dist/apps/delivery-service/src/main.js ;; event-relay) exec node dist/apps/event-relay/src/main.js ;; *) echo \"Unknown service: $SERVICE\" >&2; exit 64 ;; esac"]|"/app"|"node"|null'
@@ -393,6 +394,7 @@ daily_runner_image_bootstrap_before_rescue() (
   local compose_tag state_file partial phase manifest_target
   local dockerfile_digest dockerfile_digest_after base_config base_id base_id_after
   local base_config_after_build
+  local config_attempt
   local workdir='' archive='' context='' temporary_tag='' candidate_id=''
   local base_alias_tag=''
   local identity config singleton_fd revision extra
@@ -507,7 +509,8 @@ daily_runner_image_bootstrap_before_rescue() (
     fail 'historical daily-runner archive validation failed'
 
   temporary_owned=true
-  docker build --pull=false --provenance=false \
+  BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker build \
+    --pull=false --provenance=false \
     --file "$CONTROL/daily-runner.Dockerfile" \
     --label "org.opencontainers.image.revision=$previous_sha" \
     --tag "$temporary_tag" \
@@ -521,12 +524,19 @@ daily_runner_image_bootstrap_before_rescue() (
   [[ $candidate_id =~ ^sha256:[0-9a-f]{64}$ && \
      $revision == "$previous_sha" && -z $extra ]] || \
     fail 'historical daily-runner image identity is unexpected'
-  config=$(backend_image_rescue_image_config "$temporary_tag") || \
-    fail 'historical daily-runner image config cannot be inspected'
-  base_config_after_build=$(backend_image_rescue_image_config "$base_id") || \
-    fail 'daily-runner base image config cannot be re-inspected after build'
-  [[ $base_config_after_build == "$base_config" ]] || \
-    fail 'daily-runner base image config changed during historical build'
+  for ((config_attempt = 1;
+        config_attempt <= DAILY_RUNNER_BOOTSTRAP_CONFIG_INSPECT_ATTEMPTS;
+        config_attempt += 1)); do
+    config=$(backend_image_rescue_image_config "$temporary_tag") || \
+      fail 'historical daily-runner image config cannot be inspected'
+    base_config_after_build=$(backend_image_rescue_image_config "$base_id") || \
+      fail 'daily-runner base image config cannot be re-inspected after build'
+    [[ $base_config_after_build == "$base_config" ]] || \
+      fail 'daily-runner base image config changed during historical build'
+    [[ $config != "$base_config_after_build" ]] || break
+    ((config_attempt < DAILY_RUNNER_BOOTSTRAP_CONFIG_INSPECT_ATTEMPTS)) || break
+    sleep 1 || fail 'daily-runner image config settle wait failed'
+  done
   [[ $config == "$base_config_after_build" ]] || \
     fail 'historical daily-runner image config is unexpected'
   if [[ $base_alias_created == true ]]; then

--- a/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
@@ -124,7 +124,7 @@ backend_image_rescue_image_id() {
 }
 
 backend_image_rescue_image_config() {
-  local image=$1
+  local image=$1 read_count
 
   printf 'config-id\t%s\n' "$image" >> "$EVENTS"
   case $image in
@@ -139,9 +139,18 @@ backend_image_rescue_image_config() {
       ;;
     *)
       [[ -n $(lookup_id "$image") ]] || return 1
-      printf '%s\n' "$BUILT_CONFIG"
+      read_count=$(grep -Fc $'config-id\t'"$image" "$EVENTS")
+      if ((read_count <= BUILT_CONFIG_UNSTABLE_READS)); then
+        printf '%s\n' "$BUILT_CONFIG_TRANSIENT"
+      else
+        printf '%s\n' "$BUILT_CONFIG"
+      fi
       ;;
   esac
+}
+
+sleep() {
+  printf 'sleep\t%s\n' "$*" >> "$EVENTS"
 }
 
 fake_compose() {
@@ -242,6 +251,7 @@ docker() {
         "$LEGACY_RUNTIME_CONTAINER_NUMBER"
       ;;
     build:*)
+      [[ ${BUILDX_NO_DEFAULT_ATTESTATIONS:-} == 1 ]] || return 73
       [[ -n $(lookup_id "$BASE_TAG") ]] || return 72
       shift
       while (($# > 0)); do
@@ -359,6 +369,8 @@ reset_case() {
   BASE_TAG_CONFIG='["must-not-use"]|["config"]|"/app"|"node"|null'
   MUTATED_BASE_CONFIG=$EXPECTED_CONFIG
   BUILT_CONFIG=$EXPECTED_CONFIG
+  BUILT_CONFIG_TRANSIENT='["transient"]|["config"]|"/app"|"node"|null'
+  BUILT_CONFIG_UNSTABLE_READS=0
   BUILT_IMAGE_ID=$CANDIDATE_ID
   BUILT_REVISION_OVERRIDE=
   : > "$CONTAINERS"
@@ -831,6 +843,13 @@ BUILT_CONFIG='["unexpected"]|["config"]|"/app"|"node"|null'
 assert_fails_with 'historical daily-runner image config is unexpected' \
   daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"
 [[ -z $(lookup_id "$COMPOSE_TAG") ]]
+assert_no_temporary_state
+
+reset_case
+BUILT_CONFIG_UNSTABLE_READS=1
+daily_runner_image_bootstrap_before_rescue "$PREVIOUS_SHA" "$TARGET_SHA"
+[[ $(lookup_id "$COMPOSE_TAG") == "$CANDIDATE_ID" ]]
+[[ $(grep -Fc $'sleep\t1' "$EVENTS") == 1 ]]
 assert_no_temporary_state
 
 reset_case


### PR DESCRIPTION
## What

- force BuildKit default attestations off for the temporary historical recovery image
- retry only immutable image config inspection for up to five seconds
- retain exact equality with the re-inspected base config
- cover one transient mismatch followed by a stable exact match

## Why

Production exported an attestation manifest list even with the CLI provenance flag and returned a transient config mismatch immediately after unpack. The recovery gate remains fail-closed after the bounded settle window.