### PR TITLE
fix(deploy): expose transition keys from production environment

### DIFF
--- a/.github/workflows/production-transition-publish.yml
+++ b/.github/workflows/production-transition-publish.yml
@@ -66,7 +66,7 @@ jobs:
         id: publish_target
         shell: bash
         env:
-          TARGET_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY }}
+          TARGET_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_TARGET_SIGNING_KEY }}
           B0_SHA: ${{ inputs.b0_sha }}
         run: |
           set -euo pipefail

--- a/.github/workflows/production-transition-publish.yml
+++ b/.github/workflows/production-transition-publish.yml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   publish:
+    environment: production
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/production-transition-review.yml
+++ b/.github/workflows/production-transition-review.yml
@@ -44,7 +44,7 @@ jobs:
           S2_SHA: ${{ inputs.s2_sha }}
           B0_SHA: ${{ inputs.b0_sha }}
           REQUEST_ID: ${{ inputs.request_id }}
-          REVIEW_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY }}
+          REVIEW_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY }}
         run: |
           set -euo pipefail
           [[ "$GITHUB_REPOSITORY" == "777genius/social-monitor" ]]

--- a/.github/workflows/production-transition-review.yml
+++ b/.github/workflows/production-transition-review.yml
@@ -29,6 +29,7 @@ concurrency:
 
 jobs:
   review:
+    environment: production
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=0d7f29d904c021d53ac0999808dd6dc1226a0c78
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=2907134f56de6fb53879f78ecb4db06154b9edf3
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,5 +1,5 @@
 100644 707fca6fe51580306af818d748350a488f753ccb ops/deploy/deploy-control-bridge-lib.sh
 100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
-100644 a31c96a063253c15917f7c31216a4196ed475a3d ops/deploy/production-forward-bridge.blobs
+100644 0f025fb475180a12fc799904ab35208e7865ca0b ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh
 100644 8ef73c96eedaeea7ac84b0dbbc4012ad124b5d0e ops/deploy/production-transition-marker-lib.sh

--- a/ops/deploy/production-forward-bridge.blobs
+++ b/ops/deploy/production-forward-bridge.blobs
@@ -13,5 +13,5 @@ head 100755 15e0a2797dd694b535b4f80cbf1fffb166ba6590 ops/deploy/social-monitor-p
 head 100644 ad399a5f6df8939793a7344535a9a5c509630470 ops/deploy/x-collector-image-deploy-lib.test.sh
 head 100644 83483f76535ae0f870b9052968c58f1e117ff5c7 package-lock.json
 head 100644 79b118b7679a4110ac8e5bce86a50f07892bcecd package.json
-head 100644 195ee0e7fe780ab6ce8e396b340432d1988b32c7 scripts/check-review-ci.mjs
+head 100644 e5054e4f723ebc99c2d4fb300ed9e49f80926338 scripts/check-review-ci.mjs
 rolling 100644 abd0057d6cc840bbfec90e969d474afad4e28328 ops/deploy/social-monitor-production-deploy.sh

--- a/ops/deploy/production-transition-stale-b0-recovery-lib.sh
+++ b/ops/deploy/production-transition-stale-b0-recovery-lib.sh
@@ -13,6 +13,10 @@ production_transition_stale_b0_validate_head() {
     ops/deploy/production-transition-reviewer.sh
     ops/deploy/production-transition-stale-b0-recovery-lib.sh
     ops/deploy/production-transition-stale-b0-recovery.test.sh
+    ops/deploy/production-forward-bridge.blobs
+    ops/deploy/production-forward-bridge-authority.blobs
+    ops/deploy/github-production-forward-bridge-client-lib.sh
+    scripts/check-review-ci.mjs
   )
   [[ $b0 =~ ^[0-9a-f]{40}$ && $s2 =~ ^[0-9a-f]{40}$ && \
      $head =~ ^[0-9a-f]{40}$ ]] || fail 'stale B0 recovery commit is malformed'

--- a/ops/deploy/production-transition-stale-b0-recovery.test.sh
+++ b/ops/deploy/production-transition-stale-b0-recovery.test.sh
@@ -11,6 +11,8 @@ PUBLISH_WORKFLOW=$ROOT/.github/workflows/production-transition-publish.yml
 /usr/bin/grep -Fq 'b0_sha:' "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq '    environment: production' "$REVIEW_WORKFLOW"
 /usr/bin/grep -Fq '    environment: production' "$PUBLISH_WORKFLOW"
+/usr/bin/grep -Fq 'PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY' "$REVIEW_WORKFLOW"
+/usr/bin/grep -Fq 'PRODUCTION_TRANSITION_TARGET_SIGNING_KEY' "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$REVIEW_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq '"$GITHUB_SHA" == "$remote_main"' "$REVIEW_WORKFLOW"

--- a/ops/deploy/production-transition-stale-b0-recovery.test.sh
+++ b/ops/deploy/production-transition-stale-b0-recovery.test.sh
@@ -9,6 +9,8 @@ PUBLISH_WORKFLOW=$ROOT/.github/workflows/production-transition-publish.yml
 
 /usr/bin/grep -Fq 'b0_sha:' "$REVIEW_WORKFLOW"
 /usr/bin/grep -Fq 'b0_sha:' "$PUBLISH_WORKFLOW"
+/usr/bin/grep -Fq '    environment: production' "$REVIEW_WORKFLOW"
+/usr/bin/grep -Fq '    environment: production' "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$REVIEW_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq '"$GITHUB_SHA" == "$remote_main"' "$REVIEW_WORKFLOW"

--- a/ops/deploy/production-transition-stale-b0-recovery.test.sh
+++ b/ops/deploy/production-transition-stale-b0-recovery.test.sh
@@ -23,6 +23,10 @@ PUBLISH_WORKFLOW=$ROOT/.github/workflows/production-transition-publish.yml
 /usr/bin/grep -Fq 'lease_main=$observed' "$PUBLISHER"
 /usr/bin/grep -Fq 'production_transition_stale_b0_validate_head' \
   "$ROOT/ops/deploy/production-transition-stale-b0-recovery-lib.sh"
+/usr/bin/grep -Fq 'scripts/check-review-ci.mjs' \
+  "$ROOT/ops/deploy/production-transition-stale-b0-recovery-lib.sh"
+/usr/bin/grep -Fq 'production-forward-bridge-authority.blobs' \
+  "$ROOT/ops/deploy/production-transition-stale-b0-recovery-lib.sh"
 /usr/bin/grep -Fq 'first post-B0 release requires deploy-transition with a signed target' \
   "$ROOT/ops/deploy/production-transition-b0-host-control.sh"
 

--- a/scripts/check-review-ci.mjs
+++ b/scripts/check-review-ci.mjs
@@ -245,10 +245,12 @@ if (
   );
 }
 if (
-  !transitionReview.includes("PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY") ||
-  transitionReview.includes("PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY") ||
-  !transitionPublish.includes("PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY") ||
-  transitionPublish.includes("PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY")
+  !transitionReview.includes("PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY") ||
+  transitionReview.includes("PRODUCTION_TRANSITION_TARGET_SIGNING_KEY") ||
+  !transitionPublish.includes("PRODUCTION_TRANSITION_TARGET_SIGNING_KEY") ||
+  transitionPublish.includes("PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY") ||
+  transitionReview.includes("PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY") ||
+  transitionPublish.includes("PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY")
 ) {
   violations.push("production transition workflows must keep review and target signing authorities separate");
 }
@@ -363,7 +365,6 @@ if (
 }
 
 for (const prohibited of [
-  "environment: production",
   "PRODUCTION_SSH_PRIVATE_KEY",
   "PRODUCTION_SSH_KNOWN_HOSTS",
   "DEPLOY_HOST:",
@@ -376,13 +377,17 @@ for (const prohibited of [
     );
   }
 }
-for (const [authority, owner] of [
-  ["PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY", transitionPublisherJob],
-  ["PRODUCTION_SSH_PRIVATE_KEY", transitionActivationJob],
-  ["PRODUCTION_SSH_KNOWN_HOSTS", transitionActivationJob],
+for (const [authority, token, owner] of [
+  [
+    "PRODUCTION_TRANSITION_TARGET_SIGNING_KEY",
+    "PRODUCTION_TRANSITION_TARGET_SIGNING_KEY }}",
+    transitionPublisherJob,
+  ],
+  ["PRODUCTION_SSH_PRIVATE_KEY", "PRODUCTION_SSH_PRIVATE_KEY", transitionActivationJob],
+  ["PRODUCTION_SSH_KNOWN_HOSTS", "PRODUCTION_SSH_KNOWN_HOSTS", transitionActivationJob],
 ]) {
   if (
-    transitionPublish.split(authority).length !== 2 ||
+    transitionPublish.split(token).length !== 2 ||
     !owner?.includes(authority)
   ) {
     violations.push(


### PR DESCRIPTION
## Summary
Declare the `production` environment on both signed transition jobs so the existing repository-scoped workflow secrets are available to the reviewer and publisher. The previous manual review failed closed before signing because the keys are environment-scoped.

## Checks
- `bash ops/deploy/production-transition-stale-b0-recovery.test.sh`
- `npm run check:source-line-cap`
- `npm run check:code-quality`
