### PR TITLE
test(deploy): include postgres asset helper in X transition fixture

### DIFF
--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -921,7 +921,6 @@ fi
 [[ ! -e $STATE/postgres-pool-bootstrap.sha ]]
 [[ ! -e $RECOVERY_ACTIVATION_LOG ]]
 git -C "$REPO" checkout -q main
-
 git -C "$REPO" checkout -qb non-ancestor-current "$TARGET_SHA"
 cp "$PROJECT_ROOT/ops/deploy/social-monitor-production-deploy.sh" \
   "$PROJECT_ROOT/ops/deploy/deploy-control-lib.sh" \
@@ -933,6 +932,7 @@ cp "$PROJECT_ROOT/ops/deploy/social-monitor-production-deploy.sh" \
   "$PROJECT_ROOT/ops/deploy/daily-runner-image-bootstrap-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/x-collector-image-deploy-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/reader-summary-recovery-maintenance-lib.sh" \
+  "$PROJECT_ROOT/ops/deploy/production-backend-classification-lib.sh" \
   "$REPO/ops/deploy/"
 write_target_quorum_health_fixture "$REPO"
 git -C "$REPO" add ops/deploy

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -126,6 +126,7 @@ cp "$PROJECT_ROOT/ops/deploy/reader-summary-publication-deploy-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/reader-summary-publication-system-dsn-bootstrap-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/reader-summary-publication-pre-migration.sql" \
   "$PROJECT_ROOT/ops/deploy/reader-summary-publication-post-migration.sql" \
+  "$PROJECT_ROOT/ops/deploy/production-transition-b0-host-control.sh" \
   "$REPO/ops/deploy/"
 printf 'base\n' > "$REPO/README.md"
 git -C "$REPO" add .
@@ -133,6 +134,7 @@ git -C "$REPO" commit -qm 'test: installed legacy main'
 git -C "$REPO" push -q -u origin main
 BASE_SHA=$(git -C "$REPO" rev-parse HEAD)
 export SOCIAL_MONITOR_DEPLOY_TEST_A0=$BASE_SHA
+install -m 0644 "$REPO/ops/deploy/production-transition-b0-host-control.sh" "$CONTROL/production-transition-b0-host-control.sh"
 for component in frontend backend control; do
   printf '%s\n' "$BASE_SHA" > "$STATE/$component.sha"
 done
@@ -465,7 +467,6 @@ chmod 0755 "$INSTALLED"
 cp "$INSTALLED" "$FIXTURE/installed-entrypoint-before-recovery"
 rm -f "$STATE/postgres-pool-bootstrap.sha"
 RECOVERY_ACTIVATION_LOG=$FIXTURE/already-newer-activation.log
-
 # A waiting daily run wins before already-newer recovery can commit a marker.
 TEST_PHASE=already-newer-daily-priority
 exec {daily_priority_fd}>"$DAILY_SINGLETON_LOCK"
@@ -508,7 +509,6 @@ grep -Fx 'postgres_pool_bootstrap=postgres-pool-v1' \
 grep -Fx "postgres_pool_bootstrap_sha=$CURRENT_SHA" \
   <<< "$recovered_plan" >/dev/null
 [[ ! -e $RECOVERY_ACTIVATION_LOG ]]
-
 install_historical_control_entrypoint() {
   rm -f "$INSTALLED"
   git -C "$REPO" show \

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -664,7 +664,7 @@ rm -f "$STATE/control.sha"
 cp "$STATE/postgres-pool-bootstrap.sha" \
   "$FIXTURE/missing-control-pool-marker-before"
 assert_current_recovery_fails \
-  'control marker is not a regular non-symlink file'
+  'B0 host control marker is unsafe'
 cmp -s "$FIXTURE/missing-control-pool-marker-before" \
   "$STATE/postgres-pool-bootstrap.sha"
 
@@ -689,7 +689,7 @@ prepare_historical_reconciliation
 printf 'malformed-control\n' > "$STATE/control.sha"
 cp "$STATE/postgres-pool-bootstrap.sha" \
   "$FIXTURE/malformed-control-pool-before"
-assert_current_recovery_fails 'control marker is malformed'
+assert_current_recovery_fails 'B0 host control marker is malformed'
 cmp -s "$FIXTURE/malformed-control-pool-before" \
   "$STATE/postgres-pool-bootstrap.sha"
 
@@ -708,7 +708,7 @@ assert_current_recovery_fails \
 TEST_PHASE=already-newer-unavailable-control-marker
 prepare_historical_reconciliation
 printf '%s\n' "$UNAVAILABLE_SHA" > "$STATE/control.sha"
-assert_current_recovery_fails 'control marker commit is unavailable'
+assert_current_recovery_fails 'B0 host control commit is unavailable'
 [[ $(<"$STATE/postgres-pool-bootstrap.sha") == "$TARGET_SHA" ]]
 
 TEST_PHASE=already-newer-pool-marker-symlink
@@ -728,7 +728,7 @@ printf '%s\n' "$HISTORICAL_CONTROL_SHA" \
 rm -f "$STATE/control.sha"
 ln -s "$FIXTURE/symlink-control-target" "$STATE/control.sha"
 assert_current_recovery_fails \
-  'control marker is not a regular non-symlink file'
+  'B0 host control marker is unsafe'
 [[ -L $STATE/control.sha ]]
 [[ $(<"$STATE/postgres-pool-bootstrap.sha") == "$TARGET_SHA" ]]
 

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -390,7 +390,8 @@ committed_plan=$(run_entrypoint "$INSTALLED" plan)
 grep -Fx 'postgres_pool_bootstrap=postgres-pool-v1' <<< "$committed_plan" >/dev/null
 grep -Fx "postgres_pool_bootstrap_sha=$TARGET_SHA" <<< "$committed_plan" >/dev/null
 TEST_PHASE=already-newer-fixture
-# Model the independently advanced marker with the pre-split inline sync shape.
+# Model the independently advanced marker with the delegated sync shape that
+# predates the local entrypoint compatibility helper.
 cp "$PROJECT_ROOT/ops/deploy/social-monitor-production-deploy.sh" \
   "$REPO/ops/deploy/"
 python3 - "$REPO/ops/deploy/social-monitor-production-deploy.sh" <<'PY'
@@ -402,10 +403,10 @@ source = path.read_text(encoding="utf-8")
 start = source.index("sync_control_entrypoint() {")
 end = source.index("\n}\n\ncommit_postgres_pool_bootstrap() {", start) + 2
 helper = source[start:end]
-body = "\n".join(helper.splitlines()[1:-1]) + "\n"
-if source.count("  sync_control_entrypoint\n") != 1:
-    raise SystemExit("split helper call was not found exactly once")
-source = source.replace("  sync_control_entrypoint\n", body, 1)
+compatibility_reference = "  : sync_control_entrypoint\n"
+if source.count(compatibility_reference) != 1:
+    raise SystemExit("entrypoint compatibility reference was not found exactly once")
+source = source.replace(compatibility_reference, "", 1)
 source = source.replace(helper + "\n\n", "", 1)
 path.write_text(source, encoding="utf-8")
 PY

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -390,8 +390,7 @@ committed_plan=$(run_entrypoint "$INSTALLED" plan)
 grep -Fx 'postgres_pool_bootstrap=postgres-pool-v1' <<< "$committed_plan" >/dev/null
 grep -Fx "postgres_pool_bootstrap_sha=$TARGET_SHA" <<< "$committed_plan" >/dev/null
 TEST_PHASE=already-newer-fixture
-# Model the independently advanced marker with the delegated sync shape that
-# predates the local entrypoint compatibility helper.
+# Model the advanced marker with delegated sync before the local compatibility helper.
 cp "$PROJECT_ROOT/ops/deploy/social-monitor-production-deploy.sh" \
   "$REPO/ops/deploy/"
 python3 - "$REPO/ops/deploy/social-monitor-production-deploy.sh" <<'PY'

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -445,6 +445,7 @@ cp "$PROJECT_ROOT/ops/deploy/social-monitor-production-deploy.sh" \
   "$PROJECT_ROOT/ops/deploy/daily-runner-image-bootstrap-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/x-collector-image-deploy-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/reader-summary-recovery-maintenance-lib.sh" \
+  "$PROJECT_ROOT/ops/deploy/production-backend-classification-lib.sh" \
   "$REPO/ops/deploy/"
 write_target_quorum_health_fixture "$REPO"
 # Adapt only the committed fallback copy; this matches literal reviewed shell.
@@ -516,7 +517,6 @@ install_historical_control_entrypoint() {
     > "$INSTALLED"
   chmod 0755 "$INSTALLED"
 }
-
 assert_current_recovery_fails() {
   local expected=$1
   local target=${2:-$TARGET_SHA}

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -245,7 +245,7 @@ run_entrypoint() {
     "$action" "$target"
 }
 run_current_deploy() {
-  local target=${1:-$TARGET_SHA}
+  local target=${1:-$TARGET_SHA} operation=${2:-deploy}
   local -a environment=(
     SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
     SOCIAL_MONITOR_DEPLOY_ROOT="$ROOT"
@@ -318,8 +318,8 @@ run_current_deploy() {
       printf "frontend\n" >> "$recovery_event_log"
       return 97
     }
-    deploy_release "$3"
-  ' _ "$INSTALLED" "$RECOVERY_ACTIVATION_LOG" "$target"
+    if [[ $4 == plan ]]; then print_plan "$3"; else deploy_release "$3"; fi
+  ' _ "$INSTALLED" "$RECOVERY_ACTIVATION_LOG" "$target" "$operation"
 }
 run_current_control_deploy() {
   local -a environment=(
@@ -504,7 +504,7 @@ grep -Fx "already-deployed-or-newer=$CURRENT_SHA" \
 cmp -s "$FIXTURE/installed-entrypoint-before-recovery" "$INSTALLED"
 assert_release_a_non_activation
 [[ ! -e $CONTROL/postgres-runtime-releases/$CURRENT_SHA ]]
-recovered_plan=$(run_entrypoint "$INSTALLED" plan "$CURRENT_SHA")
+recovered_plan=$(run_current_deploy "$CURRENT_SHA" plan)
 grep -Fx 'postgres_pool_bootstrap=postgres-pool-v1' \
   <<< "$recovered_plan" >/dev/null
 grep -Fx "postgres_pool_bootstrap_sha=$CURRENT_SHA" \
@@ -611,7 +611,7 @@ assert_recovery_control_only
 
 # A stale control marker still makes current planning select control deployment.
 TEST_PHASE=already-newer-staged-plan
-staged_plan=$(run_entrypoint "$INSTALLED" plan "$CURRENT_SHA")
+staged_plan=$(run_current_deploy "$CURRENT_SHA" plan)
 grep -Fx 'control=true' <<< "$staged_plan" >/dev/null
 grep -Fx 'postgres_pool_bootstrap=postgres-pool-v1' \
   <<< "$staged_plan" >/dev/null

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -953,15 +953,10 @@ non_ancestor_current_status=$?
 set -e
 trap 'report_error "$?" "$LINENO" "$BASH_COMMAND"' ERR
 ((non_ancestor_current_status != 0))
-if grep -q '^already-deployed-or-newer=' \
-  <<< "$non_ancestor_current_output"; then
-  echo 'non-ancestor current commit reported already-deployed success' >&2
-  exit 1
-fi
+grep -F 'deploy control changed with backend or runtime assets; deploy the bridge release first' \
+  <<< "$non_ancestor_current_output" >/dev/null
 [[ ! -e $STATE/postgres-pool-bootstrap.sha ]]
-if [[ -e $RECOVERY_ACTIVATION_LOG ]]; then
-  [[ $(cat "$RECOVERY_ACTIVATION_LOG") == integration ]]
-fi
+[[ ! -e $RECOVERY_ACTIVATION_LOG ]]
 rm -f "$RECOVERY_ACTIVATION_LOG"
 git -C "$REPO" checkout -q main
 

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -160,6 +160,7 @@ git -C "$PROJECT_ROOT" show \
   "$RELEASE_A_COMMIT:ops/deploy/social-monitor-production-deploy.sh" \
   > "$REPO/ops/deploy/social-monitor-production-deploy.sh"
 cp "$PROJECT_ROOT/ops/deploy/postgres-runtime-deploy-lib.sh" \
+  "$PROJECT_ROOT/ops/deploy/postgres-runtime-asset-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/postgres-runtime-weekly-timer-state-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh" \
   "$PROJECT_ROOT/ops/deploy/postgres-runtime-activation-boundary-lib.sh" \

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -132,6 +132,7 @@ git -C "$REPO" add .
 git -C "$REPO" commit -qm 'test: installed legacy main'
 git -C "$REPO" push -q -u origin main
 BASE_SHA=$(git -C "$REPO" rev-parse HEAD)
+export SOCIAL_MONITOR_DEPLOY_TEST_A0=$BASE_SHA
 for component in frontend backend control; do
   printf '%s\n' "$BASE_SHA" > "$STATE/$component.sha"
 done
@@ -485,7 +486,6 @@ if grep -q '^already-deployed-or-newer=' <<< "$daily_priority_output"; then
   exit 1
 fi
 [[ ! -e $STATE/postgres-pool-bootstrap.sha ]]
-
 # Requesting ancestor A while integration is already at B repairs only the
 # missing bootstrap marker. The stale control and backend markers stay intact.
 TEST_PHASE=already-newer-bootstrap-recovery

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -208,7 +208,7 @@ git -C "$REPO" commit -qm 'test: Release A control bootstrap'
 git -C "$REPO" push -q origin main
 TARGET_SHA=$(git -C "$REPO" rev-parse HEAD)
 printf '[safe]\n\tdirectory = %s\n' "$REPO" > "$FIXTURE/gitconfig"
-chmod -R a+rwX "$FIXTURE"
+chmod -R u+rwX,go+rX "$FIXTURE"
 assert_release_a_non_activation() {
   cmp -s "$NON_ACTIVATING_SNAPSHOT/backend.sha" "$STATE/backend.sha"
   [[ -L $POSTGRES_RUNTIME_CURRENT ]]

--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -400,7 +400,7 @@ import sys
 path = pathlib.Path(sys.argv[1])
 source = path.read_text(encoding="utf-8")
 start = source.index("sync_control_entrypoint() {")
-end = source.index("\n}\n\ncommit_postgres_pool_bootstrap() {", start) + 2
+end = source.index("\n}\n\nsync_control_script() {", start) + 2
 helper = source[start:end]
 compatibility_reference = "  : sync_control_entrypoint\n"
 if source.count(compatibility_reference) != 1:

--- a/ops/deploy/x-collector-image-deploy-lib.test.sh
+++ b/ops/deploy/x-collector-image-deploy-lib.test.sh
@@ -219,6 +219,7 @@ CURRENT_ENTRYPOINT_SOURCE_CLOSURE=(
   ops/deploy/deploy-control-lib.sh
   ops/deploy/deploy-control-bridge-lib.sh
   ops/deploy/postgres-runtime-deploy-lib.sh
+  ops/deploy/postgres-runtime-asset-lib.sh
   ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
   ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
   ops/deploy/postgres-runtime-activation-boundary-lib.sh
@@ -386,6 +387,7 @@ A_CONTROLLER="$TRANSITION_CONTROL/github-production-deploy.sh" \
       ops/deploy/deploy-control-lib.sh
       ops/deploy/deploy-control-bridge-lib.sh
       ops/deploy/postgres-runtime-deploy-lib.sh
+      ops/deploy/postgres-runtime-asset-lib.sh
       ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
       ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
       ops/deploy/postgres-runtime-activation-boundary-lib.sh


### PR DESCRIPTION
Production backend verification reached historical transition fixtures whose source closure and trust model had drifted behind the current deploy controller.

This PR:
- adds `postgres-runtime-asset-lib.sh` to the X collector transition source closure and required-source assertion
- materializes the same helper in the PostgreSQL bootstrap transition fixture
- completes both current-controller fixture closures with the trusted B0 host control and backend classifier
- preserves trusted marker modes and pins the synthetic A0 authority
- models the delegated sync contract while still proving fallback recovery without the local compatibility helper
- routes fixture-only planning through the sourced harness and asserts the current fail-closed B0 marker errors
- requires the exact non-ancestor bridge-barrier error and proves that failed planning cannot activate a release

Production behavior is unchanged. The patch only repairs deterministic release-gate fixtures.

Validation:
- Bash syntax and the 1000-line source cap pass
- exact head `fe6d4bd5b5c711ff9d318857ff71c99c6fb1d418`: the hosted transition body prints `Legacy-main to overlap-safe bootstrap transition tests passed`; the later status 72 is only the host cleanup guard refusing recursive deletion of a temporary Git fixture
- exact-head PR CI passes the complete production lifecycle, backend E2E/unit, Flutter/WASM, security, static, and PostgreSQL gates on Ubuntu
