### PR TITLE
fix(deploy): lint full entrypoint closure

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -562,28 +562,7 @@ jobs:
           if [[ $bridge_phase == false ]]; then
             deploy_shell_files+=("${final_publication_shell_files[@]}")
           fi
-          bash -n ops/deploy/social-monitor-production-deploy.sh \
-            "${deploy_shell_files[@]}"
-          deploy_shellcheck=$(
-            shellcheck -S warning -f json -x \
-              ops/deploy/social-monitor-production-deploy.sh \
-              "${deploy_shell_files[@]}" || true
-          )
-          DEPLOY_SHELLCHECK=$deploy_shellcheck node <<'NODE'
-          const findings = JSON.parse(process.env.DEPLOY_SHELLCHECK ?? "[]");
-          const expected = new Set([
-            "ops/deploy/social-monitor-production-deploy.sh:42:2034:PUBLIC_LINK",
-            "ops/deploy/social-monitor-production-deploy.sh:43:2034:ADMIN_LINK",
-          ]);
-          const actual = new Set(findings.map((finding) =>
-            `${finding.file}:${finding.line}:${finding.code}:${String(finding.message).split(" ", 1)[0]}`));
-          if (findings.length !== expected.size || actual.size !== expected.size ||
-              [...expected].some((finding) => !actual.has(finding))) {
-            console.error("production deploy ShellCheck baseline diverged", findings);
-            process.exit(1);
-          }
-          NODE
-          shellcheck -S warning -x -e SC2034 \
+          bash ops/deploy/verify-production-shellcheck-baseline.sh \
             ops/deploy/social-monitor-production-deploy.sh \
             "${deploy_shell_files[@]}"
           python3 -m py_compile ops/deploy/verify-postgres-runtime-topology.py

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -564,27 +564,28 @@ jobs:
           fi
           bash -n ops/deploy/social-monitor-production-deploy.sh \
             "${deploy_shell_files[@]}"
-          entrypoint_shellcheck=$(
+          deploy_shellcheck=$(
             shellcheck -S warning -f json -x \
-              ops/deploy/social-monitor-production-deploy.sh || true
+              ops/deploy/social-monitor-production-deploy.sh \
+              "${deploy_shell_files[@]}" || true
           )
-          ENTRYPOINT_SHELLCHECK=$entrypoint_shellcheck node <<'NODE'
-          const findings = JSON.parse(process.env.ENTRYPOINT_SHELLCHECK ?? "[]");
+          DEPLOY_SHELLCHECK=$deploy_shellcheck node <<'NODE'
+          const findings = JSON.parse(process.env.DEPLOY_SHELLCHECK ?? "[]");
           const expected = new Set([
-            "42:2034:PUBLIC_LINK",
-            "43:2034:ADMIN_LINK",
+            "ops/deploy/social-monitor-production-deploy.sh:42:2034:PUBLIC_LINK",
+            "ops/deploy/social-monitor-production-deploy.sh:43:2034:ADMIN_LINK",
           ]);
           const actual = new Set(findings.map((finding) =>
-            `${finding.line}:${finding.code}:${String(finding.message).split(" ", 1)[0]}`));
+            `${finding.file}:${finding.line}:${finding.code}:${String(finding.message).split(" ", 1)[0]}`));
           if (findings.length !== expected.size || actual.size !== expected.size ||
               [...expected].some((finding) => !actual.has(finding))) {
-            console.error("production entrypoint ShellCheck baseline diverged", findings);
+            console.error("production deploy ShellCheck baseline diverged", findings);
             process.exit(1);
           }
           NODE
           shellcheck -S warning -x -e SC2034 \
-            ops/deploy/social-monitor-production-deploy.sh
-          shellcheck -S warning -x "${deploy_shell_files[@]}"
+            ops/deploy/social-monitor-production-deploy.sh \
+            "${deploy_shell_files[@]}"
           python3 -m py_compile ops/deploy/verify-postgres-runtime-topology.py
           python3 -m py_compile ops/deploy/verify-postgres-pool-release-contract.py
           if [[ $POSTGRES_POOL_BOOTSTRAP == uninstalled && \

--- a/ops/deploy/daily-c1-control-bridge-workflow.test.sh
+++ b/ops/deploy/daily-c1-control-bridge-workflow.test.sh
@@ -113,8 +113,22 @@ grep -F 'daily_c1_atomic_repair=61018b1d' "$workflow" >/dev/null || \
   fail 'bridge does not pin the descendant atomic PostgreSQL repair commit'
 grep -F 'backend-gate=postgres-pool-release deferred-to-bounded-repair' \
   "$workflow" >/dev/null || fail 'bridge CI blocks the reviewed bounded bootstrap repair'
-grep -F 'shellcheck -S warning -x "${deploy_shell_files[@]}"' \
-  "$workflow" >/dev/null || fail 'workflow treats informational shellcheck findings as release failures'
+grep -F 'shellcheck -S warning -f json -x \' \
+  "$workflow" >/dev/null || fail 'workflow does not inventory warning-level deploy findings'
+grep -F -A3 'shellcheck -S warning -f json -x \' "$workflow" | \
+  grep -F '"${deploy_shell_files[@]}" || true' >/dev/null || \
+  fail 'workflow finding inventory does not cover the full deploy closure'
+grep -F 'DEPLOY_SHELLCHECK=$deploy_shellcheck node' \
+  "$workflow" >/dev/null || fail 'workflow does not validate the deploy finding baseline'
+grep -F 'ops/deploy/social-monitor-production-deploy.sh:42:2034:PUBLIC_LINK' \
+  "$workflow" >/dev/null || fail 'workflow does not pin the PUBLIC_LINK finding'
+grep -F 'ops/deploy/social-monitor-production-deploy.sh:43:2034:ADMIN_LINK' \
+  "$workflow" >/dev/null || fail 'workflow does not pin the ADMIN_LINK finding'
+grep -F 'shellcheck -S warning -x -e SC2034 \' \
+  "$workflow" >/dev/null || fail 'workflow treats informational findings as release failures'
+grep -F -A3 'shellcheck -S warning -x -e SC2034 \' "$workflow" | \
+  grep -F '"${deploy_shell_files[@]}"' >/dev/null || \
+  fail 'workflow warning enforcement does not cover the full deploy closure'
 grep -F "needs.plan.outputs.daily_c1_bridge != 'true'" \
   "$workflow" >/dev/null || fail 'bridge does not defer final-only legacy transition fixtures'
 [[ $(grep -Fc "needs.plan.outputs.daily_c1_bridge != 'true'" "$workflow") == 9 ]] || \

--- a/ops/deploy/daily-c1-control-bridge-workflow.test.sh
+++ b/ops/deploy/daily-c1-control-bridge-workflow.test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+SHELLCHECK_VERIFIER=$SCRIPT_DIR/verify-production-shellcheck-baseline.sh
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/daily-c1-control-bridge.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
 REPO=$FIXTURE/repo
@@ -113,22 +114,15 @@ grep -F 'daily_c1_atomic_repair=61018b1d' "$workflow" >/dev/null || \
   fail 'bridge does not pin the descendant atomic PostgreSQL repair commit'
 grep -F 'backend-gate=postgres-pool-release deferred-to-bounded-repair' \
   "$workflow" >/dev/null || fail 'bridge CI blocks the reviewed bounded bootstrap repair'
-grep -F 'shellcheck -S warning -f json -x \' \
-  "$workflow" >/dev/null || fail 'workflow does not inventory warning-level deploy findings'
-grep -F -A3 'shellcheck -S warning -f json -x \' "$workflow" | \
-  grep -F '"${deploy_shell_files[@]}" || true' >/dev/null || \
-  fail 'workflow finding inventory does not cover the full deploy closure'
-grep -F 'DEPLOY_SHELLCHECK=$deploy_shellcheck node' \
-  "$workflow" >/dev/null || fail 'workflow does not validate the deploy finding baseline'
-grep -F 'ops/deploy/social-monitor-production-deploy.sh:42:2034:PUBLIC_LINK' \
-  "$workflow" >/dev/null || fail 'workflow does not pin the PUBLIC_LINK finding'
-grep -F 'ops/deploy/social-monitor-production-deploy.sh:43:2034:ADMIN_LINK' \
-  "$workflow" >/dev/null || fail 'workflow does not pin the ADMIN_LINK finding'
-grep -F 'shellcheck -S warning -x -e SC2034 \' \
-  "$workflow" >/dev/null || fail 'workflow treats informational findings as release failures'
-grep -F -A3 'shellcheck -S warning -x -e SC2034 \' "$workflow" | \
+grep -F -A3 'bash ops/deploy/verify-production-shellcheck-baseline.sh \' "$workflow" | \
   grep -F '"${deploy_shell_files[@]}"' >/dev/null || \
-  fail 'workflow warning enforcement does not cover the full deploy closure'
+  fail 'workflow ShellCheck verifier does not cover the full deploy closure'
+grep -F 'ops/deploy/social-monitor-production-deploy.sh:42:2034:PUBLIC_LINK' \
+  "$SHELLCHECK_VERIFIER" >/dev/null || fail 'verifier does not pin the PUBLIC_LINK finding'
+grep -F 'ops/deploy/social-monitor-production-deploy.sh:43:2034:ADMIN_LINK' \
+  "$SHELLCHECK_VERIFIER" >/dev/null || fail 'verifier does not pin the ADMIN_LINK finding'
+grep -F 'shellcheck -S warning -x -e SC2034 "${deploy_files[@]}"' \
+  "$SHELLCHECK_VERIFIER" >/dev/null || fail 'verifier does not enforce remaining warnings'
 grep -F "needs.plan.outputs.daily_c1_bridge != 'true'" \
   "$workflow" >/dev/null || fail 'bridge does not defer final-only legacy transition fixtures'
 [[ $(grep -Fc "needs.plan.outputs.daily_c1_bridge != 'true'" "$workflow") == 9 ]] || \

--- a/ops/deploy/verify-production-shellcheck-baseline.sh
+++ b/ops/deploy/verify-production-shellcheck-baseline.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+(($# > 0)) || {
+  echo 'production-shellcheck-error: no deploy files supplied' >&2
+  exit 1
+}
+
+deploy_files=("$0" "$@")
+bash -n "${deploy_files[@]}"
+deploy_shellcheck=$(
+  shellcheck -S warning -f json -x "${deploy_files[@]}" || true
+)
+DEPLOY_SHELLCHECK=$deploy_shellcheck node <<'NODE'
+const findings = JSON.parse(process.env.DEPLOY_SHELLCHECK ?? "[]");
+const expected = new Set([
+  "ops/deploy/social-monitor-production-deploy.sh:42:2034:PUBLIC_LINK",
+  "ops/deploy/social-monitor-production-deploy.sh:43:2034:ADMIN_LINK",
+]);
+const actual = new Set(findings.map((finding) =>
+  `${finding.file}:${finding.line}:${finding.code}:${String(finding.message).split(" ", 1)[0]}`));
+if (findings.length !== expected.size || actual.size !== expected.size ||
+    [...expected].some((finding) => !actual.has(finding))) {
+  console.error("production deploy ShellCheck baseline diverged", findings);
+  process.exit(1);
+}
+NODE
+shellcheck -S warning -x -e SC2034 "${deploy_files[@]}"


### PR DESCRIPTION
Fixes the production deploy gate exposed by runs 33319909416 and 33319708480.

The warning inventory now covers the complete deploy source closure and permits exactly the two frozen entrypoint SC2034 findings by file, line, code and variable name. All other SC2034 findings and every other warning-level finding remain blocking. The verifier is extracted so production-deploy.yml remains at the enforced 999-line cap.

Verification:
- exact production ShellCheck block passes for bridge and final modes
- duplicate finding and missing-file fail-closed probes pass
- daily C1 workflow contract test passes
- production maintenance dispatch test passes
- review CI contract passes
- source line-cap check passes
- diff check passes