### PR TITLE
fix(deploy): route preflight through ShellCheck baseline

### DIFF
--- a/ops/deploy/daily-c1-control-bridge-workflow.test.sh
+++ b/ops/deploy/daily-c1-control-bridge-workflow.test.sh
@@ -87,6 +87,7 @@ if deploy_control_is_exact_daily_c1_bridge_release "$base" "$missing_target"; th
 fi
 
 workflow=$PROJECT_ROOT/.github/workflows/production-deploy.yml
+release_preflight=$SCRIPT_DIR/production-release-preflight.sh
 grep -F 'daily_c1_bridge_base=e3b5b5d89b3586668e36f987f03672415b5a0f37' \
   "$workflow" >/dev/null
 grep -F 'daily_c1_bridge_expected=$(cat' "$workflow" >/dev/null || \
@@ -125,6 +126,11 @@ grep -F 'findings.length !== expected.size || actual.size !== expected.size' \
   "$SHELLCHECK_VERIFIER" >/dev/null || fail 'verifier does not reject additional warnings'
 ! grep -F 'shellcheck -S warning -x -e' "$SHELLCHECK_VERIFIER" >/dev/null || \
   fail 'verifier still relies on a non-portable broad warning exclusion'
+grep -F -A1 'bash ops/deploy/verify-production-shellcheck-baseline.sh \' \
+  "$release_preflight" | grep -F '"${deploy_shell_files[@]}"' >/dev/null || \
+  fail 'release preflight bypasses the canonical ShellCheck verifier'
+! grep -E '^[[:space:]]*shellcheck[[:space:]]' "$release_preflight" >/dev/null || \
+  fail 'release preflight still invokes ShellCheck outside the canonical verifier'
 grep -F "needs.plan.outputs.daily_c1_bridge != 'true'" \
   "$workflow" >/dev/null || fail 'bridge does not defer final-only legacy transition fixtures'
 [[ $(grep -Fc "needs.plan.outputs.daily_c1_bridge != 'true'" "$workflow") == 9 ]] || \

--- a/ops/deploy/daily-c1-control-bridge-workflow.test.sh
+++ b/ops/deploy/daily-c1-control-bridge-workflow.test.sh
@@ -129,8 +129,13 @@ grep -F 'findings.length !== expected.size || actual.size !== expected.size' \
 grep -F -A1 'bash ops/deploy/verify-production-shellcheck-baseline.sh \' \
   "$release_preflight" | grep -F '"${deploy_shell_files[@]}"' >/dev/null || \
   fail 'release preflight bypasses the canonical ShellCheck verifier'
-! grep -E '^[[:space:]]*shellcheck[[:space:]]' "$release_preflight" >/dev/null || \
+shellcheck_bypass_pattern='(^|[^[:alnum:]_.-])shellcheck([[:space:]]|$)'
+! grep -E "$shellcheck_bypass_pattern" "$release_preflight" >/dev/null || \
   fail 'release preflight still invokes ShellCheck outside the canonical verifier'
+for bypass in 'command shellcheck -x target.sh' 'result=$(shellcheck -x target.sh)'; do
+  printf '%s\n' "$bypass" | grep -E "$shellcheck_bypass_pattern" >/dev/null || \
+    fail 'release preflight ShellCheck bypass detector is incomplete'
+done
 grep -F "needs.plan.outputs.daily_c1_bridge != 'true'" \
   "$workflow" >/dev/null || fail 'bridge does not defer final-only legacy transition fixtures'
 [[ $(grep -Fc "needs.plan.outputs.daily_c1_bridge != 'true'" "$workflow") == 9 ]] || \

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -356,7 +356,10 @@ for command in commands:
 test_command = "          bash ops/deploy/production-release-b-bridge-order.test.sh"
 if workflow.count(test_command) != 1:
     raise SystemExit("Release B topology regression is not executed exactly once")
-if workflow.index(test_command) < workflow.index("shellcheck -S warning -x"):
+shellcheck_gate = "          bash ops/deploy/verify-production-shellcheck-baseline.sh \\\n"
+if workflow.count(shellcheck_gate) != 1:
+    raise SystemExit("canonical production ShellCheck verifier is not executed exactly once")
+if workflow.index(test_command) < workflow.index(shellcheck_gate):
     raise SystemExit("Release B topology regression appears only in static checks")
 PY
 

--- a/ops/deploy/production-release-preflight.sh
+++ b/ops/deploy/production-release-preflight.sh
@@ -24,8 +24,8 @@ deploy_shell_files=(
   ops/deploy/production-release-preflight.sh
   ops/deploy/social-monitor-production-forced-wrapper-cross-version.test.sh
 )
-bash -n "${deploy_shell_files[@]}"
-shellcheck -x "${deploy_shell_files[@]}"
+bash ops/deploy/verify-production-shellcheck-baseline.sh \
+  "${deploy_shell_files[@]}"
 bash ops/deploy/social-monitor-production-deploy.test.sh
 bash ops/deploy/github-production-deploy-client.test.sh
 bash ops/deploy/social-monitor-production-ssh-wrapper.test.sh


### PR DESCRIPTION
## Summary

- route production release preflight through the canonical fail-closed ShellCheck baseline verifier
- prevent direct ShellCheck invocations from bypassing the reviewed baseline
- update the Release B ordering contract to track the canonical verifier

## Verification

- canonical verifier passed for the complete release-preflight shell closure
- daily C1 workflow contract passed
- Release B ShellCheck ordering contract passed
- bash syntax and diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized production release preflight checks through a single ShellCheck verification step.
  * Preserved validation of deployment scripts while removing duplicate direct linting.
  * Updated release workflow checks to enforce the canonical verification step and its required ordering.
* **Tests**
  * Added coverage confirming the verification step runs correctly and exactly once during release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->