### PR TITLE
fix(deploy): keep loaded B0 bootstrap idempotent

### DIFF
--- a/ops/deploy/production-forward-bridge.test.sh
+++ b/ops/deploy/production-forward-bridge.test.sh
@@ -433,6 +433,7 @@ for b0_file in "${b0_files[@]}"; do
     assert_installed_blob "$B" ops/deploy/production-transition-b0-host-control.sh
   done
 done
+
 printf 'forward-bridge-test: B0 rename crashes resume\n'
 
 # Existing unsafe destinations never get treated as crash orphans. Exercise
@@ -705,3 +706,25 @@ printf 'forward-bridge-test: runtime rollback and marker crashes resume\n'
 
 printf 'production-forward-bridge-test: ok B=%s R=%s W=%s H=%s F=%s\n' \
   "$B" "$R" "$W" "$H" "$F"
+
+# A process that already loaded and froze B0 authority must still verify every
+# installed control blob, but it must not source the authority a second time.
+ENTRYPOINT=$SCRIPT_DIR/social-monitor-production-deploy.sh
+verify_loaded_b0_idempotence() (
+  export SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
+  export SOCIAL_MONITOR_DEPLOY_ROOT=$fixture
+  export SOCIAL_MONITOR_DEPLOY_REPO=$repo
+  export SOCIAL_MONITOR_DEPLOY_CONTROL=$CONTROL
+  export SOCIAL_MONITOR_DEPLOY_STATE=$STATE
+  export SOCIAL_MONITOR_DEPLOY_STAGING=$fixture/staging
+  printf '%s\n' "$B" > "$STATE/control.sha"
+  chmod 0600 "$STATE/control.sha"
+  # shellcheck source=ops/deploy/social-monitor-production-deploy.sh
+  source "$ENTRYPOINT"
+  readonly -f production_transition_host_failpoint
+  production_forward_install_b0_before_entrypoint "$F"
+)
+verify_loaded_b0_idempotence
+printf 'tampered canonical authority\n' > \
+  "$CONTROL/production-transition-canonical-lib.sh"
+expect_failure 'tampered loaded B0 authority' verify_loaded_b0_idempotence

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -307,6 +307,17 @@ load_reader_summary_publication_deploy_library() {
 }
 initialize_deploy_control_bridge
 declare -F production_transition_install_compatibility_overrides >/dev/null && production_transition_install_compatibility_overrides
+if declare -F production_transition_host_failpoint >/dev/null && declare -F production_forward_install_b0_before_entrypoint >/dev/null; then
+  production_forward_install_b0_before_entrypoint() {
+    local target=$1 remote bridge
+    production_forward_derive_graph "$target"; bridge=$PRODUCTION_FORWARD_B
+    production_forward_verify_target_graph "$bridge" "$target"
+    remote=$(git -C "$REPO" rev-parse 'origin/main^{commit}' 2>/dev/null) || production_forward_host_fail 'production forward origin main is unavailable before B0 verification'
+    [[ $remote == "$target" ]] || production_forward_host_fail 'production forward B0 verification requires exact origin main'
+    production_forward_install_blob "$target" 0755 ops/deploy/production-transition-admission.sh
+    production_forward_install_blob "$target" 0644 ops/deploy/production-transition-canonical-lib.sh; production_forward_install_blob "$bridge" 0644 ops/deploy/production-transition-b0-host-control.sh
+  }
+fi
 verify_compose_scope() (
   local rendered=$STATE/rendered-compose.$$.json
   trap 'rm -f "$rendered"' EXIT


### PR DESCRIPTION
## What changed
- keep the forward B0 bootstrap fail-closed after the authority is already loaded and frozen
- revalidate the protected graph, exact origin/main, and all three installed control blobs without sourcing B0 twice
- cover the readonly-function regression and tampered canonical control path

## Evidence
- production ShellCheck baseline passed
- exact SHA `eae553700fe47155135bbf76d56f6ed9c1984936` passed `production-forward-bridge.test.sh` on the old hosted test worker
- source/test line cap passed for 3909 files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened production deployment validation to ensure deployments use the exact intended source revision.
  * Added safeguards that prevent deployment processes from accepting corrupted or altered authority data after startup.
  * Improved installation and verification of deployment transition controls across target and bridge environments.

* **Tests**
  * Added coverage for repeated deployment checks and authority-integrity failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->