### PR TITLE
test(reader-summary): install hold contract in signal fixture

### DIFF
--- a/ops/deploy/reader-summary-publication-signal-regression.test.sh
+++ b/ops/deploy/reader-summary-publication-signal-regression.test.sh
@@ -95,6 +95,9 @@ prepare_case() {
     "$root/runtime" \
     "$case_dir/reports" \
     "$case_dir/public"
+  cp "$SCRIPT_DIR/production-runtime/reader-summary-scheduler-hold-common.sh" \
+    "$SCRIPT_DIR/production-runtime/reader-summary-scheduler-hold-status.sh" \
+    "$root/control/postgres-runtime-current/"
   printf '%s\n' "$RELEASE_SHA" > "$root/control/deploy-state/backend.sha"
   printf '%s\n' "$RELEASE_SHA" > "$root/control/postgres-runtime-current/READY"
   printf '%s\n' \


### PR DESCRIPTION
## Summary

- install the mandatory scheduler hold status contract in every publication signal fixture case
- restore real timeout and signal execution instead of the early status 76 exit

## Root cause

The daily runtime began requiring reader-summary-scheduler-hold-status.sh before entering the worker path, but the signal fixture did not install that reviewed runtime asset.

## Verification

- full publication signal regression passed
- canonical production ShellCheck baseline passed for the affected closure
- bash syntax and diff checks passed