### PR TITLE
fix(deploy): enforce shellcheck baseline once

### DIFF
--- a/ops/deploy/daily-c1-control-bridge-workflow.test.sh
+++ b/ops/deploy/daily-c1-control-bridge-workflow.test.sh
@@ -121,8 +121,10 @@ grep -F 'ops/deploy/social-monitor-production-deploy.sh:42:2034:PUBLIC_LINK' \
   "$SHELLCHECK_VERIFIER" >/dev/null || fail 'verifier does not pin the PUBLIC_LINK finding'
 grep -F 'ops/deploy/social-monitor-production-deploy.sh:43:2034:ADMIN_LINK' \
   "$SHELLCHECK_VERIFIER" >/dev/null || fail 'verifier does not pin the ADMIN_LINK finding'
-grep -F 'shellcheck -S warning -x -e 2034 "${deploy_files[@]}"' \
-  "$SHELLCHECK_VERIFIER" >/dev/null || fail 'verifier does not enforce remaining warnings'
+grep -F 'findings.length !== expected.size || actual.size !== expected.size' \
+  "$SHELLCHECK_VERIFIER" >/dev/null || fail 'verifier does not reject additional warnings'
+! grep -F 'shellcheck -S warning -x -e' "$SHELLCHECK_VERIFIER" >/dev/null || \
+  fail 'verifier still relies on a non-portable broad warning exclusion'
 grep -F "needs.plan.outputs.daily_c1_bridge != 'true'" \
   "$workflow" >/dev/null || fail 'bridge does not defer final-only legacy transition fixtures'
 [[ $(grep -Fc "needs.plan.outputs.daily_c1_bridge != 'true'" "$workflow") == 9 ]] || \

--- a/ops/deploy/verify-production-shellcheck-baseline.sh
+++ b/ops/deploy/verify-production-shellcheck-baseline.sh
@@ -25,4 +25,3 @@ if (findings.length !== expected.size || actual.size !== expected.size ||
   process.exit(1);
 }
 NODE
-shellcheck -S warning -x -e 2034 "${deploy_files[@]}"


### PR DESCRIPTION
Fixes the redundant ShellCheck enforcement failure from production run 33321762550.

The exact JSON inventory already rejects every finding except the two pinned entrypoint SC2034 records. The second exclusion-based ShellCheck pass added no coverage and behaved inconsistently across closure analysis, so it is removed. A contract assertion now forbids reintroducing broad warning exclusions, and duplicate findings remain a tested fail-closed case.

Verification:
- exact baseline passes
- duplicated finding set is rejected
- daily C1 workflow contract passes
- review CI and source line-cap checks pass
- diff check passes