### PR TITLE
fix(deploy): force daily runner image load

### DIFF
--- a/ops/deploy/daily-runner-image-bootstrap-lib.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.sh
@@ -510,7 +510,7 @@ daily_runner_image_bootstrap_before_rescue() (
 
   temporary_owned=true
   BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker build \
-    --pull=false --provenance=false \
+    --pull=false --provenance=false --load \
     --file "$CONTROL/daily-runner.Dockerfile" \
     --label "org.opencontainers.image.revision=$previous_sha" \
     --tag "$temporary_tag" \

--- a/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
+++ b/ops/deploy/daily-runner-image-bootstrap-lib.test.sh
@@ -174,7 +174,7 @@ assert_compose_sentinel_fails_fast() {
 
 docker() {
   local source destination image_id revision
-  local tag='' label='' context='' argument='' provenance=''
+  local tag='' label='' context='' argument='' provenance='' loaded=false
   printf 'docker\t%s\n' "$*" >> "$EVENTS"
   case ${1:-}:${2:-} in
     container:ls)
@@ -260,6 +260,7 @@ docker() {
         case $argument in
           --pull=false) ;;
           --provenance=false) provenance=false ;;
+          --load) loaded=true ;;
           --file)
             [[ ${1:-} == "$CONTROL/daily-runner.Dockerfile" ]]
             shift
@@ -277,6 +278,7 @@ docker() {
       done
       [[ $label == "org.opencontainers.image.revision=$PREVIOUS_SHA" ]]
       [[ $provenance == false ]]
+      [[ $loaded == true ]]
       [[ -f $context/release-content.txt ]]
       [[ $(<"$context/release-content.txt") == historical ]]
       [[ ! -e $context/target-only.txt && ! -L $context/target-only.txt ]]


### PR DESCRIPTION
## Что исправлено

- принудительно загружает rebuilt daily-runner как single Docker image через `--load`
- сохраняет `--provenance=false` и строгую побайтовую проверку runtime config
- fixture теперь fail-closed проверяет обязательный explicit load

## Причина

На production restricted deploy BuildKit экспортировал OCI manifest, после чего tag inspection стабильно не совпадал с base config. Ручной single-image probe показал корректный config. Explicit load устраняет неоднозначный output path без ослабления gate.

## Проверка

- `git diff --check`
- hosted exact Bash fixtures на старом хосте запущены параллельно
- PR CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily runner image builds so newly built images are available locally for inspection and tagging.
  * Added validation to ensure the image build process uses the required local loading option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->