### PR TITLE
fix(x-collector): align discovery lane boundaries

### DIFF
--- a/apps/x-collector/src/x_collector/search_plan.py
+++ b/apps/x-collector/src/x_collector/search_plan.py
@@ -55,9 +55,9 @@ def plan_scweet_search_passes(
                 label="latest_discovery",
                 product=SearchProduct.LATEST,
                 limit=request.limit_per_product,
-                min_likes=latest_discovery_min(request.min_likes),
-                min_retweets=latest_discovery_min(request.min_retweets),
-                min_replies=None,
+                min_likes=latest_discovery_min(request.min_likes, ceiling=5),
+                min_retweets=latest_discovery_min(request.min_retweets, ceiling=1),
+                min_replies=latest_discovery_min(request.min_replies, ceiling=1),
             ),
         )
 
@@ -97,14 +97,11 @@ def strict_minimum(value: int | None, floor: int) -> int:
     return max(value * 3, floor)
 
 
-def latest_discovery_min(value: int | None) -> int | None:
+def latest_discovery_min(value: int | None, *, ceiling: int) -> int | None:
     if value is None:
         return None
 
-    if value <= 10:
-        return value
-
-    return max(1, value // 3)
+    return min(value, ceiling)
 
 
 def dedupe_passes(
@@ -127,4 +124,3 @@ def dedupe_passes(
         result.append(search_pass)
 
     return result
-

--- a/apps/x-collector/tests/test_scweet_adapter.py
+++ b/apps/x-collector/tests/test_scweet_adapter.py
@@ -216,17 +216,41 @@ def test_collect_daily_search_runs_top_and_latest_even_when_top_requested() -> N
     ]
 
 
-def test_collect_daily_search_uses_lower_threshold_for_latest_discovery() -> None:
+def test_collect_daily_search_caps_latest_discovery_at_quality_boundaries() -> None:
     fake = FakeScweet()
     collector = ScweetDailySearchCollector(
         lambda: fake,
         FixedClock(datetime(2026, 6, 27, 12, tzinfo=UTC)),
     )
 
-    collector.collect_daily_search(request(min_likes=90))
+    collector.collect_daily_search(
+        request(min_likes=90, min_retweets=30, min_replies=15),
+    )
 
     assert fake.calls[-1]["display_type"] == "Latest"
-    assert fake.calls[-1]["min_likes"] == 30
+    assert fake.calls[-1]["min_likes"] == 5
+    assert fake.calls[-1]["min_retweets"] == 1
+    assert fake.calls[-1]["min_replies"] == 1
+
+
+def test_production_min_likes_reaches_scweet_as_latest_discovery_maximum() -> None:
+    fake = FakeScweet()
+    collector = ScweetDailySearchCollector(
+        lambda: fake,
+        FixedClock(datetime(2026, 6, 27, 12, tzinfo=UTC)),
+    )
+
+    collector.collect_daily_search(request(min_likes=30))
+
+    assert fake.calls[0]["display_type"] == "Top"
+    assert fake.calls[0]["min_likes"] == 30
+    assert fake.calls[1]["display_type"] == "Top"
+    assert fake.calls[1]["min_likes"] == 90
+    latest_request = fake.calls[-1]
+    assert latest_request["display_type"] == "Latest"
+    assert latest_request["min_likes"] == 5
+    assert latest_request["min_retweets"] is None
+    assert latest_request["min_replies"] is None
 
 
 def test_collect_daily_search_handles_non_list_scweet_response() -> None:
@@ -726,6 +750,8 @@ def request(
     search_products: tuple[SearchProduct, ...] = (SearchProduct.TOP,),
     max_items: int = 5,
     min_likes: int | None = 5,
+    min_retweets: int | None = None,
+    min_replies: int | None = None,
     cursor: str | None = None,
     window_end: datetime | None = None,
 ) -> DailySearchRequest:
@@ -744,8 +770,8 @@ def request(
         limit_per_product=10,
         max_items=max_items,
         min_likes=min_likes,
-        min_retweets=None,
-        min_replies=None,
+        min_retweets=min_retweets,
+        min_replies=min_replies,
         cursor=cursor,
     )
 

--- a/scripts/lib/x-collector-quality-report-support.spec.ts
+++ b/scripts/lib/x-collector-quality-report-support.spec.ts
@@ -209,6 +209,51 @@ describe("x collector quality report support", () => {
     }
   });
 
+  it("classifies the planned Latest tuple at the exact discovery boundary", () => {
+    const directory = mkdtempSync(join(tmpdir(), "x-collector-quality-"));
+    const dbPath = join(directory, "scweet_state.db");
+
+    try {
+      createLedgerTables({ dbPath });
+      const runs = [
+        [1, "Top", 90, 10, 5],
+        [2, "Latest", 5, null, null],
+        [3, "Latest", 6, null, null],
+      ] as const;
+      for (const [id, displayType, minLikes, minRetweets, minReplies] of runs) {
+        insertRun({
+          dbPath,
+          id,
+          displayType,
+          startedAt: "2026-07-08T00:01:00Z",
+          finishedAt: "2026-07-08T00:02:00Z",
+          tweets: 10,
+          inputJson: JSON.stringify({
+            since: "2026-07-07_00:00:00_UTC",
+            until: "2026-07-07_23:59:59_UTC",
+            display_type: displayType,
+            min_likes: minLikes,
+            min_retweets: minRetweets,
+            min_replies: minReplies,
+          }),
+        });
+      }
+
+      const ledger = buildXCollectorLedgerReport({
+        ledgerPath: dbPath,
+        collectionDate: "2026-07-07",
+      });
+
+      expect(ledger).toMatchObject({
+        strictEngagementRunCount: 1,
+        discoveryRunCount: 1,
+        hasStrictAndDiscoveryLanes: true,
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it("uses the target UTC window instead of run execution date", () => {
     const directory = mkdtempSync(join(tmpdir(), "x-collector-quality-"));
     const dbPath = join(directory, "scweet_state.db");


### PR DESCRIPTION
## What changed

- keep production Top threshold at 30 likes
- preserve strict 90/10/5 search lane
- pass a separate 5-like discovery lane to the collector
- cap discovery query inputs so accounts fetch different useful result windows instead of repeating the same first page

## Evidence

- independent read-only review: GO on the identical tree
- planner contract probe and deterministic Python/TypeScript function probes passed
- source line cap and git diff checks passed
- exact pytest/Jest runners were unavailable in the isolated worker because pinned dependencies were not installed; GitHub CI is the authoritative full runner

This is intentionally separate from Promotion V2 ranking. It only fixes X discovery boundaries and does not weaken the 30-like editorial eligibility floor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved latest-discovery search behavior by applying consistent minimum engagement thresholds for likes, retweets, and replies.
  - High requested thresholds are now safely capped during discovery searches, helping preserve broader coverage while maintaining quality.
  - Improved quality reporting so searches at the discovery boundary are classified accurately.

- **Tests**
  - Added coverage for discovery threshold handling and quality-report classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->