### PR TITLE
fix(deploy): accept installed forward bridge

### DIFF
--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -248,6 +248,16 @@ production_forward_bridge_is_installed() {
       "$anchor" "$target" "$PLAN_POSTGRES_POOL_BOOTSTRAP_SHA"
 }
 
+production_forward_plan_is_fully_reconciled() {
+  [[ $PLAN_FRONTEND == false && $PLAN_BACKEND == false &&
+     $PLAN_CONTROL == false && $PLAN_X_COLLECTOR == false &&
+     $PLAN_POSTGRES_POOL_BOOTSTRAP == "$POSTGRES_POOL_BOOTSTRAP_VERSION" &&
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA =~ ^[0-9a-f]{40}$ &&
+     $PLAN_POSTGRES_POOL_BOOTSTRAP_SHA != 0000000000000000000000000000000000000000 &&
+     $PLAN_BACKEND_BASE =~ ^[0-9a-f]{40}$ &&
+     $PLAN_BACKEND_BASE != 0000000000000000000000000000000000000000 ]]
+}
+
 prepare_production_forward_bridge() {
   local target=$1 status anchor bridge
   verify_production_forward_target_identity "$target"
@@ -273,6 +283,12 @@ prepare_production_forward_bridge() {
     fail "production forward bridge plan failed with status $status"
   fi
   print_plan
+  # A previous bounded run may have already installed B before the target
+  # deploy was interrupted. In that state inspecting B is fully reconciled:
+  # the bridge itself has no remaining work, while the target plan above still
+  # correctly describes the descendant work. Treat that as an idempotent
+  # success instead of demanding a second control transition.
+  production_forward_plan_is_fully_reconciled && return 0
   plan_is_exact_production_forward_bridge_transition || \
     fail 'production forward B plan is inconsistent with target'
   deploy_once "$bridge"

--- a/ops/deploy/production-release-a-transition.test.sh
+++ b/ops/deploy/production-release-a-transition.test.sh
@@ -298,3 +298,28 @@ prepare_production_forward_bridge descendant
   exit 1
 }
 echo 'Forward descendant pre-bridge preparation test passed'
+
+# If the bridge was installed by an earlier interrupted run, the bridge plan
+# is fully reconciled and must be accepted idempotently without redeploying B.
+capture_plan() {
+  local requested=$1
+  PLAN_FRONTEND=true PLAN_BACKEND=true PLAN_CONTROL=true PLAN_X_COLLECTOR=false
+  PLAN_BACKEND_BASE=$PRODUCTION_FORWARD_BACKEND_SHA
+  PLAN_POSTGRES_POOL_BOOTSTRAP=$POSTGRES_POOL_BOOTSTRAP_VERSION
+  PLAN_POSTGRES_POOL_BOOTSTRAP_SHA=$PRODUCTION_FORWARD_POOL_SHA
+  PLAN_POSTGRES_POOL_REPAIR=false
+  if [[ $requested == bridge ]]; then
+    PLAN_FRONTEND=false
+    PLAN_BACKEND=false
+    PLAN_CONTROL=false
+  fi
+}
+print_plan() { :; }
+bridge_deployments=0
+deploy_once() { bridge_deployments=$((bridge_deployments + 1)); }
+prepare_production_forward_bridge descendant
+[[ $bridge_deployments == 0 ]] || {
+  echo "already-installed bridge was deployed again: $bridge_deployments" >&2
+  exit 1
+}
+echo 'Installed bridge idempotency test passed'


### PR DESCRIPTION
The production bridge was already installed by the prior bounded recovery, but prepare-forward-bridge re-read the bridge plan as fully reconciled and rejected it because it expected a new control transition.

This keeps fail-closed topology and adds an idempotent success path only when the derived bridge plan is fully reconciled. A focused regression proves no second bridge deploy.

Checks: bash -n, git diff --check, remote Bash 5.2 transition tests.