### PR TITLE
fix(agent-runtime): add safe subscription runtime failure logging

### DIFF
--- a/apps/agent-runtime/src/subscription-runtime-cli-executor.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-executor.spec.ts
@@ -2,6 +2,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
+import type { StructuredLogger } from "@social-monitor/platform-logging";
 import type { AgentRuntimeExecutionRequest } from "./agent-runtime-executor.port";
 import { SubscriptionRuntimeCliExecutor } from "./subscription-runtime-cli-executor";
 
@@ -442,6 +443,60 @@ describe("SubscriptionRuntimeCliExecutor", () => {
       failure: { code: "agent_runtime.execution_attestation_invalid" },
     });
     expect(inspections).toBe(0);
+  });
+
+  it("logs a safe structured failure without recording prompt contents", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "agent-runtime-cli-test-"));
+    const cliPath = join(tempDir, "fake-failure-cli.mjs");
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "process.stdout.write(JSON.stringify({ status: 'failed', warnings: [], failure: { code: 'quota_limited', safeMessage: 'All configured accounts are limited', retryable: true, reconnectRequired: false, causeCategory: 'provider' } }));",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(cliPath, 0o755);
+    const logs: Array<{
+      level: string;
+      message: string;
+      fields?: Record<string, unknown>;
+    }> = [];
+    const logger: StructuredLogger = {
+      info: (message, fields) => logs.push({ level: "info", message, fields }),
+      warn: (message, fields) => logs.push({ level: "warn", message, fields }),
+      error: (message, fields) =>
+        logs.push({ level: "error", message, fields }),
+    };
+    const executor = new SubscriptionRuntimeCliExecutor({
+      command: cliPath,
+      ephemeral: true,
+      installationInspector,
+      logger,
+    });
+
+    const result = await executor.execute(
+      validExecutionRequest({
+        prompt: "Return JSON. secret prompt must not be logged",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: "failed",
+      failure: { code: "quota_limited" },
+    });
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        message: "agent runtime task did not complete",
+        fields: expect.objectContaining({
+          requestId: "request-1",
+          correlationId: "corr-1",
+          failureCode: "quota_limited",
+        }),
+      }),
+    );
+    expect(JSON.stringify(logs)).not.toContain("secret prompt");
   });
 });
 

--- a/apps/agent-runtime/src/subscription-runtime-cli-executor.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-executor.ts
@@ -2,6 +2,10 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import {
+  NestStructuredLogger,
+  type StructuredLogger,
+} from "@social-monitor/platform-logging";
 import type {
   AgentRuntimeExecutionRequest,
   AgentRuntimeExecutionResult,
@@ -41,27 +45,39 @@ export type SubscriptionRuntimeCliExecutorOptions = {
   readonly model?: string;
   readonly reasoningEffort?: typeof activeReaderSummaryReasoningEffort;
   readonly installationInspector?: SubscriptionRuntimeInstallationInspector;
+  readonly logger?: StructuredLogger;
 };
 
 export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort {
   private readonly installationInspector: SubscriptionRuntimeInstallationInspector;
+  private readonly logger: StructuredLogger;
 
   constructor(private readonly options: SubscriptionRuntimeCliExecutorOptions) {
     this.installationInspector =
       options.installationInspector ??
       new FileSubscriptionRuntimeInstallationInspector();
+    this.logger =
+      options.logger ??
+      new NestStructuredLogger(SubscriptionRuntimeCliExecutor.name);
   }
 
   async execute(
     request: AgentRuntimeExecutionRequest,
   ): Promise<AgentRuntimeExecutionResult> {
+    const startedAt = Date.now();
+    this.logger.info("agent runtime task started", taskFields(request));
     let admission: AdmittedSubscriptionRuntimeRequest;
     try {
       if (!configuredSubscriptionRuntimeDefaultsAreSafe(this.options)) {
+        this.logger.error("agent runtime task rejected unsafe defaults", {
+          ...taskFields(request),
+          stage: "defaults",
+        });
         return invalidAttestationResult();
       }
       admission = admitSubscriptionRuntimeRequest(request);
-    } catch {
+    } catch (error) {
+      this.logFailure(request, "admission", error);
       return invalidAttestationResult();
     }
     let admittedInstallation: SubscriptionRuntimeInstallationIdentity;
@@ -69,12 +85,17 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
       admittedInstallation = await this.installationInspector.inspect(
         this.options.command,
       );
-    } catch {
+    } catch (error) {
+      this.logFailure(request, "installation", error);
       return invalidAttestationResult();
     }
-    const tempDir = await mkdtemp(
-      join(tmpdir(), "social-monitor-agent-runtime-"),
-    );
+    let tempDir: string;
+    try {
+      tempDir = await mkdtemp(join(tmpdir(), "social-monitor-agent-runtime-"));
+    } catch (error) {
+      this.logFailure(request, "workspace", error);
+      return invalidAttestationResult();
+    }
     const inputPath = join(tempDir, "request.json");
     try {
       await writeFile(
@@ -82,7 +103,6 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
         JSON.stringify(admission.canonicalRequest),
         "utf8",
       );
-      const startedAt = Date.now();
       const initialResult = cliExecutionResult(
         await runCli({
           command: admittedInstallation.executablePath,
@@ -95,15 +115,27 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
         }),
       );
       if (!shouldRetryWithEphemeral(initialResult, this.options)) {
-        return this.attestCompletedResult(
+        const result = await this.attestCompletedResult(
           request,
           admission,
           initialResult,
           admittedInstallation,
         );
+        this.logResult(request, result, startedAt);
+        return result;
       }
+      this.logger.warn(
+        "agent runtime durable session unavailable; retrying ephemeral",
+        {
+          ...taskFields(request),
+          stage: "retry",
+          failureCode: initialResult.failure?.code,
+          durationMs: Date.now() - startedAt,
+        },
+      );
       const remainingTimeoutMs = request.timeoutMs - (Date.now() - startedAt);
       if (remainingTimeoutMs <= 0) {
+        this.logResult(request, initialResult, startedAt);
         return initialResult;
       }
       const recovered = cliExecutionResult(
@@ -114,7 +146,7 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
           timeoutMs: remainingTimeoutMs,
         }),
       );
-      return this.attestCompletedResult(
+      const result = await this.attestCompletedResult(
         request,
         admission,
         {
@@ -130,6 +162,16 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
         },
         admittedInstallation,
       );
+      this.logResult(request, result, startedAt);
+      return result;
+    } catch (error) {
+      this.logger.error("agent runtime task execution threw", {
+        ...taskFields(request),
+        stage: "execution",
+        durationMs: Date.now() - startedAt,
+        error: safeErrorMessage(error),
+      });
+      throw error;
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
@@ -137,6 +179,9 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
 
   async checkHealth(): Promise<AgentRuntimeExecutorHealth> {
     if (this.options.command.trim().length === 0) {
+      this.logger.error("agent runtime health check rejected empty command", {
+        stage: "health",
+      });
       return {
         healthy: false,
         runtimeEngine: "subscription-runtime-cli",
@@ -162,6 +207,13 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
         !probe.timedOut &&
         (probe.exitCode === 0 ||
           isUsageProbeOutput(probe.stdout, probe.stderr));
+      if (!healthy) {
+        this.logger.warn("agent runtime health probe failed", {
+          stage: "health",
+          timedOut: probe.timedOut,
+          exitCode: probe.exitCode ?? "null",
+        });
+      }
       return {
         healthy,
         runtimeEngine: "subscription-runtime-cli",
@@ -176,7 +228,11 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
               },
             ],
       };
-    } catch {
+    } catch (error) {
+      this.logger.error("agent runtime health check threw", {
+        stage: "health",
+        error: safeErrorMessage(error),
+      });
       return {
         healthy: false,
         runtimeEngine: "subscription-runtime-cli",
@@ -205,6 +261,39 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
       profile: admission.profile,
       installationInspector: this.installationInspector,
       admittedInstallation,
+    });
+  }
+
+  private logResult(
+    request: AgentRuntimeExecutionRequest,
+    result: AgentRuntimeExecutionResult,
+    startedAt: number,
+  ): void {
+    const fields = {
+      ...taskFields(request),
+      status: result.status,
+      durationMs: Date.now() - startedAt,
+      warningCount: result.warnings.length,
+      failureCode: result.failure?.code,
+      retryable: result.failure?.retryable,
+      reconnectRequired: result.failure?.reconnectRequired,
+    };
+    if (result.status === "completed") {
+      this.logger.info("agent runtime task completed", fields);
+    } else {
+      this.logger.error("agent runtime task did not complete", fields);
+    }
+  }
+
+  private logFailure(
+    request: AgentRuntimeExecutionRequest,
+    stage: string,
+    error: unknown,
+  ): void {
+    this.logger.error("agent runtime task rejected", {
+      ...taskFields(request),
+      stage,
+      error: safeErrorMessage(error),
     });
   }
 
@@ -259,3 +348,18 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
     return patch;
   }
 }
+
+const taskFields = (
+  request: AgentRuntimeExecutionRequest,
+): Readonly<Record<string, string | number | boolean | undefined>> => ({
+  requestId: request.requestId,
+  correlationId: request.correlationId,
+  provider: request.provider,
+  purpose: request.purpose,
+  timeoutMs: request.timeoutMs,
+});
+
+const safeErrorMessage = (error: unknown): string =>
+  (error instanceof Error ? error.message : String(error))
+    .replaceAll(/\s+/g, " ")
+    .slice(0, 256);


### PR DESCRIPTION
## What
- Add structured wrapper logs for subscription-runtime task lifecycle, rejection, retry, health probe and execution errors.
- Keep logs limited to correlation/request metadata, stage, status, duration and safe failure codes. Prompts, model output, auth paths and credentials are not logged.
- Add a regression test proving quota failures are observable without prompt leakage.

## Verification
- npm run build
- npx jest --config jest.config.ts apps/agent-runtime/src --runInBand
- npm run check:subscription-runtime-auth-pool-e2e
- npm run check:runtime-compose
- npm run check:source-line-cap
- npm run check:code-quality
- npx eslint on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured logging throughout subscription runtime task execution, including task starts, failures, retries, completions, and health-check outcomes.
  * Added support for supplying a custom structured logger.

* **Security & Privacy**
  * Error logs include safe diagnostic identifiers without recording prompt contents.

* **Tests**
  * Added coverage verifying structured logging for quota-limited failures and prompt redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->