### PR TITLE
fix(summaries): restore browser-like text selection

### DIFF
--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_brief_surface.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_brief_surface.dart
@@ -122,41 +122,37 @@ class _ReaderSummaryBriefSurfaceState extends State<ReaderSummaryBriefSurface> {
         if (widget.isRefreshing) const _BriefToolbar(),
         Padding(
           padding: const EdgeInsets.all(AppSpacing.md),
-          child: SelectionArea(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _AiBriefCopy(
-                  summary: widget.summary,
-                  citationsById: widget.citationsById,
-                  onOpenUrl: widget.onOpenUrl,
-                ),
-                if (!content.topicMap.isEmpty) ...[
-                  const SizedBox(height: AppSpacing.md),
-                  ReaderSummaryDeferredTopicMapPanel(
-                    topicMap: content.topicMap,
-                  ),
-                ],
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _AiBriefCopy(
+                summary: widget.summary,
+                citationsById: widget.citationsById,
+                onOpenUrl: widget.onOpenUrl,
+              ),
+              if (!content.topicMap.isEmpty) ...[
                 const SizedBox(height: AppSpacing.md),
-                _SourceFilterChips(
-                  entries: content.sourceMix,
-                  coverage: widget.summary.coverage,
-                  selectedProviderKey: _selectedProviderKey,
-                  topReadCount: content.topReads.length,
-                  onSelected: (providerKey) {
-                    setState(() => _selectedProviderKey = providerKey);
-                  },
-                ),
-                const SizedBox(height: AppSpacing.md),
-                _FilteredEvidenceList(
-                  selectedProviderKey: _selectedProviderKey,
-                  topReads: selectedTopReads,
-                  fallbackCitations: selectedCitations,
-                  citationsById: widget.citationsById,
-                  onOpenUrl: widget.onOpenUrl,
-                ),
+                ReaderSummaryDeferredTopicMapPanel(topicMap: content.topicMap),
               ],
-            ),
+              const SizedBox(height: AppSpacing.md),
+              _SourceFilterChips(
+                entries: content.sourceMix,
+                coverage: widget.summary.coverage,
+                selectedProviderKey: _selectedProviderKey,
+                topReadCount: content.topReads.length,
+                onSelected: (providerKey) {
+                  setState(() => _selectedProviderKey = providerKey);
+                },
+              ),
+              const SizedBox(height: AppSpacing.md),
+              _FilteredEvidenceList(
+                selectedProviderKey: _selectedProviderKey,
+                topReads: selectedTopReads,
+                fallbackCitations: selectedCitations,
+                citationsById: widget.citationsById,
+                onOpenUrl: widget.onOpenUrl,
+              ),
+            ],
           ),
         ),
       ],

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_view.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_view.dart
@@ -95,52 +95,50 @@ class ReaderSummaryView extends StatelessWidget {
             ? summary.content.selectedPosts.length
             : summary.content.topReads.length);
 
-    return SelectionArea(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (isRefreshing) ...[
-            const _ReaderSummaryRefreshStatus(),
-            const SizedBox(height: AppSpacing.sm),
-          ],
-          _ExecutiveBoardCard(
-            summary: summary,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (isRefreshing) ...[
+          const _ReaderSummaryRefreshStatus(),
+          const SizedBox(height: AppSpacing.sm),
+        ],
+        _ExecutiveBoardCard(
+          summary: summary,
+          citationsById: citationsById,
+          readerActionState: readerActionState,
+          intentForAction: intentForAction,
+          onAction: onAction,
+          onOpenUrl: onOpenUrl,
+        ),
+        if (topicRecommendationState case final state?)
+          if (onTopicRecommendationDecision case final onDecision?)
+            ReaderSummaryTopicRecommendationsPanel(
+              state: state,
+              onDecision: onDecision,
+            ),
+        if (summary.content.claimBoard.isNotEmpty ||
+            summary.content.reliabilityReport.risks.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.md + 2),
+          ReaderSummaryTrustPanel(
+            claims: summary.content.claimBoard,
+            reliabilityReport: summary.content.reliabilityReport,
             citationsById: citationsById,
-            readerActionState: readerActionState,
-            intentForAction: intentForAction,
-            onAction: onAction,
             onOpenUrl: onOpenUrl,
           ),
-          if (topicRecommendationState case final state?)
-            if (onTopicRecommendationDecision case final onDecision?)
-              ReaderSummaryTopicRecommendationsPanel(
-                state: state,
-                onDecision: onDecision,
-              ),
-          if (summary.content.claimBoard.isNotEmpty ||
-              summary.content.reliabilityReport.risks.isNotEmpty) ...[
-            const SizedBox(height: AppSpacing.md + 2),
-            ReaderSummaryTrustPanel(
-              claims: summary.content.claimBoard,
-              reliabilityReport: summary.content.reliabilityReport,
-              citationsById: citationsById,
-              onOpenUrl: onOpenUrl,
-            ),
-          ],
-          if (topPostsProjection != null && !topPostsProjection.isEmpty) ...[
-            const SizedBox(height: AppSpacing.md + 2),
-            ReaderSummaryTopPosts(
-              projection: topPostsProjection,
-              selectedPostCount: selectedPostCount,
-              period: summary.period,
-              citationsById: citationsById,
-              ratingFor: topPostRatingFor,
-              onRated: onTopPostRating,
-              onOpenUrl: onOpenUrl,
-            ),
-          ],
         ],
-      ),
+        if (topPostsProjection != null && !topPostsProjection.isEmpty) ...[
+          const SizedBox(height: AppSpacing.md + 2),
+          ReaderSummaryTopPosts(
+            projection: topPostsProjection,
+            selectedPostCount: selectedPostCount,
+            period: summary.period,
+            citationsById: citationsById,
+            ratingFor: topPostRatingFor,
+            onRated: onTopPostRating,
+            onOpenUrl: onOpenUrl,
+          ),
+        ],
+      ],
     );
   }
 }

--- a/apps/frontend/features/summaries/test/presentation/pages/published_summary_page_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/pages/published_summary_page_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:social_monitor_design_system/social_monitor_design_system.dart';
 import 'package:social_monitor_shared_kernel/social_monitor_shared_kernel.dart';
@@ -80,6 +82,117 @@ void main() {
       findsNothing,
     );
   });
+
+  testWidgets('summary and top posts share browser-like copy behavior', (
+    tester,
+  ) async {
+    String? clipboardText;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardText =
+                (call.arguments as Map<Object?, Object?>)['text'] as String?;
+          }
+          return null;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null),
+    );
+
+    final summary = const SummaryMapper().readerSummaryToDomain(
+      readerSummaryApiDto(),
+    );
+    final catalog = DeferredSummaryReviewCatalog(
+      const [],
+      workspaceSummarySnapshot: WorkspaceSummarySnapshot(current: summary),
+    );
+    final store = PublishedSummaryStore(
+      scope: summaryWorkspaceScope,
+      loadLatest: LoadWorkspaceSummaryUseCase(catalog),
+      loadHistory: LoadWorkspaceSummaryHistoryUseCase(catalog),
+      loadPublished: LoadPublishedSummaryUseCase(catalog),
+      openReaderSource: const OpenReaderSourceUseCase(_SourceLauncher()),
+      summaryId: summary.id,
+    );
+    addTearDown(store.dispose);
+
+    final theme = AppTheme.light();
+    await tester.pumpWidget(
+      AppHeadlessScope(
+        theme: theme,
+        appBuilder: (overlayBuilder) => MaterialApp(
+          theme: theme,
+          builder: overlayBuilder,
+          home: SelectionArea(
+            child: Scaffold(body: PublishedSummaryPage(store: store)),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SelectionArea), findsOneWidget);
+    await _selectAndCopy(tester, find.text('AI workspace summary').first, 3);
+    expect(clipboardText, 'workspace');
+
+    final topPost = find.descendant(
+      of: find.byType(ReaderSummaryTopPostsSliver),
+      matching: find.text('AI coding tools'),
+    );
+    final scrollView = find.byKey(
+      const PageStorageKey<String>('published-summary-scroll-view'),
+    );
+    for (
+      var attempt = 0;
+      attempt < 12 && topPost.evaluate().isEmpty;
+      attempt++
+    ) {
+      await tester.drag(scrollView, const Offset(0, -500));
+      await tester.pumpAndSettle();
+    }
+    expect(topPost, findsOneWidget);
+    await tester.ensureVisible(topPost);
+    await _selectAndCopy(tester, topPost, 4);
+    expect(clipboardText, 'coding');
+  });
+}
+
+Future<void> _selectAndCopy(
+  WidgetTester tester,
+  Finder text,
+  int offset,
+) async {
+  final target = text.first;
+  final paragraph = tester.renderObject<RenderParagraph>(
+    find.descendant(of: target, matching: find.byType(RichText)).first,
+  );
+  final gesture = await tester.startGesture(
+    _textOffsetToPosition(paragraph, offset),
+  );
+  addTearDown(gesture.removePointer);
+  await tester.pump(const Duration(milliseconds: 500));
+  await gesture.up();
+  await tester.pump();
+  expect(paragraph.selections, isNotEmpty);
+  expect(paragraph.selections.single.isCollapsed, isFalse);
+
+  final platform = Theme.of(tester.element(target)).platform;
+  final modifier = platform == TargetPlatform.macOS
+      ? LogicalKeyboardKey.metaLeft
+      : LogicalKeyboardKey.controlLeft;
+  await tester.sendKeyDownEvent(modifier);
+  await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+  await tester.sendKeyUpEvent(modifier);
+  await tester.pump();
+}
+
+Offset _textOffsetToPosition(RenderParagraph paragraph, int offset) {
+  const caret = Rect.fromLTWH(0, 0, 2, 20);
+  final localOffset =
+      paragraph.getOffsetForCaret(TextPosition(offset: offset), caret) +
+      Offset(0, paragraph.preferredLineHeight);
+  return paragraph.localToGlobal(localOffset) + const Offset(0, -2);
 }
 
 final class _SourceLauncher implements ReaderSourceLauncher {


### PR DESCRIPTION
## What changed

- remove nested selection regions from Summary content
- keep Summary text and Top posts inside the single app-level selection region
- add a regression test that selects and copies text from both surfaces through the clipboard

This is intentionally separate from #129, which only adds web find-in-page.

## Verification

- `flutter test features/summaries` - 305 passed
- `flutter test --platform chrome test/presentation/pages/published_summary_page_test.dart` - 2 passed
- `flutter analyze` - no issues
- `flutter test app/test/architecture/frontend_architecture_boundaries_test.dart` - 21 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Summary content and top posts now support consistent browser-like text selection and copying.
  * Copying selected text works across the workspace summary and top-post content, including platform-appropriate keyboard shortcuts.
  * Simplified text-selection handling across summary views while preserving access to briefs, topic maps, source filters, and evidence lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->