### PR TITLE
fix(deploy): restore transition signing authority

### DIFF
--- a/.github/workflows/production-transition-publish.yml
+++ b/.github/workflows/production-transition-publish.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   publish:
+    environment: production
     permissions:
       actions: read
       contents: write
@@ -60,7 +61,7 @@ jobs:
         id: publish_target
         shell: bash
         env:
-          TARGET_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY }}
+          TARGET_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_TARGET_SIGNING_KEY }}
         run: |
           set -euo pipefail
           [[ -n "$TARGET_PRIVATE_KEY" ]]
@@ -81,6 +82,8 @@ jobs:
           trap 'rm -f -- "$key"' EXIT
           printf '%s\n' "$TARGET_PRIVATE_KEY" > "$key"
           chmod 0600 "$key"
+          git config user.name 'social-monitor-transition-publisher'
+          git config user.email 'social-monitor-transition-publisher@users.noreply.github.com'
           PRODUCTION_TRANSITION_TARGET_SIGNING_KEY=$key \
             bash ops/deploy/production-transition-publisher.sh prepare \
               "$s2" "$p6" artifact/production-transition-review.statement \

--- a/.github/workflows/production-transition-review.yml
+++ b/.github/workflows/production-transition-review.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   review:
+    environment: production
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -37,7 +38,7 @@ jobs:
         env:
           S2_SHA: ${{ inputs.s2_sha }}
           REQUEST_ID: ${{ inputs.request_id }}
-          REVIEW_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY }}
+          REVIEW_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY }}
         run: |
           set -euo pipefail
           [[ "$GITHUB_REPOSITORY" == "777genius/social-monitor" ]]
@@ -52,6 +53,8 @@ jobs:
           trap 'rm -f -- "$key"' EXIT
           printf '%s\n' "$REVIEW_PRIVATE_KEY" > "$key"
           chmod 0600 "$key"
+          git config user.name 'social-monitor-transition-review'
+          git config user.email 'social-monitor-transition-review@users.noreply.github.com'
           mkdir artifact
           issued=$(date +%s)
           expires=$((issued + 3600))

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=aa2014ca722faadbb4d37d70d1cc658e9e4ffdca
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=80a1f668466b6f82f84651b29efec05309c7ea99
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=80a1f668466b6f82f84651b29efec05309c7ea99
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=52bd953396e84c43c01d98e401e13bdb05b7746b
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,5 +1,5 @@
 100644 1fc322a59e0193dfc3f17d311d2c92948ee77e87 ops/deploy/deploy-control-bridge-lib.sh
 100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
-100644 892a2893617539df754d719e98e473b3c90fa2ed ops/deploy/production-forward-bridge.blobs
+100644 0e97c929c7eb86e5e9dce9fc1f334dc5cd39a828 ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh
 100644 8ef73c96eedaeea7ac84b0dbbc4012ad124b5d0e ops/deploy/production-transition-marker-lib.sh

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,5 +1,5 @@
 100644 1fc322a59e0193dfc3f17d311d2c92948ee77e87 ops/deploy/deploy-control-bridge-lib.sh
 100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
-100644 2d02bfd8e4c13d50f2ea8c050f5744e1b08fcbcd ops/deploy/production-forward-bridge.blobs
+100644 892a2893617539df754d719e98e473b3c90fa2ed ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh
 100644 8ef73c96eedaeea7ac84b0dbbc4012ad124b5d0e ops/deploy/production-transition-marker-lib.sh

--- a/ops/deploy/production-forward-bridge.blobs
+++ b/ops/deploy/production-forward-bridge.blobs
@@ -13,5 +13,5 @@ head 100755 15e0a2797dd694b535b4f80cbf1fffb166ba6590 ops/deploy/social-monitor-p
 head 100644 ad399a5f6df8939793a7344535a9a5c509630470 ops/deploy/x-collector-image-deploy-lib.test.sh
 head 100644 a848c895df0ece8169c84b4106c995b65aeec561 package-lock.json
 head 100644 91f5cfd149abc7146f7d97698501c20259f43b28 package.json
-head 100644 bb4a2c8ed828af3e1d0a865a8f64112b1b67c800 scripts/check-review-ci.mjs
+head 100644 ab07a431825bf0417df599dfb5f21e632625fe61 scripts/check-review-ci.mjs
 rolling 100644 abd0057d6cc840bbfec90e969d474afad4e28328 ops/deploy/social-monitor-production-deploy.sh

--- a/ops/deploy/production-forward-bridge.blobs
+++ b/ops/deploy/production-forward-bridge.blobs
@@ -13,5 +13,5 @@ head 100755 15e0a2797dd694b535b4f80cbf1fffb166ba6590 ops/deploy/social-monitor-p
 head 100644 ad399a5f6df8939793a7344535a9a5c509630470 ops/deploy/x-collector-image-deploy-lib.test.sh
 head 100644 a848c895df0ece8169c84b4106c995b65aeec561 package-lock.json
 head 100644 91f5cfd149abc7146f7d97698501c20259f43b28 package.json
-head 100644 195ee0e7fe780ab6ce8e396b340432d1988b32c7 scripts/check-review-ci.mjs
+head 100644 bb4a2c8ed828af3e1d0a865a8f64112b1b67c800 scripts/check-review-ci.mjs
 rolling 100644 abd0057d6cc840bbfec90e969d474afad4e28328 ops/deploy/social-monitor-production-deploy.sh

--- a/scripts/check-review-ci.mjs
+++ b/scripts/check-review-ci.mjs
@@ -352,6 +352,9 @@ if (
   ) ||
   !transitionReviewJob.includes(
     "git config user.name 'social-monitor-transition-review'",
+  ) ||
+  !transitionReviewJob.includes(
+    "git config user.email 'social-monitor-transition-review@users.noreply.github.com'",
   )
 ) {
   violations.push(
@@ -401,6 +404,9 @@ if (
   !transitionPublisherJob?.includes("environment: production") ||
   !transitionPublisherJob.includes(
     "git config user.name 'social-monitor-transition-publisher'",
+  ) ||
+  !transitionPublisherJob.includes(
+    "git config user.email 'social-monitor-transition-publisher@users.noreply.github.com'",
   )
 ) {
   violations.push(
@@ -410,7 +416,7 @@ if (
 for (const [authority, token, owner] of [
   [
     "PRODUCTION_TRANSITION_TARGET_SIGNING_KEY",
-    "secrets.PRODUCTION_TRANSITION_TARGET_SIGNING_KEY",
+    "TARGET_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_TARGET_SIGNING_KEY }}",
     transitionPublisherJob,
   ],
   ["PRODUCTION_SSH_PRIVATE_KEY", "PRODUCTION_SSH_PRIVATE_KEY", transitionActivationJob],

--- a/scripts/check-review-ci.mjs
+++ b/scripts/check-review-ci.mjs
@@ -245,10 +245,16 @@ if (
   );
 }
 if (
-  !transitionReview.includes("PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY") ||
-  transitionReview.includes("PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY") ||
-  !transitionPublish.includes("PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY") ||
-  transitionPublish.includes("PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY")
+  !transitionReview.includes(
+    "secrets.PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY",
+  ) ||
+  transitionReview.includes("PRODUCTION_TRANSITION_TARGET_SIGNING_KEY") ||
+  !transitionPublish.includes(
+    "secrets.PRODUCTION_TRANSITION_TARGET_SIGNING_KEY",
+  ) ||
+  transitionPublish.includes("PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY") ||
+  transitionReview.includes("PRODUCTION_TRANSITION_REVIEW_PRIVATE_KEY") ||
+  transitionPublish.includes("PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY")
 ) {
   violations.push("production transition workflows must keep review and target signing authorities separate");
 }
@@ -334,8 +340,24 @@ const findJob = (source, jobId) => source.match(
   ),
 )?.[1];
 
+const transitionReviewJob = findJob(transitionReview, "review");
 const transitionPublisherJob = findJob(transitionPublish, "publish");
 const transitionActivationJob = findJob(transitionPublish, "activate");
+
+if (
+  transitionReviewJob === undefined ||
+  !transitionReviewJob.includes("environment: production") ||
+  !transitionReviewJob.includes(
+    "REVIEW_PRIVATE_KEY: ${{ secrets.PRODUCTION_TRANSITION_REVIEW_SIGNING_KEY }}",
+  ) ||
+  !transitionReviewJob.includes(
+    "git config user.name 'social-monitor-transition-review'",
+  )
+) {
+  violations.push(
+    `${transitionReviewPath}: review must receive only its production signing secret and configure deterministic commit identity`,
+  );
+}
 
 if (
   !transitionPublish.includes("\npermissions: {}\n") ||
@@ -363,7 +385,6 @@ if (
 }
 
 for (const prohibited of [
-  "environment: production",
   "PRODUCTION_SSH_PRIVATE_KEY",
   "PRODUCTION_SSH_KNOWN_HOSTS",
   "DEPLOY_HOST:",
@@ -376,13 +397,27 @@ for (const prohibited of [
     );
   }
 }
-for (const [authority, owner] of [
-  ["PRODUCTION_TRANSITION_TARGET_PRIVATE_KEY", transitionPublisherJob],
-  ["PRODUCTION_SSH_PRIVATE_KEY", transitionActivationJob],
-  ["PRODUCTION_SSH_KNOWN_HOSTS", transitionActivationJob],
+if (
+  !transitionPublisherJob?.includes("environment: production") ||
+  !transitionPublisherJob.includes(
+    "git config user.name 'social-monitor-transition-publisher'",
+  )
+) {
+  violations.push(
+    `${transitionPublishPath}: publisher must receive its production signing secret and configure deterministic commit identity`,
+  );
+}
+for (const [authority, token, owner] of [
+  [
+    "PRODUCTION_TRANSITION_TARGET_SIGNING_KEY",
+    "secrets.PRODUCTION_TRANSITION_TARGET_SIGNING_KEY",
+    transitionPublisherJob,
+  ],
+  ["PRODUCTION_SSH_PRIVATE_KEY", "PRODUCTION_SSH_PRIVATE_KEY", transitionActivationJob],
+  ["PRODUCTION_SSH_KNOWN_HOSTS", "PRODUCTION_SSH_KNOWN_HOSTS", transitionActivationJob],
 ]) {
   if (
-    transitionPublish.split(authority).length !== 2 ||
+    transitionPublish.split(token).length !== 2 ||
     !owner?.includes(authority)
   ) {
     violations.push(


### PR DESCRIPTION
## Summary
- restore the production environment boundary for signed transition review and publish jobs
- bind workflows to the existing environment-scoped review/target signing secrets
- configure deterministic Git identities before canonical P6/T construction
- strengthen the review-CI contract so this regression fails before merge
- reseal the reviewed forward authority blobs

## Evidence
- `node scripts/check-review-ci.mjs`
- `node scripts/check-source-line-cap.mjs`
- `git diff --check`
- Bash/Node syntax checks for the changed authority files

## Production failure reproduced
Run `33824763625` reached the review producer with an empty `REVIEW_PRIVATE_KEY` because current `main` had lost both `environment: production` and the environment secret name. The prior successful run `33809698436` used these exact authority bindings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Deployment**
  * Updated production transition workflows to use dedicated signing keys and the production environment.
  * Added explicit Git identity configuration for review and publishing operations.
  * Updated verified authority and deployment manifest references to newer immutable revisions.

* **Bug Fixes**
  * Strengthened workflow validation to enforce signing-key separation and prevent legacy key usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->