### PR TITLE
fix(deploy): close controller fixture runtime dependencies

### DIFF
--- a/ops/deploy/deploy-control-lib-test-fixture.sh
+++ b/ops/deploy/deploy-control-lib-test-fixture.sh
@@ -29,6 +29,7 @@ cp "$SCRIPT_DIR/social-monitor-production-deploy.sh" \
   "$SCRIPT_DIR/social-monitor-production-ssh-wrapper.sh" \
   "$SCRIPT_DIR/deploy-control-lib.sh" "$SCRIPT_DIR/deploy-control-bridge-lib.sh" \
   "$SCRIPT_DIR/postgres-runtime-deploy-lib.sh" \
+  "$SCRIPT_DIR/postgres-runtime-asset-lib.sh" \
   "$SCRIPT_DIR/postgres-runtime-activation-boundary-lib.sh" \
   "$SCRIPT_DIR/postgres-runtime-daily-c1-readiness-lib.sh" \
   "$SCRIPT_DIR/postgres-runtime-weekly-timer-state-lib.sh" \

--- a/ops/deploy/deploy-control-lib.test.sh
+++ b/ops/deploy/deploy-control-lib.test.sh
@@ -255,7 +255,7 @@ prepare_atomic_route_case() {
 
 invoke_invalid_atomic_route() (
   set -Eeuo pipefail
-  local mode=$1 surface
+  local invalid_route_mode=$1 surface
 
   ordinary_deploy_started() {
     printf 'ordinary\n' >> "$atomic_route_log"
@@ -266,7 +266,7 @@ invoke_invalid_atomic_route() (
   }
   fetch_main() { ordinary_deploy_started; }
   verify_postgres_pool_atomic_repair_target() {
-    case $mode in
+    case $invalid_route_mode in
       invalid-target) fail 'atomic repair target is invalid' ;;
       invalid-contract) fail 'atomic repair contract is invalid' ;;
       verifier-failure) return 70 ;;
@@ -275,7 +275,7 @@ invoke_invalid_atomic_route() (
     esac
   }
   postgres_pool_bootstrap_recovery_commit_blob() {
-    [[ $mode == missing-blob ]] || \
+    [[ $invalid_route_mode == missing-blob ]] || \
       fail 'atomic repair blob loader reached an unexpected case'
     fail 'atomic PostgreSQL bootstrap library is missing at reviewed commit'
   }


### PR DESCRIPTION
## Summary

- Copy the required PostgreSQL runtime asset inventory helper into the synthetic deploy-control repository.
- Rename the negative-route scenario variable so Bash dynamic scoping cannot shadow it with `deploy_release`'s local `mode`.
- Keep production behavior and all existing assertions unchanged.

## Evidence

- Reproduced production workflow 33331978957's missing-helper failure at base 29dfd629.
- Hosted implementation worker on old host, gpt-5.6-sol / xhigh / fast, account-u.
- Focused controller test reaches `Deploy control library tests passed` with CI-like unprivileged execution. The hosted cleanup environment can affect the shell exit status, so GitHub CI remains authoritative.
- Shell syntax, diff check and source line cap pass.
- Independent read-only exact-SHA review is running for 8d57769b255fc3ba816148fbc079bb2f4439dc93.

## Scope and remaining delivery

7 changed lines in test support only. Root-only daily-systemd mock drift is pre-existing and is not claimed green. This PR restores the normal unprivileged CI gate; successful production deployment and post-deploy acceptance still need to be verified after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated deployment test fixtures to include the PostgreSQL runtime asset.
  - Improved test clarity by renaming an internal parameter without changing behavior.
  - Expanded validation of deployment recovery and repair scenarios.

- **Customer Impact**
  - No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->