### PR TITLE
fix(deploy): bridge reader promotion release

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -73,8 +73,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
-      - name: Verify exact Release B target locally before production contact
-        run: bash ops/deploy/github-production-deploy-client.sh verify-release-b-target "$GITHUB_SHA"
+      - name: Verify exact post-promotion V2 graph before production contact
+        env: {GITHUB_OUTPUT: '${{ runner.temp }}/promotion-v2-maintenance.graph'}
+        run: bash ops/deploy/github-production-deploy-client.sh verify-post-promotion-v2-target "$GITHUB_SHA"
       - name: Configure restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
@@ -119,7 +120,7 @@ jobs:
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
   plan:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.maintenance_action == 'none' }}
-    name: Plan changed production components
+    name: Prepare bridge and plan final promotion target
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
@@ -127,157 +128,49 @@ jobs:
       backend: ${{ steps.plan.outputs.backend }}
       backend_base: ${{ steps.plan.outputs.backend_base }}
       control: ${{ steps.plan.outputs.control }}
-      daily_c1_bridge: ${{ steps.plan.outputs.daily_c1_bridge }}
+      daily_c1_bridge: 'false'
       frontend: ${{ steps.plan.outputs.frontend }}
       postgres_pool_bootstrap: ${{ steps.plan.outputs.postgres_pool_bootstrap }}
       postgres_pool_bootstrap_sha: ${{ steps.plan.outputs.postgres_pool_bootstrap_sha }}
       postgres_pool_repair: ${{ steps.plan.outputs.postgres_pool_repair }}
       x_collector: ${{ steps.plan.outputs.x_collector }}
-      recovery_transition: ${{ steps.plan.outputs.recovery_transition }}
-      repair_anchor: ${{ steps.plan.outputs.repair_anchor }}
-      transition_state: ${{ steps.plan.outputs.transition_state }}
+      recovery_transition: 'true'
+      repair_anchor: none
+      transition_state: target-pending
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
-      - name: Validate frozen three-phase graph before production SSH
-        run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-      - name: Verify exact Release B target locally before production contact
-        run: bash ops/deploy/github-production-deploy-client.sh verify-release-b-target "$GITHUB_SHA"
-      - name: Configure restricted production SSH
+      - name: Verify and emit exact post-promotion V2 graph
+        id: graph
+        run: bash ops/deploy/github-production-deploy-client.sh verify-post-promotion-v2-target "$GITHUB_SHA"
+      - name: Configure restricted production SSH for bridge preparation
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-      - name: Inspect transition state in B then A then E order
+      - name: Prepare B at most once without planning or deploying J or M
+        env:
+          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
+          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
+          RELEASE_B: ${{ steps.graph.outputs.release_b }}
+          JOIN_SHA: ${{ steps.graph.outputs.join }}
+          TARGET_SHA: ${{ steps.graph.outputs.target }}
+        run: bash ops/deploy/github-production-deploy-client.sh prepare-post-promotion-v2-bridge "$RELEASE_B" "$JOIN_SHA" "$TARGET_SHA"
+      - name: Close SSH so the installed B controller can take effect
+        if: always()
+        run: bash ops/deploy/github-production-deploy-client.sh cleanup
+      - name: Configure fresh restricted production SSH after B
+        env:
+          DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
+          KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
+        run: bash ops/deploy/github-production-deploy-client.sh configure
+      - name: Freshly run the ordinary final M plan
         id: plan
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        run: |
-          set -euo pipefail
-          transition=ops/deploy/production-release-a-transition.sh
-          client=ops/deploy/github-production-deploy-client.sh
-          release_e=889d50f50328c89e25b3ef898e552df631b3222f; release_a2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a; release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
-          daily_c1_atomic_repair=61018b1d376ba6695c29f9ccee1b53b1b344d4dc
-          target_plan="$RUNNER_TEMP/recovery-target-inspect.plan"; b_plan="$RUNNER_TEMP/recovery-b2-inspect.plan"
-          a_plan="$RUNNER_TEMP/recovery-a2-inspect.plan"; e_plan="$RUNNER_TEMP/recovery-e-inspect.plan"
-          repair_anchor=none
-          target_atomic_repair_plan() {
-            [[ $(awk -F= '$1 == "frontend" { print $2 }' "$target_plan") =~ ^(true|false)$ &&
-               $(awk -F= '$1 == "backend" { print $2 }' "$target_plan") == true &&
-               $(awk -F= '$1 == "backend_base" { print $2 }' "$target_plan") == 4bb8f6d4969b8449726a10859202b23e2bfb4366 &&
-               $(awk -F= '$1 == "control" { print $2 }' "$target_plan") == true &&
-               $(awk -F= '$1 == "x_collector" { print $2 }' "$target_plan") == false &&
-               $(awk -F= '$1 == "postgres_pool_bootstrap" { print $2 }' "$target_plan") == uninstalled &&
-               $(awk -F= '$1 == "postgres_pool_bootstrap_sha" { print $2 }' "$target_plan") == 0000000000000000000000000000000000000000 &&
-               $(awk -F= '$1 == "postgres_pool_repair" { print $2 }' "$target_plan") == false ]]
-          }
-          bash "$client" inspect-plan "$GITHUB_SHA" > "$target_plan"
-          daily_c1_bridge_base=e3b5b5d89b3586668e36f987f03672415b5a0f37
-          daily_c1_final_marker=ops/deploy/production-runtime/reader-summary-daily-c1.readiness
-          daily_c1_bridge=false
-          daily_c1_bridge_expected=$(cat <<'EOF' | LC_ALL=C sort
-          .github/workflows/production-deploy.yml
-          ops/deploy/daily-c1-control-bridge-workflow.test.sh
-          ops/deploy/daily-runner-image-bootstrap-lib.sh
-          ops/deploy/daily-runner-image-bootstrap-lib.test.sh
-          ops/deploy/deploy-control-bridge-lib.sh
-          ops/deploy/deploy-control-bridge-runtime-helper.test.sh
-          ops/deploy/deploy-control-lib-test-fixture.sh
-          ops/deploy/deploy-control-lib.sh
-          ops/deploy/deploy-control-lib.test.sh
-          ops/deploy/deploy-control-reviewed-library-source.test.sh
-          ops/deploy/github-production-deploy-client.sh
-          ops/deploy/github-production-deploy-client.test.sh
-          ops/deploy/postgres-runtime-activation-boundary-lib.sh
-          ops/deploy/postgres-runtime-daily-c1-readiness-lib.sh
-          ops/deploy/postgres-runtime-deploy-lib.sh
-          ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
-          ops/deploy/production-release-a-transition.sh
-          ops/deploy/production-release-a-transition.test.sh
-          ops/deploy/production-runtime/daily-c1-runtime.sh
-          ops/deploy/production-runtime/reader-summary-daily-c1.readiness
-          ops/deploy/production-runtime/social-monitor-daily.timer
-          ops/deploy/production-runtime/social-monitor-reader-summary-production-day.bootstrap.timer
-          ops/deploy/production-runtime/social-monitor-reader-summary-production-day.service.d-10-daily-c1-owner.conf
-          ops/deploy/reader-summary-publication-deploy-lib.sh
-          ops/deploy/reader-summary-publication-prebootstrap-lib.sh
-          ops/deploy/reader-summary-publication-prebootstrap-lib.test.sh
-          ops/deploy/reader-summary-recovery-maintenance-lib.sh
-          ops/deploy/social-monitor-production-deploy.sh
-          ops/deploy/x-collector-image-deploy-lib.test.sh
-          EOF
-          )
-          daily_c1_bridge_actual=$(git diff --name-only --no-renames \
-            "$daily_c1_bridge_base" "$GITHUB_SHA" -- | LC_ALL=C sort)
-          daily_c1_final_marker_mode=$(git ls-tree "$GITHUB_SHA" -- \
-            "$daily_c1_final_marker" | awk 'NR == 1 { print $1 }')
-          if git merge-base --is-ancestor "$daily_c1_bridge_base" "$GITHUB_SHA" && \
-             [[ $daily_c1_bridge_actual == "$daily_c1_bridge_expected" ]]; then
-            daily_c1_bridge=true
-          elif [[ -z $daily_c1_final_marker_mode ]]; then
-            echo 'daily C1 bridge diff does not match its exact B2 manifest' >&2
-            exit 1
-          fi
-          if [[ $daily_c1_bridge == true ]]; then
-            target_pool_bootstrap=$(awk -F= \
-              '$1 == "postgres_pool_bootstrap" { print $2 }' "$target_plan")
-            if [[ $target_pool_bootstrap == uninstalled ]]; then
-              repair_anchor=$daily_c1_atomic_repair
-              transition_state=repair-required
-            else
-              transition_state=target-pending
-            fi
-          elif target_state=$(bash "$transition" state "$GITHUB_SHA" TARGET "$target_plan" \
-              2> "$RUNNER_TEMP/recovery-target-state.err") &&
-             { case $target_state in
-                 transition_state=repair-required) target_atomic_repair_plan ;;
-                 *) true ;;
-               esac; }; then
-            transition_state=${target_state#transition_state=}
-            [[ $transition_state != repair-required ]] || \
-              repair_anchor=$daily_c1_atomic_repair
-          else
-            bash "$client" inspect-plan "$release_b2" > "$b_plan"
-            if b_state=$(bash "$transition" state "$GITHUB_SHA" B2 "$b_plan" \
-                2> "$RUNNER_TEMP/recovery-b2-state.err"); then
-              transition_state=${b_state#transition_state=}
-              [[ $transition_state != repair-required ]] || repair_anchor=$release_b2
-            else
-              bash "$client" inspect-plan "$release_a2" > "$a_plan"
-              if a_state=$(bash "$transition" state "$GITHUB_SHA" A2 "$a_plan" \
-                  2> "$RUNNER_TEMP/recovery-a2-state.err"); then
-                transition_state=${a_state#transition_state=}
-                if [[ $transition_state == repair-required ]]; then
-                  repair_anchor=$release_a2
-                else
-                  [[ $a_state == transition_state=E-complete ]]
-                fi
-              fi
-              if [[ -z ${a_state:-} ]]; then
-                bash "$client" inspect-plan "$release_e" > "$e_plan"
-                if e_state=$(bash "$transition" state "$GITHUB_SHA" E "$e_plan" \
-                    2> "$RUNNER_TEMP/recovery-e-state.err"); then
-                  transition_state=${e_state#transition_state=}
-                  [[ $transition_state != repair-required ]] || repair_anchor=$release_e
-                else
-                  cat "$RUNNER_TEMP"/recovery-{b2,a2,e}-state.err >&2
-                  exit 1
-                fi
-              fi
-            fi
-          fi
-          {
-            awk -F= '$1 == "frontend" || $1 == "backend" || \
-              $1 == "backend_base" || $1 == "control" || \
-              $1 == "x_collector" || $1 == "postgres_pool_bootstrap" || \
-              $1 == "postgres_pool_bootstrap_sha" || \
-              $1 == "postgres_pool_repair" { print }' "$target_plan"
-            printf 'recovery_transition=true\n'
-            printf 'daily_c1_bridge=%s\n' "$daily_c1_bridge"
-            printf 'repair_anchor=%s\n' "$repair_anchor"
-            printf 'transition_state=%s\n' "$transition_state"
-          } >> "$GITHUB_OUTPUT"
+          TARGET_SHA: ${{ steps.graph.outputs.target }}
+        run: bash ops/deploy/github-production-deploy-client.sh plan-post-promotion-v2-target "$TARGET_SHA"
       - name: Remove production SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
@@ -724,176 +617,13 @@ jobs:
           path: ${{ runner.temp }}/social-monitor-frontend-release.tgz
           if-no-files-found: error
           retention-days: 3
-  release_a:
-    name: Reconcile Release E and Release A before Release B
-    needs:
-      - plan
-      - verify_reader_summary_publication
-      - verify_backend
-      - build_frontend
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    environment: production
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with: {fetch-depth: 0}
-      - name: Validate graph and immutable manifests before production SSH
-        run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-      - name: Configure restricted production SSH
-        env:
-          DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
-          KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
-        run: bash ops/deploy/github-production-deploy-client.sh configure
-      - name: Repair PostgreSQL bootstrap after verification
-        if: needs.plan.outputs.transition_state == 'repair-required'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-          REPAIR_ANCHOR: ${{ needs.plan.outputs.repair_anchor }}
-          DEPLOY_RECONCILE_ATTEMPTS: 1
-          DEPLOY_RECONCILE_INTERVAL_SECONDS: 0
-        run: |
-          case $REPAIR_ANCHOR in
-            889d50f50328c89e25b3ef898e552df631b3222f|c64c3b46b6b6ba5c7ac7b04028932e09dae2116a|e3b5b5d89b3586668e36f987f03672415b5a0f37|61018b1d376ba6695c29f9ccee1b53b1b344d4dc) ;;
-            *) exit 1 ;;
-          esac
-          repair_status=0
-          bash ops/deploy/github-production-deploy-client.sh deploy "$REPAIR_ANCHOR" || repair_status=$?
-          printf 'bounded repair client status=%s; fresh inspection is authoritative\n' "$repair_status"
-      - name: Close possibly interrupted repair SSH
-        if: always()
-        run: bash ops/deploy/github-production-deploy-client.sh cleanup
-      - name: Configure fresh SSH after repair boundary
-        env:
-          DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
-          KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
-        run: bash ops/deploy/github-production-deploy-client.sh configure
-      - name: Deploy the daily C1 target through the alias-aware controller
-        if: needs.plan.outputs.daily_c1_bridge == 'true'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        run: |
-          set -euo pipefail
-          bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"
-      - name: Freshly inspect after bounded repair
-        id: recovery_state
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        run: |
-          set -euo pipefail
-          transition=ops/deploy/production-release-a-transition.sh
-          client=ops/deploy/github-production-deploy-client.sh
-          release_e=889d50f50328c89e25b3ef898e552df631b3222f; release_a2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a; release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
-          target_plan="$RUNNER_TEMP/recovery-target-fresh.plan"; b_plan="$RUNNER_TEMP/recovery-b2-fresh.plan"
-          a_plan="$RUNNER_TEMP/recovery-a2-fresh.plan"; e_plan="$RUNNER_TEMP/recovery-e-fresh.plan"
-          bash "$client" inspect-plan "$GITHUB_SHA" > "$target_plan"
-          if state=$(bash "$transition" state "$GITHUB_SHA" TARGET "$target_plan" \
-              2> "$RUNNER_TEMP/recovery-target-fresh.err"); then
-            transition_state=${state#transition_state=}
-            [[ $transition_state != repair-required ]]
-          else
-          bash "$client" inspect-plan "$release_b2" > "$b_plan"
-          if state=$(bash "$transition" state "$GITHUB_SHA" B2 "$b_plan" \
-              2> "$RUNNER_TEMP/recovery-b2-fresh.err"); then
-            transition_state=${state#transition_state=}
-          else
-            bash "$client" inspect-plan "$release_a2" > "$a_plan"
-            if a_state=$(bash "$transition" state "$GITHUB_SHA" A2 "$a_plan" \
-                2> "$RUNNER_TEMP/recovery-a2-fresh.err"); then
-              transition_state=${a_state#transition_state=}
-              [[ $transition_state == E-complete ]]
-            fi
-            if [[ -z ${a_state:-} ]]; then
-              bash "$client" inspect-plan "$release_e" > "$e_plan"
-              if e_state=$(bash "$transition" state "$GITHUB_SHA" E "$e_plan" \
-                  2> "$RUNNER_TEMP/recovery-e-fresh.err"); then
-                transition_state=${e_state#transition_state=}
-              else
-                cat "$RUNNER_TEMP"/recovery-{b2,a2,e}-fresh.err >&2
-                exit 1
-              fi
-            fi
-          fi
-          fi
-          [[ $transition_state != repair-required ]]
-          printf 'transition_state=%s\n' "$transition_state" >> "$GITHUB_OUTPUT"
-      - name: Deploy and reconcile Release E through the installed wrapper
-        if: steps.recovery_state.outputs.transition_state == 'pre-E'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        run: |
-          set -euo pipefail
-          release_e=889d50f50328c89e25b3ef898e552df631b3222f
-          bash ops/deploy/github-production-deploy-client.sh deploy "$release_e"
-      - name: Remove Release E SSH material
-        if: always()
-        run: bash ops/deploy/github-production-deploy-client.sh cleanup
-      - name: Open fresh SSH after Release E
-        if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete'
-        env:
-          DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
-          KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
-        run: bash ops/deploy/github-production-deploy-client.sh configure
-      - name: Prove E-complete through the Release A plan
-        if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        run: |
-          set -euo pipefail
-          release_a2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a
-          plan="$RUNNER_TEMP/recovery-a2-after-e.plan"
-          bash ops/deploy/github-production-deploy-client.sh \
-            inspect-plan "$release_a2" > "$plan"
-          state=$(bash ops/deploy/production-release-a-transition.sh \
-            state "$GITHUB_SHA" A2 "$plan")
-          [[ $state == transition_state=E-complete ]]
-      - name: Deploy and reconcile Release A through the installed wrapper
-        if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        run: |
-          set -euo pipefail
-          release_a2=c64c3b46b6b6ba5c7ac7b04028932e09dae2116a
-          bash ops/deploy/github-production-deploy-client.sh deploy "$release_a2"
-      - name: Remove Release A SSH material
-        if: always()
-        run: bash ops/deploy/github-production-deploy-client.sh cleanup
-      - name: Open fresh SSH after Release A
-        if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete' || steps.recovery_state.outputs.transition_state == 'A-complete'
-        env:
-          DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
-          KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
-        run: bash ops/deploy/github-production-deploy-client.sh configure
-      - name: Prove A-complete through the Release B plan
-        if: steps.recovery_state.outputs.transition_state == 'pre-E' || steps.recovery_state.outputs.transition_state == 'E-complete' || steps.recovery_state.outputs.transition_state == 'A-complete'
-        env:
-          DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
-          DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        run: |
-          set -euo pipefail
-          plan="$RUNNER_TEMP/recovery-b2-after-a.plan"
-          release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
-          bash ops/deploy/github-production-deploy-client.sh \
-            inspect-plan "$release_b2" > "$plan"
-          state=$(bash ops/deploy/production-release-a-transition.sh \
-            state "$GITHUB_SHA" B2 "$plan")
-          [[ $state == transition_state=A-complete ]]
-      - name: Remove production SSH material
-        if: always()
-        run: bash ops/deploy/github-production-deploy-client.sh cleanup
   deploy:
-    name: Deploy Release B with host locks and rollback
+    name: Deploy final promotion target with host locks and rollback
     needs:
       - plan
       - verify_reader_summary_publication
       - verify_backend
       - build_frontend
-      - release_a
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: production
@@ -903,40 +633,13 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
-      - name: Validate graph and immutable manifests before Release B SSH
-        run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
-      - name: Reconcile the old controller, deploy its reviewed bridge, and reopen SSH
+      - name: Verify exact post-promotion V2 graph before deploy SSH
+        run: bash ops/deploy/github-production-deploy-client.sh verify-post-promotion-v2-target "$GITHUB_SHA"
+      - name: Configure fresh restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
-        run: |
-          set -euo pipefail
-          client=ops/deploy/github-production-deploy-client.sh; controller_release=8b4aeb31e855ed379349a4e4827600009e174132; bridge_release=b89950632b0cefa4f7b58b687cdfd6e6cd912a04; bridge_target=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
-          current_main=77313ea03a3bac7d2298f4021d58124c810d291f; bash "$client" configure
-          bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$bridge_target" "$GITHUB_SHA"
-          bash "$client" cleanup; bash "$client" configure
-      - name: Freshly require A-complete or B-complete
-        id: b_state
-        run: |
-          set -euo pipefail
-          target_plan="$RUNNER_TEMP/recovery-target-before-deploy.plan"
-          bash ops/deploy/github-production-deploy-client.sh \
-            inspect-plan "$GITHUB_SHA" > "$target_plan"
-          if state=$(bash ops/deploy/production-release-a-transition.sh \
-              state "$GITHUB_SHA" TARGET "$target_plan"); then
-            [[ $state == transition_state=target-pending || \
-               $state == transition_state=target-complete ]]
-          else
-            plan="$RUNNER_TEMP/recovery-b2-before-deploy.plan"
-            release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
-            bash ops/deploy/github-production-deploy-client.sh \
-              inspect-plan "$release_b2" > "$plan"
-            state=$(bash ops/deploy/production-release-a-transition.sh \
-              state "$GITHUB_SHA" B2 "$plan")
-            [[ $state == transition_state=A-complete || \
-               $state == transition_state=B-complete ]]
-          fi
-          printf '%s\n' "$state" >> "$GITHUB_OUTPUT"
+        run: bash ops/deploy/github-production-deploy-client.sh configure
       - name: Download immutable frontend artifact
         if: needs.plan.outputs.frontend == 'true'
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
@@ -949,13 +652,12 @@ jobs:
           bash ops/deploy/github-production-deploy-client.sh upload "$GITHUB_SHA"
           "$RUNNER_TEMP/frontend-artifact/social-monitor-frontend-release.tgz"
       - name: Deploy changed components
-        if: steps.b_state.outputs.transition_state != 'target-complete'
         run: bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"
       - name: Remove production SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup
   acceptance:
-    name: Require separate post-deploy Release B acceptance
+    name: Require separate final promotion acceptance
     needs:
       - plan
       - deploy
@@ -965,35 +667,18 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: {fetch-depth: 0}
-      - name: Validate graph and immutable manifests before acceptance SSH
-        run: bash ops/deploy/production-release-a-transition.sh validate "$GITHUB_SHA"
+      - name: Verify exact post-promotion V2 graph before acceptance SSH
+        run: bash ops/deploy/github-production-deploy-client.sh verify-post-promotion-v2-target "$GITHUB_SHA"
       - name: Configure fresh restricted production SSH
         env:
           DEPLOY_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
           KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
         run: bash ops/deploy/github-production-deploy-client.sh configure
-      - name: Accept only B-complete durable state
+      - name: Accept only exact M-complete durable state
         env:
           DEPLOY_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER }}
-        run: |
-          set -euo pipefail
-          plan="$RUNNER_TEMP/recovery-target-acceptance.plan"
-          bash ops/deploy/github-production-deploy-client.sh \
-            inspect-plan "$GITHUB_SHA" > "$plan"
-          if state=$(bash ops/deploy/production-release-a-transition.sh \
-              state "$GITHUB_SHA" TARGET "$plan"); then
-            [[ $state == transition_state=target-complete ]]
-          else
-            awk -F= '$1 == "frontend" || $1 == "backend" || \
-              $1 == "control" || $1 == "x_collector" { if ($2 != "false") exit 1 }' "$plan"
-            release_b2=e3b5b5d89b3586668e36f987f03672415b5a0f37
-            bash ops/deploy/github-production-deploy-client.sh \
-              inspect-plan "$release_b2" > "$RUNNER_TEMP/recovery-b2-acceptance.plan"
-            state=$(bash ops/deploy/production-release-a-transition.sh state \
-              "$GITHUB_SHA" B2 "$RUNNER_TEMP/recovery-b2-acceptance.plan")
-            [[ $state == transition_state=B-complete ]]
-          fi
+        run: bash ops/deploy/github-production-deploy-client.sh accept-post-promotion-v2-target "$GITHUB_SHA"
       - name: Remove production SSH material
         if: always()
         run: bash ops/deploy/github-production-deploy-client.sh cleanup

--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -12,6 +12,7 @@ DEPLOY_CONTROL_BRIDGE_POSTGRES_DAILY_C1_HELPER_PATH=ops/deploy/postgres-runtime-
 DEPLOY_CONTROL_BRIDGE_POSTGRES_ACTIVATION_BOUNDARY_HELPER_PATH=ops/deploy/postgres-runtime-activation-boundary-lib.sh
 DEPLOY_CONTROL_BRIDGE_RECOVERY_MAINTENANCE_LIBRARY_PATH=ops/deploy/reader-summary-recovery-maintenance-lib.sh
 DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_LIBRARY_PATH=ops/deploy/backend-image-rescue-lib.sh
+DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_PIN_CLEANUP_LIBRARY_PATH=ops/deploy/backend-image-rescue-pin-cleanup-lib.sh
 DEPLOY_CONTROL_BRIDGE_X_IMAGE_LIBRARY_PATH=ops/deploy/x-collector-image-deploy-lib.sh
 DEPLOY_CONTROL_BRIDGE_SELF_PATH=ops/deploy/deploy-control-bridge-lib.sh
 DEPLOY_CONTROL_DAILY_FINAL_BASE=d494c143c242873bfac53f54c15b0f24df0ab33d
@@ -31,6 +32,10 @@ DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_TREE=903f5e8d944c6d703b2bf282d0046ba50
 DEPLOY_CONTROL_FAILED_IDLE_RELEASE_BRIDGE_BLOB=a6407769622a4da1bd677ff83c9db6ad2c710662
 DEPLOY_CONTROL_RELEASE_B_CONTROLLER=8b4aeb31e855ed379349a4e4827600009e174132
 DEPLOY_CONTROL_RELEASE_B_CURRENT_MAIN=77313ea03a3bac7d2298f4021d58124c810d291f
+DEPLOY_CONTROL_LIVE_BRIDGE_BASE=7c4070f0b9ef1aac130284bcffac50551e20a4dd
+DEPLOY_CONTROL_LIVE_REVIEWED_MAIN=c5dc5abb12aa1ac84ddbd12f141c6d4d8aca4de2
+DEPLOY_CONTROL_LIVE_DEPLOY_LIBRARY_BLOB=fd2d8095cd6e2428e02f6ca21942bab2ea10961b
+DEPLOY_CONTROL_LIVE_IMAGE_RESCUE_PIN_CLEANUP_BLOB=ed843e0be66e86bdfc430347e7467fbcb2880ce4
 DEPLOY_CONTROL_DAILY_RECOVERY_BASE=cb1595d9bdca844d6a221d21fd3c53e6845cc4cf
 DEPLOY_CONTROL_DAILY_RECOVERY_BACKEND_RESCUE_BLOB=a4291fad8b1f36f0cbb0760f3dbca6e7603138bc
 DEPLOY_CONTROL_DAILY_RECOVERY_MIGRATE_TEST_BLOB=f62a83ce95cc768c4e888e7c576bad3bd6fdbced
@@ -49,6 +54,83 @@ DEPLOY_CONTROL_DAILY_RECOVERY_HISTORY_TEST_BLOB=c7307f3e2808d02207ce8b8a62624271
 RABBITMQ_QUORUM_HEALTH_LIBRARY_PATH=ops/deploy/backend-runtime-health-lib.sh
 RABBITMQ_QUORUM_HEALTH_SCRIPT_PATH=ops/deploy/rabbitmq-quorum-health.sh
 RABBITMQ_QUORUM_RECOVERY_SCRIPT_PATH=ops/deploy/rabbitmq-quorum-recovery.sh
+
+deploy_control_require_b0_bootstrap_file() {
+  local sha=$1 install_mode=$2 relative=$3
+  local source=$REPO/$relative destination=$CONTROL/${relative##*/}
+  local next=$destination.next entry tree_mode type object tree_path extra
+  local expected_tree_mode=100${install_mode#0} expected_owner before after
+  entry=$(git -C "$REPO" ls-tree "$sha" -- "$relative") || \
+    fail "B0 bootstrap cannot inspect $relative"
+  read -r tree_mode type object tree_path extra <<< "$entry"
+  [[ -z ${extra:-} && $tree_mode == "$expected_tree_mode" && \
+     $type == blob && $object =~ ^[0-9a-f]{40}$ && \
+     $tree_path == "$relative" ]] || \
+    fail "B0 bootstrap path has an invalid mode or object: $relative"
+  [[ -f $source && ! -L $source && \
+     $(git -C "$REPO" hash-object --no-filters "$source") == "$object" ]] || \
+    fail "B0 bootstrap worktree differs from reviewed target: $relative"
+  if [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} == 1 ]]; then
+    expected_owner=$(id -u):$(id -g):${install_mode#0}
+  else
+    expected_owner=0:0:${install_mode#0}
+  fi
+  if [[ -e $destination || -L $destination ]]; then
+    [[ -f $destination && ! -L $destination && \
+       $(stat -Lc '%u:%g:%a' "$destination") == "$expected_owner" && \
+       $(git -C "$REPO" hash-object --no-filters "$destination") == "$object" ]] || \
+      fail "installed B0 bootstrap path is unsafe or differs: $relative"
+    return 0
+  fi
+  if [[ -e $next || -L $next ]]; then
+    [[ -f $next && ! -L $next && \
+       $(stat -Lc '%u:%g:%a' "$next") == "$expected_owner" && \
+       $(git -C "$REPO" hash-object --no-filters "$next") == "$object" ]] || \
+      fail "staged B0 bootstrap path is unsafe or differs: $relative"
+  elif [[ ${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-} == 1 ]]; then
+    install -m "$install_mode" "$source" "$next"
+  else
+    install -m "$install_mode" -o root -g root "$source" "$next"
+  fi
+  before=$(stat -Lc '%d:%i:%f:%s:%Y:%Z' "$next") || \
+    fail "staged B0 bootstrap path cannot be read: $relative"
+  [[ $(git -C "$REPO" hash-object --no-filters "$next") == "$object" ]] || \
+    fail "staged B0 bootstrap bytes differ: $relative"
+  after=$(stat -Lc '%d:%i:%f:%s:%Y:%Z' "$next") || \
+    fail "staged B0 bootstrap path cannot be re-read: $relative"
+  [[ $before == "$after" ]] || fail "staged B0 bootstrap path changed: $relative"
+  mv -T "$next" "$destination"
+}
+
+deploy_control_bootstrap_production_transition_b0() {
+  local sha=$1 remote needs_install=false relative present=0
+  [[ ${action:-} == deploy ]] || return 0
+  for relative in production-transition-admission.sh \
+    production-transition-b0-host-control.sh \
+    production-transition-canonical-lib.sh; do
+    git -C "$REPO" cat-file -e "$sha:ops/deploy/$relative" 2>/dev/null && \
+      present=$((present + 1))
+  done
+  ((present != 0)) || return 0
+  ((present == 3)) || fail 'B0 bootstrap target has an incomplete transition control set'
+  for relative in production-transition-admission.sh \
+    production-transition-b0-host-control.sh \
+    production-transition-canonical-lib.sh; do
+    [[ -e $CONTROL/$relative || -L $CONTROL/$relative ]] || needs_install=true
+  done
+  if [[ $needs_install == true ]]; then
+    remote=$(git -C "$REPO" rev-parse --verify 'origin/main^{commit}') || \
+      fail 'B0 bootstrap origin main is unavailable'
+    [[ $remote == "$sha" ]] || \
+      fail 'B0 bootstrap requires the exact protected-main commit'
+  fi
+  deploy_control_require_b0_bootstrap_file "$sha" 0755 \
+    ops/deploy/production-transition-admission.sh
+  deploy_control_require_b0_bootstrap_file "$sha" 0644 \
+    ops/deploy/production-transition-b0-host-control.sh
+  deploy_control_require_b0_bootstrap_file "$sha" 0644 \
+    ops/deploy/production-transition-canonical-lib.sh
+}
 
 deploy_control_bridge_sealed_paths() {
   printf '%s\n' \
@@ -399,6 +481,114 @@ deploy_control_is_reviewed_failed_idle_release_transition() {
   [[ $target_delta == "$expected_target_delta" ]]
 }
 
+# Admit only the final protected-main merge reached through the exact reviewed
+# bridge, integration join, and guard. The integration join is graph proof and
+# is never itself a deployable target.
+deploy_control_is_reviewed_live_controller_transition() {
+  local bridge=$1 target=$2 repository=${REPO:-.}
+  local bridge_delta join_delta guard_delta expected_bridge expected_guard path
+  local expected_join_delta
+  local bridge_entry join_entry target_cleanup_entry join guard
+  local guard_entry guard_mode guard_type guard_object guard_path guard_extra
+  local expected_mode
+  local target_tree guard_tree
+  local -a bridge_ancestry=() join_ancestry=() guard_ancestry=()
+  local -a target_ancestry=()
+
+  expected_bridge=$(printf '%s\n' \
+    "$DEPLOY_CONTROL_BRIDGE_SELF_PATH" \
+    "$DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH" | LC_ALL=C sort)
+  read -r -a bridge_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$bridge" 2>/dev/null)" || return 1
+  [[ ${#bridge_ancestry[@]} == 2 && \
+     ${bridge_ancestry[0]} == "$bridge" && \
+     ${bridge_ancestry[1]} == "$DEPLOY_CONTROL_LIVE_BRIDGE_BASE" ]] || \
+    return 1
+  bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_LIVE_BRIDGE_BASE" "$bridge" -- 2>/dev/null | \
+    LC_ALL=C sort) || return 1
+  [[ $bridge_delta == "$expected_bridge" ]] || return 1
+  while IFS= read -r path; do
+    bridge_entry=$(git -C "$repository" ls-tree "$bridge" -- "$path" \
+      2>/dev/null) || return 1
+    [[ $bridge_entry == 100644\ blob\ *$'\t'"$path" ]] || return 1
+  done <<< "$expected_bridge"
+  [[ $(git -C "$repository" rev-parse \
+       "$bridge:$DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH" 2>/dev/null) == \
+     "$DEPLOY_CONTROL_LIVE_DEPLOY_LIBRARY_BLOB" ]] || return 1
+
+  read -r -a target_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$target" 2>/dev/null)" || return 1
+  [[ ${#target_ancestry[@]} == 3 && \
+     ${target_ancestry[0]} == "$target" && \
+     ${target_ancestry[1]} == "$DEPLOY_CONTROL_LIVE_REVIEWED_MAIN" ]] || \
+    return 1
+  guard=${target_ancestry[2]}
+  target_tree=$(git -C "$repository" rev-parse "$target^{tree}" \
+    2>/dev/null) || return 1
+  guard_tree=$(git -C "$repository" rev-parse "$guard^{tree}" \
+    2>/dev/null) || return 1
+  [[ $target_tree == "$guard_tree" ]] || return 1
+
+  read -r -a guard_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$guard" 2>/dev/null)" || return 1
+  [[ ${#guard_ancestry[@]} == 2 && \
+     ${guard_ancestry[0]} == "$guard" ]] || return 1
+  join=${guard_ancestry[1]}
+  expected_guard=$(printf '%s\n' \
+    .github/workflows/production-deploy.yml \
+    ops/deploy/github-production-deploy-client.sh \
+    ops/deploy/github-production-deploy-client.test.sh \
+    ops/deploy/production-release-b-bridge-order.test.sh \
+    ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh | \
+    LC_ALL=C sort)
+  guard_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$join" "$guard" -- 2>/dev/null | LC_ALL=C sort) || return 1
+  [[ $guard_delta == "$expected_guard" ]] || return 1
+  while read -r expected_mode path; do
+    guard_entry=$(git -C "$repository" ls-tree "$guard" -- "$path" \
+      2>/dev/null) || return 1
+    read -r guard_mode guard_type guard_object guard_path guard_extra <<< \
+      "$guard_entry"
+    [[ -z ${guard_extra:-} && $guard_mode == "$expected_mode" && \
+       $guard_type == blob && $guard_object =~ ^[0-9a-f]{40}$ && \
+       $guard_path == "$path" ]] || return 1
+  done <<'EOF'
+100644 .github/workflows/production-deploy.yml
+100755 ops/deploy/github-production-deploy-client.sh
+100755 ops/deploy/github-production-deploy-client.test.sh
+100755 ops/deploy/production-release-b-bridge-order.test.sh
+100644 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+EOF
+
+  read -r -a join_ancestry <<< "$(git -C "$repository" \
+    rev-list --parents -n 1 "$join" 2>/dev/null)" || return 1
+  [[ ${#join_ancestry[@]} == 3 && \
+     ${join_ancestry[0]} == "$join" && \
+     ${join_ancestry[1]} == "$DEPLOY_CONTROL_LIVE_REVIEWED_MAIN" && \
+     ${join_ancestry[2]} == "$bridge" ]] || return 1
+  join_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$DEPLOY_CONTROL_LIVE_REVIEWED_MAIN" "$join" -- 2>/dev/null | \
+    LC_ALL=C sort) || return 1
+  # The deploy library converges byte-for-byte and mode-for-mode with reviewed
+  # main, so only the bridge policy remains in the F..J tree delta.
+  expected_join_delta=$DEPLOY_CONTROL_BRIDGE_SELF_PATH
+  [[ $join_delta == "$expected_join_delta" ]] || return 1
+  while IFS= read -r path; do
+    bridge_entry=$(git -C "$repository" ls-tree "$bridge" -- "$path" \
+      2>/dev/null) || return 1
+    join_entry=$(git -C "$repository" ls-tree "$join" -- "$path" \
+      2>/dev/null) || return 1
+    [[ $join_entry == "$bridge_entry" ]] || return 1
+  done <<< "$expected_bridge"
+  target_cleanup_entry=$(git -C "$repository" ls-tree "$target" -- \
+    "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_PIN_CLEANUP_LIBRARY_PATH" \
+    2>/dev/null) || return 1
+  [[ $target_cleanup_entry == \
+     "100644 blob $DEPLOY_CONTROL_LIVE_IMAGE_RESCUE_PIN_CLEANUP_BLOB"$'\t'\
+"$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_PIN_CLEANUP_LIBRARY_PATH" ]]
+}
+
 # Recover the exact reviewed rolling release after its synthetic transition
 # fixture proved too narrow for the real first-parent production graph. The
 # installed bridge is still constrained to one control-only commit, while the
@@ -435,6 +625,10 @@ deploy_control_is_reviewed_rolling_repair_transition() {
 
 deploy_control_reviewed_transition_matches() {
   local bridge=$1 target=$2
+  if deploy_control_is_reviewed_live_controller_transition \
+      "$bridge" "$target"; then
+    return 0
+  fi
   if deploy_control_is_reviewed_rolling_repair_transition \
       "$bridge" "$target"; then
     return 0
@@ -535,10 +729,10 @@ load_target_reader_summary_publication_deploy_library() {
     fail 'target publication deploy library differs from reviewed target'
   ! declare -F deploy_reader_summary_publication_migrations >/dev/null || \
     fail 'publication migration entrypoint was loaded before target validation'
-  # The bridge release deliberately lacks this target-only source file.
-  # shellcheck source=/dev/null
-  source "$publication_real" || \
-    fail 'target publication deploy library could not be loaded'
+  # The bridge release deliberately lacks this target-only source file. Load
+  # the exact target blob through the protected reviewed-library staging path.
+  source_reviewed_deploy_library "$sha" "$relative_path" \
+    'target publication deploy library'
   declare -F deploy_reader_summary_publication_migrations >/dev/null || \
     fail 'target publication deploy library is missing its migration entrypoint'
 }
@@ -615,6 +809,7 @@ initialize_deploy_control_bridge() {
 }
 
 verify_deploy_control_bridge_compatibility() {
+  local current path target_blob
   local entrypoint=$REPO/$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_PATH
   local deploy_library=$REPO/$DEPLOY_CONTROL_BRIDGE_LIBRARY_PATH
   local postgres_library=$REPO/$DEPLOY_CONTROL_BRIDGE_POSTGRES_LIBRARY_PATH
@@ -638,8 +833,21 @@ verify_deploy_control_bridge_compatibility() {
      -f $x_image_library && ! -L $x_image_library && \
      -f $bridge_library && ! -L $bridge_library ]] || \
     fail 'target integration is missing deploy control bridge sources'
+  current=$(git -C "$REPO" rev-parse HEAD) || \
+    fail 'target integration marker cannot be read'
+  if deploy_control_is_reviewed_live_controller_transition \
+      "$DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD" "$current"; then
+    while IFS= read -r path; do
+      target_blob=$(git -C "$REPO" rev-parse "$current:$path" 2>/dev/null) || \
+        fail "live transition target is missing reviewed bridge path: $path"
+      [[ $(git -C "$REPO" hash-object --no-filters "$REPO/$path") == \
+         "$target_blob" ]] || fail "live transition worktree drifted: $path"
+    done < <(deploy_control_bridge_sealed_paths; printf '%s\n' \
+      "$DEPLOY_CONTROL_BRIDGE_IMAGE_RESCUE_PIN_CLEANUP_LIBRARY_PATH")
+    return 0
+  fi
   if verify_deploy_control_daily_final_transition_files \
-      "$(git -C "$REPO" rev-parse HEAD)"; then
+      "$current"; then
     return 0
   fi
   [[ $(deploy_control_file_digest "$entrypoint") == "$DEPLOY_CONTROL_BRIDGE_ENTRYPOINT_DIGEST" && \
@@ -660,7 +868,8 @@ verify_deploy_control_bridge_target_compatibility() {
   local entrypoint_digest deploy_library_digest postgres_library_digest
   local weekly_timer_helper_digest daily_c1_helper_digest
   local activation_boundary_helper_digest recovery_maintenance_library_digest
-  local image_rescue_library_digest x_image_library_digest bridge_library_digest
+  local image_rescue_library_digest
+  local x_image_library_digest bridge_library_digest
 
   deploy_control_bridge_require_initialized
   deploy_control_bridge_git_regular_blob "$sha" \
@@ -755,7 +964,7 @@ verify_target_rabbitmq_quorum_asset() {
 }
 
 load_target_rabbitmq_quorum_backend_health() {
-  local sha=$1 health_library=$REPO/$RABBITMQ_QUORUM_HEALTH_LIBRARY_PATH
+  local sha=$1
 
   [[ $sha =~ ^[0-9a-f]{40}$ ]] || \
     fail 'target RabbitMQ quorum health SHA is invalid'
@@ -766,8 +975,8 @@ load_target_rabbitmq_quorum_backend_health() {
   verify_target_rabbitmq_quorum_asset "$sha" \
     "$RABBITMQ_QUORUM_RECOVERY_SCRIPT_PATH" 'target RabbitMQ quorum recovery script' 100755
   unset -f verify_backend verify_backend_with_retry
-  # shellcheck source=/dev/null
-  source "$health_library" || fail 'target backend health library could not be loaded'
+  source_reviewed_deploy_library "$sha" "$RABBITMQ_QUORUM_HEALTH_LIBRARY_PATH" \
+    'target backend health library'
   declare -F verify_backend >/dev/null || \
     fail 'target backend health library is missing its verification entrypoint'
   declare -F verify_backend_with_retry >/dev/null || \

--- a/ops/deploy/deploy-control-lib.sh
+++ b/ops/deploy/deploy-control-lib.sh
@@ -87,6 +87,12 @@ DEPLOY_CONTROL_BRIDGE_LIBRARY_LOADED=false
 load_deploy_control_bridge_library() {
   [[ $DEPLOY_CONTROL_BRIDGE_LIBRARY_LOADED == true ]] && return 0
   local deploy_control_library_directory deploy_control_bridge_library
+  if [[ -n ${PRODUCTION_TRANSITION_PRELUDE_COMMIT:-} ]]; then
+    production_transition_host_source_authorized_prelude \
+      ops/deploy/deploy-control-bridge-lib.sh 'deploy control bridge library'
+    DEPLOY_CONTROL_BRIDGE_LIBRARY_LOADED=true
+    return 0
+  fi
   deploy_control_library_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
   deploy_control_bridge_library=$deploy_control_library_directory/deploy-control-bridge-lib.sh
   [[ -f $deploy_control_bridge_library && ! -L $deploy_control_bridge_library ]] || \
@@ -882,7 +888,11 @@ deploy_frontend() {
 }
 
 deploy_release() {
-  local sha=$1 atomic_state
+  local sha=$1 mode=${2:-ordinary} atomic_state resume_state
+  case $mode in
+    ordinary|resume-target-prepared) ;;
+    *) fail 'deployment resume mode is invalid' ;;
+  esac
   if postgres_pool_atomic_legacy_state; then
     deploy_postgres_pool_atomic_control_bootstrap "$sha" || \
       fail 'atomic PostgreSQL bootstrap loader failed'
@@ -902,7 +912,17 @@ deploy_release() {
   install -d -m 0755 "$STATE" "$STAGING" "$RELEASES"
   local current
   current=$(git -C "$REPO" rev-parse HEAD)
-  if [[ $sha == "$current" ]] && \
+  if [[ $mode == resume-target-prepared ]]; then
+    [[ $sha == "$current" ]] || \
+      fail 'target-prepared resume requires the exact current integration target'
+    declare -F production_transition_require_target_deploy_state >/dev/null || \
+      fail 'target-prepared resume state verifier is unavailable'
+    resume_state=$(production_transition_require_target_deploy_state \
+      "$sha" allow-expired classify) || return 1
+    [[ $resume_state == target-prepared ]] || \
+      fail 'target-prepared resume requires the exact authenticated prepared state'
+  fi
+  if [[ $mode == ordinary && $sha == "$current" ]] && \
      ! postgres_pool_bootstrap_installed "$current"; then
     # The client must recapture the ordinary plan; stdout is non-authoritative.
     reconcile_current_postgres_pool_bootstrap \
@@ -937,6 +957,7 @@ deploy_release() {
     verify_deploy_control_bridge_target_compatibility "$sha"
   fi
   advance_integration "$sha"
+  deploy_control_bootstrap_production_transition_b0 "$sha"
   if [[ $backend == true ]]; then
     load_target_rabbitmq_quorum_backend_health "$sha"
     load_target_reader_summary_publication_deploy_library "$sha"

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -5,16 +5,17 @@ PATH=/usr/local/bin:/usr/bin:/bin
 
 ZERO_SHA=0000000000000000000000000000000000000000
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
-RELEASE_B_CONTROLLER_SHA=8b4aeb31e855ed379349a4e4827600009e174132
-RELEASE_B_CURRENT_MAIN_SHA=77313ea03a3bac7d2298f4021d58124c810d291f
-RELEASE_B_LEGACY_BACKEND_SHA=09a79687e042e36d4ec9c1f33f0367527f044181
-RELEASE_B_LEGACY_POOL_SHA=6fefa9da5446d5e467badcc7239fdc5a6170a756
-RELEASE_B_BRIDGE_SHA=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
-RELEASE_B_BRIDGE_TREE=0f2edeb95bbb658cebdb1aecdcda24026eca7d19
-RELEASE_B_BRIDGE_BLOB=e02f7b7684f75121521065b43148708d545ab806
-RELEASE_B_BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
-RELEASE_B_REVIEWED_TARGET_SHA=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
-RELEASE_B_REVIEWED_TARGET_TREE=237c34068c057d2dfb5efaf9d606028cdaf18525
+PROMOTION_V2_CONTROLLER_SHA=7c4070f0b9ef1aac130284bcffac50551e20a4dd
+PROMOTION_V2_CONTROLLER_TREE=72a67394bafd87ab7ed5b3024ddf66c6d040f096
+PROMOTION_V2_POOL_MARKER=0be002ec1af2d1e0799f8507cb147a6f1406a428
+PROMOTION_V2_PRODUCT_MAIN_SHA=c5dc5abb12aa1ac84ddbd12f141c6d4d8aca4de2
+PROMOTION_V2_PRODUCT_MAIN_TREE=526a56bef3b9a9a8edcf562b4b643af0f369eb8a
+PROMOTION_V2_BRIDGE_SHA=b13e68a502444bb7839dc642f12d0e34b7b954ad
+PROMOTION_V2_BRIDGE_TREE=87b0bd78d93cfefd980cf7c38f96dca2a8899268
+PROMOTION_V2_BRIDGE_BLOB=d02ac91a87656739ef2563c0481835122ec3f7f3
+PROMOTION_V2_CONTROL_BLOB=fd2d8095cd6e2428e02f6ca21942bab2ea10961b
+PROMOTION_V2_JOIN_SHA=3fc3c65649323506e8ad9914d2e5c985fa361401
+PROMOTION_V2_JOIN_TREE=54e11938300dc50f3a744dc2a2bb5044505206bd
 DAILY_C1_BRIDGE_POLICY_SHA=944fdb6da3071f70a69c7048c9fcdf1c2552603e
 SSH_DIRECTORY=${DEPLOY_SSH_DIRECTORY:-${HOME:+$HOME/.ssh}}
 SSH_KEY_PATH=${DEPLOY_SSH_KEY_PATH:-$SSH_DIRECTORY/social-monitor-production}
@@ -559,141 +560,135 @@ plan_is_fully_reconciled() {
      $PLAN_BACKEND_BASE != "$ZERO_SHA" ]]
 }
 
-plan_is_exact_release_b_bridge_transition() {
+plan_has_promotion_v2_installed_markers() {
+  [[ $PLAN_BACKEND_BASE == "$PROMOTION_V2_CONTROLLER_SHA" && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$PROMOTION_V2_POOL_MARKER" && \
+     $PLAN_POSTGRES_POOL_REPAIR == false ]]
+}
+
+plan_is_exact_promotion_v2_bridge_pending() {
+  plan_has_promotion_v2_installed_markers && \
+    [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == false && \
+       $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false ]]
+}
+
+plan_is_exact_promotion_v2_bridge_complete() {
+  plan_has_promotion_v2_installed_markers && \
+    [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == false && \
+       $PLAN_CONTROL == false && $PLAN_X_COLLECTOR == false ]]
+}
+
+plan_is_exact_promotion_v2_target_pending() {
+  plan_has_promotion_v2_installed_markers && \
+    [[ $PLAN_FRONTEND == true && $PLAN_BACKEND == true && \
+       $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false ]]
+}
+
+plan_is_exact_promotion_v2_target_complete() {
+  local target=$1
   [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == false && \
-     $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false && \
+     $PLAN_CONTROL == false && $PLAN_X_COLLECTOR == false && \
+     $PLAN_BACKEND_BASE == "$target" && \
      $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$RELEASE_B_CONTROLLER_SHA" && \
-     $PLAN_BACKEND_BASE == "$RELEASE_B_CONTROLLER_SHA" ]]
-}
-
-plan_is_exact_release_b_target_transition() {
-  [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == true && \
-     $PLAN_BACKEND_BASE == "$RELEASE_B_CONTROLLER_SHA" && \
-     $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$RELEASE_B_CONTROLLER_SHA" && \
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$target" && \
      $PLAN_POSTGRES_POOL_REPAIR == false ]]
 }
 
-plan_is_exact_release_b_current_main_target_transition() {
-  [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == false && \
-     $PLAN_BACKEND_BASE == "$RELEASE_B_CURRENT_MAIN_SHA" && \
-     $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == false && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$RELEASE_B_CURRENT_MAIN_SHA" && \
-     $PLAN_POSTGRES_POOL_REPAIR == false ]]
+git_commit_line() {
+  git -C "${GITHUB_WORKSPACE:-.}" rev-list --parents -n 1 "$1" 2>/dev/null
 }
 
-plan_is_exact_release_b_legacy_transition() {
-  [[ $PLAN_FRONTEND == true && $PLAN_BACKEND == true && \
-     $PLAN_BACKEND_BASE == "$RELEASE_B_LEGACY_BACKEND_SHA" && \
-     $PLAN_CONTROL == true && $PLAN_X_COLLECTOR == true && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA == "$RELEASE_B_LEGACY_POOL_SHA" && \
-     $PLAN_POSTGRES_POOL_REPAIR == false ]]
+git_tree() {
+  git -C "${GITHUB_WORKSPACE:-.}" rev-parse "$1^{tree}" 2>/dev/null
 }
 
-plan_is_admitted_post_release_b_forward_state() {
-  local requested_target=$1 repository=${GITHUB_WORKSPACE:-.}
-  [[ $PLAN_BACKEND_BASE =~ ^[0-9a-f]{40}$ && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" && \
-     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA =~ ^[0-9a-f]{40}$ && \
-     $PLAN_POSTGRES_POOL_REPAIR == false ]] || return 1
-  # The remote plan reports an installed bootstrap only after hashing the
-  # active deploy controller against this durable marker. Its ancestry is
-  # therefore the controller provenance proof even when control or X changes.
-  git -C "$repository" merge-base --is-ancestor \
-    "$RELEASE_B_REVIEWED_TARGET_SHA" "$PLAN_BACKEND_BASE" 2>/dev/null && \
-    git -C "$repository" merge-base --is-ancestor \
-      "$PLAN_BACKEND_BASE" "$requested_target" 2>/dev/null && \
-    git -C "$repository" merge-base --is-ancestor \
-      "$RELEASE_B_REVIEWED_TARGET_SHA" \
-      "$PLAN_POSTGRES_POOL_BOOTSTRAP_SHA" 2>/dev/null && \
-    git -C "$repository" merge-base --is-ancestor \
-      "$PLAN_POSTGRES_POOL_BOOTSTRAP_SHA" "$requested_target" 2>/dev/null
+require_commit_identity() {
+  local sha=$1 tree=$2 label=$3
+  git -C "${GITHUB_WORKSPACE:-.}" cat-file -e "$sha^{commit}" 2>/dev/null || \
+    fail "$label commit cannot be inspected"
+  [[ $(git_tree "$sha") == "$tree" ]] || fail "$label tree does not match its pin"
 }
 
-verify_release_b_bridge_identity() {
-  local sha=$1 repository=${GITHUB_WORKSPACE:-.}
-  local actual_tree delta entry mode type object path extra
-  local -a ancestry=()
+verify_post_promotion_v2_target_identity() {
+  local target=$1 repository=${GITHUB_WORKSPACE:-.} bridge_delta join_delta h_delta
+  local bridge_entries join_entries h_entries h target_tree
+  local -a parents=()
 
-  [[ $sha == "$RELEASE_B_BRIDGE_SHA" ]] || \
-    fail 'Release B bridge SHA is not the reviewed pin'
-  read -r -a ancestry <<< "$(git -C "$repository" \
-    rev-list --parents -n 1 "$sha" 2>/dev/null)" || \
-    fail 'Release B bridge ancestry cannot be inspected'
-  [[ ${#ancestry[@]} == 2 && ${ancestry[0]} == "$sha" && \
-     ${ancestry[1]} == "$RELEASE_B_CONTROLLER_SHA" ]] || \
-    fail 'Release B bridge is not the exact controller child'
-  actual_tree=$(git -C "$repository" rev-parse "$sha^{tree}" 2>/dev/null) || \
-    fail 'Release B bridge tree cannot be inspected'
-  [[ $actual_tree == "$RELEASE_B_BRIDGE_TREE" ]] || \
-    fail 'Release B bridge tree does not match its reviewed pin'
-  delta=$(git -C "$repository" diff --name-only --no-renames \
-    "$RELEASE_B_CONTROLLER_SHA" "$sha" -- 2>/dev/null) || \
-    fail 'Release B bridge delta cannot be inspected'
-  [[ $delta == "$RELEASE_B_BRIDGE_PATH" ]] || \
-    fail 'Release B bridge changes more than its reviewed controller policy'
-  entry=$(git -C "$repository" ls-tree "$sha" -- \
-    "$RELEASE_B_BRIDGE_PATH" 2>/dev/null) || \
-    fail 'Release B bridge policy blob cannot be inspected'
-  read -r mode type object path extra <<< "$entry"
-  [[ -z ${extra:-} && $mode == 100644 && $type == blob && \
-     $object == "$RELEASE_B_BRIDGE_BLOB" && \
-     $path == "$RELEASE_B_BRIDGE_PATH" ]] || \
-    fail 'Release B bridge policy blob does not match its reviewed pin'
-}
+  require_commit_identity "$PROMOTION_V2_CONTROLLER_SHA" \
+    "$PROMOTION_V2_CONTROLLER_TREE" 'promotion V2 controller'
+  require_commit_identity "$PROMOTION_V2_PRODUCT_MAIN_SHA" \
+    "$PROMOTION_V2_PRODUCT_MAIN_TREE" 'promotion V2 product main'
+  require_commit_identity "$PROMOTION_V2_BRIDGE_SHA" \
+    "$PROMOTION_V2_BRIDGE_TREE" 'promotion V2 bridge'
+  require_commit_identity "$PROMOTION_V2_JOIN_SHA" \
+    "$PROMOTION_V2_JOIN_TREE" 'promotion V2 join'
 
-verify_release_b_reviewed_target_identity() {
-  local sha=$1 requested_target=$2 repository=${GITHUB_WORKSPACE:-.}
-  local actual_tree delta entries first_parent_history parent
-  local -a ancestry=()
-  local requested_contains_reviewed=false
+  read -r -a parents <<< "$(git_commit_line "$PROMOTION_V2_BRIDGE_SHA")"
+  [[ ${#parents[@]} == 2 && ${parents[0]} == "$PROMOTION_V2_BRIDGE_SHA" && \
+     ${parents[1]} == "$PROMOTION_V2_CONTROLLER_SHA" ]] || \
+    fail 'promotion V2 bridge does not have sole parent A'
+  bridge_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$PROMOTION_V2_CONTROLLER_SHA" "$PROMOTION_V2_BRIDGE_SHA" --) || \
+    fail 'promotion V2 bridge delta cannot be inspected'
+  [[ $bridge_delta == $'ops/deploy/deploy-control-bridge-lib.sh\nops/deploy/deploy-control-lib.sh' ]] || \
+    fail 'promotion V2 bridge does not have its exact two-path delta'
+  bridge_entries=$(git -C "$repository" ls-tree "$PROMOTION_V2_BRIDGE_SHA" -- \
+    ops/deploy/deploy-control-bridge-lib.sh ops/deploy/deploy-control-lib.sh)
+  [[ $bridge_entries == \
+    "100644 blob $PROMOTION_V2_BRIDGE_BLOB"$'\t'ops/deploy/deploy-control-bridge-lib.sh$'\n'\
+"100644 blob $PROMOTION_V2_CONTROL_BLOB"$'\t'ops/deploy/deploy-control-lib.sh ]] || \
+    fail 'promotion V2 bridge blobs or modes do not match their pins'
 
-  [[ $sha == "$RELEASE_B_REVIEWED_TARGET_SHA" ]] || \
-    fail 'Release B reviewed target SHA is not the reviewed pin'
-  read -r -a ancestry <<< "$(git -C "$repository" \
-    rev-list --parents -n 1 "$sha" 2>/dev/null)" || \
-    fail 'Release B reviewed target ancestry cannot be inspected'
-  [[ ${#ancestry[@]} == 3 && ${ancestry[0]} == "$sha" && \
-     ${ancestry[1]} == "$RELEASE_B_CURRENT_MAIN_SHA" && \
-     ${ancestry[2]} == "$RELEASE_B_BRIDGE_SHA" ]] || \
-    fail 'Release B reviewed target does not have its exact ordered parents'
-  actual_tree=$(git -C "$repository" rev-parse "$sha^{tree}" 2>/dev/null) || \
-    fail 'Release B reviewed target tree cannot be inspected'
-  [[ $actual_tree == "$RELEASE_B_REVIEWED_TARGET_TREE" ]] || \
-    fail 'Release B reviewed target tree does not match its reviewed pin'
-  delta=$(git -C "$repository" diff --name-only --no-renames \
-    "$RELEASE_B_CURRENT_MAIN_SHA" "$sha" -- 2>/dev/null) || \
-    fail 'Release B reviewed target delta cannot be inspected'
-  [[ $delta == $'.github/workflows/production-deploy.yml\nops/deploy/deploy-control-bridge-lib.sh\nops/deploy/github-production-deploy-client.sh\nops/deploy/github-production-deploy-client.test.sh\nops/deploy/production-release-b-bridge-order.test.sh\nops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh' ]] || \
-    fail 'Release B reviewed target changes outside its exact reviewed delta'
-  entries=$(git -C "$repository" ls-tree "$sha" -- \
+  read -r -a parents <<< "$(git_commit_line "$PROMOTION_V2_JOIN_SHA")"
+  [[ ${#parents[@]} == 3 && ${parents[0]} == "$PROMOTION_V2_JOIN_SHA" && \
+     ${parents[1]} == "$PROMOTION_V2_PRODUCT_MAIN_SHA" && \
+     ${parents[2]} == "$PROMOTION_V2_BRIDGE_SHA" ]] || \
+    fail 'promotion V2 join does not have ordered parents F,B'
+  join_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$PROMOTION_V2_PRODUCT_MAIN_SHA" "$PROMOTION_V2_JOIN_SHA" --) || \
+    fail 'promotion V2 join delta cannot be inspected'
+  [[ $join_delta == ops/deploy/deploy-control-bridge-lib.sh ]] || \
+    fail 'promotion V2 join effective delta is not bridge-lib only'
+  join_entries=$(git -C "$repository" ls-tree "$PROMOTION_V2_JOIN_SHA" -- \
+    ops/deploy/deploy-control-bridge-lib.sh ops/deploy/deploy-control-lib.sh)
+  [[ $join_entries == "$bridge_entries" ]] || \
+    fail 'promotion V2 join bridge/control entries do not equal B'
+
+  read -r -a parents <<< "$(git_commit_line "$target")"
+  [[ ${#parents[@]} == 3 && ${parents[0]} == "$target" && \
+     ${parents[1]} == "$PROMOTION_V2_PRODUCT_MAIN_SHA" ]] || \
+    fail 'promotion V2 target does not have ordered parents F,H'
+  h=${parents[2]}
+  read -r -a parents <<< "$(git_commit_line "$h")"
+  [[ ${#parents[@]} == 2 && ${parents[0]} == "$h" && \
+     ${parents[1]} == "$PROMOTION_V2_JOIN_SHA" ]] || \
+    fail 'promotion V2 H does not have sole parent J'
+  target_tree=$(git_tree "$target")
+  [[ -n $target_tree && $target_tree == "$(git_tree "$h")" ]] || \
+    fail 'promotion V2 target tree does not equal H'
+  h_delta=$(git -C "$repository" diff --name-only --no-renames \
+    "$PROMOTION_V2_JOIN_SHA" "$h" --) || fail 'promotion V2 H delta cannot be inspected'
+  [[ $h_delta == $'.github/workflows/production-deploy.yml\nops/deploy/github-production-deploy-client.sh\nops/deploy/github-production-deploy-client.test.sh\nops/deploy/production-release-b-bridge-order.test.sh\nops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh' ]] || \
+    fail 'promotion V2 H does not change exactly the five owned paths'
+  h_entries=$(git -C "$repository" ls-tree "$h" -- \
     .github/workflows/production-deploy.yml \
-    ops/deploy/deploy-control-bridge-lib.sh \
     ops/deploy/github-production-deploy-client.sh \
     ops/deploy/github-production-deploy-client.test.sh \
     ops/deploy/production-release-b-bridge-order.test.sh \
-    ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh 2>/dev/null) || \
-    fail 'Release B reviewed target files cannot be inspected'
-  [[ $entries == $'100644 blob 1e85c36aaeb064df3235e8093acb6124d64d0398\t.github/workflows/production-deploy.yml\n100644 blob e02f7b7684f75121521065b43148708d545ab806\tops/deploy/deploy-control-bridge-lib.sh\n100755 blob 086a7d95d2a8125cd6c8f2dd39b05fe42e4c9482\tops/deploy/github-production-deploy-client.sh\n100755 blob 8db3980a225a8222765dfa95c4fd895bfb20712a\tops/deploy/github-production-deploy-client.test.sh\n100755 blob 47f97467223fa0e7a0b779741d676ad4f19b7bea\tops/deploy/production-release-b-bridge-order.test.sh\n100644 blob ab7e2c5cb06d85dce0d3e2427d8af7e9636b32ad\tops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh' ]] || \
-    fail 'Release B reviewed target file identities do not match their pins'
+    ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh)
+  [[ $h_entries == $'100644 blob '*$'\t.github/workflows/production-deploy.yml\n100755 blob '*$'\tops/deploy/github-production-deploy-client.sh\n100755 blob '*$'\tops/deploy/github-production-deploy-client.test.sh\n100755 blob '*$'\tops/deploy/production-release-b-bridge-order.test.sh\n100644 blob '*$'\tops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh' ]] || \
+    fail 'promotion V2 H path modes or blob types are invalid'
+  PROMOTION_V2_VERIFIED_H=$h
+  PROMOTION_V2_VERIFIED_TARGET=$target
+}
 
-  git -C "$repository" cat-file -e "$requested_target^{commit}" 2>/dev/null || \
-    fail 'Release B requested target commit cannot be inspected'
-  first_parent_history=$(git -C "$repository" rev-list --first-parent \
-    "$requested_target" 2>/dev/null) || \
-    fail 'Release B requested target first-parent history cannot be inspected'
-  while IFS= read -r parent; do
-    if [[ $parent == "$sha" ]]; then
-      requested_contains_reviewed=true
-      break
-    fi
-  done <<< "$first_parent_history"
-  [[ $requested_contains_reviewed == true ]] || \
-    fail 'Release B requested target does not first-parent-contain the reviewed target'
+write_post_promotion_v2_graph_outputs() {
+  local output_path=${GITHUB_OUTPUT:-}
+  [[ -n $output_path ]] || fail 'GITHUB_OUTPUT is required for graph verification'
+  printf 'release_b=%s\njoin=%s\nhead=%s\ntarget=%s\n' \
+    "$PROMOTION_V2_BRIDGE_SHA" "$PROMOTION_V2_JOIN_SHA" \
+    "$PROMOTION_V2_VERIFIED_H" "$PROMOTION_V2_VERIFIED_TARGET" >> "$output_path"
 }
 
 reconcile_deploy_plan() {
@@ -749,113 +744,89 @@ deploy_release() {
   }
 }
 
-deploy_release_b_reviewed_target() {
-  local target=$1 status
+capture_exact_promotion_v2_reconciliation() {
+  local bridge=$1 target=$2 status
   if capture_plan "$target"; then
-    status=0
+    print_plan
+    plan_is_exact_promotion_v2_target_complete "$target" && return 0
   else
     status=$?
+    ((status == 1 || status == 255)) || \
+      fail "promotion V2 target reconciliation plan failed with status $status"
   fi
-  ((status == 0)) || fail "Release B reviewed target plan failed with status $status"
-  print_plan
-  plan_is_fully_reconciled && return 0
-  { plan_is_exact_release_b_target_transition || \
-    plan_is_exact_release_b_current_main_target_transition; } || \
-    fail 'Release B reviewed target plan is not an exact admitted transition'
-  deploy_once "$target"
+  if capture_plan "$bridge"; then
+    print_plan
+    plan_is_exact_promotion_v2_bridge_complete && return 0
+    return 1
+  fi
+  status=$?
+  ((status == 255)) && return 1
+  fail "promotion V2 bridge reconciliation plan failed with status $status"
 }
 
-prepare_release_b_bridge() {
-  local sha=$1 bridge=$2 current_main=$3 bridge_target=$4 requested_target=$5 status
-  local target_plan_exact=false current_main_target_plan_exact=false
-  local legacy_target_plan_exact=false
-  [[ $sha == "$RELEASE_B_CONTROLLER_SHA" ]] || \
-    fail 'Release B controller SHA is not the reviewed pin'
-  [[ $current_main == "$RELEASE_B_CURRENT_MAIN_SHA" ]] || \
-    fail 'Release B current-main SHA is not the reviewed pin'
-  verify_release_b_bridge_identity "$bridge"
-  verify_release_b_reviewed_target_identity "$bridge_target" "$requested_target"
-
-  if capture_plan "$requested_target"; then
-    print_plan
-    plan_is_admitted_post_release_b_forward_state "$requested_target" && return 0
-  else
-    status=$?
-    ((status == 1)) || \
-      fail "Release B requested-target preflight plan failed with status $status"
-  fi
-
-  if capture_plan "$bridge_target"; then
-    print_plan
-    plan_is_fully_reconciled && return 0
-    plan_is_exact_release_b_target_transition && target_plan_exact=true
-    plan_is_exact_release_b_current_main_target_transition && \
-      current_main_target_plan_exact=true
-    plan_is_exact_release_b_legacy_transition && \
-      legacy_target_plan_exact=true
-  else
-    status=$?
-    ((status == 1)) || fail "Release B target preflight plan failed with status $status"
-  fi
-  if capture_plan "$current_main"; then
-    print_plan
-    if plan_is_fully_reconciled; then
-      [[ $current_main_target_plan_exact == true ]] || \
-        fail 'Release B reviewed target is not the exact current-main transition'
-      deploy_release_b_reviewed_target "$bridge_target"
+reconcile_promotion_v2_bridge_without_replay() {
+  local bridge=$1 target=$2 attempt
+  for ((attempt = 1; attempt <= RECONCILE_ATTEMPTS; attempt += 1)); do
+    if capture_exact_promotion_v2_reconciliation "$bridge" "$target"; then
       return 0
     fi
-    if ! plan_is_exact_release_b_target_transition; then
-      { plan_is_exact_release_b_legacy_transition && \
-        [[ $legacy_target_plan_exact == true ]]; } || \
-        fail 'Release B current-main plan is not an admitted exact transition'
-    fi
+    ((attempt == RECONCILE_ATTEMPTS)) || sleep "$RECONCILE_INTERVAL_SECONDS"
+  done
+  fail 'promotion V2 bridge did not reconcile without replay'
+}
+
+prepare_post_promotion_v2_bridge() {
+  local bridge=$1 join=$2 target=$3 status
+  [[ $bridge == "$PROMOTION_V2_BRIDGE_SHA" ]] || \
+    fail 'promotion V2 preparation bridge argument is not B'
+  [[ $join == "$PROMOTION_V2_JOIN_SHA" ]] || \
+    fail 'promotion V2 preparation join argument is not J'
+  verify_post_promotion_v2_target_identity "$target"
+
+  if capture_plan "$target"; then
+    print_plan
+    plan_is_exact_promotion_v2_target_complete "$target" && return 0
   else
     status=$?
-    ((status == 1)) || fail "Release B current-main plan failed with status $status"
+    ((status == 1)) || fail "promotion V2 target preflight plan failed with status $status"
   fi
-  [[ $target_plan_exact == true || $legacy_target_plan_exact == true ]] || \
-    fail 'Release B target plan is not the exact controller transition'
   if capture_plan "$bridge"; then
     print_plan
-    if plan_is_fully_reconciled; then
-      deploy_release_b_reviewed_target "$bridge_target"
-      return 0
-    fi
-    if plan_is_exact_release_b_bridge_transition; then
-      deploy_once "$bridge"
-      deploy_release_b_reviewed_target "$bridge_target"
-      return 0
-    fi
+    plan_is_exact_promotion_v2_bridge_complete && return 0
+    plan_is_exact_promotion_v2_bridge_pending || \
+      fail 'promotion V2 bridge plan is not exact A-to-B pending or B-complete'
   else
     status=$?
-    ((status == 1)) || \
-      fail "Release B bridge preflight plan failed with status $status"
+    fail "promotion V2 bridge preflight plan failed with status $status"
   fi
-  if capture_plan "$sha"; then
+
+  if run_remote deploy "$bridge"; then
     status=0
   else
     status=$?
   fi
-  ((status == 0)) || \
-    fail "Release B controller plan failed with status $status"
-  print_plan
-  plan_is_fully_reconciled || deploy_once "$sha"
-  if capture_plan "$bridge"; then
-    status=0
-  else
-    status=$?
-  fi
-  ((status == 0)) || fail "Release B bridge plan failed with status $status"
-  print_plan
-  if plan_is_fully_reconciled; then
-    deploy_release_b_reviewed_target "$bridge_target"
-    return 0
-  fi
-  plan_is_exact_release_b_bridge_transition || \
-    fail 'Release B bridge plan is not the exact fresh control-only transition'
-  deploy_once "$bridge"
-  deploy_release_b_reviewed_target "$bridge_target"
+  ((status == 0 || status == 255)) || \
+    fail "promotion V2 bridge deploy failed with status $status"
+  ((status != 255)) || printf '%s\n' \
+    'deploy-client: promotion V2 bridge transport became ambiguous; reconciling by plans only' >&2
+  reconcile_promotion_v2_bridge_without_replay "$bridge" "$target"
+}
+
+plan_post_promotion_v2_target() {
+  local target=$1
+  verify_post_promotion_v2_target_identity "$target"
+  read_initial_plan "$target"
+  { plan_is_exact_promotion_v2_target_pending || \
+    plan_is_exact_promotion_v2_target_complete "$target"; } || \
+    fail 'promotion V2 target plan has invalid durable markers or no pending component'
+}
+
+accept_post_promotion_v2_target() {
+  local target=$1
+  verify_post_promotion_v2_target_identity "$target"
+  inspect_plan "$target"
+  plan_is_exact_promotion_v2_target_complete "$target" || \
+    fail 'promotion V2 target is not exactly complete'
 }
 
 install_daily_c1_bridge_policy() {
@@ -903,11 +874,11 @@ case $action in
     validate_remote_environment
     inspect_plan "$2"
     ;;
-  verify-release-b-target)
-    [[ $# == 2 ]] || fail 'verify-release-b-target requires a requested target SHA'
+  verify-post-promotion-v2-target)
+    [[ $# == 2 ]] || fail 'verify-post-promotion-v2-target requires M'
     validate_sha "$2"
-    verify_release_b_reviewed_target_identity \
-      "$RELEASE_B_REVIEWED_TARGET_SHA" "$2"
+    verify_post_promotion_v2_target_identity "$2"
+    write_post_promotion_v2_graph_outputs
     ;;
   upload)
     [[ $# == 3 ]] || fail 'upload requires a target SHA and archive'
@@ -921,21 +892,32 @@ case $action in
     validate_remote_environment
     deploy_release "$2"
     ;;
+  plan-post-promotion-v2-target)
+    [[ $# == 2 ]] || fail 'plan-post-promotion-v2-target requires M'
+    validate_sha "$2"
+    validate_remote_environment
+    plan_post_promotion_v2_target "$2"
+    ;;
+  accept-post-promotion-v2-target)
+    [[ $# == 2 ]] || fail 'accept-post-promotion-v2-target requires M'
+    validate_sha "$2"
+    validate_remote_environment
+    accept_post_promotion_v2_target "$2"
+    ;;
   deploy-transition)
     [[ $# == 2 ]] || fail 'deploy-transition requires a target SHA'
     validate_sha "$2"
     validate_remote_environment
     production_transition_activate_via_trusted_host "$2"
     ;;
-  prepare-release-b-bridge)
-    [[ $# == 6 ]] || fail 'prepare-release-b-bridge requires controller, bridge, current-main, reviewed-target, and requested-target pins'
+  prepare-post-promotion-v2-bridge)
+    [[ $# == 4 ]] || fail 'prepare-post-promotion-v2-bridge requires B, J, and M'
     validate_sha "$2"
     validate_sha "$3"
     validate_sha "$4"
-    validate_sha "$5"
-    validate_sha "$6"
+    verify_post_promotion_v2_target_identity "$4"
     validate_remote_environment
-    prepare_release_b_bridge "$2" "$3" "$4" "$5" "$6"
+    prepare_post_promotion_v2_bridge "$2" "$3" "$4"
     ;;
   install-daily-c1-bridge-policy)
     [[ $# == 2 ]] || fail 'install-daily-c1-bridge-policy requires its pinned SHA'

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -109,112 +109,32 @@ fake_ssh() {
     normal_success:"deploy $TARGET_SHA"|normal_success:"deploy 944fdb6da3071f70a69c7048c9fcdf1c2552603e")
       printf 'deployed=%s\n' "$TARGET_SHA"
       ;;
-    release_b_replay:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
-      print_fake_plan false false false false "$RELEASE_B_REVIEWED_TARGET_SHA" \
-        "$RELEASE_B_REVIEWED_TARGET_SHA"
+    promotion_m_complete:"plan $TARGET_SHA")
+      print_fake_plan false false false false "$TARGET_SHA" "$TARGET_SHA"
       ;;
-    release_b_post_b:"plan $TARGET_SHA")
-      print_fake_plan true true true true "$POST_RELEASE_B_SHA" \
-        "$POST_RELEASE_B_SHA"
-      ;;
-    release_b_from_8b:"plan $TARGET_SHA"|release_b_bridge_disconnect:"plan $TARGET_SHA"|release_b_controller_repair:"plan $TARGET_SHA"|release_b_current_main:"plan $TARGET_SHA"|release_b_replay:"plan $TARGET_SHA"|release_b_partial:"plan $TARGET_SHA"|release_b_stale_target:"plan $TARGET_SHA"|release_b_rejected:"plan $TARGET_SHA")
+    promotion_b_complete:"plan $TARGET_SHA"|promotion_b_pending:"plan $TARGET_SHA"|promotion_b_disconnect:"plan $TARGET_SHA")
       exit 1
       ;;
-    release_b_current_main:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
-      if grep -qFx "deploy $RELEASE_B_REVIEWED_TARGET_SHA" "$FAKE_SSH_LOG"; then
-        print_fake_plan false false false false "$RELEASE_B_REVIEWED_TARGET_SHA" \
-          "$RELEASE_B_CURRENT_MAIN_SHA"
+    promotion_partial:"plan $TARGET_SHA")
+      print_fake_plan true false true false "$PROMOTION_POOL" "$PROMOTION_A"
+      ;;
+    promotion_x:"plan $TARGET_SHA")
+      print_fake_plan true true true true "$PROMOTION_POOL" "$PROMOTION_A"
+      ;;
+    promotion_b_complete:"plan $PROMOTION_B")
+      print_fake_plan false false false false "$PROMOTION_POOL" "$PROMOTION_A"
+      ;;
+    promotion_b_pending:"plan $PROMOTION_B"|promotion_b_disconnect:"plan $PROMOTION_B")
+      if grep -qFx "deploy $PROMOTION_B" "$FAKE_SSH_LOG"; then
+        print_fake_plan false false false false "$PROMOTION_POOL" "$PROMOTION_A"
       else
-        print_fake_plan false false true false "$RELEASE_B_CURRENT_MAIN_SHA" \
-          "$RELEASE_B_CURRENT_MAIN_SHA"
+        print_fake_plan false false true false "$PROMOTION_POOL" "$PROMOTION_A"
       fi
       ;;
-    release_b_current_main:"plan $RELEASE_B_CURRENT_MAIN_SHA")
-      print_fake_plan false false false false "$RELEASE_B_CURRENT_MAIN_SHA" \
-        "$RELEASE_B_CURRENT_MAIN_SHA"
+    promotion_b_pending:"deploy $PROMOTION_B")
+      printf 'deployed=%s\n' "$PROMOTION_B"
       ;;
-    release_b_stale_target:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
-      print_fake_plan false true true false "$RELEASE_B_POOL_MARKER" \
-        "$RELEASE_B_BACKEND_MARKER"
-      ;;
-    release_b_stale_target:"plan $RELEASE_B_CURRENT_MAIN_SHA")
-      print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
-        "$RELEASE_B_CONTROLLER_SHA"
-      ;;
-    release_b_controller_repair:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
-      if grep -qFx "deploy $RELEASE_B_REVIEWED_TARGET_SHA" "$FAKE_SSH_LOG"; then
-        print_fake_plan false false false false "$RELEASE_B_CONTROLLER_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      elif grep -qFx "deploy $RELEASE_B_CONTROLLER_SHA" "$FAKE_SSH_LOG"; then
-        print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      else
-        print_fake_plan true true true true "$RELEASE_B_POOL_MARKER" \
-          "$RELEASE_B_BACKEND_MARKER"
-      fi
-      ;;
-    release_b_from_8b:"plan $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_bridge_disconnect:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
-      if grep -qFx "deploy $RELEASE_B_REVIEWED_TARGET_SHA" "$FAKE_SSH_LOG"; then
-        print_fake_plan false false false false "$RELEASE_B_REVIEWED_TARGET_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      else
-        print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      fi
-      ;;
-    release_b_controller_repair:"plan $RELEASE_B_CURRENT_MAIN_SHA")
-      print_fake_plan true true true true "$RELEASE_B_POOL_MARKER" \
-        "$RELEASE_B_BACKEND_MARKER"
-      ;;
-    release_b_from_8b:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_bridge_disconnect:"plan $RELEASE_B_CURRENT_MAIN_SHA")
-      print_fake_plan false true true false "$RELEASE_B_CONTROLLER_SHA" \
-        "$RELEASE_B_CONTROLLER_SHA"
-      ;;
-    release_b_from_8b:"plan $RELEASE_B_BRIDGE_SHA"|release_b_bridge_disconnect:"plan $RELEASE_B_BRIDGE_SHA")
-      count=$(grep -cFx "deploy $RELEASE_B_BRIDGE_SHA" "$FAKE_SSH_LOG" || true)
-      if ((count == 0)); then
-        print_fake_plan false false true false "$RELEASE_B_CONTROLLER_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      else
-        print_fake_plan false false false false "$RELEASE_B_BRIDGE_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      fi
-      ;;
-    release_b_controller_repair:"plan $RELEASE_B_BRIDGE_SHA")
-      if grep -qFx "deploy $RELEASE_B_BRIDGE_SHA" "$FAKE_SSH_LOG"; then
-        print_fake_plan false false false false "$RELEASE_B_BRIDGE_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      elif grep -qFx "deploy $RELEASE_B_CONTROLLER_SHA" "$FAKE_SSH_LOG"; then
-        print_fake_plan false false true false "$RELEASE_B_CONTROLLER_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      else
-        print_fake_plan false true true false "$RELEASE_B_POOL_MARKER" \
-          "$RELEASE_B_BACKEND_MARKER"
-      fi
-      ;;
-    release_b_controller_repair:"plan $RELEASE_B_CONTROLLER_SHA")
-      if grep -qFx "deploy $RELEASE_B_CONTROLLER_SHA" "$FAKE_SSH_LOG"; then
-        print_fake_plan false false false false "$RELEASE_B_CONTROLLER_SHA" \
-          "$RELEASE_B_CONTROLLER_SHA"
-      else
-        print_fake_plan true true true false "$RELEASE_B_POOL_MARKER" \
-          "$RELEASE_B_BACKEND_MARKER"
-      fi
-      ;;
-    release_b_from_8b:"deploy $RELEASE_B_BRIDGE_SHA"|release_b_controller_repair:"deploy $RELEASE_B_BRIDGE_SHA")
-      printf 'deployed=%s\n' "$RELEASE_B_BRIDGE_SHA"
-      ;;
-    release_b_bridge_disconnect:"deploy $RELEASE_B_BRIDGE_SHA") exit 255 ;;
-    release_b_from_8b:"deploy $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_bridge_disconnect:"deploy $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_controller_repair:"deploy $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_current_main:"deploy $RELEASE_B_REVIEWED_TARGET_SHA")
-      printf 'deployed=%s\n' "$RELEASE_B_REVIEWED_TARGET_SHA"
-      ;;
-    release_b_controller_repair:"deploy $RELEASE_B_CONTROLLER_SHA")
-      printf 'deployed=%s\n' "$RELEASE_B_CONTROLLER_SHA"
-      ;;
-    release_b_partial:"plan $RELEASE_B_REVIEWED_TARGET_SHA")
-      printf 'frontend=false\nbackend=true\n'
-      ;;
-    release_b_rejected:"plan $RELEASE_B_REVIEWED_TARGET_SHA"|release_b_rejected:"plan $RELEASE_B_CURRENT_MAIN_SHA"|release_b_rejected:"plan $RELEASE_B_BRIDGE_SHA") exit 1 ;;
+    promotion_b_disconnect:"deploy $PROMOTION_B") exit 255 ;;
     atomic_success:"deploy $TARGET_SHA")
       printf 'postgres-pool-bootstrap=%s replay=false\n' "$TARGET_SHA"
       ;;
@@ -298,17 +218,38 @@ WORKFLOW=$SCRIPT_DIR/../../.github/workflows/production-deploy.yml
 MAINTENANCE_DISPATCH=$SCRIPT_DIR/github-production-maintenance-dispatch.sh
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/github-production-deploy-client-test.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
+export GIT_AUTHOR_NAME='Promotion V2 fixture'
+export GIT_AUTHOR_EMAIL=promotion-v2@example.invalid
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 
-TARGET_SHA=$(git -C "$SCRIPT_DIR/../.." rev-parse HEAD)
-POST_RELEASE_B_SHA=$(git -C "$SCRIPT_DIR/../.." rev-parse HEAD^)
+SOURCE_REPO=$SCRIPT_DIR/../..
+PROMOTION_A=7c4070f0b9ef1aac130284bcffac50551e20a4dd
+PROMOTION_B=b13e68a502444bb7839dc642f12d0e34b7b954ad
+PROMOTION_J=3fc3c65649323506e8ad9914d2e5c985fa361401
+PROMOTION_F=c5dc5abb12aa1ac84ddbd12f141c6d4d8aca4de2
+PROMOTION_POOL=0be002ec1af2d1e0799f8507cb147a6f1406a428
+PROMOTION_INDEX=$FIXTURE/promotion.index
+GIT_INDEX_FILE=$PROMOTION_INDEX git -C "$SOURCE_REPO" read-tree "$PROMOTION_J"
+while read -r mode path; do
+  blob=$(git -C "$SOURCE_REPO" hash-object -w -- "$SOURCE_REPO/$path")
+  GIT_INDEX_FILE=$PROMOTION_INDEX git -C "$SOURCE_REPO" update-index \
+    --add --cacheinfo "$mode,$blob,$path"
+done <<'PATHS'
+100644 .github/workflows/production-deploy.yml
+100755 ops/deploy/github-production-deploy-client.sh
+100755 ops/deploy/github-production-deploy-client.test.sh
+100755 ops/deploy/production-release-b-bridge-order.test.sh
+100644 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+PATHS
+promotion_tree=$(GIT_INDEX_FILE=$PROMOTION_INDEX git -C "$SOURCE_REPO" write-tree)
+PROMOTION_H=$(printf 'test: promotion V2 H\n' | git -C "$SOURCE_REPO" commit-tree \
+  "$promotion_tree" -p "$PROMOTION_J")
+TARGET_SHA=$(printf 'test: protected-main promotion V2 merge\n' | \
+  git -C "$SOURCE_REPO" commit-tree "$promotion_tree" \
+    -p "$PROMOTION_F" -p "$PROMOTION_H")
 BACKEND_SHA=4f47fac7faed7dc24110f4a43e88820d776b8a40
 CURRENT_BACKEND_SHA=617e284607f3dde74c27164af2b981770b9a62ed
-RELEASE_B_CONTROLLER_SHA=8b4aeb31e855ed379349a4e4827600009e174132
-RELEASE_B_CURRENT_MAIN_SHA=77313ea03a3bac7d2298f4021d58124c810d291f
-RELEASE_B_BRIDGE_SHA=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
-RELEASE_B_REVIEWED_TARGET_SHA=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
-RELEASE_B_BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
-RELEASE_B_POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
 MODEL_JOB_IDENTITY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 AUTHORITY_SHA256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 TERMINAL_SET_SHA256=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -325,15 +266,18 @@ DEPLOY_SSH_KNOWN_HOSTS_PATH=$FIXTURE/ssh/pinned-known-hosts
 DEPLOY_HOST=production.example.invalid
 DEPLOY_USER=social-monitor-deploy
 
-export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA RELEASE_B_CONTROLLER_SHA
-export POST_RELEASE_B_SHA
-export RELEASE_B_CURRENT_MAIN_SHA RELEASE_B_BRIDGE_SHA RELEASE_B_REVIEWED_TARGET_SHA
-export RELEASE_B_BACKEND_MARKER RELEASE_B_POOL_MARKER
+export TARGET_SHA BACKEND_SHA CURRENT_BACKEND_SHA
+export PROMOTION_A PROMOTION_B PROMOTION_J PROMOTION_F PROMOTION_H PROMOTION_POOL
 export MODEL_JOB_IDENTITY AUTHORITY_SHA256 TERMINAL_SET_SHA256
 export FAKE_SSH_LOG FAKE_SSH_STATE FAKE_UPLOAD_PATH
 export DEPLOY_SSH_DIRECTORY DEPLOY_SSH_KEY_PATH DEPLOY_SSH_KNOWN_HOSTS_PATH
 export DEPLOY_HOST DEPLOY_USER GITHUB_OUTPUT
 install -m 0700 "$0" "$FAKE_SSH"
+
+fixture_plan() {
+  printf 'frontend=%s\nbackend=%s\nbackend_base=%s\ncontrol=%s\nx_collector=%s\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
+    "$1" "$2" "$5" "$3" "$4" "$6"
+}
 
 (
   unset DEPLOY_RECONCILE_ATTEMPTS DEPLOY_RECONCILE_INTERVAL_SECONDS \
@@ -349,32 +293,18 @@ install -m 0700 "$0" "$FAKE_SSH"
   ((DEFAULT_PLAN_READ_INTERVAL_SECONDS == 3))
   ((DEFAULT_RECONCILE_WINDOW_SECONDS >= MINIMUM_RECONCILE_WINDOW_SECONDS))
   ((DEFAULT_RECONCILE_WINDOW_SECONDS > KNOWN_BACKEND_SOAK_SECONDS))
-  parse_plan "$(printf 'frontend=false\nbackend=false\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
-    "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_CONTROLLER_SHA")"
-  plan_is_exact_release_b_bridge_transition
-  parse_plan "$(printf 'frontend=false\nbackend=false\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
-    "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_BRIDGE_SHA")"
-  plan_is_exact_release_b_bridge_transition && exit 1
-  parse_plan "$(printf 'frontend=false\nbackend=true\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
-    "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_CONTROLLER_SHA")"
-  plan_is_exact_release_b_target_transition
-  # shellcheck disable=SC2034 # Read by the sourced target-plan predicate.
-  PLAN_POSTGRES_POOL_REPAIR=true
-  plan_is_exact_release_b_target_transition && exit 1
-  # shellcheck disable=SC2034 # Read by the sourced current-main predicate.
-  PLAN_POSTGRES_POOL_REPAIR=false
-  parse_plan "$(printf 'frontend=false\nbackend=false\nbackend_base=%s\ncontrol=true\nx_collector=false\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
-    "$RELEASE_B_CURRENT_MAIN_SHA" "$RELEASE_B_CURRENT_MAIN_SHA")"
-  plan_is_exact_release_b_current_main_target_transition
-  parse_plan "$(printf 'frontend=true\nbackend=true\nbackend_base=%s\ncontrol=true\nx_collector=true\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
-    "$RELEASE_B_BACKEND_MARKER" "$RELEASE_B_POOL_MARKER")"
-  plan_is_exact_release_b_legacy_transition
-  parse_plan "$(printf 'frontend=true\nbackend=true\nbackend_base=%s\ncontrol=true\nx_collector=true\npostgres_pool_bootstrap=postgres-pool-v1\npostgres_pool_bootstrap_sha=%s\n' \
-    "$POST_RELEASE_B_SHA" "$POST_RELEASE_B_SHA")"
-  plan_is_admitted_post_release_b_forward_state "$TARGET_SHA"
-  # shellcheck disable=SC2034 # Read by the sourced post-Release-B predicate.
-  PLAN_POSTGRES_POOL_BOOTSTRAP_SHA=$RELEASE_B_CONTROLLER_SHA
-  plan_is_admitted_post_release_b_forward_state "$TARGET_SHA" && exit 1
+  parse_plan "$(fixture_plan false false true false "$PROMOTION_A" "$PROMOTION_POOL")"
+  plan_is_exact_promotion_v2_bridge_pending
+  parse_plan "$(fixture_plan false false false false "$PROMOTION_A" "$PROMOTION_POOL")"
+  plan_is_exact_promotion_v2_bridge_complete
+  parse_plan "$(fixture_plan true true true false "$PROMOTION_A" "$PROMOTION_POOL")"
+  plan_is_exact_promotion_v2_target_pending
+  parse_plan "$(fixture_plan true false true false "$PROMOTION_A" "$PROMOTION_POOL")"
+  plan_is_exact_promotion_v2_target_pending && exit 1
+  parse_plan "$(fixture_plan true true true true "$PROMOTION_A" "$PROMOTION_POOL")"
+  plan_is_exact_promotion_v2_target_pending && exit 1
+  parse_plan "$(fixture_plan false false false false "$TARGET_SHA" "$TARGET_SHA")"
+  plan_is_exact_promotion_v2_target_complete "$TARGET_SHA"
   true
 )
 
@@ -413,18 +343,13 @@ assert_call_count() {
   }
 }
 
-# The workflow's local gate accepts the exact reviewed target and its real
-# requested descendant, but rejects current-main before any SSH call is made.
-for release_b_requested_target in \
-  "$RELEASE_B_REVIEWED_TARGET_SHA" "$TARGET_SHA"; do
-  HOME='' DEPLOY_SSH_DIRECTORY='' DEPLOY_HOST='' DEPLOY_USER='' \
-    GITHUB_WORKSPACE=$SCRIPT_DIR/../.. run_client release_b_local_identity \
-      verify-release-b-target "$release_b_requested_target"
-  [[ ! -s $FAKE_SSH_LOG ]]
-done
 HOME='' DEPLOY_SSH_DIRECTORY='' DEPLOY_HOST='' DEPLOY_USER='' \
-  GITHUB_WORKSPACE=$SCRIPT_DIR/../.. assert_fails release_b_local_identity \
-    verify-release-b-target "$RELEASE_B_CURRENT_MAIN_SHA"
+  GITHUB_WORKSPACE=$SOURCE_REPO run_client promotion_local_identity \
+    verify-post-promotion-v2-target "$TARGET_SHA"
+grep -Fx "release_b=$PROMOTION_B" "$GITHUB_OUTPUT" >/dev/null
+grep -Fx "join=$PROMOTION_J" "$GITHUB_OUTPUT" >/dev/null
+grep -Fx "head=$PROMOTION_H" "$GITHUB_OUTPUT" >/dev/null
+grep -Fx "target=$TARGET_SHA" "$GITHUB_OUTPUT" >/dev/null
 [[ ! -s $FAKE_SSH_LOG ]]
 
 DEPLOY_KEY=fake-private-key KNOWN_HOSTS=fake-known-hosts bash "$CLIENT" configure
@@ -688,56 +613,34 @@ run_client normal_success deploy "$TARGET_SHA" >/dev/null
 assert_call_count 1 "deploy $TARGET_SHA"
 assert_call_count 1 "plan $TARGET_SHA"
 
-# Every bridge/controller mutation follows a plan and is issued at most once.
-prepare_args=(prepare-release-b-bridge "$RELEASE_B_CONTROLLER_SHA" \
-  "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" \
-  "$RELEASE_B_REVIEWED_TARGET_SHA" "$TARGET_SHA")
-run_client release_b_post_b "${prepare_args[@]}" >/dev/null
+# Preparation inspects M first, deploys only B, and never replays ambiguity.
+prepare_args=(prepare-post-promotion-v2-bridge "$PROMOTION_B" \
+  "$PROMOTION_J" "$TARGET_SHA")
+run_client promotion_m_complete "${prepare_args[@]}" >/dev/null
 assert_call_count 1 "plan $TARGET_SHA"
-assert_call_count 0 "plan $RELEASE_B_REVIEWED_TARGET_SHA"
-assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_call_count 0 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
-run_client release_b_from_8b "${prepare_args[@]}" >/dev/null
-assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_call_count 2 "plan $RELEASE_B_BRIDGE_SHA"
-assert_call_count 1 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
+assert_call_count 0 "plan $PROMOTION_B"
+assert_call_count 0 "deploy $PROMOTION_B"
+run_client promotion_b_complete "${prepare_args[@]}" >/dev/null
+assert_call_count 1 "plan $TARGET_SHA"
+assert_call_count 1 "plan $PROMOTION_B"
+assert_call_count 0 "deploy $PROMOTION_B"
+run_client promotion_b_pending "${prepare_args[@]}" >/dev/null
+assert_call_count 1 "deploy $PROMOTION_B"
+assert_call_count 2 "plan $TARGET_SHA"
+assert_call_count 2 "plan $PROMOTION_B"
 assert_call_count 0 "deploy $TARGET_SHA"
-assert_call_count 0 "deploy $RELEASE_B_CONTROLLER_SHA"
-run_client release_b_bridge_disconnect "${prepare_args[@]}" >/dev/null
-assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_call_count 2 "plan $RELEASE_B_BRIDGE_SHA"
-assert_call_count 1 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
+run_client promotion_b_disconnect "${prepare_args[@]}" >/dev/null
+assert_call_count 1 "deploy $PROMOTION_B"
+assert_call_count 2 "plan $TARGET_SHA"
+assert_call_count 2 "plan $PROMOTION_B"
 assert_call_count 0 "deploy $TARGET_SHA"
-run_client release_b_controller_repair "${prepare_args[@]}" >/dev/null
-assert_call_count 1 "deploy $RELEASE_B_CONTROLLER_SHA"
-assert_call_count 1 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_call_count 1 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
-assert_call_count 0 "deploy $TARGET_SHA"
-assert_call_count 2 "plan $RELEASE_B_CONTROLLER_SHA"
-run_client release_b_current_main "${prepare_args[@]}" >/dev/null
-assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_call_count 1 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
-assert_call_count 0 "deploy $TARGET_SHA"
-assert_call_count 1 "plan $RELEASE_B_CURRENT_MAIN_SHA"
-run_client release_b_replay "${prepare_args[@]}" >/dev/null
-assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_call_count 0 "deploy $RELEASE_B_REVIEWED_TARGET_SHA"
-assert_call_count 0 "deploy $TARGET_SHA"
-assert_fails release_b_partial "${prepare_args[@]}"
-assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_fails release_b_stale_target "${prepare_args[@]}"
-assert_call_count 0 "plan $RELEASE_B_BRIDGE_SHA"
-assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_fails release_b_rejected "${prepare_args[@]}"
-assert_call_count 0 "deploy $RELEASE_B_BRIDGE_SHA"
-assert_fails release_b_replay prepare-release-b-bridge "$TARGET_SHA" \
-  "$RELEASE_B_BRIDGE_SHA" "$RELEASE_B_CURRENT_MAIN_SHA" \
-  "$RELEASE_B_REVIEWED_TARGET_SHA" "$TARGET_SHA"
+assert_fails promotion_partial plan-post-promotion-v2-target "$TARGET_SHA"
+assert_fails promotion_x plan-post-promotion-v2-target "$TARGET_SHA"
+assert_fails promotion_m_complete prepare-post-promotion-v2-bridge \
+  "$PROMOTION_A" "$PROMOTION_J" "$TARGET_SHA"
 [[ ! -s $FAKE_SSH_LOG ]]
-assert_fails release_b_replay prepare-release-b-bridge \
-  "$RELEASE_B_CONTROLLER_SHA" "$RELEASE_B_BRIDGE_SHA" \
-  "$RELEASE_B_CURRENT_MAIN_SHA" "$RELEASE_B_REVIEWED_TARGET_SHA" \
-  "$RELEASE_B_CURRENT_MAIN_SHA"
+assert_fails promotion_m_complete prepare-post-promotion-v2-bridge \
+  "$PROMOTION_B" "$PROMOTION_F" "$TARGET_SHA"
 [[ ! -s $FAKE_SSH_LOG ]]
 
 run_client normal_success install-daily-c1-bridge-policy \
@@ -815,18 +718,16 @@ assert_call_count 0 "deploy $TARGET_SHA"
 # shellcheck disable=SC2016 # Literal GitHub expressions are asserted in workflow text.
 grep -F 'postgres_pool_repair: ${{ steps.plan.outputs.postgres_pool_repair }}' \
   "$WORKFLOW" >/dev/null
-# PostgreSQL bootstrap repair is now driven by the freshly inspected transition
-# state and is restricted to one of the three frozen release anchors.
-[[ $(grep -cF \
-  "if: needs.plan.outputs.transition_state == 'repair-required'" "$WORKFLOW") == 1 ]]
-# shellcheck disable=SC2016
-grep -F 'repair_anchor: ${{ steps.plan.outputs.repair_anchor }}' \
+grep -F 'prepare-post-promotion-v2-bridge "$RELEASE_B" "$JOIN_SHA" "$TARGET_SHA"' \
   "$WORKFLOW" >/dev/null
-# shellcheck disable=SC2016
-grep -F 'REPAIR_ANCHOR: ${{ needs.plan.outputs.repair_anchor }}' \
-  "$WORKFLOW" >/dev/null
-grep -F '889d50f50328c89e25b3ef898e552df631b3222f|c64c3b46b6b6ba5c7ac7b04028932e09dae2116a|e3b5b5d89b3586668e36f987f03672415b5a0f37' \
-  "$WORKFLOW" >/dev/null
+grep -F 'plan-post-promotion-v2-target "$TARGET_SHA"' "$WORKFLOW" >/dev/null
+grep -F 'accept-post-promotion-v2-target "$GITHUB_SHA"' "$WORKFLOW" >/dev/null
+unsafe_forward_symbol=plan_is_admitted_post_release_b_forward_
+unsafe_forward_symbol+=state
+if grep -F "$unsafe_forward_symbol" "$CLIENT" >/dev/null; then
+  echo 'unsafe historical forward-state shortcut remains' >&2
+  exit 1
+fi
 for maintenance_action in \
   disk-report project-disk-cleanup \
   reader-summary-recover-missing-days reader-summary-weekly-run \

--- a/ops/deploy/production-release-b-bridge-order.test.sh
+++ b/ops/deploy/production-release-b-bridge-order.test.sh
@@ -4,377 +4,192 @@ set -euo pipefail
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
-SOURCE_REPO=${PRODUCTION_RELEASE_B_TEST_SOURCE_REPO:-$PROJECT_ROOT}
-WORKFLOW=$PROJECT_ROOT/.github/workflows/production-deploy.yml
+REPO=${PRODUCTION_RELEASE_B_TEST_SOURCE_REPO:-$PROJECT_ROOT}
 CLIENT=$PROJECT_ROOT/ops/deploy/github-production-deploy-client.sh
-BASE=8b4aeb31e855ed379349a4e4827600009e174132
-CURRENT_MAIN=77313ea03a3bac7d2298f4021d58124c810d291f
-OLD_CURRENT_MAIN=d7d0fc88e6a7bcd8e9929e35efd74002a7601449
-OLD_BRIDGE=db4537fea87a5c184a9f926867a6e6aa763ff9bd
-OLD_TARGET=bce12683c9309e037614f4808a0fc75caddc9864
-BRIDGE=b89950632b0cefa4f7b58b687cdfd6e6cd912a04
-BRIDGE_TREE=0f2edeb95bbb658cebdb1aecdcda24026eca7d19
-BRIDGE_BLOB=e02f7b7684f75121521065b43148708d545ab806
-BRIDGE_TARGET=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
-BRIDGE_TARGET_TREE=237c34068c057d2dfb5efaf9d606028cdaf18525
-CANONICAL_RELEASE_B2=e3b5b5d89b3586668e36f987f03672415b5a0f37
-CANONICAL_TARGET=05744f99b2d13e47a64a7ff12ea2ab8893f5e88a
-BRIDGE_PATH=ops/deploy/deploy-control-bridge-lib.sh
-BACKEND_MARKER=09a79687e042e36d4ec9c1f33f0367527f044181
-CONTROL_MARKER=3f4a561e9fd6626bbd1a1e1ca73f2ec7eb34c8f8
-FRONTEND_MARKER=eaac8ad433bc9741f493e61354b3dfe1c3161224
-POOL_MARKER=6fefa9da5446d5e467badcc7239fdc5a6170a756
-FIXTURE_TEMP_PARENT=$(cd "${TMPDIR:-/tmp}" && pwd -P)
-FIXTURE=$(mktemp -d "$FIXTURE_TEMP_PARENT/release-b-current-main.XXXXXX")
-declare -a FIXTURE_CHILD_PIDS=() FIXTURE_CHILD_GROUPS=()
-declare -a FIXTURE_CHILD_LABELS=()
+WORKFLOW=$PROJECT_ROOT/.github/workflows/production-deploy.yml
+A=7c4070f0b9ef1aac130284bcffac50551e20a4dd
+A_TREE=72a67394bafd87ab7ed5b3024ddf66c6d040f096
+F=c5dc5abb12aa1ac84ddbd12f141c6d4d8aca4de2
+F_TREE=526a56bef3b9a9a8edcf562b4b643af0f369eb8a
+B=b13e68a502444bb7839dc642f12d0e34b7b954ad
+B_TREE=87b0bd78d93cfefd980cf7c38f96dca2a8899268
+J=3fc3c65649323506e8ad9914d2e5c985fa361401
+J_TREE=54e11938300dc50f3a744dc2a2bb5044505206bd
+BRIDGE_BLOB=d02ac91a87656739ef2563c0481835122ec3f7f3
+CONTROL_BLOB=fd2d8095cd6e2428e02f6ca21942bab2ea10961b
+FRONTEND_MARKER=09294b6bbff4442b42bf5bd84bd45ce18731e25b
+POOL_MARKER=0be002ec1af2d1e0799f8507cb147a6f1406a428
+FIXTURE_PARENT=$(cd "${TMPDIR:-/tmp}" && pwd -P)
+FIXTURE=$(mktemp -d "$FIXTURE_PARENT/promotion-v2-h-guard.XXXXXX")
+export GIT_AUTHOR_NAME='Promotion V2 fixture'
+export GIT_AUTHOR_EMAIL=promotion-v2@example.invalid
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 
-register_fixture_child() {
-  local pid=$1 group=$2 label=$3
-  [[ $pid =~ ^[1-9][0-9]*$ && $group =~ ^[1-9][0-9]*$ ]] || {
-    printf 'fixture-cleanup-error: invalid child identity for %s\n' "$label" >&2
-    return 1
-  }
-  FIXTURE_CHILD_PIDS+=("$pid")
-  FIXTURE_CHILD_GROUPS+=("$group")
-  FIXTURE_CHILD_LABELS+=("$label")
-}
-
-wait_for_fixture_children() {
-  local index pid group label child_status deadline
-  for index in "${!FIXTURE_CHILD_PIDS[@]}"; do
-    pid=${FIXTURE_CHILD_PIDS[$index]}
-    group=${FIXTURE_CHILD_GROUPS[$index]}
-    label=${FIXTURE_CHILD_LABELS[$index]}
-    if ! timeout 10 tail --pid="$pid" -f /dev/null; then
-      printf 'fixture-cleanup-error: timed out waiting for %s (pid=%s pgid=%s)\n' \
-        "$label" "$pid" "$group" >&2
-      return 1
-    fi
-    if wait "$pid"; then
-      child_status=0
-    else
-      child_status=$?
-    fi
-    if ((child_status != 0)); then
-      printf 'fixture-cleanup-error: %s exited with status %s (pid=%s pgid=%s)\n' \
-        "$label" "$child_status" "$pid" "$group" >&2
-      return 1
-    fi
-    deadline=$((SECONDS + 10))
-    while kill -0 -- "-$group" 2>/dev/null; do
-      if ((SECONDS >= deadline)); then
-        printf 'fixture-cleanup-error: timed out waiting for %s process group %s\n' \
-          "$label" "$group" >&2
-        return 1
-      fi
-      sleep 0.1
-    done
-  done
-  FIXTURE_CHILD_PIDS=()
-  FIXTURE_CHILD_GROUPS=()
-  FIXTURE_CHILD_LABELS=()
-}
-
-remove_fixture_tree() {
-  local fixture=$1 prefix=$2 parent base
-  parent=$(dirname "$fixture")
-  base=$(basename "$fixture")
-  [[ $parent == "$FIXTURE_TEMP_PARENT" && -d $fixture && ! -L $fixture ]] || {
-    printf 'fixture-cleanup-error: refusing unvalidated fixture path: %s\n' \
-      "$fixture" >&2
-    return 1
-  }
-  case "$base" in
-    "$prefix".[[:alnum:]][[:alnum:]][[:alnum:]][[:alnum:]][[:alnum:]][[:alnum:]]) ;;
-    *)
-      printf 'fixture-cleanup-error: refusing unexpected fixture name: %s\n' \
-        "$fixture" >&2
-      return 1
-      ;;
-  esac
-  rm -rf -- "$fixture" || {
-    printf 'fixture-cleanup-error: could not remove fixture tree: %s\n' \
-      "$fixture" >&2
-    return 1
-  }
-  [[ ! -e $fixture && ! -L $fixture ]] || {
-    printf 'fixture-cleanup-error: fixture tree still exists after removal: %s\n' \
-      "$fixture" >&2
-    return 1
-  }
-}
-
+fail() { printf 'promotion-v2-test-error: %s\n' "$*" >&2; return 1; }
 cleanup_fixture() {
-  local test_status=$? cleanup_status=0
+  local status=$? parent base
   trap - EXIT
-  wait_for_fixture_children || cleanup_status=$?
-  if ((cleanup_status == 0)); then
-    remove_fixture_tree "$FIXTURE" release-b-current-main || cleanup_status=$?
-  else
-    printf 'fixture-cleanup-error: retaining fixture after child failure: %s\n' \
-      "$FIXTURE" >&2
+  parent=$(dirname "$FIXTURE")
+  base=$(basename "$FIXTURE")
+  [[ $parent == "$FIXTURE_PARENT" && -d $FIXTURE && ! -L $FIXTURE && \
+     $base == promotion-v2-h-guard.?????? ]] || {
+    printf 'fixture-cleanup-error: refusing unsafe path: %s\n' "$FIXTURE" >&2
+    exit 1
+  }
+  rm -rf -- "$FIXTURE" || status=$?
+  if ((status == 0)); then
+    [[ ! -e $FIXTURE && ! -L $FIXTURE ]] || status=1
   fi
-  if ((test_status == 0 && cleanup_status != 0)); then
-    test_status=$cleanup_status
-  fi
-  exit "$test_status"
+  exit "$status"
 }
-
-configure_fixture_repository() {
-  local repository=$1
-  # Fast-forward merges run automatic maintenance. Keep its GC attached so the
-  # owning Git process cannot return while a detached writer still uses repo.
-  git -C "$repository" config gc.autoDetach false
-  [[ $(git -C "$repository" config --bool gc.autoDetach) == false ]]
-}
-
-exercise_fixture_cleanup_race() {
-  local race_fixture completion child_pid
-  race_fixture=$(mktemp -d \
-    "$FIXTURE_TEMP_PARENT/release-b-cleanup-race.XXXXXX")
-  completion=$FIXTURE/cleanup-race-child-complete
-  # The group leader exits before its delayed writer. Removing first recreates
-  # the old race deterministically; group-aware cleanup waits, then removes.
-  setsid bash -c '
-    (
-      sleep 0.1
-      install -d "$1/repo"
-      printf "%s\n" complete > "$1/repo/maintenance-complete"
-      : > "$2"
-    ) &
-  ' release-b-cleanup-child "$race_fixture" "$completion" &
-  child_pid=$!
-  register_fixture_child "$child_pid" "$child_pid" \
-    'deterministic concurrent fixture mutator'
-  wait_for_fixture_children
-  remove_fixture_tree "$race_fixture" release-b-cleanup-race
-  [[ -f $completion && ! -e $race_fixture && ! -L $race_fixture ]]
-}
-
 trap cleanup_fixture EXIT
-exercise_fixture_cleanup_race
-GRAPH_REPO=$FIXTURE/graph
 
-SOURCE_HEAD=$(git -C "$SOURCE_REPO" rev-parse HEAD)
-TARGET=$CANONICAL_TARGET
-git -C "$SOURCE_REPO" merge-base --is-ancestor "$TARGET" "$SOURCE_HEAD" || {
-  printf 'canonical Release B target %s is not an ancestor of source HEAD %s\n' \
-    "$TARGET" "$SOURCE_HEAD" >&2
-  exit 1
+assert_rejected() {
+  local candidate=$1 label=$2
+  if (GITHUB_WORKSPACE=$REPO verify_post_promotion_v2_target_identity \
+      "$candidate") 2>/dev/null; then
+    printf 'invalid promotion graph was admitted: %s\n' "$label" >&2
+    exit 1
+  fi
 }
-git -c gc.autoDetach=false clone -q --shared "$SOURCE_REPO" "$GRAPH_REPO"
-configure_fixture_repository "$GRAPH_REPO"
-git -C "$GRAPH_REPO" config user.name 'Release B Current Main Test'
-git -C "$GRAPH_REPO" config user.email release-b-current-main@example.invalid
-for commit in "$BASE" "$CURRENT_MAIN" "$OLD_CURRENT_MAIN" "$OLD_BRIDGE" \
-  "$OLD_TARGET" "$BRIDGE" "$BRIDGE_TARGET" "$CANONICAL_RELEASE_B2" "$TARGET"; do
-  git -C "$GRAPH_REPO" cat-file -e "$commit^{commit}"
+
+for identity in "$A:$A_TREE" "$F:$F_TREE" "$B:$B_TREE" "$J:$J_TREE"; do
+  sha=${identity%%:*}; tree=${identity#*:}
+  [[ $(git -C "$REPO" rev-parse "$sha^{tree}") == "$tree" ]]
 done
+[[ $(git -C "$REPO" rev-list --parents -n 1 "$B") == "$B $A" ]]
+[[ $(git -C "$REPO" diff --name-only --no-renames "$A" "$B") == \
+  $'ops/deploy/deploy-control-bridge-lib.sh\nops/deploy/deploy-control-lib.sh' ]]
+[[ $(git -C "$REPO" ls-tree "$B" -- ops/deploy/deploy-control-bridge-lib.sh \
+  ops/deploy/deploy-control-lib.sh) == \
+  $'100644 blob '"$BRIDGE_BLOB"$'\tops/deploy/deploy-control-bridge-lib.sh\n100644 blob '"$CONTROL_BLOB"$'\tops/deploy/deploy-control-lib.sh' ]]
+[[ $(git -C "$REPO" rev-list --parents -n 1 "$J") == "$J $F $B" ]]
+[[ $(git -C "$REPO" diff --name-only --no-renames "$F" "$J") == \
+  ops/deploy/deploy-control-bridge-lib.sh ]]
 
-# The bridge is one immutable policy blob directly on the old controller.
-read -r -a bridge_parents <<< "$(git -C "$GRAPH_REPO" \
-  rev-list --parents -n 1 "$BRIDGE")"
-[[ ${#bridge_parents[@]} == 2 && ${bridge_parents[0]} == "$BRIDGE" && \
-   ${bridge_parents[1]} == "$BASE" ]]
-[[ $(git -C "$GRAPH_REPO" rev-parse "$BRIDGE^{tree}") == "$BRIDGE_TREE" ]]
-[[ $(git -C "$GRAPH_REPO" diff --name-only --no-renames \
-     "$BASE" "$BRIDGE") == "$BRIDGE_PATH" ]]
-read -r bridge_mode bridge_type bridge_blob bridge_path bridge_extra <<< "$(
-  git -C "$GRAPH_REPO" ls-tree "$BRIDGE" -- "$BRIDGE_PATH"
-)"
-[[ -z ${bridge_extra:-} && $bridge_mode == 100644 && \
-   $bridge_type == blob && $bridge_blob == "$BRIDGE_BLOB" && \
-   $bridge_path == "$BRIDGE_PATH" ]]
+H_INDEX=$FIXTURE/h.index
+GIT_INDEX_FILE=$H_INDEX git -C "$REPO" read-tree "$J"
+while read -r mode path; do
+  blob=$(git -C "$REPO" hash-object -w -- "$PROJECT_ROOT/$path")
+  GIT_INDEX_FILE=$H_INDEX git -C "$REPO" update-index \
+    --add --cacheinfo "$mode,$blob,$path"
+done <<'PATHS'
+100644 .github/workflows/production-deploy.yml
+100755 ops/deploy/github-production-deploy-client.sh
+100755 ops/deploy/github-production-deploy-client.test.sh
+100755 ops/deploy/production-release-b-bridge-order.test.sh
+100644 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+PATHS
+H_TREE=$(GIT_INDEX_FILE=$H_INDEX git -C "$REPO" write-tree)
+H=$(printf 'test: exact five-file H guard\n' | git -C "$REPO" commit-tree \
+  "$H_TREE" -p "$J")
+M=$(printf 'test: protected-main merge M\n' | git -C "$REPO" commit-tree \
+  "$H_TREE" -p "$F" -p "$H")
 
-# The bridge target is the exact cleanup-preserving two-parent integration.
-read -r -a target_parents <<< "$(git -C "$GRAPH_REPO" \
-  rev-list --parents -n 1 "$BRIDGE_TARGET")"
-[[ ${#target_parents[@]} == 3 && ${target_parents[0]} == "$BRIDGE_TARGET" && \
-   ${target_parents[1]} == "$CURRENT_MAIN" && \
-   ${target_parents[2]} == "$BRIDGE" ]]
-[[ $(git -C "$GRAPH_REPO" rev-parse "$BRIDGE_TARGET^{tree}") == \
-   "$BRIDGE_TARGET_TREE" ]]
-git -C "$GRAPH_REPO" merge-base --is-ancestor "$CURRENT_MAIN" "$BRIDGE_TARGET"
-git -C "$GRAPH_REPO" merge-base --is-ancestor "$BRIDGE" "$BRIDGE_TARGET"
-git -C "$GRAPH_REPO" rev-list --first-parent "$BRIDGE_TARGET" | \
-  grep -Fx "$CANONICAL_RELEASE_B2" >/dev/null
-[[ $(git -C "$GRAPH_REPO" rev-parse "$BRIDGE_TARGET:$BRIDGE_PATH") == \
-   "$BRIDGE_BLOB" ]]
-expected_target_delta=$(printf '%s\n' \
-  .github/workflows/production-deploy.yml \
-  ops/deploy/deploy-control-bridge-lib.sh \
-  ops/deploy/github-production-deploy-client.sh \
-  ops/deploy/github-production-deploy-client.test.sh \
-  ops/deploy/production-release-b-bridge-order.test.sh \
-  ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh | LC_ALL=C sort)
-actual_target_delta=$(git -C "$GRAPH_REPO" diff --name-only --no-renames \
-  "$CURRENT_MAIN" "$BRIDGE_TARGET" | LC_ALL=C sort)
-[[ $actual_target_delta == "$expected_target_delta" ]]
-inherited_path=ops/ingestion/source-provider-certification.json
-[[ $(git -C "$GRAPH_REPO" rev-parse "$CURRENT_MAIN:$inherited_path") == \
-   $(git -C "$GRAPH_REPO" rev-parse "$BRIDGE_TARGET:$inherited_path") ]]
-
-# The requested target is distinct and must retain the reviewed target on its
-# first-parent history; its later ordinary-controller delta is not bridge policy.
-git -C "$GRAPH_REPO" rev-list --first-parent "$TARGET" | \
-  grep -Fx "$BRIDGE_TARGET" >/dev/null
-
-# Exercise the bridge acceptance policy against the real graph and negative
-# stale/rejected topologies.
-REPO=$GRAPH_REPO
-fail() { printf 'test-error: %s\n' "$*" >&2; return 1; }
-# shellcheck source=ops/deploy/deploy-control-bridge-lib.sh
-source "$GRAPH_REPO/ops/deploy/deploy-control-bridge-lib.sh"
-deploy_control_reviewed_transition_matches "$BRIDGE" "$BRIDGE_TARGET"
-if deploy_control_reviewed_transition_matches "$OLD_BRIDGE" "$OLD_TARGET"; then
-  echo 'obsolete bce/db topology was admitted by the new bridge' >&2
-  exit 1
-fi
-if deploy_control_reviewed_transition_matches "$OLD_BRIDGE" "$BRIDGE_TARGET"; then
-  echo 'obsolete bridge was admitted for the new target' >&2
-  exit 1
-fi
-if deploy_control_reviewed_transition_matches "$BRIDGE" "$CURRENT_MAIN"; then
-  echo 'direct current-main commit was admitted as the new target' >&2
-  exit 1
-fi
-swapped_target=$(printf 'test: swapped Release B parents\n' | \
-  git -C "$GRAPH_REPO" commit-tree "$BRIDGE_TARGET^{tree}" \
-    -p "$BRIDGE" -p "$CURRENT_MAIN")
-if deploy_control_reviewed_transition_matches "$BRIDGE" "$swapped_target"; then
-  echo 'swapped target parents were admitted' >&2
-  exit 1
-fi
-wrapper_target=$(printf 'test: wrapped Release B target\n' | \
-  git -C "$GRAPH_REPO" commit-tree "$BRIDGE_TARGET^{tree}" -p "$BRIDGE_TARGET")
-if deploy_control_reviewed_transition_matches "$BRIDGE" "$wrapper_target"; then
-  echo 'wrapper target was admitted' >&2
-  exit 1
-fi
-extra_blob=$(printf 'extra target drift\n' | git -C "$GRAPH_REPO" hash-object -w --stdin)
-extra_index=$FIXTURE/extra.index
-GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" read-tree "$BRIDGE_TARGET"
-GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" update-index \
-  --add --cacheinfo "100644,$extra_blob,unreviewed-release-b-drift"
-extra_tree=$(GIT_INDEX_FILE=$extra_index git -C "$GRAPH_REPO" write-tree)
-extra_target=$(printf 'test: extra path target\n' | git -C "$GRAPH_REPO" \
-  commit-tree "$extra_tree" -p "$CURRENT_MAIN" -p "$BRIDGE")
-if deploy_control_reviewed_transition_matches "$BRIDGE" "$extra_target"; then
-  echo 'extra-path current-main topology was admitted' >&2
-  exit 1
-fi
-drift_blob=$(printf 'allowlisted byte drift\n' | \
-  git -C "$GRAPH_REPO" hash-object -w --stdin)
-drift_index=$FIXTURE/drift.index
-GIT_INDEX_FILE=$drift_index git -C "$GRAPH_REPO" read-tree "$BRIDGE_TARGET"
-GIT_INDEX_FILE=$drift_index git -C "$GRAPH_REPO" update-index --cacheinfo \
-  "100644,$drift_blob,.github/workflows/production-deploy.yml"
-drift_tree=$(GIT_INDEX_FILE=$drift_index git -C "$GRAPH_REPO" write-tree)
-drift_target=$(printf 'test: allowlisted target byte drift\n' | \
-  git -C "$GRAPH_REPO" commit-tree "$drift_tree" \
-    -p "$CURRENT_MAIN" -p "$BRIDGE")
-
-# The client independently pins the reviewed target and rejects requested
-# commits that contain it only through a side parent.
-DEPLOY_SSH_DIRECTORY=$FIXTURE/client-ssh
 # shellcheck source=ops/deploy/github-production-deploy-client.sh
 source "$CLIENT"
-GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
-  "$BRIDGE_TARGET" "$BRIDGE_TARGET"
-GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
-  "$BRIDGE_TARGET" "$TARGET"
-if (GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
-    "$drift_target" "$TARGET") 2>/dev/null; then
-  echo 'allowlisted-byte drift was admitted' >&2
+GITHUB_WORKSPACE=$REPO verify_post_promotion_v2_target_identity "$M"
+[[ $PROMOTION_V2_VERIFIED_H == "$H" && \
+   $PROMOTION_V2_VERIFIED_TARGET == "$M" ]]
+
+swapped=$(printf 'test: swapped protected-main parents\n' | \
+  git -C "$REPO" commit-tree "$H_TREE" -p "$H" -p "$F")
+squash=$(printf 'test: squashed protected-main result\n' | \
+  git -C "$REPO" commit-tree "$H_TREE" -p "$F")
+wrapper=$(printf 'test: wrapper around M\n' | \
+  git -C "$REPO" commit-tree "$H_TREE" -p "$M")
+rebased_h=$(printf 'test: rebased H\n' | \
+  git -C "$REPO" commit-tree "$H_TREE" -p "$F")
+rebased_m=$(printf 'test: merge with rebased H\n' | \
+  git -C "$REPO" commit-tree "$H_TREE" -p "$F" -p "$rebased_h")
+assert_rejected "$swapped" 'swapped M parents'
+assert_rejected "$squash" 'squashed M'
+assert_rejected "$wrapper" 'wrapper M'
+assert_rejected "$rebased_m" 'rebased H'
+assert_rejected "$F" 'wrong target SHA'
+
+EXTRA_INDEX=$FIXTURE/extra.index
+GIT_INDEX_FILE=$EXTRA_INDEX git -C "$REPO" read-tree "$H_TREE"
+extra_blob=$(printf 'unreviewed\n' | git -C "$REPO" hash-object -w --stdin)
+GIT_INDEX_FILE=$EXTRA_INDEX git -C "$REPO" update-index --add \
+  --cacheinfo "100644,$extra_blob,unreviewed-promotion-path"
+extra_tree=$(GIT_INDEX_FILE=$EXTRA_INDEX git -C "$REPO" write-tree)
+extra_h=$(printf 'test: H with extra path\n' | git -C "$REPO" commit-tree \
+  "$extra_tree" -p "$J")
+extra_m=$(printf 'test: M with extra path\n' | git -C "$REPO" commit-tree \
+  "$extra_tree" -p "$F" -p "$extra_h")
+assert_rejected "$extra_m" 'extra H path'
+
+MODE_INDEX=$FIXTURE/mode.index
+GIT_INDEX_FILE=$MODE_INDEX git -C "$REPO" read-tree "$H_TREE"
+client_blob=$(git -C "$REPO" rev-parse "$H:ops/deploy/github-production-deploy-client.sh")
+GIT_INDEX_FILE=$MODE_INDEX git -C "$REPO" update-index \
+  --cacheinfo "100644,$client_blob,ops/deploy/github-production-deploy-client.sh"
+mode_tree=$(GIT_INDEX_FILE=$MODE_INDEX git -C "$REPO" write-tree)
+mode_h=$(printf 'test: H with wrong mode\n' | git -C "$REPO" commit-tree \
+  "$mode_tree" -p "$J")
+mode_m=$(printf 'test: M with wrong mode\n' | git -C "$REPO" commit-tree \
+  "$mode_tree" -p "$F" -p "$mode_h")
+assert_rejected "$mode_m" 'wrong H mode'
+
+# Override pins only inside subshells to prove immutable A/F trees and B blobs,
+# modes, and SHA are checked rather than inferred from topology alone.
+if (PROMOTION_V2_CONTROLLER_TREE=$F_TREE; \
+    GITHUB_WORKSPACE=$REPO verify_post_promotion_v2_target_identity "$M") \
+    2>/dev/null; then exit 1; fi
+if (PROMOTION_V2_PRODUCT_MAIN_TREE=$A_TREE; \
+    GITHUB_WORKSPACE=$REPO verify_post_promotion_v2_target_identity "$M") \
+    2>/dev/null; then exit 1; fi
+if (PROMOTION_V2_BRIDGE_SHA=$A; PROMOTION_V2_BRIDGE_TREE=$A_TREE; \
+    GITHUB_WORKSPACE=$REPO verify_post_promotion_v2_target_identity "$M") \
+    2>/dev/null; then exit 1; fi
+
+BAD_B_INDEX=$FIXTURE/bad-b.index
+GIT_INDEX_FILE=$BAD_B_INDEX git -C "$REPO" read-tree "$B"
+wrong_blob=$(printf 'wrong bridge bytes\n' | git -C "$REPO" hash-object -w --stdin)
+GIT_INDEX_FILE=$BAD_B_INDEX git -C "$REPO" update-index \
+  --cacheinfo "100644,$wrong_blob,ops/deploy/deploy-control-bridge-lib.sh"
+bad_b_tree=$(GIT_INDEX_FILE=$BAD_B_INDEX git -C "$REPO" write-tree)
+bad_b=$(printf 'test: wrong B blob\n' | git -C "$REPO" commit-tree \
+  "$bad_b_tree" -p "$A")
+if (PROMOTION_V2_BRIDGE_SHA=$bad_b; PROMOTION_V2_BRIDGE_TREE=$bad_b_tree; \
+    GITHUB_WORKSPACE=$REPO verify_post_promotion_v2_target_identity "$M") \
+    2>/dev/null; then exit 1; fi
+GIT_INDEX_FILE=$BAD_B_INDEX git -C "$REPO" update-index \
+  --cacheinfo "100755,$BRIDGE_BLOB,ops/deploy/deploy-control-bridge-lib.sh"
+bad_mode_tree=$(GIT_INDEX_FILE=$BAD_B_INDEX git -C "$REPO" write-tree)
+bad_mode_b=$(printf 'test: wrong B mode\n' | git -C "$REPO" commit-tree \
+  "$bad_mode_tree" -p "$A")
+if (PROMOTION_V2_BRIDGE_SHA=$bad_mode_b; \
+    PROMOTION_V2_BRIDGE_TREE=$bad_mode_tree; \
+    GITHUB_WORKSPACE=$REPO verify_post_promotion_v2_target_identity "$M") \
+    2>/dev/null; then exit 1; fi
+
+REPO=$REPO
+# shellcheck source=/dev/null
+source <(git -C "$REPO" show "$B:ops/deploy/deploy-control-bridge-lib.sh")
+deploy_control_reviewed_transition_matches "$B" "$M"
+if deploy_control_reviewed_transition_matches "$A" "$M"; then
+  echo 'direct A-to-M was admitted' >&2
   exit 1
 fi
-side_parent_target=$(printf 'test: side-parent-only requested target\n' | \
-  git -C "$GRAPH_REPO" commit-tree "$BRIDGE_TARGET^{tree}" \
-    -p "$CURRENT_MAIN" -p "$BRIDGE_TARGET")
-if (GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
-    "$BRIDGE_TARGET" "$side_parent_target") 2>/dev/null; then
-  echo 'side-parent-only requested target was admitted' >&2
-  exit 1
-fi
-if (GITHUB_WORKSPACE=$GRAPH_REPO verify_release_b_reviewed_target_identity \
-    "$BRIDGE_TARGET" "$CURRENT_MAIN") 2>/dev/null; then
-  echo 'requested sibling of the reviewed target was admitted' >&2
+if deploy_control_reviewed_transition_matches "$B" "$J"; then
+  echo 'B-to-J staging deploy was admitted' >&2
   exit 1
 fi
 
-for exact_pin in \
-  "RELEASE_B_CONTROLLER_SHA=$BASE" \
-  "RELEASE_B_CURRENT_MAIN_SHA=$CURRENT_MAIN" \
-  "RELEASE_B_BRIDGE_SHA=$BRIDGE" \
-  "RELEASE_B_BRIDGE_TREE=$BRIDGE_TREE" \
-  "RELEASE_B_BRIDGE_BLOB=$BRIDGE_BLOB" \
-  "RELEASE_B_REVIEWED_TARGET_SHA=$BRIDGE_TARGET" \
-  "RELEASE_B_REVIEWED_TARGET_TREE=$BRIDGE_TARGET_TREE"; do
-  grep -Fqx "$exact_pin" "$CLIENT"
-done
-[[ $(grep -Fo "controller_release=$BASE" "$WORKFLOW" | wc -l) == 1 ]]
-[[ $(grep -Fo "current_main=$CURRENT_MAIN" "$WORKFLOW" | wc -l) == 1 ]]
-[[ $(grep -Fo "bridge_release=$BRIDGE" "$WORKFLOW" | wc -l) == 1 ]]
-[[ $(grep -Fo "bridge_target=$BRIDGE_TARGET" "$WORKFLOW" | wc -l) == 1 ]]
-
-python3 - "$WORKFLOW" <<'PY'
-import pathlib
-import sys
-
-workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
-local_gate = 'run: bash ops/deploy/github-production-deploy-client.sh verify-release-b-target "$GITHUB_SHA"'
-if workflow.count(local_gate) != 2:
-    raise SystemExit("local Release B identity gate must cover both workflow roots")
-
-def job(name, next_name):
-    start = workflow.index(f"  {name}:\n")
-    end = workflow.index(f"  {next_name}:\n", start)
-    return workflow[start:end]
-
-for root_name, next_name in (("production_maintenance", "plan"),
-                             ("plan", "verify_reader_summary_publication")):
-    root = job(root_name, next_name)
-    if root.count(local_gate) != 1:
-        raise SystemExit(f"{root_name} must execute exactly one local identity gate")
-    configure = "run: bash ops/deploy/github-production-deploy-client.sh configure"
-    if root.index(local_gate) > root.index(configure):
-        raise SystemExit(f"{root_name} contacts production before identity verification")
-
-release_a = job("release_a", "deploy")
-if "      - plan\n" not in release_a:
-    raise SystemExit("Release A production mutation is not gated by the verified plan job")
-commands = [
-    'bash "$client" prepare-release-b-bridge "$controller_release" "$bridge_release" "$current_main" "$bridge_target" "$GITHUB_SHA"',
-    'bash "$client" cleanup; bash "$client" configure',
-    'inspect-plan "$GITHUB_SHA"',
-    'bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"',
-]
-cursor = 0
-for command in commands:
-    cursor = workflow.index(command, cursor) + len(command)
-test_command = "          bash ops/deploy/production-release-b-bridge-order.test.sh"
-if workflow.count(test_command) != 1:
-    raise SystemExit("Release B topology regression is not executed exactly once")
-shellcheck_gate = "          bash ops/deploy/verify-production-shellcheck-baseline.sh \\\n"
-if workflow.count(shellcheck_gate) != 1:
-    raise SystemExit("canonical production ShellCheck verifier is not executed exactly once")
-if workflow.index(test_command) < workflow.index(shellcheck_gate):
-    raise SystemExit("Release B topology regression appears only in static checks")
-PY
-
-prepare_runtime_repo() {
-  local label=$1 head=$2
-  local repo=$FIXTURE/$label/repo root=$FIXTURE/$label/root
-  git -c gc.autoDetach=false clone -q --shared "$SOURCE_REPO" "$repo"
-  configure_fixture_repository "$repo"
-  git -C "$repo" checkout -q "$head"
+prepare_runtime_fixture() {
+  local repo=$FIXTURE/runtime/repo root=$FIXTURE/runtime/root
+  git -c gc.autoDetach=false clone -q --shared "$REPO" "$repo"
+  git -C "$repo" config gc.autoDetach false
+  git -C "$repo" checkout -q "$A"
+  git -C "$repo" update-ref refs/remotes/origin/main "$M"
   install -d "$root/control/deploy-state" "$root/runtime/deploy-staging" \
     "$root/runtime/frontend-releases" "$root/runtime/systemd"
-  printf '%s\n' "$FRONTEND_MARKER" > \
-    "$root/control/deploy-state/frontend.sha"
-  printf '%s\n' "$BACKEND_MARKER" > "$root/control/deploy-state/backend.sha"
-  printf '%s\n' "$CONTROL_MARKER" > "$root/control/deploy-state/control.sha"
+  printf '%s\n' "$FRONTEND_MARKER" > "$root/control/deploy-state/frontend.sha"
+  printf '%s\n' "$A" > "$root/control/deploy-state/backend.sha"
+  printf '%s\n' "$A" > "$root/control/deploy-state/control.sha"
   printf '%s\n' "$POOL_MARKER" > \
     "$root/control/deploy-state/postgres-pool-bootstrap.sha"
 }
@@ -382,9 +197,8 @@ prepare_runtime_repo() {
 run_actual_controller() (
   set -euo pipefail
   local repo=$1 root=$2 target=$3 expected_head=$4 event_log=$5
-  local state=$root/control/deploy-state
+  local operation=${6:-deploy} state=$root/control/deploy-state
   [[ $(git -C "$repo" rev-parse HEAD) == "$expected_head" ]]
-  printf 'controller=%s target=%s\n' "$expected_head" "$target" >> "$event_log"
   export SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
   export SOCIAL_MONITOR_DEPLOY_ROOT=$root
   export SOCIAL_MONITOR_DEPLOY_REPO=$repo
@@ -392,10 +206,11 @@ run_actual_controller() (
   export SOCIAL_MONITOR_DEPLOY_STATE=$state
   export SOCIAL_MONITOR_DEPLOY_STAGING=$root/runtime/deploy-staging
   export SOCIAL_MONITOR_DEPLOY_RELEASES=$root/runtime/frontend-releases
-  export SOCIAL_MONITOR_DEPLOY_PROJECT=release-b-current-main-test
+  export SOCIAL_MONITOR_DEPLOY_PROJECT=promotion-v2-controller-fixture
   # shellcheck source=ops/deploy/social-monitor-production-deploy.sh
   source "$repo/ops/deploy/social-monitor-production-deploy.sh"
   [[ $DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD == "$expected_head" ]]
+  action=$operation
   postgres_pool_atomic_legacy_state() { return 1; }
   postgres_pool_bootstrap_installed() { return 0; }
   reconcile_current_postgres_pool_bootstrap() { :; }
@@ -403,81 +218,173 @@ run_actual_controller() (
   acquire_postgres_admission_with_daily_priority() { :; }
   fetch_main() { :; }
   validate_main_commit() { [[ $1 == "$target" ]]; }
-  reconcile_github_premidnight_capture_runtime_control() { printf '%s\n' "$1"; }
+  reconcile_github_premidnight_capture_runtime_control() {
+    printf '%s\n' "$1"
+  }
   load_target_rabbitmq_quorum_backend_health() { :; }
   load_target_reader_summary_publication_deploy_library() { :; }
-  sync_control_script() { :; }
+  sync_control_script() {
+    local relative
+    if [[ $target == "$M" ]]; then
+      for relative in production-transition-admission.sh \
+        production-transition-b0-host-control.sh \
+        production-transition-canonical-lib.sh; do
+        [[ -f $CONTROL/$relative && ! -L $CONTROL/$relative ]]
+      done
+      printf 'b0-installed=%s\n' "$target" >> "$event_log"
+    fi
+    printf 'sync=%s\n' "$target" >> "$event_log"
+  }
   deploy_release_runtime_transaction() {
     printf 'runtime=%s backend=%s runtime_control=%s\n' \
       "$1" "$2" "$3" >> "$event_log"
     [[ $2 == false ]] || printf '%s\n' "$1" > "$state/backend.sha"
   }
-  deploy_frontend() { printf '%s\n' "$1" > "$state/frontend.sha"; }
-  commit_postgres_pool_bootstrap() {
-    printf '%s\n' "$1" > "$state/postgres-pool-bootstrap.sha"
+  deploy_frontend() {
+    printf 'frontend=%s\n' "$1" >> "$event_log"
+    printf '%s\n' "$1" > "$state/frontend.sha"
   }
-  deploy_release "$target"
+  commit_postgres_pool_bootstrap() {
+    printf 'pool=%s\n' "$1" >> "$event_log"
+    [[ $1 == "$B" ]] || printf '%s\n' "$1" > \
+      "$state/postgres-pool-bootstrap.sha"
+  }
+  case $operation in
+    deploy) deploy_release "$target" ;;
+    plan) print_plan "$target" ;;
+    *) return 1 ;;
+  esac
 )
 
-# The obsolete bridge can still serve only its historical target; it cannot be
-# used as the operational bridge for this new graph.
-prepare_runtime_repo obsolete "$OLD_BRIDGE"
-obsolete_repo=$FIXTURE/obsolete/repo
-obsolete_root=$FIXTURE/obsolete/root
-set +e
-obsolete_error=$(run_actual_controller "$obsolete_repo" "$obsolete_root" \
-  "$TARGET" "$OLD_BRIDGE" "$FIXTURE/obsolete/events" 2>&1)
-obsolete_status=$?
-set -e
-((obsolete_status != 0))
-grep -F 'deploy control changed with backend or runtime assets; deploy the bridge release first' \
-  <<< "$obsolete_error" >/dev/null
-[[ $(git -C "$obsolete_repo" rev-parse HEAD) == "$OLD_BRIDGE" ]]
+state_digest() {
+  find "$1" -maxdepth 1 -type f -name '*.sha' -print0 | \
+    LC_ALL=C sort -z | xargs -0 sha256sum
+}
 
-# Real 8b4 controller -> exact bridge -> reviewed target -> requested target.
-prepare_runtime_repo repaired "$BASE"
-repaired_repo=$FIXTURE/repaired/repo
-repaired_root=$FIXTURE/repaired/root
-repaired_state=$repaired_root/control/deploy-state
-repaired_events=$FIXTURE/repaired/events
-run_actual_controller "$repaired_repo" "$repaired_root" \
-  "$BASE" "$BASE" "$repaired_events" >/dev/null
-for component in frontend backend control postgres-pool-bootstrap; do
-  [[ $(<"$repaired_state/$component.sha") == "$BASE" ]]
+prepare_runtime_fixture
+runtime_repo=$FIXTURE/runtime/repo
+runtime_root=$FIXTURE/runtime/root
+runtime_state=$runtime_root/control/deploy-state
+runtime_events=$FIXTURE/runtime/events
+touch "$runtime_events"
+
+expected_b_plan=$(cat <<EOF
+frontend=false
+backend=false
+backend_base=$A
+control=true
+x_collector=false
+postgres_pool_bootstrap=postgres-pool-v1
+postgres_pool_bootstrap_sha=$POOL_MARKER
+EOF
+)
+actual_b_plan=$(run_actual_controller "$runtime_repo" "$runtime_root" \
+  "$B" "$A" "$runtime_events" plan)
+[[ $actual_b_plan == "$expected_b_plan" ]]
+
+before=$(state_digest "$runtime_state")
+if run_actual_controller "$runtime_repo" "$runtime_root" \
+    "$M" "$A" "$runtime_events" >/dev/null 2>&1; then
+  fail 'the checked-in A controller admitted direct A-to-M'
+fi
+[[ $(git -C "$runtime_repo" rev-parse HEAD) == "$A" ]]
+[[ $(state_digest "$runtime_state") == "$before" ]]
+for path in production-transition-admission.sh \
+  production-transition-b0-host-control.sh \
+  production-transition-canonical-lib.sh; do
+  [[ ! -e $runtime_root/control/$path && ! -L $runtime_root/control/$path ]]
 done
-run_actual_controller "$repaired_repo" "$repaired_root" \
-  "$BRIDGE" "$BASE" "$repaired_events" >/dev/null
-[[ $(git -C "$repaired_repo" rev-parse HEAD) == "$BRIDGE" ]]
-[[ $(<"$repaired_state/backend.sha") == "$BASE" ]]
-[[ $(<"$repaired_state/frontend.sha") == "$BASE" ]]
-run_actual_controller "$repaired_repo" "$repaired_root" \
-  "$BRIDGE_TARGET" "$BRIDGE" "$repaired_events" >/dev/null
-[[ $(git -C "$repaired_repo" rev-parse HEAD) == "$BRIDGE_TARGET" ]]
-run_actual_controller "$repaired_repo" "$repaired_root" \
-  "$TARGET" "$BRIDGE_TARGET" "$repaired_events" >/dev/null
-[[ $(git -C "$repaired_repo" rev-parse HEAD) == "$TARGET" ]]
-[[ $(<"$repaired_state/backend.sha") == "$BRIDGE_TARGET" ]]
-[[ $(<"$repaired_state/frontend.sha") == "$BASE" ]]
-[[ $(<"$repaired_state/control.sha") == "$TARGET" ]]
-[[ $(<"$repaired_state/postgres-pool-bootstrap.sha") == "$TARGET" ]]
 
-# If the host already reached current main, the same target is a direct
-# control-only fast-forward and does not need the side bridge installed.
-prepare_runtime_repo advanced "$CURRENT_MAIN"
-advanced_repo=$FIXTURE/advanced/repo
-advanced_root=$FIXTURE/advanced/root
-advanced_state=$advanced_root/control/deploy-state
-for component in frontend backend control postgres-pool-bootstrap; do
-  printf '%s\n' "$CURRENT_MAIN" > "$advanced_state/$component.sha"
-done
-run_actual_controller "$advanced_repo" "$advanced_root" \
-  "$BRIDGE_TARGET" "$CURRENT_MAIN" "$FIXTURE/advanced/events" >/dev/null
-[[ $(git -C "$advanced_repo" rev-parse HEAD) == "$BRIDGE_TARGET" ]]
-run_actual_controller "$advanced_repo" "$advanced_root" \
-  "$TARGET" "$BRIDGE_TARGET" "$FIXTURE/advanced/events" >/dev/null
-[[ $(git -C "$advanced_repo" rev-parse HEAD) == "$TARGET" ]]
-[[ $(<"$advanced_state/backend.sha") == "$CURRENT_MAIN" ]]
-[[ $(<"$advanced_state/frontend.sha") == "$CURRENT_MAIN" ]]
-[[ $(<"$advanced_state/control.sha") == "$TARGET" ]]
+run_actual_controller "$runtime_repo" "$runtime_root" \
+  "$B" "$A" "$runtime_events" >/dev/null
+[[ $(git -C "$runtime_repo" rev-parse HEAD) == "$B" ]]
+[[ $(<"$runtime_state/frontend.sha") == "$FRONTEND_MARKER" ]]
+[[ $(<"$runtime_state/backend.sha") == "$A" ]]
+[[ $(<"$runtime_state/control.sha") == "$B" ]]
+[[ $(<"$runtime_state/postgres-pool-bootstrap.sha") == "$POOL_MARKER" ]]
 
-printf 'Production Release B exact cleanup-preserving topology tests passed\n'
+before=$(state_digest "$runtime_state")
+if run_actual_controller "$runtime_repo" "$runtime_root" \
+    "$J" "$B" "$runtime_events" >/dev/null 2>&1; then
+  fail 'the fresh B controller admitted B-to-J staging'
+fi
+[[ $(git -C "$runtime_repo" rev-parse HEAD) == "$B" ]]
+[[ $(state_digest "$runtime_state") == "$before" ]]
+
+pending_m_plan=$(run_actual_controller "$runtime_repo" "$runtime_root" \
+  "$M" "$B" "$runtime_events" plan)
+expected_pending_m_plan=$(cat <<EOF
+frontend=true
+backend=true
+backend_base=$A
+control=true
+x_collector=false
+postgres_pool_bootstrap=postgres-pool-v1
+postgres_pool_bootstrap_sha=$POOL_MARKER
+EOF
+)
+[[ $pending_m_plan == "$expected_pending_m_plan" ]]
+run_actual_controller "$runtime_repo" "$runtime_root" \
+  "$M" "$B" "$runtime_events" >/dev/null
+[[ $(git -C "$runtime_repo" rev-parse HEAD) == "$M" ]]
+[[ $(<"$runtime_state/backend.sha") == "$M" ]]
+[[ $(<"$runtime_state/control.sha") == "$M" ]]
+[[ $(<"$runtime_state/postgres-pool-bootstrap.sha") == "$M" ]]
+[[ $(git -C "$runtime_repo" rev-parse refs/remotes/origin/main) == "$M" ]]
+
+python3 - "$runtime_events" "$M" <<'PY'
+import pathlib, sys
+events = pathlib.Path(sys.argv[1]).read_text().splitlines()
+target = sys.argv[2]
+ordered = [f"b0-installed={target}", f"sync={target}", f"runtime={target} "]
+cursor = 0
+for item in ordered:
+    cursor = next(i + 1 for i in range(cursor, len(events))
+                  if events[i].startswith(item))
+PY
+
+complete_plan=$(run_actual_controller "$runtime_repo" "$runtime_root" \
+  "$M" "$M" "$runtime_events" plan)
+expected_complete_plan=$(cat <<EOF
+frontend=false
+backend=false
+backend_base=$M
+control=false
+x_collector=false
+postgres_pool_bootstrap=postgres-pool-v1
+postgres_pool_bootstrap_sha=$M
+EOF
+)
+[[ $complete_plan == "$expected_complete_plan" ]]
+before=$(state_digest "$runtime_state")
+run_actual_controller "$runtime_repo" "$runtime_root" \
+  "$M" "$M" "$runtime_events" >/dev/null
+[[ $(state_digest "$runtime_state") == "$before" ]]
+[[ $(git -C "$runtime_repo" rev-parse HEAD) == "$M" ]]
+
+python3 - "$WORKFLOW" <<'PY'
+import pathlib, sys
+w = pathlib.Path(sys.argv[1]).read_text()
+for forbidden in ("prepare-release-b-bridge",
+                  "plan_is_admitted_post_release_b_forward_" + "state",
+                  "8b4aeb31e855ed379349a4e4827600009e" + "174132",
+                  "b89950632b0cefa4f7b58b687cdfd6e6cd" + "912a04",
+                  "05744f99b2d13e47a64a7ff12ea2ab8893" + "f5e88a"):
+    if forbidden in w:
+        raise SystemExit(f"historical operational fallback remains: {forbidden}")
+ordered = [
+    'verify-post-promotion-v2-target "$GITHUB_SHA"',
+    'prepare-post-promotion-v2-bridge "$RELEASE_B" "$JOIN_SHA" "$TARGET_SHA"',
+    "run: bash ops/deploy/github-production-deploy-client.sh cleanup",
+    'plan-post-promotion-v2-target "$TARGET_SHA"',
+    'run: bash ops/deploy/github-production-deploy-client.sh deploy "$GITHUB_SHA"',
+    'accept-post-promotion-v2-target "$GITHUB_SHA"',
+]
+cursor = 0
+for value in ordered:
+    cursor = w.index(value, cursor) + len(value)
+if w.count("          bash ops/deploy/production-release-b-bridge-order.test.sh") != 1:
+    raise SystemExit("five-file topology fixture must run exactly once")
+PY
+
+printf 'Exact five-file post-promotion V2 H guard tests passed\n'

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -9,6 +9,10 @@ ROLLING_ENTRYPOINT_BRIDGE_SHA=$(git -C "$PROJECT_ROOT" rev-parse 'b25e5c3d97a6ca
 ROLLING_ENTRYPOINT_BRIDGE_PARENT=f4471dd9c9ddb414b4ad502bb8ee7df7306964c6
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/rabbitmq-quorum-deploy-bridge.XXXXXX")
 trap 'rm -rf "$FIXTURE"' EXIT
+export GIT_AUTHOR_NAME='RabbitMQ bridge fixture'
+export GIT_AUTHOR_EMAIL=rabbitmq-bridge@example.invalid
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 
 if ! command stat -c '%a' "$SCRIPT_DIR/social-monitor-production-deploy.sh" >/dev/null 2>&1; then
   # Production runs GNU coreutils. Keep this deterministic fixture runnable on
@@ -155,7 +159,7 @@ assert_real_bridge_target_assets() {
         release_b_candidate_digest=bea119047fbbd2295185c84e0adeb773dc852e63b951daf5c7a831356a73a371
         release_b_sealed_digest=1718617b4bbb92f4dbfd92a59fcc482ef7a098734730b8460d21aaced44386c2
         rolling_repair_digest=1945f2b07f110d16694affc15c66b4589d294b81a4e593a9680dacf11fbc5d4d
-        current_release_digest=0db3fa488279b09a7d1530b126b309daaa8fd0db4787bb8fa2f9727d02aa7c7d
+        current_release_digest=053ac1ff8e09133d4449eb43075ba4ce6f433d1acaf696d4a97cbb789a1461e9
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then
@@ -523,10 +527,75 @@ assert_bridge_backend_rejection() {
   [[ ! -e $CASE_STATE/postgres-pool-bootstrap.sha ]]
 }
 
+assert_promotion_v2_b0_bootstrap() {
+  local promotion_f=c5dc5abb12aa1ac84ddbd12f141c6d4d8aca4de2
+  local promotion_j=3fc3c65649323506e8ad9914d2e5c985fa361401
+  local index=$FIXTURE/promotion-b0.index tree h m mode path blob
+  local repo=$FIXTURE/promotion-b0/repo control=$FIXTURE/promotion-b0/control
+  local bad_repo=$FIXTURE/promotion-b0-bad/repo
+  local bad_control=$FIXTURE/promotion-b0-bad/control output status
+
+  GIT_INDEX_FILE=$index git -C "$PROJECT_ROOT" read-tree "$promotion_j"
+  while read -r mode path; do
+    blob=$(git -C "$PROJECT_ROOT" hash-object -w -- "$PROJECT_ROOT/$path")
+    GIT_INDEX_FILE=$index git -C "$PROJECT_ROOT" update-index \
+      --add --cacheinfo "$mode,$blob,$path"
+  done <<'PATHS'
+100644 .github/workflows/production-deploy.yml
+100755 ops/deploy/github-production-deploy-client.sh
+100755 ops/deploy/github-production-deploy-client.test.sh
+100755 ops/deploy/production-release-b-bridge-order.test.sh
+100644 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+PATHS
+  tree=$(GIT_INDEX_FILE=$index git -C "$PROJECT_ROOT" write-tree)
+  h=$(printf 'test: B0 exact H\n' | git -C "$PROJECT_ROOT" commit-tree \
+    "$tree" -p "$promotion_j")
+  m=$(printf 'test: B0 protected-main M\n' | \
+    git -C "$PROJECT_ROOT" commit-tree "$tree" -p "$promotion_f" -p "$h")
+
+  git -c gc.autoDetach=false clone -q --shared "$PROJECT_ROOT" "$repo"
+  git -C "$repo" checkout -q "$m"
+  git -C "$repo" update-ref refs/remotes/origin/main "$m"
+  install -d "$control"
+  (
+    set -euo pipefail
+    REPO=$repo CONTROL=$control action=deploy SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
+    fail() { printf 'b0-test-error: %s\n' "$*" >&2; exit 1; }
+    # shellcheck source=/dev/null
+    source "$repo/ops/deploy/deploy-control-bridge-lib.sh"
+    deploy_control_bootstrap_production_transition_b0 "$m"
+    deploy_control_bootstrap_production_transition_b0 "$m"
+  )
+  [[ $(stat -c '%a' "$control/production-transition-admission.sh") == 755 ]]
+  [[ $(stat -c '%a' "$control/production-transition-b0-host-control.sh") == 644 ]]
+  [[ $(stat -c '%a' "$control/production-transition-canonical-lib.sh") == 644 ]]
+
+  git -c gc.autoDetach=false clone -q --shared "$PROJECT_ROOT" "$bad_repo"
+  git -C "$bad_repo" checkout -q "$m"
+  git -C "$bad_repo" update-ref refs/remotes/origin/main "$promotion_j"
+  install -d "$bad_control"
+  set +e
+  output=$(
+    REPO=$bad_repo CONTROL=$bad_control action=deploy \
+      SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 bash -c '
+        fail() { printf "b0-test-error: %s\n" "$*" >&2; exit 1; }
+        source "$REPO/ops/deploy/deploy-control-bridge-lib.sh"
+        deploy_control_bootstrap_production_transition_b0 "$1"
+      ' b0-bootstrap "$m" 2>&1
+  )
+  status=$?
+  set -e
+  ((status != 0))
+  grep -F 'B0 bootstrap requires the exact protected-main commit' \
+    <<< "$output" >/dev/null
+  [[ ! -e $bad_control/production-transition-admission.sh ]]
+}
+
 backend_path_block=$(sed -n '/^BACKEND_PATHS=(/,/^)/p' \
   "$SCRIPT_DIR/social-monitor-production-deploy.sh")
 assert_real_bridge_target_assets
 assert_current_backend_classification_asset
+assert_promotion_v2_b0_bootstrap
 grep -Fx "  $HEALTH_LIBRARY" <<< "$backend_path_block" >/dev/null
 grep -Fx "  $QUORUM_SCRIPT" <<< "$backend_path_block" >/dev/null
 grep -Fx "  $RECOVERY_SCRIPT" <<< "$backend_path_block" >/dev/null


### PR DESCRIPTION
## What

- Adds a startup-safe two-file controller bridge from the installed production controller.
- Preserves the reviewed Reader Promotion V2 product tree.
- Replaces the obsolete Release B workflow with exact A/B/F/J/H/M graph verification.
- Deploys only B first, reopens SSH, then deploys the final protected-main merge directly.

## Safety

- No direct A-to-target or B-to-J transition is admitted.
- Ambiguous SSH is reconciled by plan reads without replay.
- B0 host controls are installed from exact reviewed target blobs before target-only loading.
- Rollback, locks, immutable frontend artifacts and separate acceptance stay fail closed.

## Evidence

- Focused deploy-control, client, actual-controller bridge, B0, RabbitMQ, rollback and lock tests passed.
- All touched human-written files remain below 1000 LOC.
- Independent xhigh exact-head review and GitHub CI are running before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Promotion V2 deployment verification, planning, bridge preparation, and acceptance commands.
  * Added stronger validation of promotion targets, commit ancestry, repository contents, and deployment state.
  * Added support for safe, repeatable promotion workflows and bootstrap scenarios.

* **Bug Fixes**
  * Removed legacy Release B reconciliation and verification paths.
  * Improved rejection of invalid or incomplete promotion transitions.

* **Tests**
  * Expanded coverage for successful, partial, repeated, disconnected, and rejected promotion scenarios.
  * Added checks for exact promotion state, workflow ordering, and deployment safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->