### PR TITLE
fix(summary): enforce promotion tiers and verified stories

### DIFF
--- a/libs/feed/domain/policies/reader-promotion-policy-v2.spec-fixtures.ts
+++ b/libs/feed/domain/policies/reader-promotion-policy-v2.spec-fixtures.ts
@@ -46,7 +46,10 @@ export const xPromotionCandidate = (params: {
   },
 });
 
-export const redditPromotionCandidate = (): ReaderPromotionV2Candidate => ({
+export const redditPromotionCandidate = (params: {
+  readonly score?: number;
+  readonly upvoteRatio?: number;
+} = {}): ReaderPromotionV2Candidate => ({
   ...rankingInputs,
   candidateId: "fixture-reddit-01",
   canonicalIdentity: "fixture:reddit:01",
@@ -58,15 +61,16 @@ export const redditPromotionCandidate = (): ReaderPromotionV2Candidate => ({
     authority: socialMetricAuthority(),
     metrics: {
       provider: "reddit",
-      score: 64,
-      upvotes: 64,
-      upvoteRatio: 0.81,
+      score: params.score ?? 64,
+      upvotes: params.score ?? 64,
+      upvoteRatio: params.upvoteRatio ?? 0.81,
     },
   },
 });
 
-export const hackerNewsPromotionCandidate =
-(): ReaderPromotionV2Candidate => ({
+export const hackerNewsPromotionCandidate = (params: {
+  readonly points?: number;
+} = {}): ReaderPromotionV2Candidate => ({
   ...rankingInputs,
   candidateId: "fixture-hn-01",
   canonicalIdentity: "fixture:hacker-news:01",
@@ -76,11 +80,14 @@ export const hackerNewsPromotionCandidate =
     state: "observed",
     authoritative: true,
     authority: socialMetricAuthority(),
-    metrics: { provider: "hacker_news", points: 73 },
+    metrics: { provider: "hacker_news", points: params.points ?? 73 },
   },
 });
 
-export const githubPromotionCandidate = (): ReaderPromotionV2Candidate => ({
+export const githubPromotionCandidate = (params: {
+  readonly starsDelta?: number;
+  readonly forksDelta?: number;
+} = {}): ReaderPromotionV2Candidate => ({
   ...rankingInputs,
   candidateId: "fixture-github-01",
   canonicalIdentity: "fixture:github:01",
@@ -98,8 +105,8 @@ export const githubPromotionCandidate = (): ReaderPromotionV2Candidate => ({
       provider: "github",
       window: "24h",
       checkedAt: "2026-08-29T17:00:00.000Z",
-      starsDelta: 38,
-      forksDelta: 12,
+      starsDelta: params.starsDelta ?? 38,
+      forksDelta: params.forksDelta ?? 12,
     },
   },
 });

--- a/libs/feed/domain/policies/reader-promotion-policy-v2.spec.ts
+++ b/libs/feed/domain/policies/reader-promotion-policy-v2.spec.ts
@@ -11,20 +11,52 @@ import {
 } from "./reader-promotion-policy-v2.spec-fixtures";
 
 describe("Reader Promotion Policy V2", () => {
-  it("reports the distinct provider Top qualification without changing admission", () => {
-    const additional = evaluateReaderPromotionV2(xPromotionCandidate({
-      candidateId: "additional-floor",
-      likes: 35,
-      reposts: 0,
-    }));
-    const top = evaluateReaderPromotionV2(xPromotionCandidate({
-      candidateId: "top-floor",
-      likes: 70,
-      reposts: 0,
-    }));
+  it.each([
+    ["X weighted Additional floor", xPromotionCandidate({
+      candidateId: "x-additional", likes: 15, reposts: 10,
+    })],
+    ["Reddit score with Additional ratio", redditPromotionCandidate({
+      score: 50, upvoteRatio: 0.55,
+    })],
+    ["Hacker News Additional floor", hackerNewsPromotionCandidate({ points: 25 })],
+    ["GitHub stars Additional floor", githubPromotionCandidate({
+      starsDelta: 25, forksDelta: 0,
+    })],
+    ["GitHub forks Additional floor", githubPromotionCandidate({
+      starsDelta: 0, forksDelta: 50,
+    })],
+  ])("keeps %s out of Top", (_name, candidate) => {
+    expect(evaluateReaderPromotionV2(candidate)).toMatchObject({
+      admitted: true,
+      topQualified: false,
+    });
+  });
 
-    expect(additional).toMatchObject({ admitted: true, topQualified: false });
-    expect(top).toMatchObject({ admitted: true, topQualified: true });
+  it.each([
+    ["X likes branch at weighted Top", xPromotionCandidate({
+      candidateId: "x-top-likes", likes: 30, reposts: 20,
+    })],
+    ["X reposts branch at weighted Top", xPromotionCandidate({
+      candidateId: "x-top-reposts", likes: 28, reposts: 21,
+    })],
+    ["X exact repost threshold with weighted Top", xPromotionCandidate({
+      candidateId: "x-top-exact-reposts", likes: 50, reposts: 10,
+    })],
+    ["Reddit score and trusted-ratio Top floors", redditPromotionCandidate({
+      score: 50, upvoteRatio: 0.6,
+    })],
+    ["Hacker News Top floor", hackerNewsPromotionCandidate({ points: 50 })],
+    ["GitHub stars Top floor", githubPromotionCandidate({
+      starsDelta: 50, forksDelta: 0,
+    })],
+    ["GitHub forks Top floor", githubPromotionCandidate({
+      starsDelta: 0, forksDelta: 100,
+    })],
+  ])("admits %s into Top", (_name, candidate) => {
+    expect(evaluateReaderPromotionV2(candidate)).toMatchObject({
+      admitted: true,
+      topQualified: true,
+    });
   });
 
   it("ranks otherwise equal X posts with 11,112 likes above 89 likes", () => {

--- a/libs/feed/domain/policies/reader-promotion-policy-v2.spec.ts
+++ b/libs/feed/domain/policies/reader-promotion-policy-v2.spec.ts
@@ -11,6 +11,22 @@ import {
 } from "./reader-promotion-policy-v2.spec-fixtures";
 
 describe("Reader Promotion Policy V2", () => {
+  it("reports the distinct provider Top qualification without changing admission", () => {
+    const additional = evaluateReaderPromotionV2(xPromotionCandidate({
+      candidateId: "additional-floor",
+      likes: 35,
+      reposts: 0,
+    }));
+    const top = evaluateReaderPromotionV2(xPromotionCandidate({
+      candidateId: "top-floor",
+      likes: 70,
+      reposts: 0,
+    }));
+
+    expect(additional).toMatchObject({ admitted: true, topQualified: false });
+    expect(top).toMatchObject({ admitted: true, topQualified: true });
+  });
+
   it("ranks otherwise equal X posts with 11,112 likes above 89 likes", () => {
     const lower = xPromotionCandidate({
       candidateId: "x-lower",

--- a/libs/feed/domain/policies/reader-promotion-policy-v2.ts
+++ b/libs/feed/domain/policies/reader-promotion-policy-v2.ts
@@ -41,6 +41,7 @@ type ProviderSignal = {
   readonly admissionFloor: number;
   readonly topFloor: number;
   readonly floorMet: boolean;
+  readonly topFloorMet: boolean;
 };
 
 type EngagementResult =
@@ -66,7 +67,7 @@ export const evaluateReaderPromotionV2 = (
 
   const { signal } = engagement;
   const rawRelativePopularity = signal.value / signal.topFloor;
-  const topQualified = signal.value >= signal.topFloor;
+  const topQualified = signal.topFloorMet;
   const relativePopularity = rounded(rawRelativePopularity);
   const engagementSalience = rounded(
     rawRelativePopularity / (1 + rawRelativePopularity),
@@ -246,6 +247,8 @@ const providerSignal = (
         topFloor: 70,
         floorMet: value >= 35 &&
           (metrics.likes >= 15 || metrics.reposts >= 7),
+        topFloorMet: value >= 70 &&
+          (metrics.likes >= 30 || metrics.reposts >= 10),
       } };
     }
     case "reddit": {
@@ -271,6 +274,8 @@ const providerSignal = (
         topFloor: 50,
         floorMet: value >= 25 &&
           (metrics.upvoteRatio === undefined || metrics.upvoteRatio >= 0.55),
+        topFloorMet: value >= 50 &&
+          (metrics.upvoteRatio === undefined || metrics.upvoteRatio >= 0.6),
       } };
     }
     case "hacker_news":
@@ -283,6 +288,7 @@ const providerSignal = (
         admissionFloor: 25,
         topFloor: 50,
         floorMet: metrics.points >= 25,
+        topFloorMet: metrics.points >= 50,
       } };
     case "github": {
       if (metrics.window !== "24h" || !validCount(metrics.starsDelta) ||
@@ -298,6 +304,7 @@ const providerSignal = (
         admissionFloor: 25,
         topFloor: 50,
         floorMet: metrics.starsDelta >= 25 || metrics.forksDelta >= 50,
+        topFloorMet: metrics.starsDelta >= 50 || metrics.forksDelta >= 100,
       } };
     }
   }

--- a/libs/feed/domain/policies/reader-promotion-policy-v2.ts
+++ b/libs/feed/domain/policies/reader-promotion-policy-v2.ts
@@ -66,6 +66,7 @@ export const evaluateReaderPromotionV2 = (
 
   const { signal } = engagement;
   const rawRelativePopularity = signal.value / signal.topFloor;
+  const topQualified = signal.value >= signal.topFloor;
   const relativePopularity = rounded(rawRelativePopularity);
   const engagementSalience = rounded(
     rawRelativePopularity / (1 + rawRelativePopularity),
@@ -98,6 +99,7 @@ export const evaluateReaderPromotionV2 = (
     signalMethod: signal.method,
     providerSignal: fixed(signal.value),
     providerTopFloor: fixed(signal.topFloor),
+    topQualified,
     relativePopularity: fixed(relativePopularity),
     engagementSalience: fixed(engagementSalience),
     relevance: fixed(candidate.relevanceScore),
@@ -121,6 +123,7 @@ export const evaluateReaderPromotionV2 = (
     provider: candidate.provider,
     providerSignal: signal.value,
     providerTopFloor: signal.topFloor,
+    topQualified,
     relativePopularity,
     components,
     admissionAttestation,

--- a/libs/feed/domain/value-objects/reader-promotion-v2-candidate.ts
+++ b/libs/feed/domain/value-objects/reader-promotion-v2-candidate.ts
@@ -165,6 +165,8 @@ export type AdmittedReaderPromotionV2 = {
   readonly provider: ReaderPromotionV2Provider;
   readonly providerSignal: number;
   readonly providerTopFloor: number;
+  /** True only when the provider signal reaches the distinct Top floor. */
+  readonly topQualified: boolean;
   readonly relativePopularity: number;
   readonly components: ReaderPromotionV2ScoreComponents;
   readonly admissionAttestation: ReaderPromotionV2AdmissionAttestation;

--- a/libs/summary/adapters/eval/story-relation-golden-harness.ts
+++ b/libs/summary/adapters/eval/story-relation-golden-harness.ts
@@ -1,7 +1,6 @@
 import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
 
 import {
-  buildStoryRelationCandidates,
   evaluateStoryRelationGoldenCases,
   StoryClusteringService,
   type StoryRelationEvalPrediction,
@@ -16,7 +15,7 @@ import {
 } from "../../ports";
 import {
   observeSafeRecallShadow,
-  verifiedReaderSummaryStoryRelationPairs,
+  verifiedReaderSummaryStoryRelations,
 } from "../evidence/relevance-reader-summary-story-relation-decisions";
 import { AgentRuntimeReaderSummaryStoryRelationVerifier } from "../model/agent-runtime-reader-summary-story-relation-verifier.adapter";
 
@@ -61,11 +60,7 @@ export const runStoryRelationGoldenBaseline = async (params: {
       limit: evidence.length,
       now: observedAt,
     });
-    const primaryCandidates = buildStoryRelationCandidates({
-      selection,
-      evidence,
-    });
-    const approvedPrimaryPairs = await verifiedReaderSummaryStoryRelationPairs({
+    const authoritative = await verifiedReaderSummaryStoryRelations({
       query,
       evidence,
       deterministicSelection: selection,
@@ -80,13 +75,13 @@ export const runStoryRelationGoldenBaseline = async (params: {
       requestedAt: observedAt,
       verifier,
       metrics: NOOP_STORY_RANKING_METRICS,
-      primaryCandidates,
+      primaryCandidates: authoritative.candidates,
     });
     predictions.push({
       caseId: evalCase.caseId,
       sameStory:
         deterministicPairMerged(selection, evalCase.caseId) ||
-        approvedPrimaryPairs.size > 0 ||
+        authoritative.pairs.size > 0 ||
         traces.some((trace) => trace.wouldApprove),
     });
   }

--- a/libs/summary/adapters/eval/story-relation-golden.fixtures.spec.ts
+++ b/libs/summary/adapters/eval/story-relation-golden.fixtures.spec.ts
@@ -54,7 +54,7 @@ describe("story relation golden eval", () => {
     expect(serializedTranscripts).not.toContain("positive");
   });
 
-  it("evaluates shadow wouldApprove traces through the strict production adapter", async () => {
+  it("evaluates authoritative candidates once through the production adapter", async () => {
     const client = new RecordedGoldenAgentRuntimeClient();
     const result = await runStoryRelationGoldenBaseline({
       datasetVersion: STORY_RELATION_GOLDEN_DATASET_VERSION,
@@ -78,15 +78,11 @@ describe("story relation golden eval", () => {
       "claude-code-watermark-question-and-announcement",
     );
     expect(client.primaryRequestedCaseIds).toEqual([
+      "cursor-spacex-deployment",
       "anthropic-watermark-announcement-and-explainer",
       "claude-code-watermark-question-and-announcement",
     ]);
-    expect(client.shadowRequestedCaseIds).toEqual([
-      "cursor-spacex-deployment",
-    ]);
-    expect(client.shadowRequestedCaseIds).not.toContain(
-      "anthropic-watermark-announcement-and-explainer",
-    );
+    expect(client.shadowRequestedCaseIds).toEqual([]);
   });
 
   it("omits undefined precision and recall denominators", () => {

--- a/libs/summary/adapters/evidence/reader-summary-editorial-slate.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-editorial-slate.spec.ts
@@ -24,6 +24,20 @@ describe("Reader Promotion V2 editorial slate", () => {
     expect(slate.orderedCandidateIds).toEqual(["x-11112", "x-89"]);
   });
 
+  it("keeps an Additional-floor candidate out of Top", () => {
+    const additionalOnly = xEvidence("x-additional-floor", 35);
+    const slate = compose([additionalOnly]);
+
+    expect(slate.top).toEqual([]);
+    expect(slate.additional).toEqual([
+      expect.objectContaining({
+        candidateId: "x-additional-floor",
+        placement: "additional",
+        reasonCodes: expect.arrayContaining(["top_floor_not_met"]),
+      }),
+    ]);
+  });
+
   it("moves Top overflow into Additional without admitting junk", () => {
     const items = Array.from({ length: 9 }, (_, index) =>
       xEvidence(`x-${index + 1}`, 1_000 - index));
@@ -37,6 +51,9 @@ describe("Reader Promotion V2 editorial slate", () => {
     expect(slate.additional[0]?.reasonCodes).toContain(
       "top_capacity_overflow",
     );
+    expect(slate.top.every((entry) =>
+      entry.candidateId !== "x-9",
+    )).toBe(true);
   });
 
   it("rejects a viral irrelevant candidate instead of filling a slot", () => {
@@ -51,6 +68,21 @@ describe("Reader Promotion V2 editorial slate", () => {
     expect(slate.excluded).toContainEqual(expect.objectContaining({
       candidateId: "viral-irrelevant",
       reasonCodes: expect.arrayContaining(["relevance_floor_not_met"]),
+    }));
+  });
+
+  it("keeps a deterministic empty slate when no candidate reaches admission", () => {
+    const belowAdmission = xEvidence("x-no-signal", 34);
+
+    const first = compose([belowAdmission]);
+    const replay = compose([belowAdmission]);
+
+    expect(first.top).toEqual([]);
+    expect(first.additional).toEqual([]);
+    expect(first.digestMaterial).toBe(replay.digestMaterial);
+    expect(first.excluded).toContainEqual(expect.objectContaining({
+      candidateId: "x-no-signal",
+      reasonCodes: ["provider_floor_not_met"],
     }));
   });
 

--- a/libs/summary/adapters/evidence/reader-summary-editorial-slate.ts
+++ b/libs/summary/adapters/evidence/reader-summary-editorial-slate.ts
@@ -48,22 +48,25 @@ export const composeReaderSummaryEditorialSlate = (params: {
     ranked: ranking.ranked,
     semanticStoryIdByEvidenceId,
   });
+  const topQualifiedRepresentatives = representatives.filter(
+    (candidate) => candidate.topQualified,
+  );
   const activeProviderCount = new Set(
-    representatives.map((candidate) => candidate.provider),
+    topQualifiedRepresentatives.map((candidate) => candidate.provider),
   ).size;
   const providerCap = readerPostPromotionTopProviderCap(activeProviderCount);
   const top: AdmittedReaderPromotionV2[] = [];
   const topIds = new Set<string>();
   const topProviderCounts = new Map<ReaderPromotionV2Provider, number>();
 
-  for (const candidate of representatives) {
+  for (const candidate of topQualifiedRepresentatives) {
     if (top.length >= topLimit) break;
     if ((topProviderCounts.get(candidate.provider) ?? 0) > 0) continue;
     top.push(candidate);
     topIds.add(candidate.candidateId);
     topProviderCounts.set(candidate.provider, 1);
   }
-  for (const candidate of representatives) {
+  for (const candidate of topQualifiedRepresentatives) {
     if (top.length >= topLimit) break;
     if (topIds.has(candidate.candidateId)) continue;
     const providerCount = topProviderCounts.get(candidate.provider) ?? 0;
@@ -97,9 +100,11 @@ export const composeReaderSummaryEditorialSlate = (params: {
     reasonCodes: [
       "reader_promotion_v2_admitted",
       "semantic_story_representative",
-      (topProviderCounts.get(candidate.provider) ?? 0) >= providerCap
-        ? "top_provider_cap_overflow"
-        : "top_capacity_overflow",
+      !candidate.topQualified
+        ? "top_floor_not_met"
+        : ((topProviderCounts.get(candidate.provider) ?? 0) >= providerCap
+            ? "top_provider_cap_overflow"
+            : "top_capacity_overflow"),
       "additional_slot_assigned",
     ],
   }));

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
@@ -122,6 +122,12 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
     });
     const promotionPolicyItems = primaryCandidateItems.filter((item) =>
       promotionCandidateIds.has(item.feedItemId));
+    const additionalRelationCandidates = promotionSupportCandidates({
+      evidence: primaryCandidateItems,
+      clusters: candidateSelection.clusters,
+      leadIds: promotionCandidateIds,
+      promotionCandidateIds,
+    });
     const approvedRelations = await verifiedReaderSummaryStoryRelations({
       query,
       evidence: primaryCandidateItems,
@@ -129,12 +135,7 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
       requestedAt: ingestionCutoff,
       verifier: this.storyRelationVerifier,
       metrics: this.storyRankingMetrics,
-      additionalCandidates: promotionSupportCandidates({
-        evidence: primaryCandidateItems,
-        clusters: candidateSelection.clusters,
-        leadIds: promotionCandidateIds,
-        promotionCandidateIds,
-      }),
+      additionalCandidates: additionalRelationCandidates,
     });
     const authoritativeCandidateSelection = this.clusterer.cluster({
       identity: {
@@ -229,6 +230,7 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
       requestedAt: ingestionCutoff,
       verifier: this.storyRelationVerifier,
       metrics: this.storyRankingMetrics,
+      authoritativeCandidates: approvedRelations.candidates,
     });
     return personalizedSelection;
   }

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
@@ -136,12 +136,39 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
         promotionCandidateIds,
       }),
     });
-    // Model/agent relation decisions are retained as narrative evidence, but
-    // the publication slate is composed only from deterministic clustering.
+    const authoritativeCandidateSelection = this.clusterer.cluster({
+      identity: {
+        tenantId: params.tenantId,
+        workspaceId: params.workspaceId,
+        scope: params.scope,
+      },
+      items: primaryCandidateItems,
+      limit: primaryCandidateItems.length,
+      now: ingestionCutoff,
+      verifiedStoryRelationPairs: approvedRelations.pairs,
+      verifiedStrictTitleRelationPairs: approvedRelations.strictTitlePairs,
+    });
+    const authoritativeClusterByEvidenceId = new Map<string, string>();
+    for (const cluster of authoritativeCandidateSelection.clusters) {
+      for (const feedItemId of [
+        cluster.representativeFeedItemId,
+        ...cluster.duplicateFeedItemIds,
+      ]) {
+        authoritativeClusterByEvidenceId.set(feedItemId, cluster.id);
+      }
+    }
+    const graduatedRelations = approvedRelations.relations.filter(
+      (relation) =>
+        authoritativeClusterByEvidenceId.get(relation.leftFeedItemId) !==
+          undefined &&
+        authoritativeClusterByEvidenceId.get(relation.leftFeedItemId) ===
+          authoritativeClusterByEvidenceId.get(relation.rightFeedItemId),
+    );
     const deterministicPromotionSelection = promotionPolicySelection({
-      ...candidateSelection,
+      ...authoritativeCandidateSelection,
+      approvedSameStoryRelations: graduatedRelations,
       sourceWindow: {
-        ...candidateSelection.sourceWindow,
+        ...authoritativeCandidateSelection.sourceWindow,
         periodStartedAt: params.period.startedAt,
         periodEndedAt: params.period.endedAt,
         ingestionCutoff,
@@ -156,17 +183,13 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
       slate: editorialSlate,
       supplementalEvidence: githubTrendingEvidence,
     });
-    const annotatedPromotionSelection = {
-      ...deterministicPromotionSelection,
-      approvedSameStoryRelations: approvedRelations.relations,
-    };
     const relatedTopicRelations = await verifiedReaderSummaryRelatedTopics({
       query,
       // Related-topic verification needs the bounded context candidates that
       // ranking rejected from the immutable publication slate. The returned
       // relation is metadata only; finalSelection still keeps those subjects
       // out of model evidence and reader-visible promotion cards.
-      selection: annotatedPromotionSelection,
+      selection: deterministicPromotionSelection,
       requestedAt: ingestionCutoff,
       verifier: this.storyRelationVerifier,
       metrics: this.storyRankingMetrics,
@@ -175,7 +198,7 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
     });
     const personalizedSelection = {
       ...deterministicFinalSelection,
-      approvedSameStoryRelations: approvedRelations.relations,
+      approvedSameStoryRelations: graduatedRelations,
       relatedTopicRelations,
       personalization:
         ranked.value.memoryGuidance === undefined

--- a/libs/summary/adapters/evidence/relevance-reader-summary-fresh-relation-composition.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-fresh-relation-composition.spec.ts
@@ -1,0 +1,150 @@
+import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import type { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
+import type { RankedFeedItemView } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.result";
+import { ok, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+
+import { NOOP_STORY_RANKING_METRICS } from "../../ports";
+import { authoritativeReaderSummaryProviderMetadata } from
+  "../../test-fixtures/reader-summary-authoritative-provider-metadata.fixture";
+import { RelevanceReaderSummaryEvidenceSelector } from
+  "./relevance-reader-summary-evidence.selector";
+
+const now = new Date("2026-07-11T12:00:00.000Z");
+const period = {
+  cadence: "daily" as const,
+  startedAt: new Date("2026-07-11T00:00:00.000Z"),
+  endedAt: new Date("2026-07-12T00:00:00.000Z"),
+  timezone: "UTC",
+  periodKey: "2026-07-11",
+};
+
+describe("fresh daily approved story relation composition", () => {
+  it.each([
+    [
+      "Cursor and SpaceX deployment",
+      "Cursor deployed at SpaceX",
+      "SpaceX deploying Cursor",
+    ],
+    [
+      "strong Claude watermark report",
+      "Claude's snippets are watermarked",
+      "Watermarking Claude Code output",
+    ],
+  ])("groups an approved %s before composing the slate", async (
+    _caseName,
+    xTitle,
+    hackerNewsTitle,
+  ) => {
+    const selection = await selectFreshPair(xTitle, hackerNewsTitle);
+
+    expect(selection.clusters).toHaveLength(1);
+    expect(selection.clusters[0]?.providerKeys).toEqual([
+      "hacker-news",
+      "x-twitter",
+    ]);
+    expect(selection.editorialSlate?.orderedCandidateIds).toEqual(["hn"]);
+    expect(selection.approvedSameStoryRelations).toHaveLength(1);
+    const relation = selection.approvedSameStoryRelations?.[0];
+    expect([
+      relation?.leftFeedItemId,
+      relation?.rightFeedItemId,
+    ].sort()).toEqual(["hn", "x"]);
+  });
+});
+
+const selectFreshPair = (
+  xTitle: string,
+  hackerNewsTitle: string,
+) => new RelevanceReaderSummaryEvidenceSelector(
+  ranker([
+    ranked("x", "x-twitter", 2, xTitle),
+    ranked("hn", "hacker-news", 1.9, hackerNewsTitle),
+  ]),
+  emptyFeedRepository(),
+  { now: () => now },
+  NOOP_STORY_RANKING_METRICS,
+  {
+    verify: async (input) => input.candidates.map((candidate) => ({
+      leftFeedItemId: candidate.leftFeedItemId,
+      rightFeedItemId: candidate.rightFeedItemId,
+      sameStory: true,
+      confidenceScore: 0.99,
+    })),
+  },
+).select({
+  tenantId: tenantId("tenant-fresh-relation"),
+  workspaceId: workspaceId("workspace-fresh-relation"),
+  scope: { type: "workspace" },
+  period,
+  maxItems: 2,
+});
+
+const ranker = (items: readonly RankedFeedItemView[]): RankFeedItemsUseCase =>
+  ({
+    execute: async () => ok({
+      generatedAt: now.toISOString(),
+      profileApplied: false,
+      items,
+    }),
+  }) as unknown as RankFeedItemsUseCase;
+
+const emptyFeedRepository = (): FeedItemReadRepositoryPort => ({
+  readPromotionSnapshot: async () => ({
+    ok: true,
+    candidates: [],
+    sourceContent: [],
+    physicalRowsRead: 0,
+    exhausted: true,
+  }),
+  list: async () => ({ items: [] }),
+  findById: async () => null,
+});
+
+const ranked = (
+  id: string,
+  providerKey: "x-twitter" | "hacker-news",
+  score: number,
+  title: string,
+): RankedFeedItemView => ({
+  feedItemId: id,
+  sourceItemId: `source-${id}`,
+  sourceBindingId: `binding-${providerKey}`,
+  interestId: "interest-ai",
+  providerKey,
+  providerMetadata: authoritativeReaderSummaryProviderMetadata(
+    providerKey,
+    120,
+  ),
+  canonicalUrl: `https://${providerKey}.example.test/${id}`,
+  title,
+  bodyPreview: "Independent bounded source evidence.",
+  publishedAt: "2026-07-11T08:00:00.000Z",
+  observedAt: "2026-07-11T08:01:00.000Z",
+  engagementAuthority: {
+    observedAt: "2026-07-11T11:30:00.000Z",
+    regressionState: "stable",
+  },
+  score,
+  rank: id === "x" ? 1 : 2,
+  clusterId: `rank-cluster-${id}`,
+  clusterSize: 1,
+  duplicateFeedItemIds: [],
+  whyImportant: ["Relevant today"],
+  safety: {
+    status: "allowed",
+    categories: ["normalized_preview_only"],
+    rawPayloadRetained: false,
+    retentionPolicy: "normalized_preview_only",
+  },
+  contentQuality: {
+    qualityScore: 0.9,
+    interestRelevanceScore: 0.9,
+    engagementIntegrityScore: 0.8,
+    eligibleForSummary: true,
+    eligibleForTopRead: true,
+    needsLlmReview: false,
+    decision: "promote",
+    flags: [],
+    reason: "Strong fixture evidence",
+  },
+});

--- a/libs/summary/adapters/evidence/relevance-reader-summary-promotion-candidates.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-promotion-candidates.ts
@@ -58,6 +58,7 @@ export const promotionPolicySelection = (
     },
     selectedEvidence: items,
     clusters,
+    approvedSameStoryRelations: base.approvedSameStoryRelations,
   };
 };
 

--- a/libs/summary/adapters/evidence/relevance-reader-summary-scan-exhaustion.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-scan-exhaustion.spec.ts
@@ -267,6 +267,8 @@ describe("reader-summary promotion upstream scan exhaustion", () => {
       workspaceId: workspace,
       providerKey: "x-twitter",
       title: "Agent runtime transaction snapshot launches",
+      canonicalUrl:
+        "https://x.fixture.test/original/authoritative-winner-below-caps",
       publishedAt: new Date("2026-08-18T08:00:00.000Z"),
       providerMetadata: {
         kind: "x_post",
@@ -286,6 +288,8 @@ describe("reader-summary promotion upstream scan exhaustion", () => {
       workspaceId: workspace,
       providerKey: "hacker-news",
       title: "Agent runtime transaction snapshot launches",
+      canonicalUrl:
+        "https://hn.fixture.test/item/independent-support-below-caps",
       publishedAt: new Date("2026-08-18T07:59:00.000Z"),
       providerMetadata: {
         kind: "hacker_news_story",
@@ -348,14 +352,10 @@ describe("reader-summary promotion upstream scan exhaustion", () => {
     expect(projection.topReads[0]?.promotionCandidateId)
       .toBe("authoritative-winner-below-caps");
     expect(projection.topReads[0]?.citationIds)
-      .toEqual(["citation:authoritative-winner-below-caps"]);
-    const independentlyRankedSupport = [
-      ...projection.topReads,
-      ...projection.additionalPosts,
-    ].find((item) =>
-      item.promotionCandidateId === "independent-support-below-caps");
-    expect(independentlyRankedSupport?.citationIds)
-      .toEqual(["citation:independent-support-below-caps"]);
+      .toEqual([
+        "citation:authoritative-winner-below-caps",
+        "citation:independent-support-below-caps",
+      ]);
     expect(selection.selectedEvidence.map((item) => item.feedItemId))
       .toEqual(expect.arrayContaining([
         "authoritative-winner-below-caps",
@@ -498,6 +498,7 @@ const publishOriginal = (
     readonly workspaceId: ReturnType<typeof workspaceId>;
     readonly providerKey: string;
     readonly title: string;
+    readonly canonicalUrl?: string;
     readonly publishedAt: Date;
     readonly providerMetadata: JsonObject;
   },
@@ -506,7 +507,8 @@ const publishOriginal = (
   interestId: "interest-ai",
   sourceItemId: `${params.id}:source`,
   sourceBindingId: `${params.id}:binding`,
-  canonicalUrl: `https://fixture.test/original/${params.id}`,
+  canonicalUrl:
+    params.canonicalUrl ?? `https://fixture.test/original/${params.id}`,
   bodyPreview: "Original release evidence eligible for reader promotion.",
   observedAt: new Date(params.publishedAt.getTime() + 60_000),
 }));

--- a/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-decisions.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-decisions.ts
@@ -1,5 +1,6 @@
 import {
   aggregateStoryRelationDecisionTraces,
+  buildBoundedStrictTitleStoryRelationCandidates,
   buildStoryRelationCandidates,
   buildStoryRelationSafeRecallShadowCandidates,
   reconcileStoryRelationDecisions,
@@ -43,20 +44,37 @@ export const verifiedReaderSummaryStoryRelations = async (params: {
   readonly additionalCandidates?: readonly StoryRelationCandidate[];
 }): Promise<{
   readonly pairs: ReadonlySet<string>;
+  readonly strictTitlePairs: ReadonlySet<string>;
   readonly relations: readonly ApprovedSameStoryRelation[];
 }> => {
-  const candidates = uniqueCandidates([
-    ...buildStoryRelationCandidates({
+  const primaryCandidates = buildStoryRelationCandidates({
     selection: params.deterministicSelection,
     evidence: params.evidence,
-    }),
+  });
+  const strictTitleRecallCandidates =
+    buildBoundedStrictTitleStoryRelationCandidates({
+      selection: params.deterministicSelection,
+      evidence: params.evidence,
+      primaryCandidates,
+    });
+  const candidates = uniqueCandidates([
+    ...primaryCandidates,
+    ...strictTitleRecallCandidates,
     ...(params.additionalCandidates ?? []),
   ]);
   const result = await verifiedPrimaryStoryRelations({
     ...params,
     candidates,
   });
-  return result;
+  const strictTitlePairIds = new Set(
+    strictTitleRecallCandidates.map(candidatePairKey),
+  );
+  return {
+    ...result,
+    strictTitlePairs: new Set(
+      [...result.pairs].filter((pairId) => strictTitlePairIds.has(pairId)),
+    ),
+  };
 };
 
 const uniqueCandidates = (
@@ -64,12 +82,15 @@ const uniqueCandidates = (
 ): readonly StoryRelationCandidate[] => {
   const byPair = new Map<string, StoryRelationCandidate>();
   for (const candidate of candidates) {
-    const key = [candidate.leftFeedItemId, candidate.rightFeedItemId]
-      .sort().join("\u0000");
+    const key = candidatePairKey(candidate);
     if (!byPair.has(key)) byPair.set(key, candidate);
   }
   return [...byPair.values()];
 };
+
+const candidatePairKey = (candidate: StoryRelationCandidate): string =>
+  [candidate.leftFeedItemId, candidate.rightFeedItemId]
+    .sort().join("\u0000");
 
 export const scheduleReaderSummarySafeRecallShadowObservation = (params: {
   readonly query: Parameters<ReaderSummaryEvidenceSelectorPort["select"]>[0];

--- a/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-decisions.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-decisions.ts
@@ -46,6 +46,7 @@ export const verifiedReaderSummaryStoryRelations = async (params: {
   readonly pairs: ReadonlySet<string>;
   readonly strictTitlePairs: ReadonlySet<string>;
   readonly relations: readonly ApprovedSameStoryRelation[];
+  readonly candidates: readonly StoryRelationCandidate[];
 }> => {
   const primaryCandidates = buildStoryRelationCandidates({
     selection: params.deterministicSelection,
@@ -71,6 +72,7 @@ export const verifiedReaderSummaryStoryRelations = async (params: {
   );
   return {
     ...result,
+    candidates,
     strictTitlePairs: new Set(
       [...result.pairs].filter((pairId) => strictTitlePairIds.has(pairId)),
     ),
@@ -99,14 +101,11 @@ export const scheduleReaderSummarySafeRecallShadowObservation = (params: {
   readonly requestedAt: Date;
   readonly verifier?: ReaderSummaryStoryRelationVerifierPort;
   readonly metrics: StoryRankingMetricsPort;
+  readonly authoritativeCandidates: readonly StoryRelationCandidate[];
 }): void => {
-  const primaryCandidates = buildStoryRelationCandidates({
-    selection: params.deterministicSelection,
-    evidence: params.evidence,
-  });
   scheduleSafeRecallShadow(() => observeSafeRecallShadow({
     ...params,
-    primaryCandidates,
+    primaryCandidates: params.authoritativeCandidates,
   }));
 };
 

--- a/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-verification.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-verification.spec.ts
@@ -466,7 +466,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     )).toBe(true);
   });
 
-  it("observes corroboration rejected by the authoritative slate in shadow", async () => {
+  it("does not reverify an authoritative strict-title candidate in shadow", async () => {
     const verifier = new ApprovingVerifier();
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       ranker([
@@ -503,23 +503,17 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     expect(selection.selectedEvidence.map((item) => item.feedItemId)).toEqual([
       "cursor-selected",
     ]);
-    expect(verifier.inputs).toHaveLength(2);
-    expect(verifier.inputs.find((input) =>
-      input.verificationLane === "safe_recall_shadow",
-    )).toMatchObject({
-      verificationLane: "safe_recall_shadow",
-      evidence: expect.arrayContaining([
-        expect.objectContaining({ feedItemId: "cursor-selected" }),
-        expect.objectContaining({ feedItemId: "cursor-dropped" }),
-      ]),
-      candidates: [expect.objectContaining({
+    expect(verifier.inputs).toHaveLength(1);
+    expect(verifier.inputs[0]).not.toHaveProperty("verificationLane");
+    expect(verifier.inputs[0]?.candidates).toEqual([
+      expect.objectContaining({
         leftFeedItemId: "cursor-dropped",
         rightFeedItemId: "cursor-selected",
-      })],
-    });
+      }),
+    ]);
   });
 
-  it("returns production selection without awaiting a bounded shadow verifier", async () => {
+  it("does not schedule detached shadow work for an authoritative pair", async () => {
     const verifier = new DeferredShadowVerifier();
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       ranker([
@@ -550,14 +544,10 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
 
     expect(selection.clusters).toHaveLength(1);
     await settleDetachedShadow();
-    expect(verifier.input).toMatchObject({
-      verificationLane: "safe_recall_shadow",
-      timeoutMs: 30_000,
-    });
-    verifier.complete();
+    expect(verifier.input).toBeUndefined();
   });
 
-  it("records a weak Reddit watermark candidate as not approved", async () => {
+  it("records a weak Reddit watermark candidate as not approved once", async () => {
     const metrics = new CapturingMetrics();
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       ranker([
@@ -597,12 +587,13 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     await settleDetachedShadow();
 
     expect(selection.clusters).toHaveLength(2);
-    expect(metrics.shadowDecisionAggregates).toContainEqual(
+    expect(metrics.relationAggregates).toContainEqual(
       expect.objectContaining({
         disposition: "rejected_same_story_false",
         count: 1,
       }),
     );
+    expect(metrics.shadowDecisionAggregates).toEqual([]);
   });
 
   it("keeps telemetry exceptions outside the relation decision path", async () => {

--- a/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-verification.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-verification.spec.ts
@@ -39,7 +39,7 @@ const settleDetachedShadow = async (): Promise<void> => {
 };
 
 describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
-  it("retains approved cross-provider pairs as annotation-only evidence", async () => {
+  it("reclusters approved cross-provider pairs before slate composition", async () => {
     const verifier = new ApprovingVerifier();
     const metrics = new CapturingMetrics();
     const selector = new RelevanceReaderSummaryEvidenceSelector(
@@ -64,11 +64,11 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
 
     expect(verifier.inputs).toHaveLength(1);
     expect(verifier.inputs[0]?.candidates).toHaveLength(1);
-    expect(selection.clusters).toHaveLength(2);
+    expect(selection.clusters).toHaveLength(1);
     expect(selection.clusters.map((cluster) => cluster.providerKeys)).toEqual([
-      ["hacker-news"],
-      ["x-twitter"],
+      ["hacker-news", "x-twitter"],
     ]);
+    expect(selection.editorialSlate?.orderedCandidateIds).toEqual(["hn"]);
     expect(selection.approvedSameStoryRelations).toEqual([{
       leftFeedItemId: "hn",
       rightFeedItemId: "rss",
@@ -90,8 +90,22 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     );
   });
 
-  it("keeps deterministic clusters when the verifier fails", async () => {
+  it("keeps clusters separate when execution attestation fails", async () => {
     const metrics = new CapturingMetrics();
+    const verifier = new AgentRuntimeReaderSummaryStoryRelationVerifier({
+      client: new RecordedAgentRuntimeClient({
+        status: "completed",
+        structuredOutput: {
+          decisions: [{
+            leftFeedItemId: "hn",
+            rightFeedItemId: "rss",
+            sameStory: true,
+            confidenceScore: 0.99,
+          }],
+        },
+        warnings: [],
+      }, false),
+    });
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       ranker([
         ranked("hn", "hacker-news", 2),
@@ -100,11 +114,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
       emptyFeedRepository(),
       { now: () => now },
       metrics,
-      {
-        verify: async () => {
-          throw new Error("runtime unavailable");
-        },
-      },
+      verifier,
     );
 
     const selection = await selector.select({
@@ -129,6 +139,34 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
         count: 1,
       }),
     ]);
+  });
+
+  it("keeps clusters separate when relation verification times out", async () => {
+    const selector = new RelevanceReaderSummaryEvidenceSelector(
+      ranker([
+        ranked("hn", "hacker-news", 2),
+        ranked("rss", "x-twitter", 1.9),
+      ]),
+      emptyFeedRepository(),
+      { now: () => now },
+      new CapturingMetrics(),
+      {
+        verify: async () => {
+          throw new Error("verification timed out");
+        },
+      },
+    );
+
+    const selection = await selector.select({
+      tenantId: tenantId("tenant-story-verification-timeout"),
+      workspaceId: workspaceId("workspace-story-verification-timeout"),
+      scope: { type: "workspace" },
+      period,
+      maxItems: 2,
+    });
+
+    expect(selection.clusters).toHaveLength(2);
+    expect(selection.approvedSameStoryRelations).toEqual([]);
   });
 
   it("applies mixed approve and reject decisions through the runtime adapter and selector", async () => {
@@ -193,9 +231,9 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     });
 
     expect(verifier.preconditionChecked).toBe(true);
-    expect(selection.clusters).toHaveLength(4);
+    expect(selection.clusters).toHaveLength(3);
     expect(selection.clusters.map((cluster) => cluster.providerKeys))
-      .not.toContainEqual(["hacker-news", "x-twitter"]);
+      .toContainEqual(["hacker-news", "x-twitter"]);
     expect(metrics.relationMetrics).toContainEqual({
       status: "completed",
       candidateCount: 2,
@@ -289,7 +327,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     },
   );
 
-  it("keeps verified narrative partners outside immutable-slate authority", async () => {
+  it("uses verified partners in immutable-slate authority", async () => {
     const hn = ranked("hn", "hacker-news", 2.2);
     const unrelatedRss = {
       ...ranked("rss-unrelated", "x-twitter", 2.1),
@@ -330,10 +368,9 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     ]);
     expect(selection.editorialSlate?.orderedCandidateIds).toEqual([
       "hn",
-      "rss-related",
       "rss-unrelated",
     ]);
-    expect(selection.clusters).toHaveLength(3);
+    expect(selection.clusters).toHaveLength(2);
     expect(selection.approvedSameStoryRelations).toContainEqual({
       leftFeedItemId: "hn",
       rightFeedItemId: "rss-related",
@@ -341,7 +378,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     });
   });
 
-  it("produces byte-identical lanes, order, and digest for contradictory verifier outputs", async () => {
+  it("changes slate membership only for an approved relation", async () => {
     const items = [
       ranked("hn", "hacker-news", 2),
       ranked("rss", "x-twitter", 1.9),
@@ -378,8 +415,13 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
       digestMaterial: selection.editorialSlate?.digestMaterial,
     });
 
-    expect(JSON.stringify(immutableAuthority(approved))).toBe(
-      JSON.stringify(immutableAuthority(rejected)),
+    expect(immutableAuthority(approved).orderedCandidateIds).toEqual(["hn"]);
+    expect(immutableAuthority(rejected).orderedCandidateIds).toEqual([
+      "hn",
+      "rss",
+    ]);
+    expect(immutableAuthority(approved).digestMaterial).not.toBe(
+      immutableAuthority(rejected).digestMaterial,
     );
     expect(approved.approvedSameStoryRelations).toHaveLength(1);
     expect(rejected.approvedSameStoryRelations).toEqual([]);
@@ -424,59 +466,6 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     )).toBe(true);
   });
 
-  it("verifies a secondary Cursor candidate in shadow without production union", async () => {
-    const metrics = new CapturingMetrics();
-    const verifier = new ApprovingVerifier();
-    const selector = new RelevanceReaderSummaryEvidenceSelector(
-      ranker([
-        {
-          ...ranked("cursor-announcement", "x-twitter", 2),
-          title: "Cursor deployed at SpaceX",
-          bodyPreview: "Official customer story with unrelated prose.",
-        },
-        {
-          ...ranked("cursor-coverage", "hacker-news", 1.9),
-          title: "SpaceX deploying Cursor",
-          bodyPreview: "HN wrapper metadata without copied article text.",
-        },
-      ]),
-      emptyFeedRepository(),
-      { now: () => now },
-      metrics,
-      verifier,
-    );
-
-    const selection = await selector.select({
-      tenantId: tenantId("tenant-safe-recall-shadow"),
-      workspaceId: workspaceId("workspace-safe-recall-shadow"),
-      scope: { type: "workspace" },
-      period,
-      maxItems: 2,
-    });
-    await settleDetachedShadow();
-
-    expect(verifier.inputs).toHaveLength(1);
-    expect(verifier.inputs[0]?.verificationLane).toBe("safe_recall_shadow");
-    expect(selection.clusters).toHaveLength(2);
-    expect(selection.clusters.every((cluster) =>
-      cluster.duplicateFeedItemIds.length === 0,
-    )).toBe(true);
-    expect(metrics.shadowGenerationAggregates).toContainEqual(
-      expect.objectContaining({
-        reasonCode: "title_normalized_entity_event_evidence",
-        count: 1,
-      }),
-    );
-    expect(metrics.shadowDecisionAggregates).toContainEqual(
-      expect.objectContaining({ disposition: "approved", count: 1 }),
-    );
-    expect(metrics.relationMetrics).toContainEqual({
-      status: "skipped",
-      candidateCount: 0,
-      approvedCount: 0,
-    });
-  });
-
   it("observes corroboration rejected by the authoritative slate in shadow", async () => {
     const verifier = new ApprovingVerifier();
     const selector = new RelevanceReaderSummaryEvidenceSelector(
@@ -514,8 +503,10 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     expect(selection.selectedEvidence.map((item) => item.feedItemId)).toEqual([
       "cursor-selected",
     ]);
-    expect(verifier.inputs).toHaveLength(1);
-    expect(verifier.inputs[0]).toMatchObject({
+    expect(verifier.inputs).toHaveLength(2);
+    expect(verifier.inputs.find((input) =>
+      input.verificationLane === "safe_recall_shadow",
+    )).toMatchObject({
       verificationLane: "safe_recall_shadow",
       evidence: expect.arrayContaining([
         expect.objectContaining({ feedItemId: "cursor-selected" }),
@@ -557,7 +548,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
       maxItems: 2,
     });
 
-    expect(selection.clusters).toHaveLength(2);
+    expect(selection.clusters).toHaveLength(1);
     await settleDetachedShadow();
     expect(verifier.input).toMatchObject({
       verificationLane: "safe_recall_shadow",
@@ -636,8 +627,9 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
       }),
     ).resolves.toMatchObject({
       clusters: [
-        expect.objectContaining({ providerKeys: ["hacker-news"] }),
-        expect.objectContaining({ providerKeys: ["x-twitter"] }),
+        expect.objectContaining({
+          providerKeys: ["hacker-news", "x-twitter"],
+        }),
       ],
     });
   });
@@ -741,6 +733,14 @@ class DeferredShadowVerifier implements ReaderSummaryStoryRelationVerifierPort {
   private completeVerification?: (decisions: readonly unknown[]) => void;
 
   verify(input: ReaderSummaryStoryRelationVerifierInput): Promise<readonly unknown[]> {
+    if (input.verificationLane !== "safe_recall_shadow") {
+      return Promise.resolve(input.candidates.map((candidate) => ({
+        leftFeedItemId: candidate.leftFeedItemId,
+        rightFeedItemId: candidate.rightFeedItemId,
+        sameStory: true,
+        confidenceScore: 0.99,
+      })));
+    }
     this.input = input;
     return new Promise((resolve) => {
       this.completeVerification = resolve;
@@ -753,12 +753,17 @@ class DeferredShadowVerifier implements ReaderSummaryStoryRelationVerifierPort {
 }
 
 class RecordedAgentRuntimeClient implements AgentRuntimeClientPort {
-  constructor(private readonly recordedResult: AgentRuntimeTaskResult) {}
+  constructor(
+    private readonly recordedResult: AgentRuntimeTaskResult,
+    private readonly attested = true,
+  ) {}
 
   async runTask(
     command: AgentRuntimeTaskCommand,
   ): Promise<AgentRuntimeTaskResult> {
-    return withTestExecutionAttestation(command, this.recordedResult);
+    return this.attested
+      ? withTestExecutionAttestation(command, this.recordedResult)
+      : this.recordedResult;
   }
 
   async checkHealth(): Promise<AgentRuntimeHealthResult> {

--- a/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
+++ b/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
@@ -3,6 +3,7 @@ import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
 import {
   buildReaderSummaryCoveragePlan,
   buildReaderPostPromotionProjection,
+  primaryReaderSummaryEvidence,
   ReaderSummaryArtifact,
   ReaderSummaryPublicationPolicy,
 } from "../../domain";
@@ -53,14 +54,33 @@ describe("DeterministicReaderSummaryModelAdapter", () => {
     expect(attempt.draft.headline).not.toContain(";");
     expect(attempt.draft.content?.headline).toBe(attempt.draft.headline);
     expect(attempt.draft.headline).not.toContain("disposable Linux VM");
+    expect(input.evidence.editorialSlate?.additional).toEqual([
+      expect.objectContaining({
+        candidateId: "feed-2",
+        placement: "additional",
+        reasonCodes: expect.arrayContaining(["top_floor_not_met"]),
+      }),
+    ]);
+    expect(input.evidence.selectedEvidence.map((item) => item.feedItemId))
+      .toContain("feed-2");
+    expect(input.evidence.editorialSlate?.excluded).toContainEqual(
+      expect.objectContaining({
+        candidateId: "feed-5",
+        reasonCodes: expect.arrayContaining(["provider_floor_not_met"]),
+      }),
+    );
+    expect(input.evidence.selectedEvidence.map((item) => item.feedItemId))
+      .not.toContain("feed-5");
     expect(
       attempt.draft.content?.topReads.map((item) => item.providerKey),
     ).toEqual([
       "hacker-news",
       "x-twitter",
       "github-repo-radar",
-      "reddit",
     ]);
+    expect(
+      attempt.draft.content?.selectedPosts?.map((item) => item.providerKey),
+    ).toEqual(["reddit"]);
     expect(
       attempt.draft.content?.topReads.map((item) => item.providerKey),
     ).not.toContain("github-trending-page");
@@ -262,6 +282,18 @@ const dailySynthesisReaderSummaryInput = (): ReaderSummaryModelInput => {
       bodyPreview:
         "Maintainers discuss permission boundaries and safer execution defaults.",
     },
+    {
+      ...evidenceItem("reddit", 5, 2.2),
+      title: "Below-floor discussion must not enter the reader slate",
+      promotionFacts: {
+        ...promotionFacts("reddit", 5),
+        metrics: {
+          provider: "reddit",
+          score: 24,
+          upvoteRatio: 0.99,
+        },
+      },
+    },
   ];
   const evidence = readerSummaryEvidence(selectedEvidence);
 
@@ -325,7 +357,9 @@ const readerSummaryInputForEvidence = (
     periodKey: "daily:2026-06-23T00:00:00.000Z:2026-06-24T00:00:00.000Z:UTC",
   },
   evidence,
-  coveragePlan: buildReaderSummaryCoveragePlan(evidence),
+  coveragePlan: buildReaderSummaryCoveragePlan(
+    primaryReaderSummaryEvidence(evidence),
+  ),
   contextArtifacts: [],
   policy: {
     language: "auto",

--- a/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
+++ b/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
@@ -294,7 +294,7 @@ const dailySynthesisReaderSummaryInput = (): ReaderSummaryModelInput => {
         },
       },
     },
-  ];
+  ] satisfies ReaderSummaryModelInput["evidence"]["selectedEvidence"];
   const evidence = readerSummaryEvidence(selectedEvidence);
 
   return readerSummaryInputForEvidence(evidence);

--- a/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.ts
+++ b/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.ts
@@ -217,7 +217,17 @@ export class DeterministicReaderSummaryModelAdapter implements ReaderSummaryMode
           })
       : [];
 
-    const headline = buildReaderHeadline(input, selectedEvidence);
+    const headlineEvidence = input.evidence.editorialSlate === undefined
+      ? selectedEvidence
+      : input.evidence.editorialSlate.orderedCandidateIds.flatMap(
+          (candidateId) => {
+            const item = input.evidence.selectedEvidence.find(
+              (evidence) => evidence.feedItemId === candidateId,
+            );
+            return item === undefined ? [] : [item];
+          },
+        );
+    const headline = buildReaderHeadline(input, headlineEvidence);
     const executiveSummary = buildExecutiveSummary(input);
     const narrativeSections = buildDeterministicReaderSummaryNarrative({
       input,

--- a/libs/summary/domain/services/story-cluster-membership.ts
+++ b/libs/summary/domain/services/story-cluster-membership.ts
@@ -18,12 +18,15 @@ import {
   storyTopicTokens,
   storyTitleIdentity,
 } from "./story-topic-tokenizer";
+import { strictStoryRelationTitleEvidence } from
+  "./story-relation-title-evidence";
 
 export const belongsToVerifiedStoryCluster = (
   item: SummaryEvidenceItem,
   clusterItems: readonly SummaryEvidenceItem[],
   policy: StoryRankingPolicy,
   verifiedStoryRelationPairs?: ReadonlySet<string>,
+  verifiedStrictTitleRelationPairs?: ReadonlySet<string>,
 ): boolean =>
   clusterItems.length > 0 &&
   clusterItems.every((candidate) => {
@@ -34,12 +37,14 @@ export const belongsToVerifiedStoryCluster = (
       return true;
     }
 
-    return (
-      verifiedStoryRelationPairs?.has(
-        verifiedStoryRelationPairKey(item.feedItemId, candidate.feedItemId),
-      ) === true &&
-      isVerifiedStoryRelationGuardEligible(item, candidate, policy)
+    const pairKey = verifiedStoryRelationPairKey(
+      item.feedItemId,
+      candidate.feedItemId,
     );
+    return verifiedStrictTitleRelationPairs?.has(pairKey) === true
+      ? isVerifiedStrictTitleRelationGuardEligible(item, candidate, policy)
+      : verifiedStoryRelationPairs?.has(pairKey) === true &&
+          isVerifiedStoryRelationGuardEligible(item, candidate, policy);
   });
 
 export const hasCrossProviderClaimFacetConflict = (
@@ -218,7 +223,6 @@ export const isVerifiedStoryRelationGuardEligible = (
   ) {
     return false;
   }
-
   const itemTokens = storyIdentityTokens(item, policy);
   const candidateTokens = storyIdentityTokens(candidate, policy);
   const sharedTopicTokens = sharedStoryTopicTokenCount(
@@ -269,6 +273,25 @@ export const isVerifiedStoryRelationGuardEligible = (
     : hasConcreteSubject &&
         hasConcreteContext &&
         sharedTopicTokens >= minimumSharedTopicTokens;
+};
+
+const isVerifiedStrictTitleRelationGuardEligible = (
+  item: SummaryEvidenceItem,
+  candidate: SummaryEvidenceItem,
+  policy: StoryRankingPolicy,
+): boolean => {
+  if (readerPostProviderFamily(item.providerKey) ===
+      readerPostProviderFamily(candidate.providerKey)) {
+    return false;
+  }
+  const itemKey = storyKey(item, policy);
+  const candidateKey = storyKey(candidate, policy);
+  return (itemKey === candidateKey ||
+      !canonicalStoryKeysConflict(itemKey, candidateKey)) &&
+    storyClaimFacetsAreCompatible(item, candidate, policy) &&
+    Math.abs(item.publishedAt.getTime() - candidate.publishedAt.getTime()) <=
+      VERIFIED_STORY_RELATION_MAX_TIME_DISTANCE_MS &&
+    strictStoryRelationTitleEvidence(item.title, candidate.title) !== undefined;
 };
 
 const VERIFIED_STORY_RELATION_MAX_TIME_DISTANCE_MS = 30 * 60 * 60 * 1000;

--- a/libs/summary/domain/services/story-clustering.service.ts
+++ b/libs/summary/domain/services/story-clustering.service.ts
@@ -35,6 +35,7 @@ export class StoryClusteringService {
     readonly items: readonly SummaryEvidenceItem[];
     readonly limit: number;
     readonly verifiedStoryRelationPairs?: ReadonlySet<string>;
+    readonly verifiedStrictTitleRelationPairs?: ReadonlySet<string>;
     readonly now?: Date;
   }): SummaryEvidenceSelection {
     const limit = normalizeLimit(params.limit, this.policy);
@@ -45,6 +46,7 @@ export class StoryClusteringService {
         now,
         this.policy,
         params.verifiedStoryRelationPairs,
+        params.verifiedStrictTitleRelationPairs,
       ),
     ]
       .sort(compareStoryClusters)
@@ -74,6 +76,7 @@ const buildClusters = (
   now: Date,
   policy: StoryRankingPolicy,
   verifiedStoryRelationPairs: ReadonlySet<string> | undefined,
+  verifiedStrictTitleRelationPairs: ReadonlySet<string> | undefined,
 ): readonly StoryCluster[] => {
   const groups: {
     readonly key: string;
@@ -91,6 +94,7 @@ const buildClusters = (
           candidate.items,
           policy,
           verifiedStoryRelationPairs,
+          verifiedStrictTitleRelationPairs,
         ),
     );
 

--- a/libs/summary/domain/services/story-relation-safe-recall-shadow.spec.ts
+++ b/libs/summary/domain/services/story-relation-safe-recall-shadow.spec.ts
@@ -262,12 +262,24 @@ describe("story relation safe-recall shadow candidates", () => {
       evidence: [...items].reverse(),
       primaryCandidates,
     });
+    const detachedOverflow = buildStoryRelationSafeRecallShadowCandidates({
+      selection,
+      evidence: items,
+      primaryCandidates: forward.candidates,
+    });
 
     expect(primaryCandidates).toEqual([]);
     expect(forward.candidates).toHaveLength(
       STORY_RELATION_SAFE_RECALL_SHADOW_MAX_CANDIDATES,
     );
     expect(reversed).toEqual(forward);
+    expect(detachedOverflow.candidates).not.toHaveLength(0);
+    expect(detachedOverflow.candidates.every((candidate) =>
+      !forward.candidates.some((authoritative) =>
+        authoritative.leftFeedItemId === candidate.leftFeedItemId &&
+        authoritative.rightFeedItemId === candidate.rightFeedItemId,
+      ),
+    )).toBe(true);
     expect(forward.aggregates).toContainEqual({
       reasonCode: "excluded_global_cap",
       candidatePolicyVersion:

--- a/libs/summary/domain/services/story-relation-safe-recall-shadow.spec.ts
+++ b/libs/summary/domain/services/story-relation-safe-recall-shadow.spec.ts
@@ -47,6 +47,27 @@ describe("story relation safe-recall shadow candidates", () => {
     ]);
   });
 
+  it("rejects strict-title pairs from aliases of the same provider", () => {
+    const left = evidence(
+      "cursor-x",
+      "x-twitter",
+      "Cursor deployed at SpaceX",
+      "Official deployment note.",
+    );
+    const right = evidence(
+      "cursor-twitter",
+      "twitter",
+      "SpaceX deploying Cursor",
+      "A reposted wrapper.",
+    );
+
+    expect(buildStoryRelationSafeRecallShadowCandidates({
+      selection: splitSelection(left, right),
+      evidence: [left, right],
+      primaryCandidates: [],
+    }).candidates).toEqual([]);
+  });
+
   it("generates official plus HN watermark morphology without body promotion", () => {
     const official = evidence(
       "watermark-official",

--- a/libs/summary/domain/services/story-relation-safe-recall-shadow.ts
+++ b/libs/summary/domain/services/story-relation-safe-recall-shadow.ts
@@ -6,6 +6,8 @@ import type {
 import { verifiedStoryRelationPairKey } from "./story-cluster-membership";
 import type { StoryRelationCandidate } from "./story-relation-candidates";
 import { strictStoryRelationTitleEvidence } from "./story-relation-title-evidence";
+import { readerPostProviderFamily } from
+  "../policies/reader-post-promotion-policy";
 
 export const STORY_RELATION_SAFE_RECALL_SHADOW_POLICY_VERSION =
   "reader_summary.story_relation.safe_recall_shadow.v2";
@@ -128,11 +130,23 @@ export const buildStoryRelationSafeRecallShadowCandidates = (params: {
   };
 };
 
+/**
+ * Returns the bounded strict-title candidates that may enter an attested
+ * primary verification lane. A candidate alone never authorizes a merge.
+ */
+export const buildBoundedStrictTitleStoryRelationCandidates = (params: {
+  readonly selection: SummaryEvidenceSelection;
+  readonly evidence: readonly SummaryEvidenceItem[];
+  readonly primaryCandidates: readonly StoryRelationCandidate[];
+}): readonly StoryRelationCandidate[] =>
+  buildStoryRelationSafeRecallShadowCandidates(params).candidates;
+
 const isSafeRecallShadowGuardEligible = (
   left: SummaryEvidenceItem,
   right: SummaryEvidenceItem,
 ): boolean =>
-  left.providerKey !== right.providerKey &&
+  readerPostProviderFamily(left.providerKey) !==
+    readerPostProviderFamily(right.providerKey) &&
   Math.abs(left.publishedAt.getTime() - right.publishedAt.getTime()) <=
     safeRecallMaxTimeDistanceMs;
 

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -102,7 +102,7 @@ describe("reader summary daily story relation production wiring", () => {
     expect(frozenRuntime.storyCommands).toHaveLength(0);
   });
 
-  it("records cross-source relation without mutating the immutable slate", async () => {
+  it("reclusters an approved attested relation before composing the slate", async () => {
     const result = await selectDailyEvidence({
       sameStory: true,
       attested: true,
@@ -110,17 +110,17 @@ describe("reader summary daily story relation production wiring", () => {
     });
 
     expect(result.runtime.storyCommands).toHaveLength(1);
-    expect(result.selection.clusters).toHaveLength(2);
+    expect(result.selection.clusters).toHaveLength(1);
     expect(result.selection.clusters.map((cluster) => cluster.providerKeys))
-      .toEqual([["hacker-news"], ["reddit"]]);
+      .toEqual([["hacker-news", "reddit"]]);
     expect(result.selection.approvedSameStoryRelations).toEqual([{
       leftFeedItemId: "typescript-hn",
       rightFeedItemId: "typescript-reddit",
       confidence: 0.98,
     }]);
     expect(buildReaderSummaryCoveragePlan(result.selection).lead).toMatchObject({
-      feedItemIds: ["typescript-hn"],
-      providerKeys: ["hacker-news"],
+      feedItemIds: ["typescript-hn", "typescript-reddit"],
+      providerKeys: ["hacker-news", "reddit"],
     });
     expect(result.record).toHaveBeenCalledWith(expect.objectContaining({
       taskRole: "story_relation",
@@ -132,6 +132,29 @@ describe("reader summary daily story relation production wiring", () => {
         reasoningEffort: "high",
       }),
     }));
+  });
+
+  it.each([
+    {
+      name: "Cursor and SpaceX deployment",
+      firstTitle: "Cursor deployed at SpaceX",
+      secondTitle: "SpaceX deploying Cursor",
+    },
+    {
+      name: "strong Claude watermark report",
+      firstTitle: "Claude's snippets are watermarked",
+      secondTitle: "Watermarking Claude Code output",
+    },
+  ])("groups an attested $name through the runtime verifier", async (scenario) => {
+    const result = await selectDailyEvidence({
+      ...scenario,
+      sameStory: true,
+      attested: true,
+    });
+
+    expect(result.runtime.storyCommands).toHaveLength(1);
+    expect(result.selection.clusters).toHaveLength(1);
+    expect(result.selection.approvedSameStoryRelations).toHaveLength(1);
   });
 
   it("keeps historical Promotion V2 on the real verifier/finalizer wiring", async () => {
@@ -182,11 +205,21 @@ describe("reader summary daily story relation production wiring", () => {
 
   it.each([
     {
-      name: "an unrelated question sharing product names",
+      name: "a weak question sharing product names",
       sameStory: false,
       attested: true,
       secondTitle: "Should a TypeScript compiler rewrite move to Go?",
       storyAttestationRecorded: true,
+      runtimeCommandCount: 1,
+    },
+    {
+      name: "an unrelated report",
+      sameStory: false,
+      attested: true,
+      firstTitle: "Cursor deployed at SpaceX",
+      secondTitle: "Cursor deployed at a university",
+      storyAttestationRecorded: false,
+      runtimeCommandCount: 0,
     },
     {
       name: "an approving response with a failed attestation",
@@ -194,31 +227,72 @@ describe("reader summary daily story relation production wiring", () => {
       attested: false,
       secondTitle: "Go rewrite of the TypeScript compiler reaches developers",
       storyAttestationRecorded: false,
+      runtimeCommandCount: 1,
     },
   ])("keeps $name ungrouped", async (scenario) => {
     const result = await selectDailyEvidence(scenario);
 
-    expect(result.runtime.storyCommands).toHaveLength(1);
+    expect(result.runtime.storyCommands).toHaveLength(scenario.runtimeCommandCount);
     expect(result.selection.clusters).toHaveLength(2);
     expect(result.selection.approvedSameStoryRelations).toEqual([]);
     expect(result.record.mock.calls.some(([record]) =>
       record.taskRole === "story_relation",
     )).toBe(scenario.storyAttestationRecorded);
   });
+
+  it("keeps same-provider evidence separate without requesting a relation", async () => {
+    const result = await selectDailyEvidence({
+      sameStory: true,
+      attested: true,
+      secondTitle: "Go rewrite of the TypeScript compiler reaches developers",
+      secondProviderKey: "hacker-news",
+    });
+
+    expect(result.runtime.storyCommands).toHaveLength(0);
+    expect(result.selection.clusters).toHaveLength(2);
+    expect(result.selection.approvedSameStoryRelations).toEqual([]);
+  });
+
+  it.each(["malformed", "timeout"] as const)(
+    "keeps a %s runtime response separate",
+    async (runtimeMode) => {
+      const result = await selectDailyEvidence({
+        sameStory: true,
+        attested: true,
+        secondTitle: "Go rewrite of the TypeScript compiler reaches developers",
+        runtimeMode,
+      });
+
+      expect(result.runtime.storyCommands).toHaveLength(1);
+      expect(result.selection.clusters).toHaveLength(2);
+      expect(result.selection.approvedSameStoryRelations).toEqual([]);
+    },
+  );
 });
 
 const selectDailyEvidence = async (input: {
   readonly sameStory: boolean;
   readonly attested: boolean;
+  readonly firstTitle?: string;
   readonly secondTitle: string;
+  readonly secondProviderKey?: "hacker-news" | "reddit";
+  readonly runtimeMode?: "decision" | "malformed" | "timeout";
 }) => {
-  const runtime = new FakeRuntime(input.sameStory, input.attested);
+  const runtime = new FakeRuntime(
+    input.sameStory,
+    input.attested,
+    input.runtimeMode ?? "decision",
+  );
   const record = jest.fn(async (value: VerifiedReaderSummaryExecutionAttestation) => {
     void value;
   });
   const wiring = createReaderSummaryDailyCapturePublicationWiring({
     replay: null,
-    feedItems: feedRepository(input.secondTitle),
+    feedItems: feedRepository({
+      firstTitle: input.firstTitle,
+      secondTitle: input.secondTitle,
+      secondProviderKey: input.secondProviderKey,
+    }),
     summaryClient: {} as never,
     clock,
     attestationSink: { record },
@@ -233,17 +307,26 @@ const selectDailyEvidence = async (input: {
     period,
     maxItems: 2,
   });
+  await new Promise<void>((resolve) => setImmediate(resolve));
   return { record, runtime, selection };
 };
 
-const feedRepository = (
-  secondTitle = "Go rewrite of the TypeScript compiler reaches developers",
+const feedRepository = (input: {
+  readonly firstTitle?: string;
+  readonly secondTitle?: string;
+  readonly secondProviderKey?: "hacker-news" | "reddit";
+} = {},
 ): InMemoryFeedItemReadRepository => {
+  const firstTitle = input.firstTitle ??
+    "TypeScript compiler rewrite moves to Go";
+  const secondTitle = input.secondTitle ??
+    "Go rewrite of the TypeScript compiler reaches developers";
+  const secondProviderKey = input.secondProviderKey ?? "reddit";
   const repository = new AuthorityFeedItemReadRepository();
   repository.upsert(feedItem({
     id: "typescript-hn",
     providerKey: "hacker-news",
-    title: "TypeScript compiler rewrite moves to Go",
+    title: firstTitle,
     bodyPreview: "Microsoft details the plan for AI-assisted editors.",
     providerMetadata: {
       kind: "hacker_news_story",
@@ -260,14 +343,14 @@ const feedRepository = (
   }));
   repository.upsert(feedItem({
     id: "typescript-reddit",
-    providerKey: "reddit",
+    providerKey: secondProviderKey,
     title: secondTitle,
     bodyPreview: secondTitle.startsWith("Should")
       ? "A forum question compares compiler choices for coding agents."
       : "The engineering team explains the pipeline for coding agents.",
     providerMetadata: {
-      kind: "reddit_post",
-      score: 190,
+      kind: secondProviderKey === "reddit" ? "reddit_post" : "hacker_news_story",
+      ...(secondProviderKey === "reddit" ? { score: 190 } : { points: 190 }),
       promotionAuthority: {
         official: true,
         trusted: true,
@@ -327,6 +410,7 @@ class FakeRuntime implements AgentRuntimeClientPort {
   constructor(
     private readonly sameStory: boolean,
     private readonly attested: boolean,
+    private readonly mode: "decision" | "malformed" | "timeout" = "decision",
   ) {}
 
   async runTask(
@@ -335,11 +419,21 @@ class FakeRuntime implements AgentRuntimeClientPort {
     const storyRelation = command.purpose ===
       "social_monitor.reader_summary.verify_story_relations.v2";
     if (storyRelation) this.storyCommands.push(command);
+    if (storyRelation && this.mode === "timeout") {
+      throw new Error("fixture relation verification timed out");
+    }
     const result: AgentRuntimeTaskResult = {
       status: "completed",
       structuredOutput: {
         decisions: storyRelation
-          ? [{
+          ? this.mode === "malformed"
+            ? [{
+                leftFeedItemId: "typescript-hn",
+                rightFeedItemId: "typescript-reddit",
+                sameStory: "not-a-boolean",
+                confidenceScore: 2,
+              }]
+            : [{
               leftFeedItemId: "typescript-hn",
               rightFeedItemId: "typescript-reddit",
               sameStory: this.sameStory,


### PR DESCRIPTION
## What

- Enforces the existing provider Top floor as a real Top-placement invariant.
- Keeps admission-floor-only stories eligible for Additional instead of letting them leak into Top.
- Graduates only approved, attested and bounded cross-source relations into authoritative clustering before the immutable V2 slate is composed.
- Adds fresh-composition coverage for Cursor/SpaceX and Claude watermark positive and negative cases.

## Why

An exact-head production audit found that the merged V2 score normalized against the Top floor but did not require that floor for Top placement. The same audit found that approved story relations were attached after clustering, so reader-visible duplicates stayed separate.

## Safety

- Existing rating thresholds and scoring formulas are unchanged.
- Provider caps, deterministic ordering, no-signal and duplicate exclusion remain fail closed.
- Failed attestation, timeout, malformed, unrelated and same-provider relations remain ungrouped.
- No deploy, migration, provider, telemetry or production-control surface is changed.

## Evidence

- 92 focused Bun tests passed with 237 assertions.
- `npm run check:architecture` passed.
- `npm run check:code-quality` passed.
- `npm run check:source-line-cap` passed across 3,908 files.
- Independent `gpt-5.6-sol/xhigh` exact-SHA review is running against `3c8f4d4a8280df62733258792ea81ee33378c8af`.
- GitHub CI is the canonical Jest and full contract gate for this exact head.
