### PR TITLE
fix(deploy): configure transition commit identity

### DIFF
--- a/.github/workflows/production-transition-publish.yml
+++ b/.github/workflows/production-transition-publish.yml
@@ -95,6 +95,8 @@ jobs:
           trap 'rm -f -- "$key"' EXIT
           printf '%s\n' "$TARGET_PRIVATE_KEY" > "$key"
           chmod 0600 "$key"
+          git config user.name 'social-monitor-transition-publisher'
+          git config user.email 'social-monitor-transition-publisher@users.noreply.github.com'
           PRODUCTION_TRANSITION_TARGET_SIGNING_KEY=$key \
             bash ops/deploy/production-transition-publisher.sh prepare \
               "$s2" "$p6" artifact/production-transition-review.statement \

--- a/.github/workflows/production-transition-review.yml
+++ b/.github/workflows/production-transition-review.yml
@@ -69,6 +69,8 @@ jobs:
           trap 'rm -f -- "$key"' EXIT
           printf '%s\n' "$REVIEW_PRIVATE_KEY" > "$key"
           chmod 0600 "$key"
+          git config user.name 'social-monitor-transition-review'
+          git config user.email 'social-monitor-transition-review@users.noreply.github.com'
           mkdir artifact
           issued=$(date +%s)
           expires=$((issued + 3600))

--- a/ops/deploy/production-transition-stale-b0-recovery.test.sh
+++ b/ops/deploy/production-transition-stale-b0-recovery.test.sh
@@ -13,6 +13,8 @@ PUBLISH_WORKFLOW=$ROOT/.github/workflows/production-transition-publish.yml
 /usr/bin/grep -Fq '    environment: production' "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY' "$REVIEW_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_TARGET_SIGNING_KEY' "$PUBLISH_WORKFLOW"
+/usr/bin/grep -Fq "git config user.name 'social-monitor-transition-review'" "$REVIEW_WORKFLOW"
+/usr/bin/grep -Fq "git config user.name 'social-monitor-transition-publisher'" "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$REVIEW_WORKFLOW"
 /usr/bin/grep -Fq 'PRODUCTION_TRANSITION_RECOVERY_MODE=stale-b0' "$PUBLISH_WORKFLOW"
 /usr/bin/grep -Fq '"$GITHUB_SHA" == "$remote_main"' "$REVIEW_WORKFLOW"


### PR DESCRIPTION
Configure deterministic Git identity for signed P6/T construction in transition workflows. Without this, the production environment secrets load correctly but git commit-tree fails with empty ident.