### PR TITLE
fix(deploy): remove unused health path binding

### DIFF
--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -848,7 +848,7 @@ verify_target_rabbitmq_quorum_asset() {
 }
 
 load_target_rabbitmq_quorum_backend_health() {
-  local sha=$1 health_library=$REPO/$RABBITMQ_QUORUM_HEALTH_LIBRARY_PATH
+  local sha=$1
 
   [[ $sha =~ ^[0-9a-f]{40}$ ]] || \
     fail 'target RabbitMQ quorum health SHA is invalid'

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -155,7 +155,7 @@ assert_real_bridge_target_assets() {
         release_b_candidate_digest=bea119047fbbd2295185c84e0adeb773dc852e63b951daf5c7a831356a73a371
         release_b_sealed_digest=1718617b4bbb92f4dbfd92a59fcc482ef7a098734730b8460d21aaced44386c2
         rolling_repair_digest=1945f2b07f110d16694affc15c66b4589d294b81a4e593a9680dacf11fbc5d4d
-        current_release_digest=f04763ebe27da204e4ec1df1f43679781b4f1c41983662da9f9900f780d170a0
+        current_release_digest=0db3fa488279b09a7d1530b126b309daaa8fd0db4787bb8fa2f9727d02aa7c7d
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then


### PR DESCRIPTION
## Summary

- remove the unused health library binding reported by the exact production ShellCheck closure
- keep reviewed asset validation and loading behavior unchanged

## Verification

- full 63-file production ShellCheck closure passed
- Bash syntax validation passed as part of the canonical verifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment validation to use the correct current release checksum.
  * Improved compatibility in RabbitMQ quorum deployment health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->