### PR TITLE
fix(deploy): make forward manifest ordering locale-independent

### DIFF
--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=0d7f29d904c021d53ac0999808dd6dc1226a0c78
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=0712ab8df828cb8b51403d0e7b646a55fe2b12c8
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,5 +1,5 @@
 100644 707fca6fe51580306af818d748350a488f753ccb ops/deploy/deploy-control-bridge-lib.sh
-100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
-100644 a31c96a063253c15917f7c31216a4196ed475a3d ops/deploy/production-forward-bridge.blobs
+100644 8bbd4e691299d7f99fedbad8c94d9e68f4f6b213 ops/deploy/production-forward-bridge-host-lib.sh
+100644 1fa795156fe2f005d096b6fedfe25ea37e0bb872 ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh
 100644 8ef73c96eedaeea7ac84b0dbbc4012ad124b5d0e ops/deploy/production-transition-marker-lib.sh

--- a/ops/deploy/production-forward-bridge-host-lib.sh
+++ b/ops/deploy/production-forward-bridge-host-lib.sh
@@ -171,8 +171,10 @@ production_forward_read_manifest() {
        $path != *'..'* && $path != /* ]] || \
       production_forward_host_fail 'production forward manifest row is invalid'
     key=$scope' '$path
-    [[ -z $previous_key || $key > "$previous_key" ]] || \
-      production_forward_host_fail 'production forward manifest is not strict sorted unique'
+    if [[ -n $previous_key ]]; then
+      LC_ALL=C bash -c '[[ $1 > $2 ]]' _ "$key" "$previous_key" || \
+        production_forward_host_fail 'production forward manifest is not strict sorted unique'
+    fi
     previous_key=$key
     if [[ $scope == bridge ]]; then
       [[ -z $PRODUCTION_FORWARD_BRIDGE_ENTRY && \

--- a/ops/deploy/production-forward-bridge.blobs
+++ b/ops/deploy/production-forward-bridge.blobs
@@ -5,7 +5,7 @@ head 100644 930d8b0966f0556a227068d7aa1564c7e8fea83a ops/deploy/deploy-control-b
 head 100755 ae3d1e344efd54970e06721fc67a060dbc703da6 ops/deploy/github-production-deploy-client.sh
 head 100755 933cc3009d04cc8011ffcaf63b15d6967d34dcbb ops/deploy/github-production-deploy-client.test.sh
 head 100755 d0ded4cdbd36577537bdf00c91c5829fd120f3c4 ops/deploy/production-forward-bootstrap-marker-resume.test.sh
-head 100755 cf27559253df7a0f3fca8bace5d39a789de281d6 ops/deploy/production-forward-bridge.test.sh
+head 100755 da4b04829671cab7e9076ece25eac977ed33853c ops/deploy/production-forward-bridge.test.sh
 head 100755 73673a20e6abe803bfbaf0cc00383b68036aeced ops/deploy/production-release-b-bridge-order.test.sh
 head 100755 75c765a3003c952ade9e69865287ebb782e5b1d9 ops/deploy/production-transition-b0-host-control.test.sh
 head 100644 57a52e56ec879624eb33f3c77834b5b005fa9412 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh

--- a/ops/deploy/production-forward-bridge.test.sh
+++ b/ops/deploy/production-forward-bridge.test.sh
@@ -122,6 +122,17 @@ production_forward_verify_target_graph "$B" "$F"
 production_forward_verify_target_graph "$B" "$H"
 printf 'forward-bridge-test: exact topology accepted\n'
 
+# The manifest is generated in the bytewise C locale, but the host shell may
+# run with a different UTF-8 collation.  Validate the reader under that host
+# locale so ordering remains deterministic at the production boundary.
+if locale -a 2>/dev/null | grep -Eiq '^en_US(\.UTF-8)?$|^en_US\.utf8$'; then
+  host_locale=$(locale -a | grep -Ei '^en_US(\.UTF-8)?$|^en_US\.utf8$' | head -n 1)
+  LC_ALL="$host_locale"; export LC_ALL
+  production_forward_read_manifest "$B"
+  printf 'forward-bridge-test: manifest ordering is locale-independent (%s)\n' \
+    "$host_locale"
+fi
+
 target_diagnostic=$( (
   capture_plan() { return 23; }
   prepare_production_forward_bridge "$F"


### PR DESCRIPTION
## What changed
- compare forward manifest keys under `LC_ALL=C` regardless of the host shell locale
- add a regression assertion for `en_US.utf8` when that locale is available
- refresh the reviewed blob/authority hashes

## Verification
- `bash ops/deploy/production-forward-bridge.test.sh` on the old hosted worker host (`codex-workers-eu-01-old`, machine-id `937321...`)
- Result: `production-forward-bridge-test: ok`

This PR is a bounded reliability fix. It does not mutate production or resolve the separate frozen-B0 recovery mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved production deployment manifest validation so ordering remains consistent across different system locales.
  - Added coverage to verify deterministic manifest handling when an English UTF-8 locale is available.

- **Maintenance**
  - Updated production forward-bridge release references and authority metadata to their latest versions.
  - Included the deployment control bridge in the production authority manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->