### PR TITLE
fix(deploy): refresh ShellCheck baseline locations

### DIFF
--- a/ops/deploy/verify-production-shellcheck-baseline.sh
+++ b/ops/deploy/verify-production-shellcheck-baseline.sh
@@ -14,10 +14,10 @@ deploy_shellcheck=$(
 DEPLOY_SHELLCHECK=$deploy_shellcheck node <<'NODE'
 const findings = JSON.parse(process.env.DEPLOY_SHELLCHECK ?? "[]");
 const expected = new Set([
-  "ops/deploy/production-forward-bridge.test.sh:416:2120:run_b0_install",
-  "ops/deploy/production-forward-bridge.test.sh:577:2034:PRODUCTION_TRANSITION_HOST_LOCK_FD",
-  "ops/deploy/production-forward-bridge.test.sh:579:2034:PRODUCTION_TRANSITION_HOST_LOCK_ACTIVE",
-  "ops/deploy/production-forward-bridge.test.sh:590:2034:PRODUCTION_TRANSITION_HOST_LOCK_OWNER",
+  "ops/deploy/production-forward-bridge.test.sh:410:2120:run_b0_install",
+  "ops/deploy/production-forward-bridge.test.sh:571:2034:PRODUCTION_TRANSITION_HOST_LOCK_FD",
+  "ops/deploy/production-forward-bridge.test.sh:573:2034:PRODUCTION_TRANSITION_HOST_LOCK_ACTIVE",
+  "ops/deploy/production-forward-bridge.test.sh:584:2034:PRODUCTION_TRANSITION_HOST_LOCK_OWNER",
   "ops/deploy/social-monitor-production-deploy.sh:42:2034:PUBLIC_LINK",
   "ops/deploy/social-monitor-production-deploy.sh:43:2034:ADMIN_LINK",
 ]);


### PR DESCRIPTION
## What

- Refreshes four exact line locations in the reviewed production ShellCheck allowlist after PR #270 shifted the existing test code.
- Keeps the same warning codes, symbols and strict exact-match behavior.
- Does not change deploy behavior or the warned scripts.

## Why

Production deploy run `33843619859` failed in `backend-gate=bridge-classification` because the allowlist still referenced the pre-PR #270 line numbers.

## Verification

- Exact bridge-phase ShellCheck command from the failed deploy passed with all six reviewed warnings.
- `bash -n` and ShellCheck for the verifier passed.
- `git diff --check` passed.
- Production lifecycle reached and passed the repaired baseline; its later sandbox-only cleanup was blocked by the hosted `codex-safe-rm` guard.
