### PR TITLE
fix(deploy): skip redundant authority reload

### DIFF
--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -129,13 +129,14 @@ deploy_control_bootstrap_production_transition_b0() {
 # All other releases retain the controller's original fast-forward contract.
 advance_integration() {
   local sha=$1 current
+  [[ -z $(git -C "$REPO" status --porcelain) ]] || \
+    fail 'integration worktree is dirty'
+  current=$(git -C "$REPO" rev-parse HEAD)
+  [[ $current != "$sha" ]] || return 0
   if deploy_control_is_reviewed_forward_bridge_transition \
       "$DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD" "$sha"; then
     production_forward_install_b0_before_entrypoint "$sha"
   fi
-  [[ -z $(git -C "$REPO" status --porcelain) ]] || \
-    fail 'integration worktree is dirty'
-  current=$(git -C "$REPO" rev-parse HEAD)
   if git -C "$REPO" merge-base --is-ancestor "$sha" "$current"; then
     return 0
   fi

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=17568d8cafd8b4a7ef50ef8146f9c5dbc1a29b52
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=24509327756fe914a0ab20f8c843209154ff4014
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=24509327756fe914a0ab20f8c843209154ff4014
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=aa2014ca722faadbb4d37d70d1cc658e9e4ffdca
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=17568d8cafd8b4a7ef50ef8146f9c5dbc1a29b52
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=0d7f29d904c021d53ac0999808dd6dc1226a0c78
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=0d7f29d904c021d53ac0999808dd6dc1226a0c78
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=17568d8cafd8b4a7ef50ef8146f9c5dbc1a29b52
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,5 +1,5 @@
 100644 707fca6fe51580306af818d748350a488f753ccb ops/deploy/deploy-control-bridge-lib.sh
 100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
-100644 a31c96a063253c15917f7c31216a4196ed475a3d ops/deploy/production-forward-bridge.blobs
+100644 3e08935366bbeaee6d395214eeb2753f7161db6b ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh
 100644 8ef73c96eedaeea7ac84b0dbbc4012ad124b5d0e ops/deploy/production-transition-marker-lib.sh

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,5 +1,5 @@
 100644 1fc322a59e0193dfc3f17d311d2c92948ee77e87 ops/deploy/deploy-control-bridge-lib.sh
 100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
-100644 3e08935366bbeaee6d395214eeb2753f7161db6b ops/deploy/production-forward-bridge.blobs
+100644 2d02bfd8e4c13d50f2ea8c050f5744e1b08fcbcd ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh
 100644 8ef73c96eedaeea7ac84b0dbbc4012ad124b5d0e ops/deploy/production-transition-marker-lib.sh

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,5 +1,5 @@
 100644 707fca6fe51580306af818d748350a488f753ccb ops/deploy/deploy-control-bridge-lib.sh
 100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
-100644 3e08935366bbeaee6d395214eeb2753f7161db6b ops/deploy/production-forward-bridge.blobs
+100644 a31c96a063253c15917f7c31216a4196ed475a3d ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh
 100644 8ef73c96eedaeea7ac84b0dbbc4012ad124b5d0e ops/deploy/production-transition-marker-lib.sh

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,4 +1,4 @@
-100644 707fca6fe51580306af818d748350a488f753ccb ops/deploy/deploy-control-bridge-lib.sh
+100644 1fc322a59e0193dfc3f17d311d2c92948ee77e87 ops/deploy/deploy-control-bridge-lib.sh
 100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
 100644 3e08935366bbeaee6d395214eeb2753f7161db6b ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh

--- a/ops/deploy/production-forward-bridge.blobs
+++ b/ops/deploy/production-forward-bridge.blobs
@@ -11,7 +11,7 @@ head 100755 75c765a3003c952ade9e69865287ebb782e5b1d9 ops/deploy/production-trans
 head 100644 57a52e56ec879624eb33f3c77834b5b005fa9412 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 head 100755 15e0a2797dd694b535b4f80cbf1fffb166ba6590 ops/deploy/social-monitor-production-deploy.test.sh
 head 100644 ad399a5f6df8939793a7344535a9a5c509630470 ops/deploy/x-collector-image-deploy-lib.test.sh
-head 100644 a848c895df0ece8169c84b4106c995b65aeec561 package-lock.json
-head 100644 91f5cfd149abc7146f7d97698501c20259f43b28 package.json
+head 100644 83483f76535ae0f870b9052968c58f1e117ff5c7 package-lock.json
+head 100644 79b118b7679a4110ac8e5bce86a50f07892bcecd package.json
 head 100644 195ee0e7fe780ab6ce8e396b340432d1988b32c7 scripts/check-review-ci.mjs
 rolling 100644 abd0057d6cc840bbfec90e969d474afad4e28328 ops/deploy/social-monitor-production-deploy.sh

--- a/ops/deploy/production-forward-bridge.blobs
+++ b/ops/deploy/production-forward-bridge.blobs
@@ -11,7 +11,7 @@ head 100755 75c765a3003c952ade9e69865287ebb782e5b1d9 ops/deploy/production-trans
 head 100644 57a52e56ec879624eb33f3c77834b5b005fa9412 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 head 100755 15e0a2797dd694b535b4f80cbf1fffb166ba6590 ops/deploy/social-monitor-production-deploy.test.sh
 head 100644 ad399a5f6df8939793a7344535a9a5c509630470 ops/deploy/x-collector-image-deploy-lib.test.sh
-head 100644 83483f76535ae0f870b9052968c58f1e117ff5c7 package-lock.json
-head 100644 79b118b7679a4110ac8e5bce86a50f07892bcecd package.json
+head 100644 a848c895df0ece8169c84b4106c995b65aeec561 package-lock.json
+head 100644 91f5cfd149abc7146f7d97698501c20259f43b28 package.json
 head 100644 195ee0e7fe780ab6ce8e396b340432d1988b32c7 scripts/check-review-ci.mjs
 rolling 100644 abd0057d6cc840bbfec90e969d474afad4e28328 ops/deploy/social-monitor-production-deploy.sh

--- a/ops/deploy/production-forward-bridge.blobs
+++ b/ops/deploy/production-forward-bridge.blobs
@@ -8,7 +8,7 @@ head 100755 d0ded4cdbd36577537bdf00c91c5829fd120f3c4 ops/deploy/production-forwa
 head 100755 cf27559253df7a0f3fca8bace5d39a789de281d6 ops/deploy/production-forward-bridge.test.sh
 head 100755 73673a20e6abe803bfbaf0cc00383b68036aeced ops/deploy/production-release-b-bridge-order.test.sh
 head 100755 75c765a3003c952ade9e69865287ebb782e5b1d9 ops/deploy/production-transition-b0-host-control.test.sh
-head 100644 57a52e56ec879624eb33f3c77834b5b005fa9412 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+head 100644 ec7341ecdbc16ac44dfd40e33c95733e0983d62c ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 head 100755 15e0a2797dd694b535b4f80cbf1fffb166ba6590 ops/deploy/social-monitor-production-deploy.test.sh
 head 100644 ad399a5f6df8939793a7344535a9a5c509630470 ops/deploy/x-collector-image-deploy-lib.test.sh
 head 100644 a848c895df0ece8169c84b4106c995b65aeec561 package-lock.json

--- a/ops/deploy/production-forward-bridge.test.sh
+++ b/ops/deploy/production-forward-bridge.test.sh
@@ -467,6 +467,25 @@ done
 reset_b0_destinations
 run_b0_install
 
+# A terminal transition may leave the exact target checked out while component
+# markers still require an idempotent deploy resume. Trusted B0 functions are
+# already readonly in that process, so advancing an already-current checkout
+# must not reinstall and source the same authority a second time.
+run_current_target_advance_with_loaded_authority() (
+  export SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
+  source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
+  source "$CONTROL/production-transition-b0-host-control.sh"
+  while read -r _ _ authority_function; do
+    [[ $authority_function != production_transition_* ]] || \
+      readonly -f "$authority_function"
+  done < <(declare -F)
+  DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD=$B
+  advance_integration "$F"
+)
+git -C "$repo" checkout -q "$F"
+run_current_target_advance_with_loaded_authority
+printf 'forward-bridge-test: current target skips redundant B0 source\n'
+
 # A predecessor-started process loads no test-defined host helper. It installs
 # and sources the reviewed B0 authority before the fast-forward failpoint. The
 # retry is a separate fresh shell starting with HEAD=F.

--- a/ops/deploy/production-forward-bridge.test.sh
+++ b/ops/deploy/production-forward-bridge.test.sh
@@ -467,25 +467,6 @@ done
 reset_b0_destinations
 run_b0_install
 
-# A terminal transition may leave the exact target checked out while component
-# markers still require an idempotent deploy resume. Trusted B0 functions are
-# already readonly in that process, so advancing an already-current checkout
-# must not reinstall and source the same authority a second time.
-run_current_target_advance_with_loaded_authority() (
-  export SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
-  source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
-  source "$CONTROL/production-transition-b0-host-control.sh"
-  while read -r _ _ authority_function; do
-    [[ $authority_function != production_transition_* ]] || \
-      readonly -f "$authority_function"
-  done < <(declare -F)
-  DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD=$B
-  advance_integration "$F"
-)
-git -C "$repo" checkout -q "$F"
-run_current_target_advance_with_loaded_authority
-printf 'forward-bridge-test: current target skips redundant B0 source\n'
-
 # A predecessor-started process loads no test-defined host helper. It installs
 # and sources the reviewed B0 authority before the fast-forward failpoint. The
 # retry is a separate fresh shell starting with HEAD=F.

--- a/ops/deploy/production-transition-prelude-authority.test.sh
+++ b/ops/deploy/production-transition-prelude-authority.test.sh
@@ -149,4 +149,29 @@ set -e
 grep -F 'production prelude current commit is not authenticated origin main history' \
   <<< "$output" >/dev/null
 [[ ! -e $PRELUDE_SENTINEL ]]
+
+# A terminal authenticated transition can leave the exact target checked out
+# while component receipts still require an ordinary deploy resume. That path
+# must not reinstall and source B0 authority whose functions are already
+# readonly in the trusted production process.
+CURRENT_TARGET_REPO=$FIXTURE/current-target-repo
+git init -q -b main "$CURRENT_TARGET_REPO"
+git -C "$CURRENT_TARGET_REPO" config user.name 'Current Target Resume Test'
+git -C "$CURRENT_TARGET_REPO" config user.email current-target@example.invalid
+printf 'current target\n' > "$CURRENT_TARGET_REPO/README"
+git -C "$CURRENT_TARGET_REPO" add README
+git -C "$CURRENT_TARGET_REPO" commit -qm 'test: current target'
+CURRENT_TARGET=$(git -C "$CURRENT_TARGET_REPO" rev-parse HEAD)
+(
+  REPO=$CURRENT_TARGET_REPO
+  DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD=$CURRENT_TARGET
+  source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
+  deploy_control_is_reviewed_forward_bridge_transition() { return 0; }
+  production_forward_install_b0_before_entrypoint() {
+    printf 'redundant authority reload\n' > "$FIXTURE/redundant-authority-reload"
+    return 97
+  }
+  advance_integration "$CURRENT_TARGET"
+)
+[[ ! -e $FIXTURE/redundant-authority-reload ]]
 printf '%s\n' 'Production transition prelude authority tests passed'

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -150,7 +150,7 @@ assert_real_bridge_target_assets() {
         release_b_candidate_digest=bea119047fbbd2295185c84e0adeb773dc852e63b951daf5c7a831356a73a371
         release_b_sealed_digest=1718617b4bbb92f4dbfd92a59fcc482ef7a098734730b8460d21aaced44386c2
         rolling_repair_digest=1945f2b07f110d16694affc15c66b4589d294b81a4e593a9680dacf11fbc5d4d
-        current_release_digest=4d5083cf3af758640633482b89d6644e463dc717ea3deb4bf72b908bbe26451d
+        current_release_digest=0d8d2047d1af38caf8cc1336f47363fc117b83f8b562098de64083e9cad9782d
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then


### PR DESCRIPTION
## Summary
- keep the integration worktree cleanliness invariant
- return idempotently when the exact target is already checked out
- avoid reloading trusted B0 authority after its functions were sealed readonly
- reseal the changed forward bridge authority for an audited transition

## Regression
Reproduces the production state where checkout already equals target while component receipts still need resume. The test fails if `advance_integration` calls the B0 installer in that state.

## Evidence
- `node scripts/check-review-ci.mjs`
- production ShellCheck baseline
- focused Bash 5 tests on the old hosted server
- Linux exact-head PR lifecycle CI