### PR TITLE
fix(deploy): recover stale production B0 safely

### DIFF
--- a/.github/workflows/production-transition-publish.yml
+++ b/.github/workflows/production-transition-publish.yml
@@ -14,6 +14,11 @@ on:
         description: Correlation nonce
         required: true
         type: string
+      b0_sha:
+        description: Optional trusted B0 matching the review for one stale-host recovery
+        required: false
+        default: ''
+        type: string
 
 permissions: {}
 
@@ -61,6 +66,7 @@ jobs:
         shell: bash
         env:
           TARGET_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY }}
+          B0_SHA: ${{ inputs.b0_sha }}
         run: |
           set -euo pipefail
           [[ -n "$TARGET_PRIVATE_KEY" ]]
@@ -75,6 +81,12 @@ jobs:
             'refs/production-transition/artifact/*:refs/production-transition/artifact/*'
           s2=$(sed -n 's/^s2=//p' artifact/review.result)
           p6=$(sed -n 's/^p6=//p' artifact/review.result)
+          review_b0=$(sed -n 's/^b0=//p' artifact/review.result)
+          [[ -z "$B0_SHA" || "$B0_SHA" == "$review_b0" ]]
+          if [[ -n "$B0_SHA" ]]; then
+            export PRODUCTION_TRANSITION_STALE_B0_SHA="$B0_SHA"
+            export PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0
+          fi
           [[ "$s2" == "$(git rev-parse refs/production-transition/artifact/s2)" ]]
           [[ "$p6" == "$(git rev-parse refs/production-transition/artifact/p6)" ]]
           key=$(mktemp "$RUNNER_TEMP/transition-target-key.XXXXXX")

--- a/.github/workflows/production-transition-review.yml
+++ b/.github/workflows/production-transition-review.yml
@@ -1,7 +1,7 @@
 name: Production transition review
 
 run-name: >-
-  production-transition-review s2=${{ inputs.s2_sha }} request=${{ inputs.request_id }}
+  production-transition-review s2=${{ inputs.s2_sha }} b0=${{ inputs.b0_sha }} request=${{ inputs.request_id }}
 
 on:
   workflow_dispatch:
@@ -13,6 +13,11 @@ on:
       request_id:
         description: Correlation nonce
         required: true
+        type: string
+      b0_sha:
+        description: Optional trusted B0 for one stale-host recovery
+        required: false
+        default: ''
         type: string
 
 permissions:
@@ -36,6 +41,7 @@ jobs:
         shell: bash
         env:
           S2_SHA: ${{ inputs.s2_sha }}
+          B0_SHA: ${{ inputs.b0_sha }}
           REQUEST_ID: ${{ inputs.request_id }}
           REVIEW_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY }}
         run: |
@@ -45,9 +51,18 @@ jobs:
           [[ "$GITHUB_REF" == "refs/heads/main" ]]
           [[ "$S2_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$REQUEST_ID" =~ ^[0-9a-f]{32}$ ]]
+          [[ -z "$B0_SHA" || "$B0_SHA" =~ ^[0-9a-f]{40}$ ]]
+          remote_main=$(git ls-remote --exit-code origin refs/heads/main | awk 'NR == 1 {print $1}')
+          [[ "$GITHUB_SHA" == "$remote_main" && "$S2_SHA" == "$GITHUB_SHA" ]]
           [[ -n "$REVIEW_PRIVATE_KEY" ]]
           git -c protocol.version=2 fetch --no-tags --no-write-fetch-head \
             --filter=blob:none origin "$S2_SHA"
+          if [[ -n "$B0_SHA" ]]; then
+            git -c protocol.version=2 fetch --no-tags --no-write-fetch-head \
+              --filter=blob:none origin "$B0_SHA"
+            export PRODUCTION_TRANSITION_STALE_B0_SHA="$B0_SHA"
+            export PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0
+          fi
           key=$(mktemp "$RUNNER_TEMP/transition-review-key.XXXXXX")
           trap 'rm -f -- "$key"' EXIT
           printf '%s\n' "$REVIEW_PRIVATE_KEY" > "$key"

--- a/ops/deploy/production-transition-publisher.sh
+++ b/ops/deploy/production-transition-publisher.sh
@@ -40,6 +40,7 @@ publisher_verify_origin() {
 
 publisher_initialize_context() {
   local mode=${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-0} remote_main
+  local stale_b0 recovery_mode
   if [[ $mode == 1 ]]; then
     REPO=${PRODUCTION_TRANSITION_TEST_REPOSITORY:?test repository is required}
     REMOTE=${PRODUCTION_TRANSITION_TEST_REMOTE:?test remote is required}
@@ -71,6 +72,16 @@ $PRODUCTION_TRANSITION_TARGET_FINGERPRINT
     PRODUCTION_TRANSITION_EFFECTIVE_NOW_EPOCH=$(/usr/bin/date +%s)
     publisher_verify_origin
     remote_main=$(publisher_remote_main)
+    stale_b0=${PRODUCTION_TRANSITION_STALE_B0_SHA:-}
+    recovery_mode=${PRODUCTION_TRANSITION_RECOVERY_MODE:-}
+    if [[ -n $stale_b0 ]]; then
+      production_transition_validate_sha "$stale_b0" 'stale B0'
+      [[ $recovery_mode == stale-b0 ]] || \
+        publisher_fail 'stale B0 requires the explicit recovery mode'
+    else
+      [[ -z $recovery_mode ]] || \
+        publisher_fail 'recovery mode requires an explicit stale B0'
+    fi
     [[ ${GITHUB_REPOSITORY:-} == "$PRODUCTION_TRANSITION_REPOSITORY_ID" && \
        ${GITHUB_WORKFLOW_REF:-} == "$PRODUCTION_TRANSITION_PUBLISH_WORKFLOW_REF" && \
        ${GITHUB_SHA:-} == "$remote_main" && \
@@ -156,7 +167,13 @@ publisher_prepare() (
     return 0
   fi
   ((status == 2)) || publisher_fail 'canonical review consumption state is unreadable'
-  [[ $remote_main == "$b0" ]] || publisher_fail 'signed B0 differs from protected main lease'
+  if [[ -n ${PRODUCTION_TRANSITION_STALE_B0_SHA:-} ]]; then
+    [[ ${PRODUCTION_TRANSITION_STALE_B0_SHA} == "$b0" && \
+       $remote_main == "$s2" ]] || \
+      publisher_fail 'stale B0 recovery lease is not the reviewed S2'
+  else
+    [[ $remote_main == "$b0" ]] || publisher_fail 'signed B0 differs from protected main lease'
+  fi
   production_transition_verify_canonical_review "$s2" "$p6" "$statement" \
     "$signature" "$review_signers" fresh >/dev/null
   statement_digest=$(production_transition_sha256_file "$statement")
@@ -186,13 +203,14 @@ publisher_prepare() (
 
 publisher_publish() (
   local target=$1 statement='' signature='' target_signers='' b0 review_id
-  local verification consumption_ref consumed status observed
+  local verification consumption_ref consumed status observed s2 lease_main
   cleanup() { [[ -z $statement ]] || /usr/bin/rm -f -- "$statement"; \
     [[ -z $signature ]] || /usr/bin/rm -f -- "$signature"; \
     [[ -z $target_signers ]] || /usr/bin/rm -f -- "$target_signers"; }
   trap cleanup EXIT
   production_transition_validate_sha "$target" T
   b0=$(production_transition_git -C "$REPO" rev-parse "$target^1^1")
+  s2=$(production_transition_git -C "$REPO" rev-parse "$target^2")
   PRODUCTION_TRANSITION_BRIDGE_BASE=$b0
   statement=$(/usr/bin/mktemp "${TMPDIR:-/tmp}/publisher-statement.XXXXXX")
   signature=$(/usr/bin/mktemp "${TMPDIR:-/tmp}/publisher-signature.XXXXXX")
@@ -220,12 +238,20 @@ publisher_publish() (
     return 0
   fi
   ((status == 2)) || publisher_fail 'canonical review consumption state is unreadable'
-  [[ $observed == "$b0" ]] || publisher_fail 'protected main moved after signed B0 lease'
+  if [[ -n ${PRODUCTION_TRANSITION_STALE_B0_SHA:-} ]]; then
+    [[ ${PRODUCTION_TRANSITION_STALE_B0_SHA} == "$b0" && \
+       $observed == "$s2" ]] || \
+      publisher_fail 'protected main moved after stale B0 recovery lease'
+    lease_main=$s2
+  else
+    [[ $observed == "$b0" ]] || publisher_fail 'protected main moved after signed B0 lease'
+    lease_main=$b0
+  fi
   production_transition_verify_target_contract "$target" "$statement" \
     "$signature" fresh "$target_signers" \
     "$PRODUCTION_TRANSITION_EFFECTIVE_TARGET_FINGERPRINT" >/dev/null
   production_transition_git -C "$REPO" push --atomic \
-    --force-with-lease="$MAIN_REF:$b0" \
+    --force-with-lease="$MAIN_REF:$lease_main" \
     --force-with-lease="$consumption_ref:0000000000000000000000000000000000000000" \
     "$REMOTE" "$target:$MAIN_REF" "$target:$consumption_ref" || \
     publisher_fail 'atomic protected-main publication failed'

--- a/ops/deploy/production-transition-reviewer.sh
+++ b/ops/deploy/production-transition-reviewer.sh
@@ -39,6 +39,7 @@ reviewer_verify_origin() {
 
 reviewer_initialize_context() {
   local mode=${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-0}
+  local remote_main stale_b0 recovery_mode
   if [[ $mode == 1 ]]; then
     REPO=${PRODUCTION_TRANSITION_TEST_REPOSITORY:?test repository is required}
     PRODUCTION_TRANSITION_BRIDGE_BASE=\
@@ -70,8 +71,27 @@ ${PRODUCTION_TRANSITION_TEST_REPLAY_ID:?test replay id is required}
       reviewer_fail 'test overrides are forbidden in production mode'
     REPO=${GITHUB_WORKSPACE:?GitHub review workspace is required}
     reviewer_verify_origin
-    PRODUCTION_TRANSITION_BRIDGE_BASE=$(production_transition_git -C "$REPO" \
+    remote_main=$(production_transition_git -C "$REPO" \
       ls-remote --exit-code origin refs/heads/main | /usr/bin/awk 'NR == 1 {print $1}')
+    stale_b0=${PRODUCTION_TRANSITION_STALE_B0_SHA:-}
+    recovery_mode=${PRODUCTION_TRANSITION_RECOVERY_MODE:-}
+    if [[ -n $stale_b0 ]]; then
+      [[ $recovery_mode == stale-b0 ]] || \
+        reviewer_fail 'stale B0 requires the explicit recovery mode'
+      production_transition_validate_sha "$stale_b0" 'stale B0'
+      production_transition_git -C "$REPO" cat-file -e "$stale_b0^{commit}" || \
+        reviewer_fail 'stale B0 is unavailable in the review checkout'
+      [[ $remote_main == "${GITHUB_SHA:-}" && $GITHUB_SHA =~ ^[0-9a-f]{40}$ ]] || \
+        reviewer_fail 'stale B0 recovery requires the exact protected main checkout'
+      [[ $(production_transition_git -C "$REPO" rev-list --parents -n 1 \
+        "$GITHUB_SHA") == "$GITHUB_SHA $stale_b0" ]] || \
+        reviewer_fail 'stale B0 recovery requires S2 to be its direct child'
+      PRODUCTION_TRANSITION_BRIDGE_BASE=$stale_b0
+    else
+      [[ -z $recovery_mode ]] || \
+        reviewer_fail 'recovery mode requires an explicit stale B0'
+      PRODUCTION_TRANSITION_BRIDGE_BASE=$remote_main
+    fi
     PRODUCTION_TRANSITION_ANCHOR_BASE=$PINNED_A0
     PRODUCTION_TRANSITION_EFFECTIVE_REVIEW_FINGERPRINT=\
 $PRODUCTION_TRANSITION_REVIEW_FINGERPRINT
@@ -80,7 +100,7 @@ $PRODUCTION_TRANSITION_TARGET_FINGERPRINT
     PRODUCTION_TRANSITION_EFFECTIVE_NOW_EPOCH=$(/usr/bin/date +%s)
     [[ ${GITHUB_REPOSITORY:-} == "$PRODUCTION_TRANSITION_REPOSITORY_ID" && \
        ${GITHUB_WORKFLOW_REF:-} == "$PRODUCTION_TRANSITION_WORKFLOW_REF" && \
-       ${GITHUB_SHA:-} == "$PRODUCTION_TRANSITION_BRIDGE_BASE" && \
+       ${GITHUB_SHA:-} == "$remote_main" && \
        ${GITHUB_EVENT_NAME:-} == workflow_dispatch && \
        ${GITHUB_RUN_ID:-} =~ ^[1-9][0-9]*$ && \
        ${GITHUB_RUN_ATTEMPT:-} =~ ^[1-9][0-9]*$ ]] || \

--- a/ops/deploy/production-transition-stale-b0-recovery.test.sh
+++ b/ops/deploy/production-transition-stale-b0-recovery.test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+PUBLISHER=$ROOT/ops/deploy/production-transition-publisher.sh
+REVIEW_WORKFLOW=$ROOT/.github/workflows/production-transition-review.yml
+PUBLISH_WORKFLOW=$ROOT/.github/workflows/production-transition-publish.yml
+
+/usr/bin/grep -Fq 'b0_sha:' "$REVIEW_WORKFLOW"
+/usr/bin/grep -Fq 'b0_sha:' "$PUBLISH_WORKFLOW"
+/usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$REVIEW_WORKFLOW"
+/usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$PUBLISH_WORKFLOW"
+/usr/bin/grep -Fq '"$S2_SHA" == "$GITHUB_SHA"' "$REVIEW_WORKFLOW"
+/usr/bin/grep -Fq 'S2 is not the sole child of exact B0' \
+  "$ROOT/ops/deploy/production-transition-canonical-lib.sh"
+/usr/bin/grep -Fq 'remote_main == "$s2"' "$PUBLISHER"
+/usr/bin/grep -Fq 'protected main moved after stale B0 recovery lease' "$PUBLISHER"
+/usr/bin/grep -Fq 'lease_main=$s2' "$PUBLISHER"
+/usr/bin/grep -Fq 'first post-B0 release requires deploy-transition with a signed target' \
+  "$ROOT/ops/deploy/production-transition-b0-host-control.sh"
+
+printf 'production stale-B0 recovery contract checks passed\n'


### PR DESCRIPTION
## Summary
- add an explicit stale-B0 recovery mode for the signed production transition
- require the recovery S2 to be the exact current protected `main` and the direct child of the supplied B0
- bind publication to the observed S2 with `force-with-lease`, preserving normal transition behavior
- add a focused recovery contract test

## Safety
The ordinary transition path is unchanged. Recovery still uses the existing review and target signing authorities, protected manifests, canonical P6/T admission, exact host B0 validation, and the trusted-host `deploy-transition` command. No production state is changed by this PR.

## Checks
- `npm run check:source-line-cap`
- `npm run check:code-quality`
- `bash ops/deploy/production-transition-stale-b0-recovery.test.sh`
- production deploy shellcheck baseline
