### PR TITLE
test(deploy): align bounded repair contract

### DIFF
--- a/ops/deploy/daily-c1-control-bridge-workflow.test.sh
+++ b/ops/deploy/daily-c1-control-bridge-workflow.test.sh
@@ -111,7 +111,7 @@ grep -F 'transition_state=repair-required' "$workflow" >/dev/null || \
   fail 'bridge cannot schedule bounded repair for a missing PostgreSQL bootstrap'
 grep -F 'daily_c1_atomic_repair=61018b1d' "$workflow" >/dev/null || \
   fail 'bridge does not pin the descendant atomic PostgreSQL repair commit'
-grep -F 'backend-gate=postgres-pool-release deferred-to-bounded-B2-repair' \
+grep -F 'backend-gate=postgres-pool-release deferred-to-bounded-repair' \
   "$workflow" >/dev/null || fail 'bridge CI blocks the reviewed bounded bootstrap repair'
 grep -F 'shellcheck -S warning -x "${deploy_shell_files[@]}"' \
   "$workflow" >/dev/null || fail 'workflow treats informational shellcheck findings as release failures'


### PR DESCRIPTION
## Summary
- align the stale daily C1 bridge assertion with the canonical bounded-repair event emitted since 43a6219a
- restore the production deploy CI contract without changing runtime behavior

## Evidence
- bash ops/deploy/daily-c1-control-bridge-workflow.test.sh
- npm run check:review-ci
- npm run check:source-line-cap
- git diff --check github/main..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated deployment workflow validation to reflect the renamed bounded repair label.
  * Confirmed the backend gate uses the current workflow terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->