### PR TITLE
fix(ops): reuse sealed auth after status timeout

### DIFF
--- a/ops/deploy/host/refresh-codex-auth.sh
+++ b/ops/deploy/host/refresh-codex-auth.sh
@@ -73,6 +73,7 @@ fi
 
 MANIFEST_ACCOUNTS=()
 REQUIRE_MANIFEST_ACCOUNT_MEMBERSHIP=false
+AUTH_POOL_REVIEW_MAX_AGE_SECONDS=129600
 # This remains based on the default runtime cursor so every invocation shares
 # one install lock. Only the rotation cursor and selected-account name vary by
 # approved pool.
@@ -91,6 +92,14 @@ file_sha256() {
   fi
 }
 
+stream_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
 require_canonical_directory() {
   local directory=$1 label=$2 canonical
   [[ -d $directory && ! -L $directory ]] || fail "$label is missing or unsafe"
@@ -103,6 +112,20 @@ require_not_group_or_other_writable() {
   mode=$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path")
   [[ $mode =~ ^[0-7]{3,4}$ ]] || fail "$label mode is invalid"
   (( (8#$mode & 022) == 0 )) || fail "$label is writable by group or other"
+}
+
+require_mode() {
+  local path=$1 expected=$2 label=$3 mode
+  mode=$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path")
+  [[ $mode =~ ^[0-7]{3,4}$ ]] || fail "$label mode is invalid"
+  ((8#$mode == 8#$expected)) || fail "$label mode is invalid"
+}
+
+require_owner() {
+  local path=$1 expected=$2 label=$3 owner expected_owner
+  owner=$(stat -c '%u' "$path" 2>/dev/null || stat -f '%u' "$path")
+  expected_owner=$(id -u "$expected")
+  [[ $owner == "$expected_owner" ]] || fail "$label owner is invalid"
 }
 
 resolve_approved_account_auth() {
@@ -147,7 +170,8 @@ remove_auth_pool_directory() {
 
 materialize_auth_pool_snapshot() {
   local stage_dir digest_input generation snapshot_dir account selected
-  local manifest_next manifest_changed=true
+  local manifest_next approval_next approval_seal reviewed_at manifest_sha256
+  local manifest_changed=true
 
   install -d -m 0750 -o "$TARGET_DIR_OWNER" -g "$TARGET_GROUP" \
     "$POOL_SNAPSHOT_ROOT" "$POOL_SNAPSHOT_ROOT/snapshots"
@@ -189,6 +213,7 @@ materialize_auth_pool_snapshot() {
     find "$snapshot_dir" -type f -exec chmod "$TARGET_MODE" {} +
   fi
 
+  reviewed_at=${BROKER_REVIEWED_AT_EPOCH:?broker review time is required}
   manifest_next=$POOL_SNAPSHOT_ROOT/current.json.next.$$
   jq -n --arg generation "$generation" \
     --argjson accounts "$(printf '%s\n' "${available_accounts[@]}" | \
@@ -204,6 +229,37 @@ materialize_auth_pool_snapshot() {
     ' > "$manifest_next"
   chown "$TARGET_OWNER:$TARGET_GROUP" "$manifest_next"
   chmod "$TARGET_MODE" "$manifest_next"
+  manifest_sha256=$(file_sha256 "$manifest_next")
+  approval_seal=$(
+    {
+      printf '%s\0' 'schemaVersion=1' "$CONTROLLER_JOB_ID" "$REGISTRY_ROOT" \
+        "$reviewed_at" "$generation" "$manifest_sha256"
+      for account in "${available_accounts[@]}"; do
+        printf '%s\0' "$account" \
+          "snapshots/$generation/$account/auth.json" \
+          "$(file_sha256 "$snapshot_dir/$account/auth.json")"
+      done
+    } | stream_sha256
+  )
+  approval_next=$POOL_SNAPSHOT_ROOT/current.approval.json.next.$$
+  jq -n --arg snapshot_id "$generation" \
+    --arg controller_job_id "$CONTROLLER_JOB_ID" \
+    --arg registry_root "$REGISTRY_ROOT" \
+    --argjson reviewed_at "$reviewed_at" \
+    --arg manifest_sha256 "$manifest_sha256" \
+    --arg approval_seal "$approval_seal" '
+      {
+        schemaVersion: 1,
+        snapshotId: $snapshot_id,
+        controllerJobId: $controller_job_id,
+        registryRootDir: $registry_root,
+        reviewedAtEpoch: $reviewed_at,
+        poolManifestSha256: $manifest_sha256,
+        approvalSealSha256: $approval_seal
+      }
+    ' > "$approval_next"
+  chown "$TARGET_OWNER:$TARGET_GROUP" "$approval_next"
+  chmod "$TARGET_MODE" "$approval_next"
   if [[ -f $POOL_SNAPSHOT_ROOT/current.json && \
         ! -L $POOL_SNAPSHOT_ROOT/current.json ]] && \
       cmp -s "$manifest_next" "$POOL_SNAPSHOT_ROOT/current.json"; then
@@ -214,7 +270,169 @@ materialize_auth_pool_snapshot() {
   else
     rm -f "$manifest_next"
   fi
+  mv -f "$approval_next" "$POOL_SNAPSHOT_ROOT/current.approval.json"
   prune_expired_auth_pool_snapshots "$generation"
+}
+
+reuse_sealed_auth_after_status_failure() {
+  local manifest=$POOL_SNAPSHOT_ROOT/current.json approval_manifest
+  local manifest_data approval_data snapshot_id manifest_sha256
+  local reviewed_at approval_seal expected_seal snapshot_dir snapshots_dir
+  local account relative_path cached_auth cached_hash current_account now age
+  local account_directory cached_count=0
+  local -a cached_accounts=() cached_paths=() cached_hashes=()
+
+  require_canonical_directory "$POOL_SNAPSHOT_ROOT" 'auth pool snapshot root'
+  require_not_group_or_other_writable "$POOL_SNAPSHOT_ROOT" \
+    'auth pool snapshot root'
+  require_owner "$POOL_SNAPSHOT_ROOT" "$TARGET_DIR_OWNER" \
+    'auth pool snapshot root'
+  snapshots_dir=$POOL_SNAPSHOT_ROOT/snapshots
+  require_canonical_directory "$snapshots_dir" 'auth pool snapshots directory'
+  require_not_group_or_other_writable "$snapshots_dir" \
+    'auth pool snapshots directory'
+  require_owner "$snapshots_dir" "$TARGET_DIR_OWNER" \
+    'auth pool snapshots directory'
+  [[ -f $manifest && ! -L $manifest ]] || \
+    fail 'sealed auth pool manifest is missing or unsafe'
+  [[ $(realpath -e "$manifest") == "$manifest" ]] || \
+    fail 'sealed auth pool manifest is not canonical'
+  require_not_group_or_other_writable "$manifest" 'sealed auth pool manifest'
+  require_mode "$manifest" "$TARGET_MODE" 'sealed auth pool manifest'
+  require_owner "$manifest" "$TARGET_OWNER" 'sealed auth pool manifest'
+
+  manifest_data=$(jq -cer '
+      if (
+        type == "object" and
+        (keys | sort) == ["accounts", "schemaVersion", "snapshotId"] and
+        .schemaVersion == 1 and
+        (.snapshotId | type == "string" and test("^[0-9a-f]{64}$")) and
+        (.accounts | type == "array" and length > 0 and
+          all(.[];
+            type == "object" and (keys | sort) == ["id", "relativePath"] and
+            (.id | type == "string" and
+              test("^[A-Za-z0-9][A-Za-z0-9._-]*$")) and
+            (.relativePath | type == "string"))) and
+        ([.accounts[].id] | length == (unique | length))
+      ) then . else empty end
+    ' "$manifest") || fail 'sealed auth pool manifest contract is invalid'
+  manifest_sha256=$(file_sha256 "$manifest")
+  snapshot_id=$(jq -r '.snapshotId' <<<"$manifest_data")
+  approval_manifest=$POOL_SNAPSHOT_ROOT/current.approval.json
+  [[ -f $approval_manifest && ! -L $approval_manifest ]] || \
+    fail 'sealed broker approval manifest is missing or unsafe'
+  [[ $(realpath -e "$approval_manifest") == "$approval_manifest" ]] || \
+    fail 'sealed broker approval manifest is not canonical'
+  require_not_group_or_other_writable "$approval_manifest" \
+    'sealed broker approval manifest'
+  require_mode "$approval_manifest" "$TARGET_MODE" \
+    'sealed broker approval manifest'
+  require_owner "$approval_manifest" "$TARGET_OWNER" \
+    'sealed broker approval manifest'
+  approval_data=$(jq -cer --arg job_id "$CONTROLLER_JOB_ID" \
+    --arg registry_root "$REGISTRY_ROOT" --arg snapshot_id "$snapshot_id" \
+    --arg manifest_sha256 "$manifest_sha256" '
+      if (
+        type == "object" and
+        (keys | sort) == [
+          "approvalSealSha256", "controllerJobId", "poolManifestSha256",
+          "registryRootDir", "reviewedAtEpoch", "schemaVersion", "snapshotId"
+        ] and
+        .schemaVersion == 1 and
+        .controllerJobId == $job_id and
+        .registryRootDir == $registry_root and
+        .snapshotId == $snapshot_id and
+        .poolManifestSha256 == $manifest_sha256 and
+        (.reviewedAtEpoch | type == "number" and . == floor and . >= 0) and
+        (.approvalSealSha256 | type == "string" and test("^[0-9a-f]{64}$"))
+      ) then . else empty end
+    ' "$approval_manifest") || \
+    fail 'sealed broker approval manifest contract is invalid'
+  reviewed_at=$(jq -r '.reviewedAtEpoch' <<<"$approval_data")
+  approval_seal=$(jq -r '.approvalSealSha256' <<<"$approval_data")
+  now=$(date +%s)
+  [[ $now =~ ^[0-9]+$ && $reviewed_at -le $now ]] || \
+    fail 'sealed auth pool review time is invalid'
+  age=$((now - reviewed_at))
+  ((age <= AUTH_POOL_REVIEW_MAX_AGE_SECONDS)) || \
+    fail 'sealed auth pool review is too old to reuse'
+
+  snapshot_dir=$POOL_SNAPSHOT_ROOT/snapshots/$snapshot_id
+  require_canonical_directory "$snapshot_dir" 'sealed auth pool snapshot'
+  require_not_group_or_other_writable "$snapshot_dir" 'sealed auth pool snapshot'
+  require_owner "$snapshot_dir" "$TARGET_DIR_OWNER" 'sealed auth pool snapshot'
+  while IFS=$'\t' read -r account relative_path; do
+    [[ $relative_path == "snapshots/$snapshot_id/$account/auth.json" ]] || \
+      fail 'sealed auth pool account path is invalid'
+    if [[ $REQUIRE_MANIFEST_ACCOUNT_MEMBERSHIP == true ]]; then
+      is_manifest_account "$account" || \
+        fail 'sealed auth pool account is no longer in the approved pool manifest'
+    fi
+    cached_auth=$POOL_SNAPSHOT_ROOT/$relative_path
+    account_directory=${cached_auth%/auth.json}
+    require_canonical_directory "$account_directory" \
+      'sealed auth pool account directory'
+    require_not_group_or_other_writable "$account_directory" \
+      'sealed auth pool account directory'
+    require_owner "$account_directory" "$TARGET_DIR_OWNER" \
+      'sealed auth pool account directory'
+    [[ -f $cached_auth && ! -L $cached_auth ]] || \
+      fail 'sealed auth pool account file is missing or unsafe'
+    [[ $(realpath -e "$cached_auth") == "$cached_auth" ]] || \
+      fail 'sealed auth pool account file is not canonical'
+    require_not_group_or_other_writable "$cached_auth" \
+      'sealed auth pool account file'
+    require_mode "$cached_auth" "$TARGET_MODE" 'sealed auth pool account file'
+    require_owner "$cached_auth" "$TARGET_OWNER" 'sealed auth pool account file'
+    cached_hash=$(file_sha256 "$cached_auth")
+    cached_accounts+=("$account")
+    cached_paths+=("$relative_path")
+    cached_hashes+=("$cached_hash")
+    cached_count=$((cached_count + 1))
+  done < <(jq -r '.accounts[] | [.id, .relativePath] | @tsv' <<<"$manifest_data")
+  ((cached_count > 0)) || fail 'sealed auth pool has no accounts'
+  (( $(find "$snapshot_dir" -mindepth 2 -maxdepth 2 -type f \
+    -name auth.json | wc -l) == cached_count )) || \
+    fail 'sealed auth pool snapshot contains unexpected auth files'
+  expected_seal=$(
+    {
+      printf '%s\0' 'schemaVersion=1' "$CONTROLLER_JOB_ID" "$REGISTRY_ROOT" \
+        "$reviewed_at" "$snapshot_id" "$manifest_sha256"
+      for ((account_index = 0; account_index < cached_count; account_index += 1)); do
+        printf '%s\0' "${cached_accounts[$account_index]}" \
+          "${cached_paths[$account_index]}" "${cached_hashes[$account_index]}"
+      done
+    } | stream_sha256
+  )
+  [[ $expected_seal == "$approval_seal" ]] || \
+    fail 'sealed auth pool approval seal does not match'
+
+  [[ -f $ACCOUNT_NAME_FILE && ! -L $ACCOUNT_NAME_FILE ]] || \
+    fail 'current auth account identity is missing or unsafe'
+  require_not_group_or_other_writable "$ACCOUNT_NAME_FILE" \
+    'current auth account identity'
+  require_mode "$ACCOUNT_NAME_FILE" 0600 'current auth account identity'
+  require_owner "$ACCOUNT_NAME_FILE" "$TARGET_OWNER" \
+    'current auth account identity'
+  read -r current_account < "$ACCOUNT_NAME_FILE"
+  for account in "${cached_accounts[@]}"; do
+    if [[ $account == "$current_account" ]]; then
+      relative_path="snapshots/$snapshot_id/$account/auth.json"
+      cached_auth=$POOL_SNAPSHOT_ROOT/$relative_path
+      [[ -f $TARGET_DIR/auth.json && ! -L $TARGET_DIR/auth.json ]] || \
+        fail 'current auth is missing or unsafe'
+      [[ $(realpath -e "$TARGET_DIR/auth.json") == "$TARGET_DIR/auth.json" ]] || \
+        fail 'current auth is not canonical'
+      require_not_group_or_other_writable "$TARGET_DIR/auth.json" 'current auth'
+      require_mode "$TARGET_DIR/auth.json" "$TARGET_MODE" 'current auth'
+      require_owner "$TARGET_DIR/auth.json" "$TARGET_OWNER" 'current auth'
+      cmp -s "$cached_auth" "$TARGET_DIR/auth.json" || \
+        fail 'current auth does not match the sealed approved account'
+      echo 'broker status unavailable; retained sealed approved current auth' >&2
+      return 0
+    fi
+  done
+  fail 'current auth account is not in the sealed approved pool'
 }
 
 prune_expired_auth_pool_snapshots() {
@@ -380,8 +598,20 @@ rm -f "$TARGET_DIR/auth.json.next"
 install -d -m 0750 "$PROBE_WORKSPACE"
 install -d -m 0700 "$PROBE_TMP_ROOT"
 
-status_json=$(timeout 30 subscription-runtime-codex-goal tool codex_goal_accounts_status \
-  --args-json "{\"jobId\":\"$CONTROLLER_JOB_ID\",\"registryRootDir\":\"$REGISTRY_ROOT\",\"liveCheck\":false}")
+if status_json=$(timeout 30 subscription-runtime-codex-goal tool \
+  codex_goal_accounts_status \
+  --args-json "{\"jobId\":\"$CONTROLLER_JOB_ID\",\"registryRootDir\":\"$REGISTRY_ROOT\",\"liveCheck\":false}"); then
+  :
+else
+  status_exit=$?
+  case $status_exit in
+    75 | 124)
+      reuse_sealed_auth_after_status_failure
+      exit 0
+      ;;
+    *) fail "broker status failed with exit $status_exit" ;;
+  esac
+fi
 
 jq -e --arg job_id "$CONTROLLER_JOB_ID" --arg registry_root "$REGISTRY_ROOT" '
   (.ok == true)
@@ -401,6 +631,9 @@ jq -e --arg job_id "$CONTROLLER_JOB_ID" --arg registry_root "$REGISTRY_ROOT" '
       (.availableDeduped | type == "number" and . == floor and
         . == $available_count)))
 ' >/dev/null <<<"$status_json"
+BROKER_REVIEWED_AT_EPOCH=$(date +%s)
+[[ $BROKER_REVIEWED_AT_EPOCH =~ ^[0-9]+$ ]] || \
+  fail 'broker review time is invalid'
 
 available_accounts=()
 while IFS= read -r account; do

--- a/ops/deploy/host/refresh-codex-auth.sh
+++ b/ops/deploy/host/refresh-codex-auth.sh
@@ -40,6 +40,7 @@ if [[ ${SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE:-} == 1 ]]; then
   TARGET_MODE=0400
   POOL_POINTER=${SOCIAL_MONITOR_AUTH_POOL_POINTER:-}
   POOL_REGISTRY_PREFIX=${SOCIAL_MONITOR_AUTH_POOL_REGISTRY_PREFIX:-/var/data/social-monitor/worker-jobs/}
+  BROKER_STATUS_TIMEOUT_SECONDS=${SOCIAL_MONITOR_AUTH_BROKER_STATUS_TIMEOUT_SECONDS:-30}
 elif ((EUID == 0)); then
   PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
   PROJECT_ROOT=/var/data/social-monitor
@@ -57,6 +58,7 @@ elif ((EUID == 0)); then
   TARGET_GROUP=1000
   TARGET_MODE=0440
   POOL_REGISTRY_PREFIX=/var/data/social-monitor/worker-jobs/
+  BROKER_STATUS_TIMEOUT_SECONDS=30
   unset SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE SOCIAL_MONITOR_AUTH_ROOT \
     SOCIAL_MONITOR_AUTH_TARGET_DIR SOCIAL_MONITOR_AUTH_REGISTRY_ROOT \
     SOCIAL_MONITOR_AUTH_PROJECT_ROOT \
@@ -65,11 +67,18 @@ elif ((EUID == 0)); then
     SOCIAL_MONITOR_AUTH_PROBE_WORKSPACE SOCIAL_MONITOR_AUTH_CHANGED_MARKER \
     SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT SOCIAL_MONITOR_AUTH_POOL_POINTER \
     SOCIAL_MONITOR_AUTH_POOL_REGISTRY_PREFIX \
-    SOCIAL_MONITOR_AUTH_POOL_SNAPSHOT_ROOT
+    SOCIAL_MONITOR_AUTH_POOL_SNAPSHOT_ROOT \
+    SOCIAL_MONITOR_AUTH_BROKER_STATUS_TIMEOUT_SECONDS
 else
   echo 'auth-refresh-error: production entrypoint requires root' >&2
   exit 1
 fi
+
+[[ $BROKER_STATUS_TIMEOUT_SECONDS =~ ^[1-9][0-9]*$ ]] \
+  && ((BROKER_STATUS_TIMEOUT_SECONDS <= 30)) || {
+  echo 'auth-refresh-error: broker status timeout must be between 1 and 30 seconds' >&2
+  exit 1
+}
 
 MANIFEST_ACCOUNTS=()
 REQUIRE_MANIFEST_ACCOUNT_MEMBERSHIP=false
@@ -598,7 +607,8 @@ rm -f "$TARGET_DIR/auth.json.next"
 install -d -m 0750 "$PROBE_WORKSPACE"
 install -d -m 0700 "$PROBE_TMP_ROOT"
 
-if status_json=$(timeout 30 subscription-runtime-codex-goal tool \
+if status_json=$(timeout "$BROKER_STATUS_TIMEOUT_SECONDS" \
+  subscription-runtime-codex-goal tool \
   codex_goal_accounts_status \
   --args-json "{\"jobId\":\"$CONTROLLER_JOB_ID\",\"registryRootDir\":\"$REGISTRY_ROOT\",\"liveCheck\":false}"); then
   :

--- a/ops/deploy/refresh-codex-auth.test.sh
+++ b/ops/deploy/refresh-codex-auth.test.sh
@@ -119,6 +119,9 @@ expected_registry=${SOCIAL_MONITOR_TEST_EXPECTED_REGISTRY_ROOT:?}
 if [[ -n ${SOCIAL_MONITOR_TEST_STATUS_LOG:-} ]]; then
   printf '%s\n' "$*" >> "$SOCIAL_MONITOR_TEST_STATUS_LOG"
 fi
+if [[ -n ${SOCIAL_MONITOR_TEST_STATUS_EXIT:-} ]]; then
+  exit "$SOCIAL_MONITOR_TEST_STATUS_EXIT"
+fi
 if [[ -n ${SOCIAL_MONITOR_TEST_RAW_STATUS_JSON:-} ]]; then
   printf '%s\n' "$SOCIAL_MONITOR_TEST_RAW_STATUS_JSON"
   exit 0
@@ -133,6 +136,14 @@ accounts=${SOCIAL_MONITOR_TEST_ACCOUNTS:-'["account-a","account-b"]'}
 account_count=$(jq -er 'length' <<<"$accounts")
 printf '{"ok":true,"jobId":"%s","registryRootDir":"%s","hasAvailableAccount":true,"availableDedupedAccountNames":%s,"summary":{"ready":%s,"availableDeduped":%s}}\n' \
   "$expected_job" "$expected_registry" "$accounts" "$account_count" "$account_count"
+SH
+cat > "$BIN/date" <<'SH'
+#!/usr/bin/env bash
+if [[ ${1:-} == +%s && -n ${SOCIAL_MONITOR_TEST_DATE_EPOCH:-} ]]; then
+  printf '%s\n' "$SOCIAL_MONITOR_TEST_DATE_EPOCH"
+  exit 0
+fi
+exec /bin/date "$@"
 SH
 cat > "$BIN/codex" <<'SH'
 #!/usr/bin/env bash
@@ -180,8 +191,8 @@ if [[ $recursive == true ]]; then
 fi
 exec /bin/rm "$@"
 SH
-chmod 0755 "$BIN/subscription-runtime-codex-goal" "$BIN/codex" "$BIN/flock" \
-  "$BIN/rm"
+chmod 0755 "$BIN/subscription-runtime-codex-goal" "$BIN/date" "$BIN/codex" \
+  "$BIN/flock" "$BIN/rm"
 
 run_refresh() {
 PATH="$BIN:$PATH" \
@@ -261,6 +272,13 @@ jq -e '
   (.accounts | map(.id) == ["account-a", "account-b"]) and
   (.accounts | all(.relativePath | startswith("snapshots/")))
 ' "$POOL_SNAPSHOT_ROOT/current.json" >/dev/null
+jq -e '
+  .schemaVersion == 1 and
+  .controllerJobId == "test-controller" and
+  (.reviewedAtEpoch | type == "number") and
+  (.poolManifestSha256 | test("^[0-9a-f]{64}$")) and
+  (.approvalSealSha256 | test("^[0-9a-f]{64}$"))
+' "$POOL_SNAPSHOT_ROOT/current.approval.json" >/dev/null
 [[ $(stat -c '%a' "$POOL_SNAPSHOT_ROOT/current.json" 2>/dev/null || \
       stat -f '%Lp' "$POOL_SNAPSHOT_ROOT/current.json") == 400 ]]
 while IFS=$'\t' read -r account relative_path; do
@@ -383,6 +401,129 @@ cmp "$AUTH_ROOT/account-m/auth.json" "$TARGET_DIR/auth.json"
 
 pool_target_hash=$(cksum < "$TARGET_DIR/auth.json")
 rm -f "$CHANGED_MARKER"
+
+# A transient broker timeout may reuse only the exact current auth whose
+# recent broker review, authority identity, account set and bytes are sealed.
+sealed_manifest_copy=$FIXTURE/sealed-current.json
+sealed_approval_copy=$FIXTURE/sealed-current-approval.json
+sealed_target_copy=$FIXTURE/sealed-target-auth.json
+cp "$POOL_SNAPSHOT_ROOT/current.json" "$sealed_manifest_copy"
+cp "$POOL_SNAPSHOT_ROOT/current.approval.json" "$sealed_approval_copy"
+cp "$TARGET_DIR/auth.json" "$sealed_target_copy"
+sealed_relative_path=$(jq -r \
+  '.accounts[] | select(.id == "account-m") | .relativePath' \
+  "$POOL_SNAPSHOT_ROOT/current.json")
+sealed_account_auth=$POOL_SNAPSHOT_ROOT/$sealed_relative_path
+sealed_account_copy=$FIXTURE/sealed-account-auth.json
+cp "$sealed_account_auth" "$sealed_account_copy"
+sealed_manifest_hash=$(cksum < "$POOL_SNAPSHOT_ROOT/current.json")
+sealed_approval_hash=$(cksum < "$POOL_SNAPSHOT_ROOT/current.approval.json")
+printf '{"account":"unapproved-new-bytes"}\n' > \
+  "$AUTH_ROOT/account-m/auth.json"
+rm -f "$PROBE_LOG" "$CHANGED_MARKER"
+SOCIAL_MONITOR_TEST_STATUS_EXIT=124 SOCIAL_MONITOR_TEST_PROBE_LOG="$PROBE_LOG" \
+  run_pool_refresh >/dev/null 2>&1
+[[ ! -e $PROBE_LOG ]]
+[[ ! -e $CHANGED_MARKER ]]
+[[ $(cksum < "$TARGET_DIR/auth.json") == "$pool_target_hash" ]]
+[[ $(cksum < "$POOL_SNAPSHOT_ROOT/current.json") == "$sealed_manifest_hash" ]]
+[[ $(cksum < "$POOL_SNAPSHOT_ROOT/current.approval.json") == \
+  "$sealed_approval_hash" ]]
+[[ $(cat "$POOL_CURSOR_FILE") == 0 ]]
+[[ $(cat "$POOL_ACCOUNT_NAME_FILE") == account-m ]]
+SOCIAL_MONITOR_TEST_STATUS_EXIT=75 SOCIAL_MONITOR_TEST_PROBE_LOG="$PROBE_LOG" \
+  run_pool_refresh >/dev/null 2>&1
+[[ ! -e $PROBE_LOG ]]
+[[ ! -e $CHANGED_MARKER ]]
+[[ $(cksum < "$TARGET_DIR/auth.json") == "$pool_target_hash" ]]
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=127 run_pool_refresh >/dev/null 2>&1; then
+  echo 'non-transient broker status failure reused prior auth' >&2
+  exit 1
+fi
+cp "$sealed_account_copy" "$AUTH_ROOT/account-m/auth.json"
+
+mv "$POOL_SNAPSHOT_ROOT/current.json" "$FIXTURE/missing-current.json"
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused auth without a sealed pool manifest' >&2
+  exit 1
+fi
+install -m 0400 "$sealed_manifest_copy" "$POOL_SNAPSHOT_ROOT/current.json"
+
+mv "$POOL_SNAPSHOT_ROOT/current.approval.json" \
+  "$FIXTURE/missing-current-approval.json"
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused auth without sealed broker approval' >&2
+  exit 1
+fi
+install -m 0400 "$sealed_approval_copy" \
+  "$POOL_SNAPSHOT_ROOT/current.approval.json"
+
+install -m 0600 "$sealed_manifest_copy" "$POOL_SNAPSHOT_ROOT/current.json"
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused an unsealed writable pool manifest' >&2
+  exit 1
+fi
+install -m 0400 "$sealed_manifest_copy" "$POOL_SNAPSHOT_ROOT/current.json"
+
+jq '.approvalSealSha256 = ("0" * 64)' "$sealed_approval_copy" \
+  > "$FIXTURE/tampered-seal.json"
+install -m 0400 "$FIXTURE/tampered-seal.json" \
+  "$POOL_SNAPSHOT_ROOT/current.approval.json"
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused a tampered approval seal' >&2
+  exit 1
+fi
+install -m 0400 "$sealed_approval_copy" \
+  "$POOL_SNAPSHOT_ROOT/current.approval.json"
+
+chmod 0600 "$sealed_account_auth"
+printf '{"account":"tampered-snapshot"}\n' > "$sealed_account_auth"
+chmod 0400 "$sealed_account_auth"
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused tampered sealed account bytes' >&2
+  exit 1
+fi
+chmod 0600 "$sealed_account_auth"
+cp "$sealed_account_copy" "$sealed_account_auth"
+chmod 0400 "$sealed_account_auth"
+
+chmod 0600 "$TARGET_DIR/auth.json"
+printf '{"account":"tampered-current"}\n' > "$TARGET_DIR/auth.json"
+chmod 0400 "$TARGET_DIR/auth.json"
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused current auth outside the sealed bytes' >&2
+  exit 1
+fi
+install -m 0400 "$sealed_target_copy" "$TARGET_DIR/auth.json"
+
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused auth sealed for a foreign pool identity' >&2
+  exit 1
+fi
+[[ $(cksum < "$TARGET_DIR/auth.json") == "$pool_target_hash" ]]
+
+jq '.accounts = ["account-a"]' "$POOL_JOB_DIRECTORY/job.json" \
+  > "$FIXTURE/changed-pool-membership.json"
+mv "$FIXTURE/changed-pool-membership.json" "$POOL_JOB_DIRECTORY/job.json"
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused an account removed from the approved pool' >&2
+  exit 1
+fi
+write_pool_manifest "$POOL_JOB_ID" social-monitor "$POOL_JOB_ROOT" \
+  "$POOL_WORKSPACE" "$REGISTRY_ROOT"
+
+reviewed_at=$(jq -r '.reviewedAtEpoch' \
+  "$POOL_SNAPSHOT_ROOT/current.approval.json")
+stale_now=$((reviewed_at + 129601))
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 \
+  SOCIAL_MONITOR_TEST_DATE_EPOCH="$stale_now" \
+  run_pool_refresh >/dev/null 2>&1; then
+  echo 'status timeout reused auth beyond the broker review window' >&2
+  exit 1
+fi
+[[ $(cksum < "$TARGET_DIR/auth.json") == "$pool_target_hash" ]]
+[[ ! -e $CHANGED_MARKER ]]
+
 if SOCIAL_MONITOR_TEST_STATUS_JSON='{"ok":true,"hasAvailableAccount":false,"availableDedupedAccountNames":[],"summary":{"ready":0,"availableDeduped":0}}' \
   SOCIAL_MONITOR_TEST_STATUS_LOG="$STATUS_LOG" run_pool_refresh >/dev/null 2>&1; then
   echo 'nonready broker-managed pool was accepted' >&2

--- a/ops/deploy/refresh-codex-auth.test.sh
+++ b/ops/deploy/refresh-codex-auth.test.sh
@@ -119,6 +119,14 @@ expected_registry=${SOCIAL_MONITOR_TEST_EXPECTED_REGISTRY_ROOT:?}
 if [[ -n ${SOCIAL_MONITOR_TEST_STATUS_LOG:-} ]]; then
   printf '%s\n' "$*" >> "$SOCIAL_MONITOR_TEST_STATUS_LOG"
 fi
+if [[ -n ${SOCIAL_MONITOR_TEST_STATUS_HANG_GATE:-} ]]; then
+  : > "${SOCIAL_MONITOR_TEST_STATUS_HANG_GATE}.entered"
+  /usr/bin/sleep 10 &
+  hang_pid=$!
+  trap 'kill "$hang_pid" 2>/dev/null || true; wait "$hang_pid" 2>/dev/null || true; : > "${SOCIAL_MONITOR_TEST_STATUS_HANG_GATE}.terminated"; exit 143' TERM
+  wait "$hang_pid"
+  exit 99
+fi
 if [[ -n ${SOCIAL_MONITOR_TEST_STATUS_EXIT:-} ]]; then
   exit "$SOCIAL_MONITOR_TEST_STATUS_EXIT"
 fi
@@ -209,6 +217,7 @@ SOCIAL_MONITOR_AUTH_PROBE_TMP_ROOT="$PROBE_TMP_ROOT" \
 SOCIAL_MONITOR_AUTH_POOL_SNAPSHOT_ROOT="$POOL_SNAPSHOT_ROOT" \
 SOCIAL_MONITOR_AUTH_POOL_POINTER="$POOL_POINTER" \
 SOCIAL_MONITOR_AUTH_POOL_REGISTRY_PREFIX="$PROJECT_ROOT/worker-jobs/" \
+SOCIAL_MONITOR_AUTH_BROKER_STATUS_TIMEOUT_SECONDS="${SOCIAL_MONITOR_AUTH_BROKER_STATUS_TIMEOUT_SECONDS:-30}" \
 SOCIAL_MONITOR_TEST_SYSTEM_FLOCK="$SYSTEM_FLOCK" \
 SOCIAL_MONITOR_TEST_EXPECTED_JOB_ID="${SOCIAL_MONITOR_TEST_EXPECTED_JOB_ID:-test-controller}" \
 SOCIAL_MONITOR_TEST_EXPECTED_REGISTRY_ROOT="${SOCIAL_MONITOR_TEST_EXPECTED_REGISTRY_ROOT:-$REGISTRY_ROOT}" \
@@ -421,8 +430,35 @@ sealed_approval_hash=$(cksum < "$POOL_SNAPSHOT_ROOT/current.approval.json")
 printf '{"account":"unapproved-new-bytes"}\n' > \
   "$AUTH_ROOT/account-m/auth.json"
 rm -f "$PROBE_LOG" "$CHANGED_MARKER"
-SOCIAL_MONITOR_TEST_STATUS_EXIT=124 SOCIAL_MONITOR_TEST_PROBE_LOG="$PROBE_LOG" \
-  run_pool_refresh >/dev/null 2>&1
+STATUS_HANG_GATE=$FIXTURE/status-hang
+STATUS_WATCHDOG_MARKER=$FIXTURE/status-timeout-watchdog-fired
+rm -f "$STATUS_HANG_GATE.entered" "$STATUS_HANG_GATE.terminated" \
+  "$STATUS_WATCHDOG_MARKER"
+SOCIAL_MONITOR_TEST_STATUS_HANG_GATE="$STATUS_HANG_GATE" \
+  SOCIAL_MONITOR_AUTH_BROKER_STATUS_TIMEOUT_SECONDS=1 \
+  SOCIAL_MONITOR_TEST_PROBE_LOG="$PROBE_LOG" \
+  run_pool_refresh >/dev/null 2>&1 &
+timeout_refresh_pid=$!
+(
+  /usr/bin/sleep 30
+  if kill -0 "$timeout_refresh_pid" 2>/dev/null; then
+    : > "$STATUS_WATCHDOG_MARKER"
+    kill -TERM "$timeout_refresh_pid" 2>/dev/null || true
+    /usr/bin/sleep 0.1
+    kill -KILL "$timeout_refresh_pid" 2>/dev/null || true
+  fi
+) &
+timeout_watchdog_pid=$!
+timeout_refresh_exit=0
+wait "$timeout_refresh_pid" || timeout_refresh_exit=$?
+kill "$timeout_watchdog_pid" 2>/dev/null || true
+wait "$timeout_watchdog_pid" 2>/dev/null || true
+if [[ -e $STATUS_WATCHDOG_MARKER || $timeout_refresh_exit != 0 ]]; then
+  echo 'broker status hang was not bounded by the entrypoint timeout' >&2
+  exit 1
+fi
+[[ -f $STATUS_HANG_GATE.entered ]]
+[[ -f $STATUS_HANG_GATE.terminated ]]
 [[ ! -e $PROBE_LOG ]]
 [[ ! -e $CHANGED_MARKER ]]
 [[ $(cksum < "$TARGET_DIR/auth.json") == "$pool_target_hash" ]]
@@ -443,24 +479,24 @@ fi
 cp "$sealed_account_copy" "$AUTH_ROOT/account-m/auth.json"
 
 mv "$POOL_SNAPSHOT_ROOT/current.json" "$FIXTURE/missing-current.json"
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused auth without a sealed pool manifest' >&2
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 run_pool_refresh >/dev/null 2>&1; then
+  echo 'transient status failure reused auth without a sealed pool manifest' >&2
   exit 1
 fi
 install -m 0400 "$sealed_manifest_copy" "$POOL_SNAPSHOT_ROOT/current.json"
 
 mv "$POOL_SNAPSHOT_ROOT/current.approval.json" \
   "$FIXTURE/missing-current-approval.json"
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused auth without sealed broker approval' >&2
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 run_pool_refresh >/dev/null 2>&1; then
+  echo 'transient status failure reused auth without sealed broker approval' >&2
   exit 1
 fi
 install -m 0400 "$sealed_approval_copy" \
   "$POOL_SNAPSHOT_ROOT/current.approval.json"
 
 install -m 0600 "$sealed_manifest_copy" "$POOL_SNAPSHOT_ROOT/current.json"
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused an unsealed writable pool manifest' >&2
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 run_pool_refresh >/dev/null 2>&1; then
+  echo 'transient status failure reused an unsealed writable pool manifest' >&2
   exit 1
 fi
 install -m 0400 "$sealed_manifest_copy" "$POOL_SNAPSHOT_ROOT/current.json"
@@ -469,8 +505,8 @@ jq '.approvalSealSha256 = ("0" * 64)' "$sealed_approval_copy" \
   > "$FIXTURE/tampered-seal.json"
 install -m 0400 "$FIXTURE/tampered-seal.json" \
   "$POOL_SNAPSHOT_ROOT/current.approval.json"
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused a tampered approval seal' >&2
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 run_pool_refresh >/dev/null 2>&1; then
+  echo 'transient status failure reused a tampered approval seal' >&2
   exit 1
 fi
 install -m 0400 "$sealed_approval_copy" \
@@ -479,8 +515,8 @@ install -m 0400 "$sealed_approval_copy" \
 chmod 0600 "$sealed_account_auth"
 printf '{"account":"tampered-snapshot"}\n' > "$sealed_account_auth"
 chmod 0400 "$sealed_account_auth"
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused tampered sealed account bytes' >&2
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 run_pool_refresh >/dev/null 2>&1; then
+  echo 'transient status failure reused tampered sealed account bytes' >&2
   exit 1
 fi
 chmod 0600 "$sealed_account_auth"
@@ -490,14 +526,14 @@ chmod 0400 "$sealed_account_auth"
 chmod 0600 "$TARGET_DIR/auth.json"
 printf '{"account":"tampered-current"}\n' > "$TARGET_DIR/auth.json"
 chmod 0400 "$TARGET_DIR/auth.json"
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused current auth outside the sealed bytes' >&2
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 run_pool_refresh >/dev/null 2>&1; then
+  echo 'transient status failure reused current auth outside the sealed bytes' >&2
   exit 1
 fi
 install -m 0400 "$sealed_target_copy" "$TARGET_DIR/auth.json"
 
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused auth sealed for a foreign pool identity' >&2
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 run_refresh >/dev/null 2>&1; then
+  echo 'transient status failure reused auth sealed for a foreign pool identity' >&2
   exit 1
 fi
 [[ $(cksum < "$TARGET_DIR/auth.json") == "$pool_target_hash" ]]
@@ -505,8 +541,8 @@ fi
 jq '.accounts = ["account-a"]' "$POOL_JOB_DIRECTORY/job.json" \
   > "$FIXTURE/changed-pool-membership.json"
 mv "$FIXTURE/changed-pool-membership.json" "$POOL_JOB_DIRECTORY/job.json"
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 run_pool_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused an account removed from the approved pool' >&2
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 run_pool_refresh >/dev/null 2>&1; then
+  echo 'transient status failure reused an account removed from the approved pool' >&2
   exit 1
 fi
 write_pool_manifest "$POOL_JOB_ID" social-monitor "$POOL_JOB_ROOT" \
@@ -515,10 +551,10 @@ write_pool_manifest "$POOL_JOB_ID" social-monitor "$POOL_JOB_ROOT" \
 reviewed_at=$(jq -r '.reviewedAtEpoch' \
   "$POOL_SNAPSHOT_ROOT/current.approval.json")
 stale_now=$((reviewed_at + 129601))
-if SOCIAL_MONITOR_TEST_STATUS_EXIT=124 \
+if SOCIAL_MONITOR_TEST_STATUS_EXIT=75 \
   SOCIAL_MONITOR_TEST_DATE_EPOCH="$stale_now" \
   run_pool_refresh >/dev/null 2>&1; then
-  echo 'status timeout reused auth beyond the broker review window' >&2
+  echo 'transient status failure reused auth beyond the broker review window' >&2
   exit 1
 fi
 [[ $(cksum < "$TARGET_DIR/auth.json") == "$pool_target_hash" ]]


### PR DESCRIPTION
## What changed

- bound the broker account-status call to the existing 30 second production timeout
- reuse only a canonical, sealed, recently broker-reviewed auth pool after transient status 75/124
- fail closed for missing, tampered, foreign, stale or membership-invalid snapshots
- reproduce a real hanging broker process and prove timeout termination in the focused test

## Evidence

- independent xhigh read-only review: GO on the identical two commit trees
- successful path, shared lock, cursor and account-change semantics retained
- ShellCheck, source line cap, secret scan and diff checks passed in review
- local root execution printed all assertions passed but returned 1 during root relocation cleanup; GitHub CI is the authoritative native runner for this exact head

This fixes the observed daily timer failure where auth refresh exited 124 before collection. It does not weaken broker-reviewed account authority.
