### PR TITLE
fix(deploy): scope entrypoint lint baseline

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -491,7 +491,6 @@ jobs:
             done
           fi
           deploy_shell_files=(
-            ops/deploy/social-monitor-production-deploy.sh
             ops/deploy/backend-runtime-health-lib.sh
             ops/deploy/backend-runtime-health-lib.test.sh
             ops/deploy/otel-collector-deploy-lifecycle.test.sh
@@ -563,7 +562,28 @@ jobs:
           if [[ $bridge_phase == false ]]; then
             deploy_shell_files+=("${final_publication_shell_files[@]}")
           fi
-          bash -n "${deploy_shell_files[@]}"
+          bash -n ops/deploy/social-monitor-production-deploy.sh \
+            "${deploy_shell_files[@]}"
+          entrypoint_shellcheck=$(
+            shellcheck -S warning -f json -x \
+              ops/deploy/social-monitor-production-deploy.sh || true
+          )
+          ENTRYPOINT_SHELLCHECK=$entrypoint_shellcheck node <<'NODE'
+          const findings = JSON.parse(process.env.ENTRYPOINT_SHELLCHECK ?? "[]");
+          const expected = new Set([
+            "42:2034:PUBLIC_LINK",
+            "43:2034:ADMIN_LINK",
+          ]);
+          const actual = new Set(findings.map((finding) =>
+            `${finding.line}:${finding.code}:${String(finding.message).split(" ", 1)[0]}`));
+          if (findings.length !== expected.size || actual.size !== expected.size ||
+              [...expected].some((finding) => !actual.has(finding))) {
+            console.error("production entrypoint ShellCheck baseline diverged", findings);
+            process.exit(1);
+          }
+          NODE
+          shellcheck -S warning -x -e SC2034 \
+            ops/deploy/social-monitor-production-deploy.sh
           shellcheck -S warning -x "${deploy_shell_files[@]}"
           python3 -m py_compile ops/deploy/verify-postgres-runtime-topology.py
           python3 -m py_compile ops/deploy/verify-postgres-pool-release-contract.py

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -39,6 +39,8 @@ OTEL_COLLECTOR_IMAGE=$PINNED_OTEL_COLLECTOR_IMAGE
 OTEL_COLLECTOR_CONFIG_PATH=$REPO/ops/observability/otel-collector.yml
 export OTEL_COLLECTOR_IMAGE OTEL_COLLECTOR_CONFIG_PATH
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
+PUBLIC_LINK=$ROOT/runtime/frontend-public-web
+ADMIN_LINK=$ROOT/runtime/frontend-admin-web
 DEPLOY_LOCK=$CONTROL/production-deploy.lock
 # Deployment, the control-owned daily runner, and every manual production DB
 # command use this admission lock. Daily separately owns a singleton lock so it

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -39,8 +39,6 @@ OTEL_COLLECTOR_IMAGE=$PINNED_OTEL_COLLECTOR_IMAGE
 OTEL_COLLECTOR_CONFIG_PATH=$REPO/ops/observability/otel-collector.yml
 export OTEL_COLLECTOR_IMAGE OTEL_COLLECTOR_CONFIG_PATH
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
-PUBLIC_LINK=$ROOT/runtime/frontend-public-web
-ADMIN_LINK=$ROOT/runtime/frontend-admin-web
 DEPLOY_LOCK=$CONTROL/production-deploy.lock
 # Deployment, the control-owned daily runner, and every manual production DB
 # command use this admission lock. Daily separately owns a singleton lock so it


### PR DESCRIPTION
Keeps the frozen production entrypoint byte-identical to the reviewed release while allowing exactly its two known legacy SC2034 findings. Every other warning-level ShellCheck finding still fails deployment, and any baseline drift fails closed. Verified with the bridge workflow contract, review CI contract, source line cap, entrypoint ShellCheck, and git diff validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Production deployment verification now performs dedicated validation of the deployment entrypoint.
  * ShellCheck findings are checked against an expected baseline to detect unexpected warnings.
  * Deployment scripts continue to receive syntax and lint validation, with known warnings handled explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->