### PR TITLE
test(reader-summary): count route authority RLS

### DIFF
--- a/scripts/lib/reader-summary-daily-canonical-recovery-v4-postgres-contract.ts
+++ b/scripts/lib/reader-summary-daily-canonical-recovery-v4-postgres-contract.ts
@@ -398,7 +398,7 @@ export const assertReaderSummaryDailyCanonicalRecoveryV4PostgresContract = async
     `v4 did not persist exactly two matching plans and eight immutable rows: ${JSON.stringify(count)}`,
   );
   assert(
-    count.forcedRls === "4" && count.unsafeFunctions === "0",
+    count.forcedRls === "5" && count.unsafeFunctions === "0",
     `v4 RLS or SECURITY DEFINER hardening diverged: ${JSON.stringify(count)}`,
   );
 


### PR DESCRIPTION
Updates the mandatory PostgreSQL recovery E2E to count the new route authority table as the fifth FORCE RLS protected V4 table. Production deploy run 33317146388 observed all expected rows and zero unsafe functions; only the stale count diverged. The route-authority migration contract passes 7/7 locally.