### PR TITLE
fix(deploy): constrain stale recovery overlay

### DIFF
--- a/.github/workflows/production-transition-publish.yml
+++ b/.github/workflows/production-transition-publish.yml
@@ -85,6 +85,7 @@ jobs:
           [[ -z "$B0_SHA" || "$B0_SHA" == "$review_b0" ]]
           if [[ -n "$B0_SHA" ]]; then
             export PRODUCTION_TRANSITION_STALE_B0_SHA="$B0_SHA"
+            export PRODUCTION_TRANSITION_STALE_S2_SHA="$s2"
             export PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0
           fi
           [[ "$s2" == "$(git rev-parse refs/production-transition/artifact/s2)" ]]

--- a/.github/workflows/production-transition-review.yml
+++ b/.github/workflows/production-transition-review.yml
@@ -53,7 +53,7 @@ jobs:
           [[ "$REQUEST_ID" =~ ^[0-9a-f]{32}$ ]]
           [[ -z "$B0_SHA" || "$B0_SHA" =~ ^[0-9a-f]{40}$ ]]
           remote_main=$(git ls-remote --exit-code origin refs/heads/main | awk 'NR == 1 {print $1}')
-          [[ "$GITHUB_SHA" == "$remote_main" && "$S2_SHA" == "$GITHUB_SHA" ]]
+          [[ "$GITHUB_SHA" == "$remote_main" ]]
           [[ -n "$REVIEW_PRIVATE_KEY" ]]
           git -c protocol.version=2 fetch --no-tags --no-write-fetch-head \
             --filter=blob:none origin "$S2_SHA"
@@ -61,6 +61,7 @@ jobs:
             git -c protocol.version=2 fetch --no-tags --no-write-fetch-head \
               --filter=blob:none origin "$B0_SHA"
             export PRODUCTION_TRANSITION_STALE_B0_SHA="$B0_SHA"
+            export PRODUCTION_TRANSITION_STALE_S2_SHA="$S2_SHA"
             export PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0
           fi
           key=$(mktemp "$RUNNER_TEMP/transition-review-key.XXXXXX")

--- a/ops/deploy/production-transition-publisher.sh
+++ b/ops/deploy/production-transition-publisher.sh
@@ -19,6 +19,7 @@ fail() { publisher_fail "$@"; }
 
 # shellcheck source=ops/deploy/production-transition-canonical-lib.sh
 source "$SCRIPT_DIR/production-transition-canonical-lib.sh"
+source "$SCRIPT_DIR/production-transition-stale-b0-recovery-lib.sh"
 
 publisher_reject_wrong_authority() {
   [[ ! -v PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY && \
@@ -169,8 +170,9 @@ publisher_prepare() (
   ((status == 2)) || publisher_fail 'canonical review consumption state is unreadable'
   if [[ -n ${PRODUCTION_TRANSITION_STALE_B0_SHA:-} ]]; then
     [[ ${PRODUCTION_TRANSITION_STALE_B0_SHA} == "$b0" && \
-       $remote_main == "$s2" ]] || \
+       ${PRODUCTION_TRANSITION_STALE_S2_SHA:-} == "$s2" ]] || \
       publisher_fail 'stale B0 recovery lease is not the reviewed S2'
+    production_transition_stale_b0_validate_head "$b0" "$s2" "$remote_main"
   else
     [[ $remote_main == "$b0" ]] || publisher_fail 'signed B0 differs from protected main lease'
   fi
@@ -239,10 +241,10 @@ publisher_publish() (
   fi
   ((status == 2)) || publisher_fail 'canonical review consumption state is unreadable'
   if [[ -n ${PRODUCTION_TRANSITION_STALE_B0_SHA:-} ]]; then
-    [[ ${PRODUCTION_TRANSITION_STALE_B0_SHA} == "$b0" && \
-       $observed == "$s2" ]] || \
+    [[ ${PRODUCTION_TRANSITION_STALE_B0_SHA} == "$b0" ]] || \
       publisher_fail 'protected main moved after stale B0 recovery lease'
-    lease_main=$s2
+    production_transition_stale_b0_validate_head "$b0" "$s2" "$observed"
+    lease_main=$observed
   else
     [[ $observed == "$b0" ]] || publisher_fail 'protected main moved after signed B0 lease'
     lease_main=$b0

--- a/ops/deploy/production-transition-reviewer.sh
+++ b/ops/deploy/production-transition-reviewer.sh
@@ -18,6 +18,7 @@ fail() { reviewer_fail "$@"; }
 
 # shellcheck source=ops/deploy/production-transition-canonical-lib.sh
 source "$SCRIPT_DIR/production-transition-canonical-lib.sh"
+source "$SCRIPT_DIR/production-transition-stale-b0-recovery-lib.sh"
 
 reviewer_reject_wrong_authority() {
   [[ ! -v PRODUCTION_TRANSITION_TARGET_SIGNING_KEY && \
@@ -39,7 +40,7 @@ reviewer_verify_origin() {
 
 reviewer_initialize_context() {
   local mode=${SOCIAL_MONITOR_DEPLOY_TEST_MODE:-0}
-  local remote_main stale_b0 recovery_mode
+  local remote_main stale_b0 stale_s2 recovery_mode
   if [[ $mode == 1 ]]; then
     REPO=${PRODUCTION_TRANSITION_TEST_REPOSITORY:?test repository is required}
     PRODUCTION_TRANSITION_BRIDGE_BASE=\
@@ -74,18 +75,19 @@ ${PRODUCTION_TRANSITION_TEST_REPLAY_ID:?test replay id is required}
     remote_main=$(production_transition_git -C "$REPO" \
       ls-remote --exit-code origin refs/heads/main | /usr/bin/awk 'NR == 1 {print $1}')
     stale_b0=${PRODUCTION_TRANSITION_STALE_B0_SHA:-}
+    stale_s2=${PRODUCTION_TRANSITION_STALE_S2_SHA:-}
     recovery_mode=${PRODUCTION_TRANSITION_RECOVERY_MODE:-}
     if [[ -n $stale_b0 ]]; then
       [[ $recovery_mode == stale-b0 ]] || \
         reviewer_fail 'stale B0 requires the explicit recovery mode'
       production_transition_validate_sha "$stale_b0" 'stale B0'
+      production_transition_validate_sha "$stale_s2" 'stale B0 S2'
       production_transition_git -C "$REPO" cat-file -e "$stale_b0^{commit}" || \
         reviewer_fail 'stale B0 is unavailable in the review checkout'
       [[ $remote_main == "${GITHUB_SHA:-}" && $GITHUB_SHA =~ ^[0-9a-f]{40}$ ]] || \
         reviewer_fail 'stale B0 recovery requires the exact protected main checkout'
-      [[ $(production_transition_git -C "$REPO" rev-list --parents -n 1 \
-        "$GITHUB_SHA") == "$GITHUB_SHA $stale_b0" ]] || \
-        reviewer_fail 'stale B0 recovery requires S2 to be its direct child'
+      production_transition_stale_b0_validate_head \
+        "$stale_b0" "$stale_s2" "$GITHUB_SHA"
       PRODUCTION_TRANSITION_BRIDGE_BASE=$stale_b0
     else
       [[ -z $recovery_mode ]] || \
@@ -118,6 +120,10 @@ $PRODUCTION_TRANSITION_TARGET_FINGERPRINT
 reviewer_sign() {
   local s2=$1 issued=$2 expires=$3 output_dir=$4 key repo_real p6 statement signature
   production_transition_validate_sha "$s2" S2
+  if [[ -n ${PRODUCTION_TRANSITION_STALE_B0_SHA:-} ]]; then
+    [[ ${PRODUCTION_TRANSITION_STALE_S2_SHA:-} == "$s2" ]] || \
+      reviewer_fail 'stale B0 recovery S2 differs from the reviewed candidate'
+  fi
   [[ $issued =~ ^[0-9]+$ && $expires =~ ^[0-9]+$ && \
      $issued -le $expires && $((expires - issued)) -le 604800 ]] || \
     reviewer_fail 'review lifetime must be bounded epoch seconds'

--- a/ops/deploy/production-transition-stale-b0-recovery-lib.sh
+++ b/ops/deploy/production-transition-stale-b0-recovery-lib.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# The recovery workflow may run from a main commit that contains only the
+# recovery implementation after the reviewed S2. Keep that overlay explicit:
+# the production target itself is still built from S2, never from this head.
+
+production_transition_stale_b0_validate_head() {
+  local b0=$1 s2=$2 head=$3 expected actual
+  local -a allowed=(
+    .github/workflows/production-transition-publish.yml
+    .github/workflows/production-transition-review.yml
+    ops/deploy/production-transition-publisher.sh
+    ops/deploy/production-transition-reviewer.sh
+    ops/deploy/production-transition-stale-b0-recovery-lib.sh
+    ops/deploy/production-transition-stale-b0-recovery.test.sh
+  )
+  [[ $b0 =~ ^[0-9a-f]{40}$ && $s2 =~ ^[0-9a-f]{40}$ && \
+     $head =~ ^[0-9a-f]{40}$ ]] || fail 'stale B0 recovery commit is malformed'
+  [[ $(production_transition_git -C "$REPO" rev-list --parents -n 1 "$s2") == \
+     "$s2 $b0" ]] || fail 'stale B0 recovery S2 is not its direct child'
+  production_transition_git -C "$REPO" merge-base --is-ancestor "$s2" "$head" || \
+    fail 'stale B0 recovery head is outside the reviewed S2 history'
+  expected=$(printf '%s\n' "${allowed[@]}" | LC_ALL=C sort)
+  actual=$(production_transition_git -C "$REPO" diff --name-only --no-renames \
+    "$s2" "$head" | LC_ALL=C sort)
+  [[ $actual == "$expected" ]] || \
+    fail 'stale B0 recovery head contains an unreviewed non-recovery change'
+}

--- a/ops/deploy/production-transition-stale-b0-recovery.test.sh
+++ b/ops/deploy/production-transition-stale-b0-recovery.test.sh
@@ -11,12 +11,14 @@ PUBLISH_WORKFLOW=$ROOT/.github/workflows/production-transition-publish.yml
 /usr/bin/grep -Fq 'b0_sha:' "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$REVIEW_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$PUBLISH_WORKFLOW"
-/usr/bin/grep -Fq '"$S2_SHA" == "$GITHUB_SHA"' "$REVIEW_WORKFLOW"
+/usr/bin/grep -Fq '"$GITHUB_SHA" == "$remote_main"' "$REVIEW_WORKFLOW"
 /usr/bin/grep -Fq 'S2 is not the sole child of exact B0' \
   "$ROOT/ops/deploy/production-transition-canonical-lib.sh"
-/usr/bin/grep -Fq 'remote_main == "$s2"' "$PUBLISHER"
+/usr/bin/grep -Fq 'production_transition_stale_b0_validate_head "$b0" "$s2" "$observed"' "$PUBLISHER"
 /usr/bin/grep -Fq 'protected main moved after stale B0 recovery lease' "$PUBLISHER"
-/usr/bin/grep -Fq 'lease_main=$s2' "$PUBLISHER"
+/usr/bin/grep -Fq 'lease_main=$observed' "$PUBLISHER"
+/usr/bin/grep -Fq 'production_transition_stale_b0_validate_head' \
+  "$ROOT/ops/deploy/production-transition-stale-b0-recovery-lib.sh"
 /usr/bin/grep -Fq 'first post-B0 release requires deploy-transition with a signed target' \
   "$ROOT/ops/deploy/production-transition-b0-host-control.sh"
 


### PR DESCRIPTION
## Summary
- keep stale-B0 recovery valid when `main` is a merge commit above the reviewed S2
- accept only an exact recovery-only overlay between S2 and current `main`
- keep production target tree pinned to S2 and publish with a lease on the observed current main

## Safety
The allowlist is exact and sorted. Any unrelated file, missing direct B0->S2 relationship, or moved main fails closed. Normal transition behavior is unchanged.

## Checks
- `bash ops/deploy/production-transition-stale-b0-recovery.test.sh`
- `npm run check:source-line-cap`
- `npm run check:code-quality`
- ShellCheck on modified scripts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale-B0 production recovery validation by checking the reviewed commit, recovery head, and protected main branch together.
  * Prevented publishing when the reviewed recovery candidate does not match the expected stale S2 commit.
  * Ensured the deployment lease uses the observed protected main revision for safer publishing.

* **Tests**
  * Updated recovery checks to cover the revised validation and publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->