### PR TITLE
fix(summary): wire story verifier into production capture

### DIFF
--- a/scripts/capture-durable-reader-summary-from-postgres.ts
+++ b/scripts/capture-durable-reader-summary-from-postgres.ts
@@ -77,8 +77,9 @@ import { assertImmutableRecoveryInputs } from "./lib/reader-summary-recovery-fil
 import { canonicalJsonSha256 } from "@social-monitor/contracts/grpc/agent_runtime/v1/execution-attestation";
 import {
   createReaderSummaryDailyCaptureContext,
-  createReaderSummaryDailyPublicationExecutionWiring,
 } from "./lib/reader-summary-daily-publication-finalizer";
+import { createReaderSummaryDailyCapturePublicationWiring } from
+  "./lib/reader-summary-daily-story-relation-verifier";
 import {
   readerSummaryProductionDayAttemptIdentity,
   readerSummaryProductionDayIdempotencyKey,
@@ -296,6 +297,7 @@ async function main(): Promise<void> {
         summaryClient: summaryConnection,
         clock,
         attestationSink: executionAttestations,
+        storyRelationVerifier,
       });
     const queue = new CapturingReaderSummaryJobQueue();
     const ids = new CryptoIdGenerator();

--- a/scripts/capture-durable-reader-summary-from-postgres.ts
+++ b/scripts/capture-durable-reader-summary-from-postgres.ts
@@ -291,13 +291,15 @@ async function main(): Promise<void> {
       summaryConnection,
     );
     const publicationWiring =
-      createReaderSummaryDailyPublicationExecutionWiring({
+      createReaderSummaryDailyCapturePublicationWiring({
         replay: dailyReplay,
         feedItems,
         summaryClient: summaryConnection,
         clock,
         attestationSink: executionAttestations,
-        storyRelationVerifier,
+        summaryModelMode: modelMode,
+        env: process.env,
+        agentRuntimeClient,
       });
     const queue = new CapturingReaderSummaryJobQueue();
     const ids = new CryptoIdGenerator();

--- a/scripts/lib/reader-summary-daily-publication-finalizer.ts
+++ b/scripts/lib/reader-summary-daily-publication-finalizer.ts
@@ -37,6 +37,7 @@ import type {
   ReaderSummaryModelEstimate,
   ReaderSummaryModelPort,
   ReaderSummaryModelRoute,
+  ReaderSummaryStoryRelationVerifierPort,
 } from "@social-monitor/summary/ports";
 import type { Clock } from "@social-monitor/shared-kernel";
 
@@ -212,6 +213,7 @@ export const createReaderSummaryDailyPublicationExecutionWiring = (input: {
   >[0];
   readonly clock: Clock;
   readonly attestationSink: VerifiedReaderSummaryExecutionAttestationSink;
+  readonly storyRelationVerifier?: ReaderSummaryStoryRelationVerifierPort | null;
 }): ReaderSummaryDailyPublicationExecutionWiring => {
   if (input.replay?.outputKind === "output_text") {
     const frozen = createReaderSummaryDailyFrozenOutputTextWiring({
@@ -249,6 +251,11 @@ export const createReaderSummaryDailyPublicationExecutionWiring = (input: {
   ) {
     throw new Error("Daily immutable authority v2 recovery requires output_text");
   }
+  if (input.replay === null && input.storyRelationVerifier === undefined) {
+    throw new Error(
+      "Fresh daily publication must explicitly configure its story relation verifier",
+    );
+  }
   const githubProjectionReader =
     new PrismaReaderSummaryGitHubProjectionReader(input.summaryClient);
   if (input.feedItems === undefined) {
@@ -264,6 +271,9 @@ export const createReaderSummaryDailyPublicationExecutionWiring = (input: {
     input.feedItems,
     input.clock,
     new StoryRankingMetricsRecorder(new InMemoryMetricsRecorder()),
+    input.replay === null
+      ? input.storyRelationVerifier ?? undefined
+      : undefined,
   );
   if (input.replay === null) {
     return Object.freeze({ evidenceSelector, githubProjectionReader });

--- a/scripts/lib/reader-summary-daily-story-relation-verifier.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-verifier.ts
@@ -1,0 +1,74 @@
+import {
+  AgentRuntimeReaderSummaryStoryRelationVerifier,
+  resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions,
+} from "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter";
+import type {
+  VerifiedReaderSummaryExecutionAttestationSink,
+} from "@social-monitor/summary/adapters/model/reader-summary-execution-attestation";
+import type {
+  AgentRuntimeClientPort,
+  ReaderSummaryStoryRelationVerifierPort,
+} from "@social-monitor/summary/ports";
+
+import {
+  createReaderSummaryDailyPublicationExecutionWiring,
+  type ReaderSummaryDailyReplayInput,
+} from
+  "./reader-summary-daily-publication-finalizer";
+
+type DailyPublicationExecutionInput = Omit<
+  Parameters<typeof createReaderSummaryDailyPublicationExecutionWiring>[0],
+  "storyRelationVerifier"
+>;
+
+export const createReaderSummaryDailyCapturePublicationWiring = (
+  input: DailyPublicationExecutionInput & StoryRelationCompositionInput,
+) => {
+  const {
+    agentRuntimeClient,
+    env,
+    summaryModelMode,
+    ...publicationInput
+  } = input;
+  return createReaderSummaryDailyPublicationExecutionWiring({
+    ...publicationInput,
+    storyRelationVerifier: buildReaderSummaryDailyStoryRelationVerifier({
+      replay: publicationInput.replay,
+      summaryModelMode,
+      env,
+      agentRuntimeClient,
+      attestationSink: publicationInput.attestationSink,
+    }),
+  });
+};
+
+type StoryRelationCompositionInput = {
+  readonly replay: ReaderSummaryDailyReplayInput | null;
+  readonly summaryModelMode:
+    | "deterministic"
+    | "openai-responses"
+    | "agent-runtime";
+  readonly env: NodeJS.ProcessEnv;
+  readonly agentRuntimeClient: AgentRuntimeClientPort | null;
+  readonly attestationSink: VerifiedReaderSummaryExecutionAttestationSink;
+};
+
+const buildReaderSummaryDailyStoryRelationVerifier = (
+  input: StoryRelationCompositionInput,
+): ReaderSummaryStoryRelationVerifierPort | null => {
+  if (input.replay !== null || input.summaryModelMode !== "agent-runtime") {
+    return null;
+  }
+  if (input.agentRuntimeClient === null) {
+    throw new Error(
+      "Fresh agent-runtime daily publication requires a story relation verifier client",
+    );
+  }
+  return new AgentRuntimeReaderSummaryStoryRelationVerifier({
+    ...resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions(
+      input.env,
+      input.agentRuntimeClient,
+    ),
+    verifiedAttestationSink: input.attestationSink,
+  });
+};

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -3,6 +3,8 @@ import { InMemoryFeedItemReadRepository } from
 import { FeedItem } from "@social-monitor/feed/domain";
 import { withTestExecutionAttestation } from
   "@social-monitor/summary/adapters/model/reader-summary-execution-attestation.spec-support";
+import type { VerifiedReaderSummaryExecutionAttestation } from
+  "@social-monitor/summary/adapters/model/reader-summary-execution-attestation";
 import {
   buildReaderSummaryCoveragePlan,
   buildReaderSummaryPeriod,
@@ -163,7 +165,9 @@ const selectDailyEvidence = async (input: {
   readonly secondTitle: string;
 }) => {
   const runtime = new FakeRuntime(input.sameStory, input.attested);
-  const record = jest.fn(async () => undefined);
+  const record = jest.fn(async (value: VerifiedReaderSummaryExecutionAttestation) => {
+    void value;
+  });
   const wiring = createReaderSummaryDailyCapturePublicationWiring({
     replay: null,
     feedItems: feedRepository(input.secondTitle),

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -1,0 +1,253 @@
+import { InMemoryFeedItemReadRepository } from
+  "@social-monitor/feed/adapters/persistence/in-memory-feed-item-read.repository";
+import { FeedItem } from "@social-monitor/feed/domain";
+import { withTestExecutionAttestation } from
+  "@social-monitor/summary/adapters/model/reader-summary-execution-attestation.spec-support";
+import {
+  buildReaderSummaryCoveragePlan,
+  buildReaderSummaryPeriod,
+} from "@social-monitor/summary/domain";
+import type {
+  AgentRuntimeClientPort,
+  AgentRuntimeHealthResult,
+  AgentRuntimeTaskCommand,
+  AgentRuntimeTaskResult,
+} from "@social-monitor/summary/ports";
+import { FixedClock, tenantId, workspaceId, type JsonObject } from
+  "@social-monitor/shared-kernel";
+
+import { createReaderSummaryDailyPublicationExecutionWiring } from
+  "./reader-summary-daily-publication-finalizer";
+import { buildReaderSummaryDailyStoryRelationVerifier } from
+  "./reader-summary-daily-story-relation-verifier";
+
+const now = new Date("2026-08-31T12:00:00.000Z");
+const clock = new FixedClock(now);
+const tenant = tenantId("tenant-daily-story-wiring");
+const workspace = workspaceId("workspace-daily-story-wiring");
+const period = buildReaderSummaryPeriod({
+  cadence: "daily",
+  startedAt: new Date("2026-08-31T00:00:00.000Z"),
+  endedAt: new Date("2026-09-01T00:00:00.000Z"),
+  timezone: "UTC",
+});
+
+describe("reader summary daily story relation production wiring", () => {
+  it("fails fresh wiring closed when verifier composition was omitted", () => {
+    expect(() => createReaderSummaryDailyPublicationExecutionWiring({
+      replay: null,
+      feedItems: feedRepository(),
+      summaryClient: {} as never,
+      clock,
+      attestationSink: { record: jest.fn(async () => undefined) },
+    })).toThrow(
+      "Fresh daily publication must explicitly configure its story relation verifier",
+    );
+
+    expect(() => buildReaderSummaryDailyStoryRelationVerifier({
+      replay: null,
+      summaryModelMode: "agent-runtime",
+      env: {},
+      agentRuntimeClient: null,
+      attestationSink: { record: jest.fn(async () => undefined) },
+    })).toThrow(
+      "Fresh agent-runtime daily publication requires a story relation verifier client",
+    );
+  });
+
+  it("groups promoted cross-source evidence through the concrete runtime adapter", async () => {
+    const result = await selectDailyEvidence({
+      sameStory: true,
+      attested: true,
+      secondTitle: "Go rewrite of the TypeScript compiler reaches developers",
+    });
+
+    expect(result.runtime.storyCommands).toHaveLength(1);
+    expect(result.selection.clusters).toHaveLength(1);
+    expect(result.selection.clusters[0]?.providerKeys).toEqual([
+      "hacker-news",
+      "reddit",
+    ]);
+    expect(result.selection.approvedSameStoryRelations).toEqual([{
+      leftFeedItemId: "typescript-hn",
+      rightFeedItemId: "typescript-reddit",
+      confidence: 0.98,
+    }]);
+    expect(buildReaderSummaryCoveragePlan(result.selection).lead).toMatchObject({
+      feedItemIds: ["typescript-hn", "typescript-reddit"],
+      providerKeys: ["hacker-news", "reddit"],
+    });
+    expect(result.record).toHaveBeenCalledWith(expect.objectContaining({
+      taskRole: "story_relation",
+      attempt: "primary",
+      attestation: expect.objectContaining({
+        purpose: "social_monitor.reader_summary.verify_story_relations.v2",
+        provider: "codex",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+      }),
+    }));
+  });
+
+  it.each([
+    {
+      name: "an unrelated question sharing product names",
+      sameStory: false,
+      attested: true,
+      secondTitle: "Should a TypeScript compiler rewrite move to Go?",
+      storyAttestationRecorded: true,
+    },
+    {
+      name: "an approving response with a failed attestation",
+      sameStory: true,
+      attested: false,
+      secondTitle: "Go rewrite of the TypeScript compiler reaches developers",
+      storyAttestationRecorded: false,
+    },
+  ])("keeps $name ungrouped", async (scenario) => {
+    const result = await selectDailyEvidence(scenario);
+
+    expect(result.runtime.storyCommands).toHaveLength(1);
+    expect(result.selection.clusters).toHaveLength(2);
+    expect(result.selection.approvedSameStoryRelations).toEqual([]);
+    expect(result.record.mock.calls.some(([record]) =>
+      record.taskRole === "story_relation",
+    )).toBe(scenario.storyAttestationRecorded);
+  });
+});
+
+const selectDailyEvidence = async (input: {
+  readonly sameStory: boolean;
+  readonly attested: boolean;
+  readonly secondTitle: string;
+}) => {
+  const runtime = new FakeRuntime(input.sameStory, input.attested);
+  const record = jest.fn(async () => undefined);
+  const verifier = buildReaderSummaryDailyStoryRelationVerifier({
+    replay: null,
+    summaryModelMode: "agent-runtime",
+    env: {},
+    agentRuntimeClient: runtime,
+    attestationSink: { record },
+  });
+  const wiring = createReaderSummaryDailyPublicationExecutionWiring({
+    replay: null,
+    feedItems: feedRepository(input.secondTitle),
+    summaryClient: {} as never,
+    clock,
+    attestationSink: { record },
+    storyRelationVerifier: verifier,
+  });
+  const selection = await wiring.evidenceSelector.select({
+    tenantId: tenant,
+    workspaceId: workspace,
+    scope: { type: "workspace" },
+    period,
+    maxItems: 2,
+  });
+  return { record, runtime, selection };
+};
+
+const feedRepository = (
+  secondTitle = "Go rewrite of the TypeScript compiler reaches developers",
+): InMemoryFeedItemReadRepository => {
+  const repository = new InMemoryFeedItemReadRepository();
+  repository.upsert(feedItem({
+    id: "typescript-hn",
+    providerKey: "hacker-news",
+    title: "TypeScript compiler rewrite moves to Go",
+    bodyPreview: "Microsoft details the plan for AI-assisted editors.",
+    providerMetadata: {
+      kind: "hacker_news_story",
+      points: 210,
+      promotionAuthority: {
+        official: true,
+        trusted: true,
+        attestedBy: "source_catalog",
+      },
+    },
+  }));
+  repository.upsert(feedItem({
+    id: "typescript-reddit",
+    providerKey: "reddit",
+    title: secondTitle,
+    bodyPreview: secondTitle.startsWith("Should")
+      ? "A forum question compares compiler choices for coding agents."
+      : "The engineering team explains the pipeline for coding agents.",
+    providerMetadata: {
+      kind: "reddit_post",
+      score: 190,
+      promotionAuthority: {
+        official: true,
+        trusted: true,
+        attestedBy: "source_catalog",
+      },
+    },
+  }));
+  return repository;
+};
+
+const feedItem = (input: {
+  readonly id: string;
+  readonly providerKey: string;
+  readonly title: string;
+  readonly bodyPreview: string;
+  readonly providerMetadata: JsonObject;
+}) => FeedItem.publish({
+  id: input.id,
+  tenantId: tenant,
+  workspaceId: workspace,
+  interestId: "interest-ai",
+  sourceItemId: `source-${input.id}`,
+  sourceBindingId: `binding-${input.providerKey}`,
+  providerKey: input.providerKey,
+  canonicalUrl: `https://${input.providerKey}.example.test/${input.id}`,
+  title: input.title,
+  bodyPreview: input.bodyPreview,
+  publishedAt: new Date("2026-08-31T08:00:00.000Z"),
+  observedAt: new Date("2026-08-31T08:01:00.000Z"),
+  providerMetadata: input.providerMetadata,
+});
+
+class FakeRuntime implements AgentRuntimeClientPort {
+  readonly storyCommands: AgentRuntimeTaskCommand[] = [];
+
+  constructor(
+    private readonly sameStory: boolean,
+    private readonly attested: boolean,
+  ) {}
+
+  async runTask(
+    command: AgentRuntimeTaskCommand,
+  ): Promise<AgentRuntimeTaskResult> {
+    const storyRelation = command.purpose ===
+      "social_monitor.reader_summary.verify_story_relations.v2";
+    if (storyRelation) this.storyCommands.push(command);
+    const result: AgentRuntimeTaskResult = {
+      status: "completed",
+      structuredOutput: {
+        decisions: storyRelation
+          ? [{
+              leftFeedItemId: "typescript-hn",
+              rightFeedItemId: "typescript-reddit",
+              sameStory: this.sameStory,
+              confidenceScore: 0.98,
+            }]
+          : [],
+      },
+      warnings: [],
+    };
+    return this.attested
+      ? withTestExecutionAttestation(command, result)
+      : result;
+  }
+
+  async checkHealth(): Promise<AgentRuntimeHealthResult> {
+    return {
+      status: "serving",
+      runtimeEngine: "fake-daily-runtime",
+      runtimeVersion: "1",
+      warnings: [],
+    };
+  }
+}

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -16,9 +16,9 @@ import type {
 import { FixedClock, tenantId, workspaceId, type JsonObject } from
   "@social-monitor/shared-kernel";
 
-import { createReaderSummaryDailyPublicationExecutionWiring } from
+import * as dailyPublicationFinalizer from
   "./reader-summary-daily-publication-finalizer";
-import { buildReaderSummaryDailyStoryRelationVerifier } from
+import { createReaderSummaryDailyCapturePublicationWiring } from
   "./reader-summary-daily-story-relation-verifier";
 
 const now = new Date("2026-08-31T12:00:00.000Z");
@@ -33,26 +33,67 @@ const period = buildReaderSummaryPeriod({
 });
 
 describe("reader summary daily story relation production wiring", () => {
-  it("fails fresh wiring closed when verifier composition was omitted", () => {
-    expect(() => createReaderSummaryDailyPublicationExecutionWiring({
+  it("fails fresh live wiring closed and keeps non-live paths verifier-free", async () => {
+    expect(() => createReaderSummaryDailyCapturePublicationWiring({
       replay: null,
       feedItems: feedRepository(),
       summaryClient: {} as never,
       clock,
       attestationSink: { record: jest.fn(async () => undefined) },
-    })).toThrow(
-      "Fresh daily publication must explicitly configure its story relation verifier",
-    );
-
-    expect(() => buildReaderSummaryDailyStoryRelationVerifier({
-      replay: null,
       summaryModelMode: "agent-runtime",
       env: {},
       agentRuntimeClient: null,
-      attestationSink: { record: jest.fn(async () => undefined) },
     })).toThrow(
       "Fresh agent-runtime daily publication requires a story relation verifier client",
     );
+
+    const localRuntime = new FakeRuntime(true, true);
+    const localWiring = createReaderSummaryDailyCapturePublicationWiring({
+      replay: null,
+      feedItems: feedRepository(),
+      summaryClient: {} as never,
+      clock,
+      attestationSink: { record: jest.fn(async () => undefined) },
+      summaryModelMode: "deterministic",
+      env: {},
+      agentRuntimeClient: localRuntime,
+    });
+    await localWiring.evidenceSelector.select({
+      tenantId: tenant,
+      workspaceId: workspace,
+      scope: { type: "workspace" },
+      period,
+      maxItems: 2,
+    });
+    expect(localRuntime.storyCommands).toHaveLength(0);
+
+    const frozenRuntime = new FakeRuntime(true, true);
+    const frozenReplay = Object.freeze({
+      outputKind: "output_text" as const,
+    }) as never;
+    const executionFactory = jest.spyOn(
+      dailyPublicationFinalizer,
+      "createReaderSummaryDailyPublicationExecutionWiring",
+    ).mockReturnValue({} as never);
+    try {
+      createReaderSummaryDailyCapturePublicationWiring({
+        replay: frozenReplay,
+        feedItems: feedRepository(),
+        summaryClient: {} as never,
+        clock,
+        attestationSink: { record: jest.fn(async () => undefined) },
+        summaryModelMode: "agent-runtime",
+        env: {},
+        agentRuntimeClient: frozenRuntime,
+      });
+      expect(executionFactory).toHaveBeenCalledWith(expect.objectContaining({
+        replay: frozenReplay,
+        storyRelationVerifier: null,
+      }));
+    } finally {
+      executionFactory.mockRestore();
+    }
+    expect(frozenRuntime.storyCommands).toHaveLength(0);
   });
 
   it("groups promoted cross-source evidence through the concrete runtime adapter", async () => {
@@ -123,20 +164,15 @@ const selectDailyEvidence = async (input: {
 }) => {
   const runtime = new FakeRuntime(input.sameStory, input.attested);
   const record = jest.fn(async () => undefined);
-  const verifier = buildReaderSummaryDailyStoryRelationVerifier({
-    replay: null,
-    summaryModelMode: "agent-runtime",
-    env: {},
-    agentRuntimeClient: runtime,
-    attestationSink: { record },
-  });
-  const wiring = createReaderSummaryDailyPublicationExecutionWiring({
+  const wiring = createReaderSummaryDailyCapturePublicationWiring({
     replay: null,
     feedItems: feedRepository(input.secondTitle),
     summaryClient: {} as never,
     clock,
     attestationSink: { record },
-    storyRelationVerifier: verifier,
+    summaryModelMode: "agent-runtime",
+    env: {},
+    agentRuntimeClient: runtime,
   });
   const selection = await wiring.evidenceSelector.select({
     tenantId: tenant,
@@ -165,6 +201,9 @@ const feedRepository = (
         trusted: true,
         attestedBy: "source_catalog",
       },
+      interestQuerySnapshot: {
+        query: "TypeScript, developer tools",
+      },
     },
   }));
   repository.upsert(feedItem({
@@ -181,6 +220,9 @@ const feedRepository = (
         official: true,
         trusted: true,
         attestedBy: "source_catalog",
+      },
+      interestQuerySnapshot: {
+        query: "TypeScript, developer tools",
       },
     },
   }));


### PR DESCRIPTION
## What changed

Connect the existing attestation-validated story-relation verifier to the actual durable production capture path. Fresh agent-runtime capture fails closed if its verifier client is missing. Deterministic local execution and frozen replay remain verifier-free.

The regression exercises the public capture composition, real ranking, validated adapter output, grouping and independent interest metadata. Negative cases preserve separation for unrelated evidence and invalid attestations.

## Evidence

- Focused wiring/frozen/finalizer suites: 25 tests passed on the preserved patch.
- Typecheck, architecture, code quality, runtime profile and source-line cap passed.
- Independent review of `e680d85` returned GO and reran all 25 focused tests.
- CI found a test-only recorder mock typing issue. `75ffd0e` fixes it without changing production code or assertions; an independent delta review returned GO on that exact SHA.
- Final-head CI is required before merge. The candidate is based on main `850c87f`.

## Boundaries

391 changed lines across four files. No engagement-floor, relevance, recall-threshold or shadow-rollout changes. This fixes missing production wiring; it does not claim the original Cursor or watermark pairs now have complete semantic recall. Their exact-input audit and follow-up are separate.
