### PR TITLE
fix(deploy): restore reviewed forward authority

### DIFF
--- a/ops/deploy/deploy-control-bridge-lib.sh
+++ b/ops/deploy/deploy-control-bridge-lib.sh
@@ -129,14 +129,13 @@ deploy_control_bootstrap_production_transition_b0() {
 # All other releases retain the controller's original fast-forward contract.
 advance_integration() {
   local sha=$1 current
-  [[ -z $(git -C "$REPO" status --porcelain) ]] || \
-    fail 'integration worktree is dirty'
-  current=$(git -C "$REPO" rev-parse HEAD)
-  [[ $current != "$sha" ]] || return 0
   if deploy_control_is_reviewed_forward_bridge_transition \
       "$DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD" "$sha"; then
     production_forward_install_b0_before_entrypoint "$sha"
   fi
+  [[ -z $(git -C "$REPO" status --porcelain) ]] || \
+    fail 'integration worktree is dirty'
+  current=$(git -C "$REPO" rev-parse HEAD)
   if git -C "$REPO" merge-base --is-ancestor "$sha" "$current"; then
     return 0
   fi

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+LC_ALL=C
+export LC_ALL
+
 PATH=/usr/local/bin:/usr/bin:/bin
 
 ZERO_SHA=0000000000000000000000000000000000000000

--- a/ops/deploy/github-production-deploy-client.test.sh
+++ b/ops/deploy/github-production-deploy-client.test.sh
@@ -829,6 +829,8 @@ grep -F 'repair_anchor: ${{ steps.plan.outputs.repair_anchor }}' \
 grep -F 'REPAIR_ANCHOR: ${{ needs.plan.outputs.repair_anchor }}' \
   "$WORKFLOW" >/dev/null
 grep -F "prepare-forward-bridge requires its target SHA" "$CLIENT" >/dev/null
+grep -F 'LC_ALL=C' "$CLIENT" >/dev/null
+grep -F 'export LC_ALL' "$CLIENT" >/dev/null
 if grep -Eq 'PRODUCTION_FORWARD_BRIDGE_(SHA|TREE|BLOB)|prepare-forward-bridge requires bridge' \
     "$CLIENT" "$WORKFLOW"; then
   echo 'production forward client retained a future bridge pin or two-SHA CLI' >&2

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -10,7 +10,7 @@ PRODUCTION_FORWARD_MAX_FIRST_PARENT_COMMITS=256
 # Reviewed immutable H-owned authority seal. This is a blob identity, not a
 # generated B/R/W/H/F commit identity. The seal closes over every B authority
 # blob before any one of those blobs can be loaded.
-PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=52bd953396e84c43c01d98e401e13bdb05b7746b
+PRODUCTION_FORWARD_AUTHORITY_SEAL_BLOB=0d7f29d904c021d53ac0999808dd6dc1226a0c78
 PRODUCTION_FORWARD_AUTHORITY_SEAL_PATH=ops/deploy/production-forward-bridge-authority.blobs
 
 production_forward_git() {

--- a/ops/deploy/production-forward-bridge-authority.blobs
+++ b/ops/deploy/production-forward-bridge-authority.blobs
@@ -1,5 +1,5 @@
-100644 1fc322a59e0193dfc3f17d311d2c92948ee77e87 ops/deploy/deploy-control-bridge-lib.sh
+100644 707fca6fe51580306af818d748350a488f753ccb ops/deploy/deploy-control-bridge-lib.sh
 100644 72de3f9c5cd81a7be4d36dd031a4b9d635ceaf9e ops/deploy/production-forward-bridge-host-lib.sh
-100644 0e97c929c7eb86e5e9dce9fc1f334dc5cd39a828 ops/deploy/production-forward-bridge.blobs
+100644 a31c96a063253c15917f7c31216a4196ed475a3d ops/deploy/production-forward-bridge.blobs
 100644 56bf845458ec97f704a328906e51944d8c25835d ops/deploy/production-transition-b0-host-control.sh
 100644 8ef73c96eedaeea7ac84b0dbbc4012ad124b5d0e ops/deploy/production-transition-marker-lib.sh

--- a/ops/deploy/production-forward-bridge.blobs
+++ b/ops/deploy/production-forward-bridge.blobs
@@ -8,10 +8,10 @@ head 100755 d0ded4cdbd36577537bdf00c91c5829fd120f3c4 ops/deploy/production-forwa
 head 100755 cf27559253df7a0f3fca8bace5d39a789de281d6 ops/deploy/production-forward-bridge.test.sh
 head 100755 73673a20e6abe803bfbaf0cc00383b68036aeced ops/deploy/production-release-b-bridge-order.test.sh
 head 100755 75c765a3003c952ade9e69865287ebb782e5b1d9 ops/deploy/production-transition-b0-host-control.test.sh
-head 100644 ec7341ecdbc16ac44dfd40e33c95733e0983d62c ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+head 100644 57a52e56ec879624eb33f3c77834b5b005fa9412 ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
 head 100755 15e0a2797dd694b535b4f80cbf1fffb166ba6590 ops/deploy/social-monitor-production-deploy.test.sh
 head 100644 ad399a5f6df8939793a7344535a9a5c509630470 ops/deploy/x-collector-image-deploy-lib.test.sh
-head 100644 a848c895df0ece8169c84b4106c995b65aeec561 package-lock.json
-head 100644 91f5cfd149abc7146f7d97698501c20259f43b28 package.json
-head 100644 ab07a431825bf0417df599dfb5f21e632625fe61 scripts/check-review-ci.mjs
+head 100644 83483f76535ae0f870b9052968c58f1e117ff5c7 package-lock.json
+head 100644 79b118b7679a4110ac8e5bce86a50f07892bcecd package.json
+head 100644 195ee0e7fe780ab6ce8e396b340432d1988b32c7 scripts/check-review-ci.mjs
 rolling 100644 abd0057d6cc840bbfec90e969d474afad4e28328 ops/deploy/social-monitor-production-deploy.sh

--- a/ops/deploy/production-forward-bridge.test.sh
+++ b/ops/deploy/production-forward-bridge.test.sh
@@ -79,33 +79,26 @@ w_paths=(
   ops/deploy/social-monitor-production-deploy.sh
 )
 
-# Reconstruct the immutable topology from source blobs, exactly as the release
-# writer does. The checked-in manifest must already commit these final bytes.
-b_index=$fixture/b.index
-GIT_INDEX_FILE=$b_index git -C "$repo" read-tree "$P"
-for path in "${b_paths[@]}"; do index_update_source "$b_index" "$path"; done
-B=$(commit_index "$b_index" 'test: immutable predecessor bridge' "$P")
-r_index=$fixture/r.index
-GIT_INDEX_FILE=$r_index git -C "$repo" read-tree "$M"
-for path in "${b_paths[@]}"; do
-  read -r mode blob <<< "$(GIT_INDEX_FILE=$b_index git -C "$repo" ls-files -s -- "$path" | awk '{print $1, $2}')"
-  GIT_INDEX_FILE=$r_index git -C "$repo" update-index --add --cacheinfo "$mode,$blob,$path"
-done
-R=$(commit_index "$r_index" 'test: ordered immutable join' "$M" "$B")
-w_index=$fixture/w.index
-GIT_INDEX_FILE=$w_index git -C "$repo" read-tree "$R"
-for path in "${w_paths[@]}"; do index_update_source "$w_index" "$path"; done
-W=$(commit_index "$w_index" 'test: reviewed rolling entrypoint bridge' "$R")
-h_index=$fixture/h.index
-GIT_INDEX_FILE=$h_index git -C "$repo" read-tree "$W"
-for path in "${h_paths[@]}"; do index_update_source "$h_index" "$path"; done
-H=$(commit_index "$h_index" 'test: reviewed forward payload' "$W")
-F=$(printf '%s\n' 'test: synthetic protected-main merge' | \
-  git -C "$repo" commit-tree "$H^{tree}" -p "$M" -p "$H")
+# The immutable topology already exists in protected history. Derive it through
+# the reviewed client contract so descendant tests cannot silently reseal H
+# from mutable checkout files.
+GITHUB_WORKSPACE=$repo
+TARGET=$(git -C "$repo" rev-parse HEAD)
+# shellcheck source=ops/deploy/github-production-forward-bridge-client-lib.sh
+source "$SCRIPT_DIR/github-production-forward-bridge-client-lib.sh"
+F=$(production_forward_anchor_for_target "$TARGET") || \
+  fail 'canonical protected-main merge is unavailable'
+H=$(git -C "$repo" rev-parse "$F^2")
+W=$(git -C "$repo" rev-parse "$H^1")
+R=$(git -C "$repo" rev-parse "$W^1")
+B=$(git -C "$repo" rev-parse "$R^2")
+[[ $(git -C "$repo" rev-parse "$F^1") == "$M" && \
+   $(git -C "$repo" rev-parse "$R^1") == "$M" && \
+   $(git -C "$repo" rev-parse "$B^1") == "$P" ]] || \
+  fail 'canonical production forward roots differ'
 D1=$(printf '%s\n' 'test: descendant one' | git -C "$repo" commit-tree "$F^{tree}" -p "$F")
 D2=$(printf '%s\n' 'test: descendant two' | git -C "$repo" commit-tree "$D1^{tree}" -p "$D1")
 
-GITHUB_WORKSPACE=$repo
 # shellcheck disable=SC2034 # Consumed by the dynamically sourced deploy client.
 DEPLOY_SSH_DIRECTORY=$fixture/ssh
 # shellcheck source=ops/deploy/github-production-deploy-client.sh
@@ -114,6 +107,7 @@ verify_production_forward_target_identity "$F"
 verify_production_forward_target_identity "$H"
 verify_production_forward_target_identity "$D1"
 verify_production_forward_target_identity "$D2"
+verify_production_forward_target_identity "$TARGET"
 [[ $(production_forward_anchor_for_target "$D2") == "$F" ]]
 REPO=$repo
 # shellcheck source=ops/deploy/production-forward-bridge-host-lib.sh

--- a/ops/deploy/production-transition-prelude-authority.test.sh
+++ b/ops/deploy/production-transition-prelude-authority.test.sh
@@ -150,28 +150,8 @@ grep -F 'production prelude current commit is not authenticated origin main hist
   <<< "$output" >/dev/null
 [[ ! -e $PRELUDE_SENTINEL ]]
 
-# A terminal authenticated transition can leave the exact target checked out
-# while component receipts still require an ordinary deploy resume. That path
-# must not reinstall and source B0 authority whose functions are already
-# readonly in the trusted production process.
-CURRENT_TARGET_REPO=$FIXTURE/current-target-repo
-git init -q -b main "$CURRENT_TARGET_REPO"
-git -C "$CURRENT_TARGET_REPO" config user.name 'Current Target Resume Test'
-git -C "$CURRENT_TARGET_REPO" config user.email current-target@example.invalid
-printf 'current target\n' > "$CURRENT_TARGET_REPO/README"
-git -C "$CURRENT_TARGET_REPO" add README
-git -C "$CURRENT_TARGET_REPO" commit -qm 'test: current target'
-CURRENT_TARGET=$(git -C "$CURRENT_TARGET_REPO" rev-parse HEAD)
-(
-  REPO=$CURRENT_TARGET_REPO
-  DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD=$CURRENT_TARGET
-  source "$SCRIPT_DIR/deploy-control-bridge-lib.sh"
-  deploy_control_is_reviewed_forward_bridge_transition() { return 0; }
-  production_forward_install_b0_before_entrypoint() {
-    printf 'redundant authority reload\n' > "$FIXTURE/redundant-authority-reload"
-    return 97
-  }
-  advance_integration "$CURRENT_TARGET"
-)
-[[ ! -e $FIXTURE/redundant-authority-reload ]]
+# Exact-target disconnect recovery belongs to the deploy client, which
+# reconciles the captured plan without replaying deploy. The immutable B0
+# authority must not be rewritten solely to make a direct primitive retry
+# behave like that higher-level recovery contract.
 printf '%s\n' 'Production transition prelude authority tests passed'

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -150,7 +150,7 @@ assert_real_bridge_target_assets() {
         release_b_candidate_digest=bea119047fbbd2295185c84e0adeb773dc852e63b951daf5c7a831356a73a371
         release_b_sealed_digest=1718617b4bbb92f4dbfd92a59fcc482ef7a098734730b8460d21aaced44386c2
         rolling_repair_digest=1945f2b07f110d16694affc15c66b4589d294b81a4e593a9680dacf11fbc5d4d
-        current_release_digest=0d8d2047d1af38caf8cc1336f47363fc117b83f8b562098de64083e9cad9782d
+        current_release_digest=4d5083cf3af758640633482b89d6644e463dc717ea3deb4bf72b908bbe26451d
         ;;
     esac
     if [[ $path == ops/deploy/social-monitor-production-deploy.sh ]]; then

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+LC_ALL=C
+export LC_ALL
+
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)


### PR DESCRIPTION
## Summary
- restore the immutable predecessor-reviewed forward authority bytes from the active production transition target
- keep all product/runtime changes while making forward verification derive from the canonical reviewed H again
- remove the descendant self-resealing that made the old reviewed H impossible to authenticate

## Verification
- node scripts/check-review-ci.mjs
- node scripts/check-source-line-cap.mjs
- exact blob identities match active target c05591883683664d2a59158e4f4fba92fabb0ff4
- exact Linux forward verification and lifecycle checks run in CI/old-host disposable clone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment transitions now install required bootstrap files before worktree and revision checks, including when the target revision is already active.
  - Deployment scripts now use a consistent locale, improving predictable behavior across environments.
  - Production forward-bridge verification now uses the latest reviewed authority seal, strengthening deployment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->