### PR TITLE
fix(deploy): skip loaded B0 bootstrap on ordinary releases

### DIFF
--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""One-incident operator recovery; never deploys an application or writes markers.
+
+Install/review this exact script independently of the broken controller. Review
+the inspect output, then bind apply to its SHA256. Only the protected-main
+control delta below is admitted. A failed/interrupted apply is NOT success:
+rollback accepts only recognizable old/new path and index states. Unknown
+bytes or an outstanding Git lock require operator investigation, not reset.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+
+ROOT = Path('/var/data/social-monitor')
+MACHINE = 'be0aad971ea647fab370acd110b469b7'
+PREIMAGE = '8c402ecadff1db34a9d5991b777a5eb8032282de'
+LIVE = 'c05591883683664d2a59158e4f4fba92fabb0ff4'
+ORIGIN = 'https://github.com/777genius/social-monitor.git'
+CONTROLLER = 'ops/deploy/deploy-control-lib.sh'
+CONTROLLER_SHA256 = '3caf2f61ef68ef9697d4e2d5dd3eb057abbcc201942670d4e81fba5ab89f20ad'
+ALLOWED = frozenset('ops/deploy/' + name for name in (
+    'deploy-control-lib.sh', 'production-transition-b0-bootstrap.test.sh',
+    'production-transition-bridge.manifest', 'production-transition-review.statement',
+    'production-transition-review.statement.sig',
+    'rabbitmq-quorum-deploy-bridge-transition.test.sh',
+    'b0-controller-repair.py', 'b0-controller-repair.test.py'))
+MARKERS = ('backend.sha', 'frontend.sha', 'control.sha',
+           'postgres-pool-bootstrap.sha', 'production-transition-activated.sha')
+STATE_FILES = (*MARKERS, 'production-transition-b0-host.state',
+               'production-transition-review-consumption.v2')
+CONTROLS = ('github-production-deploy.sh', 'github-production-deploy-wrapper.sh',
+            'production-transition-b0-host-control.sh',
+            'production-transition-canonical-lib.sh', 'production-transition-admission.sh')
+LOCKS = ('deploy-state/production-transition-b0-host.lock',
+         'production-deploy.lock', 'daily-run.lock')
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def canonical(value: object) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(',', ':')) + '\n').encode()
+
+
+def execute(*args: str) -> bytes:
+    result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            timeout=120, check=False)
+    require(result.returncode == 0, f'command failed: {args[0]} {args[1:3]}')
+    return result.stdout
+
+
+def regular(path: Path) -> tuple[bytes, list[int]]:
+    with os.fdopen(os.open(path, os.O_RDONLY | os.O_NOFOLLOW), 'rb') as stream:
+        before = os.fstat(stream.fileno())
+        require(stat.S_ISREG(before.st_mode) and before.st_nlink == 1
+                and before.st_uid == os.geteuid() and not before.st_mode & 0o022,
+                f'unsafe file: {path}')
+        data = stream.read()
+        after = os.fstat(stream.fileno())
+        identity = lambda s: [s.st_dev, s.st_ino, s.st_mode, s.st_size, s.st_mtime_ns, s.st_ctime_ns]
+        require(identity(before) == identity(after) == identity(path.lstat()),
+                f'file changed during read: {path}')
+        return data, identity(after)
+
+
+def durable(path: Path, data: bytes) -> None:
+    with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600), 'wb') as stream:
+        stream.write(data)
+        stream.flush()
+        os.fsync(stream.fileno())
+    directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+class ControllerRepair:
+    """Scope and audit of this incident, not a general deployment authority."""
+
+    def __init__(self, root: Path, preimage: str, live: str, controller_hash: str):
+        self.root, self.repo, self.control = root, root / 'integration', root / 'control'
+        self.preimage, self.live, self.controller_hash = preimage, live, controller_hash
+
+    def git(self, *args: str) -> bytes:
+        return execute('/usr/bin/git', '-C', str(self.repo), *args)
+
+    def remote(self) -> str:
+        lines = self.git('ls-remote', '--exit-code', 'origin', 'refs/heads/main').decode().splitlines()
+        require(len(lines) == 1 and lines[0].endswith('\trefs/heads/main'), 'ambiguous main lease')
+        return lines[0].split()[0]
+
+    def hazards(self) -> None:
+        require(self.repo.resolve() == self.repo and (self.repo / '.git').is_dir()
+                and not (self.repo / '.git').is_symlink(), 'unsafe integration/common directory')
+        require(self.git('rev-parse', '--git-common-dir').strip() == b'.git', 'integration is not common Git root')
+        require(not (self.repo / '.git/HEAD').read_text().startswith('ref:'), 'integration must be detached')
+        for name in ('index.lock', 'HEAD.lock', 'MERGE_HEAD', 'CHERRY_PICK_HEAD', 'REVERT_HEAD',
+                     'rebase-merge', 'rebase-apply', 'sequencer', 'info/grafts', 'info/sparse-checkout'):
+            require(not os.path.lexists(self.repo / '.git' / name), f'unfinished/unsafe Git state: {name}')
+        require(not self.git('for-each-ref', '--format=%(refname)', 'refs/replace').strip(), 'replace refs refused')
+        hooks = self.git('rev-parse', '--git-path', 'hooks').decode().strip()
+        hooks_path = Path(hooks) if Path(hooks).is_absolute() else self.repo / hooks
+        # Do not disable or bypass installed hooks. Refuse ones this recovery
+        # could execute, including reference-transaction and fsmonitor hooks.
+        for name in ('post-merge', 'post-checkout', 'reference-transaction', 'post-index-change'):
+            require(not os.path.lexists(hooks_path / name), f'recovery would invoke hook: {name}')
+        for key in ('core.fsmonitor', 'core.sparseCheckout', 'core.splitIndex'):
+            value = subprocess.run(['/usr/bin/git', '-C', str(self.repo), 'config', '--get', key],
+                                   stdout=subprocess.PIPE, check=False).stdout.strip()
+            require(value in (b'', b'false'), f'unsupported Git setting: {key}')
+        require(not self._has_filters(), 'Git content filters refused')
+
+    def _has_filters(self) -> bool:
+        return subprocess.run(['/usr/bin/git', '-C', str(self.repo), 'config', '--get-regexp',
+                               r'^filter\..*\.(clean|smudge|process)$'], stdout=subprocess.DEVNULL,
+                              check=False).returncode == 0
+
+    @contextlib.contextmanager
+    def locked(self):
+        with contextlib.ExitStack() as stack:
+            for name in LOCKS:
+                if name == 'daily-run.lock':
+                    self.daily_probe()
+                path = self.control / name
+                _, identity = regular(path)
+                stream = stack.enter_context(os.fdopen(os.open(path, os.O_RDWR | os.O_NOFOLLOW), 'r+b'))
+                info = os.fstat(stream.fileno())
+                require([info.st_dev, info.st_ino] == identity[:2], 'lock inode changed')
+                fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                require(path.lstat().st_ino == info.st_ino, 'lock replaced')
+            self.daily_probe()
+            yield
+
+    def daily_probe(self) -> None:
+        path = self.control / 'daily-run-singleton.lock'
+        _, identity = regular(path)
+        with os.fdopen(os.open(path, os.O_RDWR | os.O_NOFOLLOW), 'r+b') as stream:
+            info = os.fstat(stream.fileno())
+            require([info.st_dev, info.st_ino] == identity[:2], 'daily lock changed')
+            fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def protected(self) -> dict:
+        result = {}
+        for name in STATE_FILES:
+            path = self.control / 'deploy-state' / name
+            data, identity = regular(path)
+            if name in MARKERS:
+                require(data == (self.live + '\n').encode(), f'live marker drift: {name}')
+            result[str(path.relative_to(self.root))] = [digest(data), identity]
+        for name in CONTROLS:
+            data, identity = regular(self.control / name)
+            result['control/' + name] = [digest(data), identity]
+        for name in ('production-transition-scheduler-hold.v2', 'production-transition-b0-host.state.next'):
+            require(not os.path.lexists(self.control / 'deploy-state' / name), f'incomplete transition: {name}')
+        link = self.control / 'postgres-runtime-current'
+        require(link.is_symlink(), 'runtime current is not a symlink')
+        result['runtime-link'] = [os.readlink(link), link.lstat().st_ino]
+        require(link.resolve() == self.control / 'postgres-runtime-releases' / self.live,
+                'runtime link left live release')
+        data, identity = regular(link / 'READY')
+        require(data == (self.live + '\n').encode(), 'runtime READY drift')
+        result['runtime-ready'] = [digest(data), identity]
+        result['containers'] = self.runtime_identity()
+        return result
+
+    def runtime_identity(self) -> str:
+        names = ['social-monitor-prod-' + role + '-1' for role in (
+            'api', 'agent-runtime', 'ingestion-worker', 'intelligence-worker',
+            'delivery-service', 'event-relay', 'frontend', 'x-collector')]
+        return digest(execute('/usr/bin/docker', 'inspect', '--format',
+                              '{{.Id}} {{.Image}} {{.State.StartedAt}} {{.RestartCount}}', *names))
+
+    def plan(self, target: str) -> dict:
+        require(re.fullmatch('[0-9a-f]{40}', target) is not None, 'full target SHA required')
+        self.hazards()
+        require(self.git('rev-parse', 'HEAD').decode().strip() == self.preimage, 'preimage HEAD differs')
+        require(not self.git('status', '--porcelain=v1').strip(), 'integration is dirty')
+        require(self.remote() == target, 'target is not exact protected main')
+        self.git('merge-base', '--is-ancestor', self.preimage, target)
+        paths = self.git('diff', '--name-only', '--no-renames', self.preimage, target).decode().splitlines()
+        require(CONTROLLER in paths and set(paths) <= ALLOWED, 'delta is not this control-only repair')
+        require(digest(self.git('show', target + ':' + CONTROLLER)) == self.controller_hash, 'wrong controller fix')
+        entries = {}
+        for name in paths:
+            versions = []
+            for commit in (self.preimage, target):
+                row = self.git('ls-tree', commit, '--', name).decode().strip()
+                if not row:
+                    versions.append(None)
+                    continue
+                mode, kind, tail = row.split(' ', 2)
+                blob, actual = tail.split('\t')
+                require(kind == 'blob' and mode in ('100644', '100755') and actual == name,
+                        'non-regular repair path')
+                versions.append([mode, blob, digest(self.git('cat-file', 'blob', blob))])
+            require(versions[1] is not None, 'repair must not remove files')
+            entries[name] = versions
+        return {'version': 1, 'preimage': self.preimage, 'target': target,
+                'target_tree': self.git('rev-parse', target + '^{tree}').decode().strip(),
+                'delta_sha256': digest(self.git('diff', '--binary', '--full-index', self.preimage, target)),
+                'entries': entries, 'protected': self.protected(),
+                'git_directory_inode': (self.repo / '.git').stat().st_ino}
+
+    def run_path(self, target: str) -> Path:
+        require(re.fullmatch('[0-9a-f]{40}', target) is not None, 'full target SHA required')
+        return self.control / ('b0-controller-repair-' + target)
+
+    def apply(self, target: str, approved: str) -> None:
+        with self.locked():
+            plan = self.plan(target)
+            require(digest(canonical(plan)) == approved, 'reviewed plan drifted')
+            run = self.run_path(target)
+            run.mkdir(mode=0o700)  # Existing/partial runs must use explicit rollback, never blind retry.
+            durable(run / 'plan.json', canonical(plan))
+            durable(run / 'index.backup', regular(self.repo / '.git/index')[0])
+            for number, versions in enumerate(plan['entries'].values()):
+                if versions[0]:
+                    durable(run / f'old-blob-{number}', self.git('cat-file', 'blob', versions[0][1]))
+            durable(run / 'prepared', canonical({'plan_sha256': approved}))
+            # This is an audited control recovery only. No target code or hook
+            # is invoked; the installed entrypoint and all markers stay intact.
+            self.git('merge', '--ff-only', '--no-edit', target)
+            require(not self.git('status', '--porcelain=v1').strip(), 'post-repair checkout is dirty')
+            require(self.git('rev-parse', 'HEAD').decode().strip() == target, 'target not reached')
+            require(self.protected() == plan['protected'], 'protected state changed')
+            require((self.repo / '.git').stat().st_ino == plan['git_directory_inode'], 'Git directory replaced')
+            durable(run / 'control-repaired', canonical({'application_deployed': False, 'target': target}))
+
+    def rollback(self, target: str, approved: str) -> None:
+        with self.locked():
+            self.hazards()
+            run = self.run_path(target)
+            data, _ = regular(run / 'plan.json')
+            require(digest(data) == approved, 'rollback plan differs from review')
+            plan = json.loads(data)
+            require(plan['preimage'] == self.preimage and plan['target'] == target, 'rollback identity mismatch')
+            require(not (run / 'ordinary-handoff').exists(), 'ordinary deployment handoff forbids rollback')
+            require(self.protected() == plan['protected'], 'protected state drift forbids rollback')
+            require(self.git('rev-parse', 'HEAD').decode().strip() in (self.preimage, target), 'unknown HEAD')
+            require((self.repo / '.git').stat().st_ino == plan['git_directory_inode'], 'Git directory replaced')
+            allowed = set(plan['entries'])
+            for args in (('diff', '--name-only', '--no-renames', self.preimage),
+                         ('diff', '--cached', '--name-only', '--no-renames', self.preimage)):
+                require(set(self.git(*args).decode().splitlines()) <= allowed, 'unrelated edits forbid rollback')
+            # Recognize mixed file/index/ref states, not just old/new HEAD.
+            for name, versions in plan['entries'].items():
+                path = self.repo / name
+                if os.path.lexists(path):
+                    content, identity = regular(path)
+                    require(any(v and v[2] == digest(content) and int(v[0][-3:], 8) == stat.S_IMODE(identity[2])
+                                for v in versions), 'unknown bytes/mode in interrupted repair')
+                else:
+                    require(versions[0] is None, 'missing historical file needs investigation')
+                indexed = self.git('ls-files', '--stage', '--', name).decode().strip()
+                require(not indexed or any(v and indexed == f'{v[0]} {v[1]} 0\t{name}' for v in versions),
+                        'unknown index entry needs investigation')
+            for name, versions in plan['entries'].items():
+                if versions[0]:
+                    self.git('restore', '--source=' + self.preimage, '--staged', '--worktree', '--', name)
+                else:
+                    self.git('update-index', '--force-remove', '--', name)
+                    path = self.repo / name
+                    if path.exists():
+                        path.unlink()  # Only a new, reviewed, hash-verified repair file.
+            self.git('checkout', '--detach', self.preimage)
+            require(not self.git('status', '--porcelain=v1').strip(), 'rollback is not clean')
+            require(self.protected() == plan['protected'], 'rollback changed protected state')
+            durable(run / 'rolled-back', canonical({'preimage': self.preimage}))
+
+    def handoff(self, target: str, approved: str) -> None:
+        with self.locked():
+            self.hazards()
+            run = self.run_path(target)
+            data, _ = regular(run / 'plan.json')
+            require(digest(data) == approved, 'handoff plan differs from review')
+            plan = json.loads(data)
+            require((run / 'control-repaired').is_file(), 'control repair has not completed')
+            require(self.remote() == target and self.git('rev-parse', 'HEAD').decode().strip() == target,
+                    'handoff target/lease drifted')
+            require(not self.git('status', '--porcelain=v1').strip(), 'handoff checkout is dirty')
+            require(self.protected() == plan['protected'], 'handoff protected state changed')
+            durable(run / 'ordinary-handoff', canonical({'target': target, 'application_deployed': False}))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('action', choices=('inspect', 'apply', 'rollback', 'handoff'))
+    parser.add_argument('target')
+    parser.add_argument('--approved-plan-sha256', default='')
+    args = parser.parse_args()
+    require(os.geteuid() == 0 and Path('/etc/machine-id').read_text().strip() == MACHINE,
+            'operator recovery is pinned to the production machine')
+    require(not any(key.startswith('GIT_') for key in os.environ), 'Git environment overrides refused')
+    repair = ControllerRepair(ROOT, PREIMAGE, LIVE, CONTROLLER_SHA256)
+    require(repair.git('remote', 'get-url', 'origin').decode().strip() == ORIGIN, 'origin differs')
+    if args.action == 'inspect':
+        with repair.locked():
+            plan = repair.plan(args.target)
+        print(canonical({'plan': plan, 'plan_sha256': digest(canonical(plan))}).decode(), end='')
+    else:
+        require(re.fullmatch('[0-9a-f]{64}', args.approved_plan_sha256) is not None, 'reviewed plan SHA256 required')
+        getattr(repair, args.action)(args.target, args.approved_plan_sha256)
+        print(canonical({'action': args.action, 'target': args.target, 'application_deployed': False}).decode(), end='')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except (RuntimeError, OSError, subprocess.TimeoutExpired) as error:
+        print(f'b0-controller-repair-refused: {error}', file=sys.stderr)
+        sys.exit(1)

--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -27,12 +27,13 @@ PREIMAGE = '8c402ecadff1db34a9d5991b777a5eb8032282de'
 LIVE = 'c05591883683664d2a59158e4f4fba92fabb0ff4'
 ORIGIN = 'https://github.com/777genius/social-monitor.git'
 CONTROLLER = 'ops/deploy/deploy-control-lib.sh'
-CONTROLLER_SHA256 = '3caf2f61ef68ef9697d4e2d5dd3eb057abbcc201942670d4e81fba5ab89f20ad'
+CONTROLLER_SHA256 = 'f0b717cb29067bae349340c473b924918d790ba1d0c45620a96f7854e54f7c5d'
 ALLOWED = frozenset('ops/deploy/' + name for name in (
     'deploy-control-lib.sh', 'production-transition-b0-bootstrap.test.sh',
     'production-transition-bridge.manifest', 'production-transition-review.statement',
     'production-transition-review.statement.sig',
     'rabbitmq-quorum-deploy-bridge-transition.test.sh',
+    'deploy-control-current-target-lib.sh',
     'b0-controller-repair.py', 'b0-controller-repair.test.py'))
 MARKERS = ('backend.sha', 'frontend.sha', 'control.sha',
            'postgres-pool-bootstrap.sha', 'production-transition-activated.sha')
@@ -84,7 +85,11 @@ def durable(path: Path, data: bytes) -> None:
         stream.write(data)
         stream.flush()
         os.fsync(stream.fileno())
-    directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    sync_directory(path.parent)
+
+
+def sync_directory(path: Path) -> None:
+    directory = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
     try:
         os.fsync(directory)
     finally:
@@ -125,11 +130,13 @@ class ControllerRepair:
             value = subprocess.run(['/usr/bin/git', '-C', str(self.repo), 'config', '--get', key],
                                    stdout=subprocess.PIPE, check=False).stdout.strip()
             require(value in (b'', b'false'), f'unsupported Git setting: {key}')
-        require(not self._has_filters(), 'Git content filters refused')
+        require(not self._has_filters(), 'Git content filters/external diff refused')
+        require(all(row.startswith(b'H ') for row in self.git('ls-files', '-v', '-z').split(b'\0') if row),
+                'skip-worktree/assume-unchanged index entries refused')
 
     def _has_filters(self) -> bool:
         return subprocess.run(['/usr/bin/git', '-C', str(self.repo), 'config', '--get-regexp',
-                               r'^filter\..*\.(clean|smudge|process)$'], stdout=subprocess.DEVNULL,
+                               r'^(filter\..*\.(clean|smudge|process)|diff\..*\.textconv|diff\.external)$'], stdout=subprocess.DEVNULL,
                               check=False).returncode == 0
 
     @contextlib.contextmanager
@@ -166,6 +173,10 @@ class ControllerRepair:
             result[str(path.relative_to(self.root))] = [digest(data), identity]
         for name in CONTROLS:
             data, identity = regular(self.control / name)
+            source = {'github-production-deploy.sh': 'social-monitor-production-deploy.sh',
+                      'github-production-deploy-wrapper.sh': 'social-monitor-production-ssh-wrapper.sh'}.get(name, name)
+            require(data == self.git('show', self.live + ':ops/deploy/' + source),
+                    f'installed historical control differs: {name}')
             result['control/' + name] = [digest(data), identity]
         for name in ('production-transition-scheduler-hold.v2', 'production-transition-b0-host.state.next'):
             require(not os.path.lexists(self.control / 'deploy-state' / name), f'incomplete transition: {name}')
@@ -183,9 +194,9 @@ class ControllerRepair:
     def runtime_identity(self) -> str:
         names = ['social-monitor-prod-' + role + '-1' for role in (
             'api', 'agent-runtime', 'ingestion-worker', 'intelligence-worker',
-            'delivery-service', 'event-relay', 'frontend', 'x-collector')]
+            'delivery-service', 'event-relay', 'frontend', 'x-collector', 'rabbitmq', 'redis')]
         return digest(execute('/usr/bin/docker', 'inspect', '--format',
-                              '{{.Id}} {{.Image}} {{.State.StartedAt}} {{.RestartCount}}', *names))
+                              '{{.Id}} {{.Image}} {{.State.Running}} {{.State.Pid}} {{.State.StartedAt}} {{.RestartCount}} {{json .Mounts}}', *names))
 
     def plan(self, target: str) -> dict:
         require(re.fullmatch('[0-9a-f]{40}', target) is not None, 'full target SHA required')
@@ -211,6 +222,14 @@ class ControllerRepair:
                         'non-regular repair path')
                 versions.append([mode, blob, digest(self.git('cat-file', 'blob', blob))])
             require(versions[1] is not None, 'repair must not remove files')
+            path = self.repo / name
+            if versions[0] is None:
+                require(not os.path.lexists(path), 'new repair path already exists')
+            else:
+                data, identity = regular(path)
+                require(digest(data) == versions[0][2]
+                        and stat.S_IMODE(identity[2]) == int(versions[0][0][-3:], 8),
+                        'preimage repair path bytes/mode differ')
             entries[name] = versions
         return {'version': 1, 'preimage': self.preimage, 'target': target,
                 'target_tree': self.git('rev-parse', target + '^{tree}').decode().strip(),
@@ -228,6 +247,7 @@ class ControllerRepair:
             require(digest(canonical(plan)) == approved, 'reviewed plan drifted')
             run = self.run_path(target)
             run.mkdir(mode=0o700)  # Existing/partial runs must use explicit rollback, never blind retry.
+            sync_directory(self.control)
             durable(run / 'plan.json', canonical(plan))
             durable(run / 'index.backup', regular(self.repo / '.git/index')[0])
             for number, versions in enumerate(plan['entries'].values()):
@@ -291,7 +311,9 @@ class ControllerRepair:
             data, _ = regular(run / 'plan.json')
             require(digest(data) == approved, 'handoff plan differs from review')
             plan = json.loads(data)
-            require((run / 'control-repaired').is_file(), 'control repair has not completed')
+            completed, _ = regular(run / 'control-repaired')
+            require(completed == canonical({'application_deployed': False, 'target': target}),
+                    'control repair receipt differs')
             require(self.remote() == target and self.git('rev-parse', 'HEAD').decode().strip() == target,
                     'handoff target/lease drifted')
             require(not self.git('status', '--porcelain=v1').strip(), 'handoff checkout is dirty')

--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -141,6 +141,11 @@ class ControllerRepair:
 
     @contextlib.contextmanager
     def locked(self):
+        for directory in (self.root, self.control, self.control / 'deploy-state'):
+            info = directory.lstat()
+            require(directory.resolve() == directory and stat.S_ISDIR(info.st_mode)
+                    and info.st_uid == os.geteuid() and not info.st_mode & 0o022,
+                    'unsafe recovery directory')
         with contextlib.ExitStack() as stack:
             for name in LOCKS:
                 if name == 'daily-run.lock':
@@ -194,9 +199,14 @@ class ControllerRepair:
     def runtime_identity(self) -> str:
         names = ['social-monitor-prod-' + role + '-1' for role in (
             'api', 'agent-runtime', 'ingestion-worker', 'intelligence-worker',
-            'delivery-service', 'event-relay', 'frontend', 'x-collector', 'rabbitmq', 'redis')]
-        return digest(execute('/usr/bin/docker', 'inspect', '--format',
-                              '{{.Id}} {{.Image}} {{.State.Running}} {{.State.Pid}} {{.State.StartedAt}} {{.RestartCount}} {{json .Mounts}}', *names))
+            'delivery-service', 'event-relay', 'frontend', 'x-collector', 'rabbitmq', 'redis', 'otel-collector', 'caddy')]
+        data = execute('/usr/bin/docker', 'inspect', '--format',
+                       '{{.Id}} {{.Image}} {{.State.Running}} {{.State.Pid}} {{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} {{.State.StartedAt}} {{.RestartCount}} {{json .Mounts}}', *names)
+        rows = [row.split(maxsplit=5) for row in data.decode().splitlines()]
+        require(len(rows) == len(names) and all(len(row) == 6 and row[2] == 'true'
+                and row[3].isdigit() and int(row[3]) > 0 and row[4] in ('healthy', 'none') for row in rows),
+                'production containers are not stably running')
+        return digest(data)
 
     def plan(self, target: str) -> dict:
         require(re.fullmatch('[0-9a-f]{40}', target) is not None, 'full target SHA required')

--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -27,7 +27,7 @@ PREIMAGE = '8c402ecadff1db34a9d5991b777a5eb8032282de'
 LIVE = 'c05591883683664d2a59158e4f4fba92fabb0ff4'
 ORIGIN = 'https://github.com/777genius/social-monitor.git'
 CONTROLLER = 'ops/deploy/deploy-control-lib.sh'
-CONTROLLER_SHA256 = 'f0b717cb29067bae349340c473b924918d790ba1d0c45620a96f7854e54f7c5d'
+CONTROLLER_SHA256 = '2b80efe62990d8eaf6ea79f0ff7d45c153563036e2503bd0a634db813807fc18'
 ALLOWED = frozenset('ops/deploy/' + name for name in (
     'deploy-control-lib.sh', 'production-transition-b0-bootstrap.test.sh',
     'production-transition-bridge.manifest', 'production-transition-review.statement',
@@ -247,7 +247,38 @@ class ControllerRepair:
                 'target_tree': self.git('rev-parse', target + '^{tree}').decode().strip(),
                 'delta_sha256': digest(self.git('diff', '--binary', '--full-index', self.preimage, target)),
                 'entries': entries, 'protected': self.protected(),
-                'git_directory_inode': (self.repo / '.git').stat().st_ino}
+                'git_directory_identity': self.git_directory_identity()}
+
+    def git_directory_identity(self) -> list[int]:
+        info = (self.repo / '.git').lstat()
+        require(stat.S_ISDIR(info.st_mode), 'Git directory is not a directory')
+        return [info.st_dev, info.st_ino]
+
+    def verify_checkout(self, plan: dict, revision: int = 1) -> None:
+        require(self.git_directory_identity() == plan['git_directory_identity'], 'Git directory replaced')
+        expected_head = plan['target'] if revision else plan['preimage']
+        require(self.git('rev-parse', 'HEAD').decode().strip() == expected_head, 'checkout HEAD differs')
+        require(not self.git('status', '--porcelain=v1').strip(), 'checkout is dirty')
+        for name, versions in plan['entries'].items():
+            expected = versions[revision]
+            path = self.repo / name
+            indexed = self.git('ls-files', '--stage', '--', name).decode().strip()
+            if expected is None:
+                require(not os.path.lexists(path) and not indexed, 'removed repair path remains')
+                continue
+            data, identity = regular(path)
+            require(digest(data) == expected[2] and stat.S_IMODE(identity[2]) == int(expected[0][-3:], 8),
+                    'checkout bytes/mode differ from reviewed blob')
+            require(indexed == f'{expected[0]} {expected[1]} 0\t{name}', 'checkout index differs')
+        require(self.protected() == plan['protected'], 'protected state changed')
+
+    def seal_checkout(self, plan: dict, revision: int = 1) -> None:
+        self.verify_checkout(plan, revision)
+        # Linux syncfs flushes this filesystem, including fetched Git objects,
+        # worktree, index, refs and their directories, without walking worktrees.
+        # Any flush failure forbids the durable completion/cutoff receipt.
+        execute('/usr/bin/sync', '--file-system', str(self.repo))
+        self.verify_checkout(plan, revision)
 
     def run_path(self, target: str) -> Path:
         require(re.fullmatch('[0-9a-f]{40}', target) is not None, 'full target SHA required')
@@ -269,10 +300,7 @@ class ControllerRepair:
             # This is an audited control recovery only. No target code or hook
             # is invoked; the installed entrypoint and all markers stay intact.
             self.git('merge', '--ff-only', '--no-edit', target)
-            require(not self.git('status', '--porcelain=v1').strip(), 'post-repair checkout is dirty')
-            require(self.git('rev-parse', 'HEAD').decode().strip() == target, 'target not reached')
-            require(self.protected() == plan['protected'], 'protected state changed')
-            require((self.repo / '.git').stat().st_ino == plan['git_directory_inode'], 'Git directory replaced')
+            self.seal_checkout(plan)
             durable(run / 'control-repaired', canonical({'application_deployed': False, 'target': target}))
 
     def rollback(self, target: str, approved: str) -> None:
@@ -286,7 +314,7 @@ class ControllerRepair:
             require(not (run / 'ordinary-handoff').exists(), 'ordinary deployment handoff forbids rollback')
             require(self.protected() == plan['protected'], 'protected state drift forbids rollback')
             require(self.git('rev-parse', 'HEAD').decode().strip() in (self.preimage, target), 'unknown HEAD')
-            require((self.repo / '.git').stat().st_ino == plan['git_directory_inode'], 'Git directory replaced')
+            require(self.git_directory_identity() == plan['git_directory_identity'], 'Git directory replaced')
             allowed = set(plan['entries'])
             for args in (('diff', '--name-only', '--no-renames', self.preimage),
                          ('diff', '--cached', '--name-only', '--no-renames', self.preimage)):
@@ -312,8 +340,7 @@ class ControllerRepair:
                     if path.exists():
                         path.unlink()  # Only a new, reviewed, hash-verified repair file.
             self.git('checkout', '--detach', self.preimage)
-            require(not self.git('status', '--porcelain=v1').strip(), 'rollback is not clean')
-            require(self.protected() == plan['protected'], 'rollback changed protected state')
+            self.seal_checkout(plan, revision=0)
             durable(run / 'rolled-back', canonical({'preimage': self.preimage}))
 
     def handoff(self, target: str, approved: str) -> None:
@@ -328,8 +355,7 @@ class ControllerRepair:
                     'control repair receipt differs')
             require(self.remote() == target and self.git('rev-parse', 'HEAD').decode().strip() == target,
                     'handoff target/lease drifted')
-            require(not self.git('status', '--porcelain=v1').strip(), 'handoff checkout is dirty')
-            require(self.protected() == plan['protected'], 'handoff protected state changed')
+            self.seal_checkout(plan)
             durable(run / 'ordinary-handoff', canonical({'target': target, 'application_deployed': False}))
 
 

--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -35,7 +35,8 @@ ALLOWED = frozenset('ops/deploy/' + name for name in (
     'rabbitmq-quorum-deploy-bridge-transition.test.sh',
     'deploy-control-current-target-lib.sh',
     'b0-controller-repair.py', 'b0-controller-repair.test.py',
-    'social-monitor-production-deploy.test.sh'))
+    'social-monitor-production-deploy.test.sh',
+    'x-collector-image-deploy-lib.test.sh'))
 MARKERS = ('backend.sha', 'frontend.sha', 'control.sha',
            'postgres-pool-bootstrap.sha', 'production-transition-activated.sha')
 STATE_FILES = (*MARKERS, 'production-transition-b0-host.state',

--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -27,7 +27,7 @@ PREIMAGE = '8c402ecadff1db34a9d5991b777a5eb8032282de'
 LIVE = 'c05591883683664d2a59158e4f4fba92fabb0ff4'
 ORIGIN = 'https://github.com/777genius/social-monitor.git'
 CONTROLLER = 'ops/deploy/deploy-control-lib.sh'
-CONTROLLER_SHA256 = '2b80efe62990d8eaf6ea79f0ff7d45c153563036e2503bd0a634db813807fc18'
+CONTROLLER_SHA256 = 'c5612b8cd1092ec04bf3d5271e98e0bc58918cc23832f7f57c3947cb91e011eb'
 ALLOWED = frozenset('ops/deploy/' + name for name in (
     'deploy-control-lib.sh', 'production-transition-b0-bootstrap.test.sh',
     'production-transition-bridge.manifest', 'production-transition-review.statement',
@@ -214,7 +214,7 @@ class ControllerRepair:
         require(re.fullmatch('[0-9a-f]{40}', target) is not None, 'full target SHA required')
         self.hazards()
         require(self.git('rev-parse', 'HEAD').decode().strip() == self.preimage, 'preimage HEAD differs')
-        require(not self.git('status', '--porcelain=v1').strip(), 'integration is dirty')
+        require(not self.git('status', '--porcelain=v1', '--untracked-files=all').strip(), 'integration is dirty')
         require(self.remote() == target, 'target is not exact protected main')
         self.git('merge-base', '--is-ancestor', self.preimage, target)
         paths = self.git('diff', '--name-only', '--no-renames', self.preimage, target).decode().splitlines()
@@ -258,7 +258,7 @@ class ControllerRepair:
         require(self.git_directory_identity() == plan['git_directory_identity'], 'Git directory replaced')
         expected_head = plan['target'] if revision else plan['preimage']
         require(self.git('rev-parse', 'HEAD').decode().strip() == expected_head, 'checkout HEAD differs')
-        require(not self.git('status', '--porcelain=v1').strip(), 'checkout is dirty')
+        require(not self.git('status', '--porcelain=v1', '--untracked-files=all').strip(), 'checkout is dirty')
         for name, versions in plan['entries'].items():
             expected = versions[revision]
             path = self.repo / name

--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -34,7 +34,8 @@ ALLOWED = frozenset('ops/deploy/' + name for name in (
     'production-transition-review.statement.sig',
     'rabbitmq-quorum-deploy-bridge-transition.test.sh',
     'deploy-control-current-target-lib.sh',
-    'b0-controller-repair.py', 'b0-controller-repair.test.py'))
+    'b0-controller-repair.py', 'b0-controller-repair.test.py',
+    'social-monitor-production-deploy.test.sh'))
 MARKERS = ('backend.sha', 'frontend.sha', 'control.sha',
            'postgres-pool-bootstrap.sha', 'production-transition-activated.sha')
 STATE_FILES = (*MARKERS, 'production-transition-b0-host.state',

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -217,6 +217,7 @@ class RepairTests(unittest.TestCase):
         self.repair.apply(self.target, self.approved)
         self.git('config', 'core.autocrlf', 'true')
         (self.repo / repair_module.CONTROLLER).write_bytes(b'new controller\r\n')
+        self.assertEqual(self.git('diff', '--', repair_module.CONTROLLER), b'')
         self.assertEqual(self.git('status', '--porcelain').strip(), b'')
         with self.assertRaisesRegex(RuntimeError, 'bytes/mode'):
             self.repair.handoff(self.target, self.approved)
@@ -229,6 +230,7 @@ class RepairTests(unittest.TestCase):
             if args[0] == 'merge':
                 original('config', 'core.autocrlf', 'true')
                 (self.repo / repair_module.CONTROLLER).write_bytes(b'new controller\r\n')
+                self.assertEqual(original('diff', '--', repair_module.CONTROLLER), b'')
             return result
 
         with patch.object(self.repair, 'git', side_effect=git):

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -224,8 +224,10 @@ class RepairTests(unittest.TestCase):
     def test_handoff_rejects_git_clean_but_converted_bytes(self):
         self.repair.apply(self.target, self.approved)
         self.git('config', 'core.autocrlf', 'true')
-        (self.repo / repair_module.CONTROLLER).write_bytes(b'new controller\r\n')
-        self.assertEqual(self.git('diff', '--', repair_module.CONTROLLER), b'')
+        path = self.repo / repair_module.CONTROLLER
+        path.unlink()
+        self.git('restore', '--source=HEAD', '--worktree', repair_module.CONTROLLER)
+        self.assertEqual(path.read_bytes(), b'new controller\r\n')
         self.assertEqual(self.git('status', '--porcelain').strip(), b'')
         with self.assertRaisesRegex(RuntimeError, 'bytes/mode'):
             self.repair.handoff(self.target, self.approved)
@@ -234,11 +236,12 @@ class RepairTests(unittest.TestCase):
         original = self.repair.git
 
         def git(*args):
-            result = original(*args)
             if args[0] == 'merge':
                 original('config', 'core.autocrlf', 'true')
-                (self.repo / repair_module.CONTROLLER).write_bytes(b'new controller\r\n')
-                self.assertEqual(original('diff', '--', repair_module.CONTROLLER), b'')
+            result = original(*args)
+            if args[0] == 'merge':
+                self.assertEqual((self.repo / repair_module.CONTROLLER).read_bytes(), b'new controller\r\n')
+                self.assertEqual(original('status', '--porcelain').strip(), b'')
             return result
 
         with patch.object(self.repair, 'git', side_effect=git):

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -279,6 +279,23 @@ class RepairTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'plan drifted'):
             self.repair.apply(self.target, '0' * 64)
         self.assertFalse(self.repair.run_path(self.target).exists())
+
+    def test_plan_refuses_untracked_files_hidden_by_git_configuration(self):
+        self.git('config', 'status.showUntrackedFiles', 'no')
+        self.write('hidden-untracked', 'unreviewed build input\n')
+        self.assertEqual(self.git('status', '--porcelain').strip(), b'')
+        with self.assertRaisesRegex(RuntimeError, 'integration is dirty'):
+            self.repair.apply(self.target, self.approved)
+        self.assertFalse(self.repair.run_path(self.target).exists())
+
+    def test_handoff_refuses_untracked_files_hidden_by_git_configuration(self):
+        self.repair.apply(self.target, self.approved)
+        self.git('config', 'status.showUntrackedFiles', 'no')
+        self.write('hidden-untracked', 'unreviewed build input\n')
+        self.assertEqual(self.git('status', '--porcelain').strip(), b'')
+        with self.assertRaisesRegex(RuntimeError, 'checkout is dirty'):
+            self.repair.handoff(self.target, self.approved)
+        self.assertFalse((self.repair.run_path(self.target) / 'ordinary-handoff').exists())
         self.assert_preserved()
 
     def test_runtime_restart_after_review_is_refused(self):
@@ -434,8 +451,11 @@ exit 99
             self.assertEqual(result.returncode, 42, f'fresh process {attempt}: {result.stderr.decode()}')
             self.assertIn(b'real-pre-activation-boundary-reached', result.stdout)
             self.assertEqual((empty_control / 'deploy-state/backend.sha').read_text(), repair_module.LIVE + '\n')
-        for mode in ('tracked', 'staged', 'untracked'):
-            path = real / ('recovery-untracked.txt' if mode == 'untracked' else 'README.md')
+        for mode in ('tracked', 'staged', 'untracked', 'hidden-untracked'):
+            untracked = mode.endswith('untracked')
+            path = real / ('recovery-untracked.txt' if untracked else 'README.md')
+            if mode == 'hidden-untracked':
+                self.command('git', '-C', str(real), 'config', 'status.showUntrackedFiles', 'no')
             path.write_text('unreviewed application input\n')
             if mode == 'staged':
                 self.command('git', '-C', str(real), 'add', 'README.md')
@@ -444,10 +464,20 @@ exit 99
             self.assertNotEqual(result.returncode, 42, mode)
             self.assertIn(b'integration worktree is dirty', result.stderr, mode)
             self.assertNotIn(b'real-pre-activation-boundary-reached', result.stdout, mode)
-            if mode == 'untracked':
+            if untracked:
                 path.unlink()
             else:
                 self.command('git', '-C', str(real), 'restore', '--source=HEAD', '--staged', '--worktree', 'README.md')
+        failing_status = full_release.replace('deploy_release "$4"', '''git() {
+  [[ ${3:-} != status ]] || return 73
+  command git "$@"
+}
+deploy_release "$4"''')
+        result = subprocess.run([*args[:2], failing_status, *args[3:]],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        self.assertNotEqual(result.returncode, 42)
+        self.assertIn(b'cannot inspect integration worktree', result.stderr)
+        self.assertNotIn(b'real-pre-activation-boundary-reached', result.stdout)
         self.assertEqual(entrypoint.read_bytes(), self.command(
             'git', '-C', str(real), 'show', repair_module.PREIMAGE + ':ops/deploy/social-monitor-production-deploy.sh'))
 

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -25,6 +25,10 @@ class RepairTests(unittest.TestCase):
         self.git('config', 'user.email', 'repair@example.invalid')
         self.write('README', 'application source must stay unchanged\n')
         self.write('.gitignore', 'ignored/\n')
+        for name in repair_module.CONTROLS:
+            source = {'github-production-deploy.sh': 'social-monitor-production-deploy.sh',
+                      'github-production-deploy-wrapper.sh': 'social-monitor-production-ssh-wrapper.sh'}.get(name, name)
+            self.write('ops/deploy/' + source, 'installed control remains unchanged\n')
         self.write(repair_module.CONTROLLER, 'old controller\n')
         self.write('ops/deploy/production-transition-b0-bootstrap.test.sh', 'old test\n')
         self.git('add', '.')
@@ -212,19 +216,35 @@ class RepairTests(unittest.TestCase):
         real = self.root / 'real-history'
         self.command('git', 'clone', '--no-local', '--no-checkout', '-q', str(source), str(real))
         target = self.command('git', '-C', str(source), 'rev-parse', 'HEAD').strip().decode()
+        real_origin = self.root / 'real-origin.git'
+        self.command('git', 'clone', '--bare', '--no-local', '-q', str(source), str(real_origin))
+        self.command('git', '-C', str(real_origin), 'update-ref', 'refs/heads/main', target)
+        self.command('git', '-C', str(real), 'remote', 'set-url', 'origin', str(real_origin))
+        self.command('git', '-C', str(real), 'fetch', '-q', 'origin', 'main')
         self.command('git', '-C', str(real), 'checkout', '--detach', '-q', repair_module.PREIMAGE)
         entrypoint = real / 'ops/deploy/social-monitor-production-deploy.sh'
         # Real pathspecs and compatibility verifier, not the earlier mocked
         # component_changed=false shortcut. All filesystem effects are in /tmp.
         empty_control = self.root / 'real-control'
         (empty_control / 'deploy-state').mkdir(parents=True)
+        for name in repair_module.MARKERS:
+            (empty_control / 'deploy-state' / name).write_text(repair_module.LIVE + '\n')
+        for name in repair_module.CONTROLS:
+            source_name = {'github-production-deploy.sh': 'social-monitor-production-deploy.sh',
+                           'github-production-deploy-wrapper.sh': 'social-monitor-production-ssh-wrapper.sh'}.get(name, name)
+            (empty_control / name).write_bytes(self.command(
+                'git', '-C', str(real), 'show', repair_module.LIVE + ':ops/deploy/' + source_name))
+            (empty_control / name).chmod(0o755 if name.endswith(('deploy.sh', 'wrapper.sh', 'admission.sh')) else 0o644)
         script = '''set -euo pipefail
 export SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 SOCIAL_MONITOR_DEPLOY_ROOT="$1"
 export SOCIAL_MONITOR_DEPLOY_REPO="$2" SOCIAL_MONITOR_DEPLOY_CONTROL="$3"
+export PRODUCTION_TRANSITION_PRELUDE_COMMIT="$(git -C "$2" rev-parse HEAD)"
 source "$2/ops/deploy/social-monitor-production-deploy.sh"
 printf '%s\\n' "$5" > "$STATE/backend.sha"
 component_changed backend "$4" "${BACKEND_PATHS[@]}"
+postgres_pool_bootstrap_installed "$4"
 verify_deploy_control_bridge_target_compatibility "$4"
+verify_deploy_control_bridge_compatibility
 '''
         args = ['bash', '-c', script, 'real-compatibility', str(self.root), str(real),
                 str(empty_control), target, repair_module.LIVE]

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -176,6 +176,44 @@ class RepairTests(unittest.TestCase):
                 self.repair.apply(self.target, self.approved)
         self.assertFalse(self.repair.run_path(self.target).exists())
 
+    def test_tampered_installed_authority_is_not_accepted_as_a_new_plan(self):
+        (self.control / 'production-transition-b0-host-control.sh').write_text('wrong authority\n')
+        with self.assertRaisesRegex(RuntimeError, 'historical control differs'):
+            self.repair.plan(self.target)
+        self.assertFalse(self.repair.run_path(self.target).exists())
+
+    def test_parent_receipt_directory_is_durable_before_git_mutation(self):
+        events = []
+        original_sync = repair_module.sync_directory
+        original_git = self.repair.git
+
+        def sync(path):
+            events.append(('fsync', path))
+            original_sync(path)
+
+        def git(*args):
+            if args[0] == 'merge':
+                self.assertIn(('fsync', self.control), events)
+                self.assertTrue((self.repair.run_path(self.target) / 'prepared').is_file())
+            return original_git(*args)
+
+        with patch.object(repair_module, 'sync_directory', side_effect=sync), patch.object(self.repair, 'git', side_effect=git):
+            self.repair.apply(self.target, self.approved)
+
+    def test_handoff_rejects_symlink_receipt(self):
+        self.repair.apply(self.target, self.approved)
+        receipt = self.repair.run_path(self.target) / 'control-repaired'
+        receipt.rename(receipt.with_suffix('.saved'))
+        receipt.symlink_to(receipt.with_suffix('.saved'))
+        with self.assertRaises(OSError):
+            self.repair.handoff(self.target, self.approved)
+
+    def test_stopped_container_is_refused_even_without_restart_counter_change(self):
+        rows = b'id image false 0 healthy started 0 []\n' * 12
+        with patch.object(repair_module, 'execute', return_value=rows):
+            with self.assertRaisesRegex(RuntimeError, 'stably running'):
+                repair_module.ControllerRepair.runtime_identity(self.repair)
+
     def test_production_or_authority_path_delta_is_refused(self):
         self.git('checkout', '--detach', '-q', self.target)
         self.write('README', 'application changed\n')
@@ -254,6 +292,31 @@ verify_deploy_control_bridge_compatibility
         self.command('git', '-C', str(real), 'merge', '--ff-only', '--no-edit', target)
         after = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
         self.assertEqual(after.returncode, 0, after.stderr.decode())
+        # Exercise the complete real pre-activation deploy_release path,
+        # including its early bootstrap return and all three legacy install
+        # callsites. Only application/control effects past that boundary are
+        # substituted; classifiers, Git movement and compatibility are real.
+        full_release = script + '''
+while read -r _ _ function_name; do
+  [[ $function_name != production_transition_* ]] || readonly -f "$function_name"
+done < <(declare -F)
+action=deploy
+sync_control_script() { :; }
+deploy_release_runtime_transaction() {
+  [[ $2 == true ]]
+  verify_deploy_control_bridge_compatibility
+  printf 'real-pre-activation-boundary-reached\\n'
+  exit 42
+}
+deploy_release "$4"
+exit 99
+'''
+        for attempt in range(2):
+            result = subprocess.run([*args[:2], full_release, *args[3:]],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+            self.assertEqual(result.returncode, 42, f'fresh process {attempt}: {result.stderr.decode()}')
+            self.assertIn(b'real-pre-activation-boundary-reached', result.stdout)
+            self.assertEqual((empty_control / 'deploy-state/backend.sha').read_text(), repair_module.LIVE + '\n')
         self.assertEqual(entrypoint.read_bytes(), self.command(
             'git', '-C', str(real), 'show', repair_module.PREIMAGE + ':ops/deploy/social-monitor-production-deploy.sh'))
 

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Disposable repositories only: refusal, mixed Git crash states and preservation."""
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location('repair', Path(__file__).with_name('b0-controller-repair.py'))
+repair_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(repair_module)
+
+
+class RepairTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix='b0-repair-test-', dir='/tmp')
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.repo = self.root / 'integration'
+        self.repo.mkdir()
+        self.command('git', 'init', '-q', '-b', 'main', str(self.repo))
+        self.git('config', 'user.name', 'Repair fixture')
+        self.git('config', 'user.email', 'repair@example.invalid')
+        self.write('README', 'application source must stay unchanged\n')
+        self.write('.gitignore', 'ignored/\n')
+        self.write(repair_module.CONTROLLER, 'old controller\n')
+        self.write('ops/deploy/production-transition-b0-bootstrap.test.sh', 'old test\n')
+        self.git('add', '.')
+        self.git('commit', '-qm', 'test: preimage')
+        self.base = self.git('rev-parse', 'HEAD').strip().decode()
+        self.write(repair_module.CONTROLLER, 'new controller\n')
+        self.write('ops/deploy/production-transition-b0-bootstrap.test.sh', 'new test\n')
+        self.write('ops/deploy/b0-controller-repair.py', 'new repair\n')
+        self.git('add', '.')
+        self.git('commit', '-qm', 'test: control-only repair')
+        self.target = self.git('rev-parse', 'HEAD').strip().decode()
+        self.origin = self.root / 'origin.git'
+        self.command('git', 'clone', '--bare', '--no-local', '-q', str(self.repo), str(self.origin))
+        self.git('remote', 'add', 'origin', str(self.origin))
+        self.git('checkout', '--detach', '-q', self.base)
+        self.other = self.root / 'other-worktree'
+        self.git('worktree', 'add', '--detach', '-q', str(self.other), self.base)
+        (self.other / 'uncommitted').write_text('another task\n')
+        self.write('ignored/payload', 'keep local data\n')
+        self.ignored_inode = (self.repo / 'ignored/payload').stat().st_ino
+        self.other_head = (self.repo / '.git/worktrees/other-worktree/HEAD').read_bytes()
+        self.control = self.root / 'control'
+        state = self.control / 'deploy-state'
+        state.mkdir(parents=True)
+        for name in repair_module.STATE_FILES:
+            (state / name).write_text(self.base + '\n')
+        for name in repair_module.CONTROLS:
+            (self.control / name).write_text('installed control remains unchanged\n')
+        for name in (*repair_module.LOCKS, 'daily-run-singleton.lock'):
+            (self.control / name).touch()
+        runtime = self.control / 'postgres-runtime-releases' / self.base
+        runtime.mkdir(parents=True)
+        (runtime / 'READY').write_text(self.base + '\n')
+        (self.control / 'postgres-runtime-current').symlink_to(runtime)
+        self.repair = repair_module.ControllerRepair(
+            self.root, self.base, self.base, repair_module.digest(b'new controller\n'))
+        identity = patch.object(self.repair, 'runtime_identity', return_value='fixture-containers-unchanged')
+        identity.start()
+        self.addCleanup(identity.stop)
+        self.plan = self.repair.plan(self.target)
+        self.approved = repair_module.digest(repair_module.canonical(self.plan))
+
+    def command(self, *args):
+        result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        return result.stdout
+
+    def git(self, *args):
+        return self.command('git', '-C', str(self.repo), *args)
+
+    def write(self, name, data):
+        path = self.repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(data)
+
+    def assert_preserved(self):
+        self.assertEqual((self.repo / 'ignored/payload').read_text(), 'keep local data\n')
+        self.assertEqual((self.repo / 'ignored/payload').stat().st_ino, self.ignored_inode)
+        self.assertEqual((self.repo / '.git/worktrees/other-worktree/HEAD').read_bytes(), self.other_head)
+        self.assertEqual((self.other / 'uncommitted').read_text(), 'another task\n')
+        self.assertEqual(self.repair.protected(), self.plan['protected'])
+
+    def interrupt_merge(self, change):
+        original = self.repair.git
+
+        def interrupted(*args):
+            if args[0] == 'merge':
+                change()
+                raise RuntimeError('simulated process loss inside Git fast-forward')
+            return original(*args)
+
+        with patch.object(self.repair, 'git', side_effect=interrupted):
+            with self.assertRaisesRegex(RuntimeError, 'process loss'):
+                self.repair.apply(self.target, self.approved)
+        self.assertTrue((self.repair.run_path(self.target) / 'prepared').is_file())
+        self.assertFalse((self.repair.run_path(self.target) / 'control-repaired').exists())
+
+    def test_apply_and_explicit_rollback_preserve_worktrees_and_data(self):
+        self.repair.apply(self.target, self.approved)
+        self.assertEqual(self.git('rev-parse', 'HEAD').strip().decode(), self.target)
+        self.assert_preserved()
+        self.repair.rollback(self.target, self.approved)
+        self.assertEqual(self.git('rev-parse', 'HEAD').strip().decode(), self.base)
+        self.assert_preserved()
+
+    def test_partial_files_before_index_and_head_can_roll_back(self):
+        def partial():
+            self.write(repair_module.CONTROLLER, 'new controller\n')
+            self.write('ops/deploy/b0-controller-repair.py', 'new repair\n')
+        self.interrupt_merge(partial)
+        self.repair.rollback(self.target, self.approved)
+        self.assert_preserved()
+
+    def test_partial_index_with_old_head_can_roll_back(self):
+        def partial():
+            self.write(repair_module.CONTROLLER, 'new controller\n')
+            self.git('add', repair_module.CONTROLLER)
+        self.interrupt_merge(partial)
+        self.repair.rollback(self.target, self.approved)
+        self.assert_preserved()
+
+    def test_target_head_with_mixed_old_new_files_can_roll_back(self):
+        def partial():
+            self.git('merge', '--ff-only', '--no-edit', self.target)
+            self.write(repair_module.CONTROLLER, 'old controller\n')
+            self.git('add', repair_module.CONTROLLER)
+        self.interrupt_merge(partial)
+        self.repair.rollback(self.target, self.approved)
+        self.assert_preserved()
+
+    def test_unknown_partial_bytes_fail_closed_without_reset(self):
+        self.interrupt_merge(lambda: self.write(repair_module.CONTROLLER, 'unknown truncated bytes'))
+        with self.assertRaisesRegex(RuntimeError, 'unknown bytes'):
+            self.repair.rollback(self.target, self.approved)
+        self.assertEqual((self.repo / repair_module.CONTROLLER).read_text(), 'unknown truncated bytes')
+
+    def test_git_lock_left_by_interrupted_process_is_not_removed(self):
+        self.interrupt_merge(lambda: (self.repo / '.git/index.lock').touch())
+        with self.assertRaisesRegex(RuntimeError, 'Git state'):
+            self.repair.rollback(self.target, self.approved)
+        self.assertTrue((self.repo / '.git/index.lock').exists())
+
+    def test_protected_drift_and_unrelated_edits_forbid_rollback(self):
+        self.repair.apply(self.target, self.approved)
+        self.write('README', 'other writer changed source\n')
+        with self.assertRaisesRegex(RuntimeError, 'unrelated edits'):
+            self.repair.rollback(self.target, self.approved)
+        self.assertEqual((self.repo / 'README').read_text(), 'other writer changed source\n')
+
+    def test_handoff_permanently_closes_rollback(self):
+        self.repair.apply(self.target, self.approved)
+        self.repair.handoff(self.target, self.approved)
+        with self.assertRaisesRegex(RuntimeError, 'handoff forbids'):
+            self.repair.rollback(self.target, self.approved)
+
+    def test_wrong_plan_is_refused_before_writes(self):
+        with self.assertRaisesRegex(RuntimeError, 'plan drifted'):
+            self.repair.apply(self.target, '0' * 64)
+        self.assertFalse(self.repair.run_path(self.target).exists())
+        self.assert_preserved()
+
+    def test_runtime_restart_after_review_is_refused(self):
+        with patch.object(self.repair, 'runtime_identity', return_value='restarted'):
+            with self.assertRaisesRegex(RuntimeError, 'plan drifted'):
+                self.repair.apply(self.target, self.approved)
+        self.assertFalse(self.repair.run_path(self.target).exists())
+
+    def test_production_or_authority_path_delta_is_refused(self):
+        self.git('checkout', '--detach', '-q', self.target)
+        self.write('README', 'application changed\n')
+        self.git('add', 'README')
+        self.git('commit', '-qm', 'test: forbidden application delta')
+        forbidden = self.git('rev-parse', 'HEAD').strip().decode()
+        self.git('push', '-q', 'origin', 'HEAD:refs/heads/main')
+        self.git('checkout', '--detach', '-q', self.base)
+        with self.assertRaisesRegex(RuntimeError, 'control-only'):
+            self.repair.plan(forbidden)
+
+    def test_hooks_are_refused_not_disabled(self):
+        hook = self.repo / '.git/hooks/post-merge'
+        hook.write_text('#!/bin/sh\nexit 0\n')
+        hook.chmod(0o755)
+        with self.assertRaisesRegex(RuntimeError, 'invoke hook'):
+            self.repair.apply(self.target, self.approved)
+        self.assertTrue(hook.exists())
+
+    def test_held_deploy_lock_and_symlink_marker_are_refused(self):
+        with (self.control / 'production-deploy.lock').open('r+') as lock:
+            repair_module.fcntl.flock(lock, repair_module.fcntl.LOCK_EX)
+            with self.assertRaises(BlockingIOError):
+                self.repair.apply(self.target, self.approved)
+        marker = self.control / 'deploy-state/backend.sha'
+        marker.rename(marker.with_suffix('.saved'))
+        marker.symlink_to(marker.with_suffix('.saved'))
+        with self.assertRaises(OSError):
+            self.repair.apply(self.target, self.approved)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -164,6 +164,102 @@ class RepairTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'handoff forbids'):
             self.repair.rollback(self.target, self.approved)
 
+    def test_durability_barrier_precedes_each_success_receipt(self):
+        original = repair_module.execute
+        barriers = []
+        run = self.repair.run_path(self.target)
+
+        def execute(*args):
+            if args[0] == '/usr/bin/sync':
+                receipt = 'control-repaired' if not barriers else 'ordinary-handoff'
+                self.assertFalse((run / receipt).exists())
+                barriers.append(receipt)
+            return original(*args)
+
+        with patch.object(repair_module, 'execute', side_effect=execute):
+            self.repair.apply(self.target, self.approved)
+            self.repair.handoff(self.target, self.approved)
+        self.assertEqual(barriers, ['control-repaired', 'ordinary-handoff'])
+
+    def test_failed_flush_does_not_certify_repair_or_close_rollback(self):
+        original = repair_module.execute
+
+        def execute(*args):
+            if args[0] == '/usr/bin/sync':
+                raise RuntimeError('simulated filesystem flush failure')
+            return original(*args)
+
+        with patch.object(repair_module, 'execute', side_effect=execute):
+            with self.assertRaisesRegex(RuntimeError, 'flush failure'):
+                self.repair.apply(self.target, self.approved)
+        run = self.repair.run_path(self.target)
+        self.assertFalse((run / 'control-repaired').exists())
+        self.assertFalse((run / 'ordinary-handoff').exists())
+        self.repair.rollback(self.target, self.approved)
+        self.assert_preserved()
+
+    def test_failed_handoff_flush_leaves_rollback_available(self):
+        self.repair.apply(self.target, self.approved)
+        original = repair_module.execute
+
+        def execute(*args):
+            if args[0] == '/usr/bin/sync':
+                raise RuntimeError('simulated handoff flush failure')
+            return original(*args)
+
+        with patch.object(repair_module, 'execute', side_effect=execute):
+            with self.assertRaisesRegex(RuntimeError, 'flush failure'):
+                self.repair.handoff(self.target, self.approved)
+        self.assertFalse((self.repair.run_path(self.target) / 'ordinary-handoff').exists())
+        self.repair.rollback(self.target, self.approved)
+
+    def test_handoff_rejects_git_clean_but_converted_bytes(self):
+        self.repair.apply(self.target, self.approved)
+        self.git('config', 'core.autocrlf', 'true')
+        (self.repo / repair_module.CONTROLLER).write_bytes(b'new controller\r\n')
+        self.assertEqual(self.git('status', '--porcelain').strip(), b'')
+        with self.assertRaisesRegex(RuntimeError, 'bytes/mode'):
+            self.repair.handoff(self.target, self.approved)
+
+    def test_apply_rejects_clean_conversion_after_merge(self):
+        original = self.repair.git
+
+        def git(*args):
+            result = original(*args)
+            if args[0] == 'merge':
+                original('config', 'core.autocrlf', 'true')
+                (self.repo / repair_module.CONTROLLER).write_bytes(b'new controller\r\n')
+            return result
+
+        with patch.object(self.repair, 'git', side_effect=git):
+            with self.assertRaisesRegex(RuntimeError, 'bytes/mode'):
+                self.repair.apply(self.target, self.approved)
+        self.assertFalse((self.repair.run_path(self.target) / 'control-repaired').exists())
+
+    def test_handoff_checks_git_device_and_inode(self):
+        self.repair.apply(self.target, self.approved)
+        device, inode = self.plan['git_directory_identity']
+        for changed in ([device + 1, inode], [device, inode + 1]):
+            with patch.object(self.repair, 'git_directory_identity', return_value=changed):
+                with self.assertRaisesRegex(RuntimeError, 'Git directory replaced'):
+                    self.repair.handoff(self.target, self.approved)
+        self.assertFalse((self.repair.run_path(self.target) / 'ordinary-handoff').exists())
+
+    def test_handoff_revalidates_after_durability_barrier(self):
+        self.repair.apply(self.target, self.approved)
+        original = repair_module.execute
+
+        def execute(*args):
+            result = original(*args)
+            if args[0] == '/usr/bin/sync':
+                self.write(repair_module.CONTROLLER, 'concurrent mutation\n')
+            return result
+
+        with patch.object(repair_module, 'execute', side_effect=execute):
+            with self.assertRaisesRegex(RuntimeError, 'dirty'):
+                self.repair.handoff(self.target, self.approved)
+        self.assertFalse((self.repair.run_path(self.target) / 'ordinary-handoff').exists())
+
     def test_wrong_plan_is_refused_before_writes(self):
         with self.assertRaisesRegex(RuntimeError, 'plan drifted'):
             self.repair.apply(self.target, '0' * 64)
@@ -316,6 +412,20 @@ exit 99
             self.assertEqual(result.returncode, 42, f'fresh process {attempt}: {result.stderr.decode()}')
             self.assertIn(b'real-pre-activation-boundary-reached', result.stdout)
             self.assertEqual((empty_control / 'deploy-state/backend.sha').read_text(), repair_module.LIVE + '\n')
+        for mode in ('tracked', 'staged', 'untracked'):
+            path = real / ('recovery-untracked.txt' if mode == 'untracked' else 'README.md')
+            path.write_text('unreviewed application input\n')
+            if mode == 'staged':
+                self.command('git', '-C', str(real), 'add', 'README.md')
+            result = subprocess.run([*args[:2], full_release, *args[3:]],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+            self.assertNotEqual(result.returncode, 42, mode)
+            self.assertIn(b'integration worktree is dirty', result.stderr, mode)
+            self.assertNotIn(b'real-pre-activation-boundary-reached', result.stdout, mode)
+            if mode == 'untracked':
+                path.unlink()
+            else:
+                self.command('git', '-C', str(real), 'restore', '--source=HEAD', '--staged', '--worktree', 'README.md')
         self.assertEqual(entrypoint.read_bytes(), self.command(
             'git', '-C', str(real), 'show', repair_module.PREIMAGE + ':ops/deploy/social-monitor-production-deploy.sh'))
 

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -294,16 +294,15 @@ verify_deploy_control_bridge_compatibility
         self.assertEqual(after.returncode, 0, after.stderr.decode())
         # Exercise the complete real pre-activation deploy_release path,
         # including its early bootstrap return and all three legacy install
-        # callsites. Only application/control effects past that boundary are
-        # substituted; classifiers, Git movement and compatibility are real.
+        # callsites. Stop at target-owned publication prebootstrap, which may
+        # reconstruct runtime images. No Docker/DB effect belongs in this proof.
         full_release = script + '''
 while read -r _ _ function_name; do
   [[ $function_name != production_transition_* ]] || readonly -f "$function_name"
 done < <(declare -F)
 action=deploy
-sync_control_script() { :; }
-deploy_release_runtime_transaction() {
-  [[ $2 == true ]]
+load_target_reader_summary_publication_deploy_library() {
+  [[ $1 == "$sha" ]]
   verify_deploy_control_bridge_compatibility
   printf 'real-pre-activation-boundary-reached\\n'
   exit 42

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -202,6 +202,41 @@ class RepairTests(unittest.TestCase):
         with self.assertRaises(OSError):
             self.repair.apply(self.target, self.approved)
 
+    def test_exact_production_preimage_compatibility_when_history_available(self):
+        source = Path(__file__).resolve().parents[2]
+        available = subprocess.run(['git', '-C', str(source), 'cat-file', '-e',
+                                    repair_module.PREIMAGE + '^{commit}'],
+                                   stderr=subprocess.DEVNULL, check=False).returncode == 0
+        if not available:
+            self.skipTest('historical production commit unavailable in shallow checkout')
+        real = self.root / 'real-history'
+        self.command('git', 'clone', '--no-local', '--no-checkout', '-q', str(source), str(real))
+        target = self.command('git', '-C', str(source), 'rev-parse', 'HEAD').strip().decode()
+        self.command('git', '-C', str(real), 'checkout', '--detach', '-q', repair_module.PREIMAGE)
+        entrypoint = real / 'ops/deploy/social-monitor-production-deploy.sh'
+        # Real pathspecs and compatibility verifier, not the earlier mocked
+        # component_changed=false shortcut. All filesystem effects are in /tmp.
+        empty_control = self.root / 'real-control'
+        (empty_control / 'deploy-state').mkdir(parents=True)
+        script = '''set -euo pipefail
+export SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 SOCIAL_MONITOR_DEPLOY_ROOT="$1"
+export SOCIAL_MONITOR_DEPLOY_REPO="$2" SOCIAL_MONITOR_DEPLOY_CONTROL="$3"
+source "$2/ops/deploy/social-monitor-production-deploy.sh"
+printf '%s\\n' "$5" > "$STATE/backend.sha"
+component_changed backend "$4" "${BACKEND_PATHS[@]}"
+verify_deploy_control_bridge_target_compatibility "$4"
+'''
+        args = ['bash', '-c', script, 'real-compatibility', str(self.root), str(real),
+                str(empty_control), target, repair_module.LIVE]
+        before = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        self.assertNotEqual(before.returncode, 0)
+        self.assertIn(b'deploy the bridge release first', before.stderr)
+        self.command('git', '-C', str(real), 'merge', '--ff-only', '--no-edit', target)
+        after = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        self.assertEqual(after.returncode, 0, after.stderr.decode())
+        self.assertEqual(entrypoint.read_bytes(), self.command(
+            'git', '-C', str(real), 'show', repair_module.PREIMAGE + ':ops/deploy/social-monitor-production-deploy.sh'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -18,6 +18,14 @@ class RepairTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory(prefix='b0-repair-test-', dir='/tmp')
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name)
+        # Hermetic disposable Git fixtures must not inherit a CI runner's LFS
+        # filters or developer configuration. Production main() still refuses
+        # all GIT_* overrides and checks the real machine configuration.
+        environment = patch.dict(os.environ, {
+            'GIT_CONFIG_NOSYSTEM': '1', 'GIT_CONFIG_GLOBAL': str(self.root / 'git-config'),
+        })
+        environment.start()
+        self.addCleanup(environment.stop)
         self.repo = self.root / 'integration'
         self.repo.mkdir()
         self.command('git', 'init', '-q', '-b', 'main', str(self.repo))
@@ -330,6 +338,13 @@ class RepairTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'invoke hook'):
             self.repair.apply(self.target, self.approved)
         self.assertTrue(hook.exists())
+
+    def test_git_content_filters_remain_refused(self):
+        self.git('config', 'filter.fixture.clean', 'false')
+        with self.assertRaisesRegex(RuntimeError, 'content filters'):
+            self.repair.apply(self.target, self.approved)
+        self.assertEqual(self.git('config', '--get', 'filter.fixture.clean').strip(), b'false')
+        self.assertFalse(self.repair.run_path(self.target).exists())
 
     def test_held_deploy_lock_and_symlink_marker_are_refused(self):
         with (self.control / 'production-deploy.lock').open('r+') as lock:

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -228,6 +228,8 @@ class RepairTests(unittest.TestCase):
         path.unlink()
         self.git('restore', '--source=HEAD', '--worktree', repair_module.CONTROLLER)
         self.assertEqual(path.read_bytes(), b'new controller\r\n')
+        self.git('add', repair_module.CONTROLLER)
+        self.assertEqual(self.git('diff', '--cached'), b'')
         self.assertEqual(self.git('status', '--porcelain').strip(), b'')
         with self.assertRaisesRegex(RuntimeError, 'bytes/mode'):
             self.repair.handoff(self.target, self.approved)

--- a/ops/deploy/deploy-control-current-target-lib.sh
+++ b/ops/deploy/deploy-control-current-target-lib.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# A fresh ordinary retry already loaded the exact authenticated target. The
+# historical bridge mistakes target=current for its first bootstrap and tries
+# to source readonly B0 functions again. Preserve its checks for all transitions;
+# for this identity case prove all loaded/installed control blobs instead.
+deploy_control_verify_loaded_current_target() {
+  local target=$1 path index=0 variable expected actual mode
+  [[ $target == "${PRODUCTION_TRANSITION_PRELUDE_COMMIT:-}" && \
+     $target == "${DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD:-}" && \
+     $target == "$(git -C "$REPO" rev-parse --verify 'HEAD^{commit}')" ]] || return 1
+  local -a digest_keys=(ENTRYPOINT LIBRARY POSTGRES_LIBRARY POSTGRES_WEEKLY_TIMER_HELPER \
+    POSTGRES_DAILY_C1_HELPER POSTGRES_ACTIVATION_BOUNDARY_HELPER \
+    RECOVERY_MAINTENANCE_LIBRARY IMAGE_RESCUE_LIBRARY IMAGE_RESCUE_PIN_CLEANUP_LIBRARY \
+    X_IMAGE_LIBRARY SELF)
+  while IFS= read -r path; do
+    ((index < ${#digest_keys[@]})) || fail 'current target control path count differs'
+    mode=$(deploy_control_bridge_git_regular_blob "$target" "$path" 'current target control')
+    verify_postgres_pool_bootstrap_recovery_file "$target" "$path" "$REPO/$path" \
+      'current target control'
+    [[ $(stat -c '%a' "$REPO/$path") == "${mode#100}" ]] || \
+      fail 'current target control mode differs'
+    expected=$(deploy_control_git_blob_digest "$target" "$path")
+    variable=DEPLOY_CONTROL_BRIDGE_${digest_keys[$index]}_DIGEST
+    actual=${!variable:-}
+    [[ $expected == "$actual" ]] || fail 'current target differs from initialized control'
+    index=$((index + 1))
+  done < <(deploy_control_bridge_sealed_paths)
+  ((index == ${#digest_keys[@]})) || fail 'current target control path set is incomplete'
+}
+
+deploy_control_install_current_target_checks() {
+  local definition
+  definition=$(declare -f verify_deploy_control_bridge_target_compatibility)
+  definition=${definition/verify_deploy_control_bridge_target_compatibility/deploy_control_legacy_target_compatibility}
+  eval "$definition"
+  definition=$(declare -f verify_deploy_control_bridge_compatibility)
+  definition=${definition/verify_deploy_control_bridge_compatibility/deploy_control_legacy_runtime_compatibility}
+  eval "$definition"
+  verify_deploy_control_bridge_target_compatibility() {
+    if deploy_control_verify_loaded_current_target "$1"; then return 0; fi
+    deploy_control_legacy_target_compatibility "$@"
+  }
+  verify_deploy_control_bridge_compatibility() {
+    local current
+    current=$(git -C "$REPO" rev-parse --verify 'HEAD^{commit}') || \
+      fail 'current target identity is unavailable'
+    if deploy_control_verify_loaded_current_target "$current"; then return 0; fi
+    deploy_control_legacy_runtime_compatibility "$@"
+  }
+}

--- a/ops/deploy/deploy-control-lib.sh
+++ b/ops/deploy/deploy-control-lib.sh
@@ -915,7 +915,7 @@ deploy_release() {
   fetch_main
   validate_main_commit "$sha"
   install -d -m 0755 "$STATE" "$STAGING" "$RELEASES"
-  local current
+  local current checkout_status
   current=$(git -C "$REPO" rev-parse HEAD)
   if [[ $mode == resume-target-prepared ]]; then
     [[ $sha == "$current" ]] || \
@@ -962,7 +962,9 @@ deploy_release() {
     verify_deploy_control_bridge_target_compatibility "$sha"
   fi
   if [[ $sha == "$current" ]]; then
-    [[ -z $(git -C "$REPO" status --porcelain) ]] || fail 'integration worktree is dirty'
+    checkout_status=$(git -C "$REPO" status --porcelain --untracked-files=all) || \
+      fail 'cannot inspect integration worktree'
+    [[ -z $checkout_status ]] || fail 'integration worktree is dirty'
   else
     advance_integration "$sha"
   fi

--- a/ops/deploy/deploy-control-lib.sh
+++ b/ops/deploy/deploy-control-lib.sh
@@ -105,6 +105,11 @@ load_deploy_control_bridge_library() {
 initialize_deploy_control_bridge() {
   load_deploy_control_bridge_library
   initialize_deploy_control_bridge
+  if [[ -n ${PRODUCTION_TRANSITION_PRELUDE_COMMIT:-} ]]; then
+    source_reviewed_deploy_library "$DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD" \
+      ops/deploy/deploy-control-current-target-lib.sh 'current target control checks'
+    deploy_control_install_current_target_checks
+  fi
 }
 
 probe_daily_singleton_clear() {
@@ -956,7 +961,7 @@ deploy_release() {
         $x_image_provenance_release == true ]]; then
     verify_deploy_control_bridge_target_compatibility "$sha"
   fi
-  advance_integration "$sha"
+  [[ $sha == "$current" ]] || advance_integration "$sha"
   # The entrypoint already authenticated and froze an installed B0 authority.
   # Re-sourcing that authority after an ordinary fast-forward would attempt to
   # redefine readonly functions. A predecessor that has not loaded B0 still

--- a/ops/deploy/deploy-control-lib.sh
+++ b/ops/deploy/deploy-control-lib.sh
@@ -957,7 +957,13 @@ deploy_release() {
     verify_deploy_control_bridge_target_compatibility "$sha"
   fi
   advance_integration "$sha"
-  deploy_control_bootstrap_production_transition_b0 "$sha"
+  # The entrypoint already authenticated and froze an installed B0 authority.
+  # Re-sourcing that authority after an ordinary fast-forward would attempt to
+  # redefine readonly functions. A predecessor that has not loaded B0 still
+  # performs the exact bootstrap before any target-controlled work is loaded.
+  if ! declare -F production_transition_host_failpoint >/dev/null; then
+    deploy_control_bootstrap_production_transition_b0 "$sha"
+  fi
   if [[ $backend == true ]]; then
     load_target_rabbitmq_quorum_backend_health "$sha"
     load_target_reader_summary_publication_deploy_library "$sha"

--- a/ops/deploy/deploy-control-lib.sh
+++ b/ops/deploy/deploy-control-lib.sh
@@ -961,7 +961,11 @@ deploy_release() {
         $x_image_provenance_release == true ]]; then
     verify_deploy_control_bridge_target_compatibility "$sha"
   fi
-  [[ $sha == "$current" ]] || advance_integration "$sha"
+  if [[ $sha == "$current" ]]; then
+    [[ -z $(git -C "$REPO" status --porcelain) ]] || fail 'integration worktree is dirty'
+  else
+    advance_integration "$sha"
+  fi
   # The entrypoint already authenticated and froze an installed B0 authority.
   # Re-sourcing that authority after an ordinary fast-forward would attempt to
   # redefine readonly functions. A predecessor that has not loaded B0 still

--- a/ops/deploy/production-forward-bridge-host-lib.sh
+++ b/ops/deploy/production-forward-bridge-host-lib.sh
@@ -381,12 +381,11 @@ production_forward_install_b0_before_entrypoint() {
     ops/deploy/production-transition-canonical-lib.sh
   production_forward_install_blob "$bridge" 0644 \
     ops/deploy/production-transition-b0-host-control.sh
-  # A predecessor without B0 must load the verified authority before moving.
-  # An already-loaded readonly B0 only needs the blob checks above repeated.
-  if ! declare -F production_transition_host_failpoint >/dev/null; then
-    # shellcheck source=/dev/null
-    source "$CONTROL/production-transition-b0-host-control.sh"
-  fi
+  # The predecessor process did not load this newly installed authority at
+  # startup. Source the verified B blob before any post-fast-forward phase can
+  # call one of its functions.
+  # shellcheck source=/dev/null
+  source "$CONTROL/production-transition-b0-host-control.sh"
 }
 
 production_forward_file_matches_commit() {

--- a/ops/deploy/production-forward-bridge.test.sh
+++ b/ops/deploy/production-forward-bridge.test.sh
@@ -107,16 +107,7 @@ verify_production_forward_target_identity "$F"
 verify_production_forward_target_identity "$H"
 verify_production_forward_target_identity "$D1"
 verify_production_forward_target_identity "$D2"
-# Ordinary descendants may use the frozen forward authority only while its
-# sealed B paths remain unchanged. An authenticated successor transition is
-# expected to change one of those paths and must stay rejected by this legacy
-# client instead of weakening the historical seal.
-if git -C "$repo" diff --quiet "$F" "$TARGET" -- "${b_paths[@]}"; then
-  verify_production_forward_target_identity "$TARGET"
-else
-  expect_failure 'authenticated successor through legacy forward client' \
-    verify_production_forward_target_identity "$TARGET"
-fi
+verify_production_forward_target_identity "$TARGET"
 [[ $(production_forward_anchor_for_target "$D2") == "$F" ]]
 REPO=$repo
 # shellcheck source=ops/deploy/production-forward-bridge-host-lib.sh
@@ -714,25 +705,3 @@ printf 'forward-bridge-test: runtime rollback and marker crashes resume\n'
 
 printf 'production-forward-bridge-test: ok B=%s R=%s W=%s H=%s F=%s\n' \
   "$B" "$R" "$W" "$H" "$F"
-
-# Repeating B0 installation in a process that already froze the authority must
-# validate the blobs without sourcing readonly functions a second time.
-verify_loaded_b0_install() {
-  REPO=$repo CONTROL=$CONTROL STATE=$STATE TARGET=$F SCRIPT_DIR=$SCRIPT_DIR \
-    SOCIAL_MONITOR_DEPLOY_TEST_MODE=1 bash -Eeuo pipefail -c '
-      fail() { printf "loaded-b0-install: %s\n" "$*" >&2; exit 1; }
-      source "$CONTROL/production-transition-b0-host-control.sh"
-      while read -r _ _ authority_function; do
-        [[ $authority_function != production_transition_* ]] || \
-          readonly -f "$authority_function"
-      done < <(declare -F)
-      source "$SCRIPT_DIR/production-forward-bridge-host-lib.sh"
-      production_forward_install_b0_before_entrypoint "$TARGET"
-    '
-}
-reset_b0_destinations
-run_b0_install
-verify_loaded_b0_install
-printf 'tampered canonical authority\n' > \
-  "$CONTROL/production-transition-canonical-lib.sh"
-expect_failure 'tampered loaded B0 authority' verify_loaded_b0_install

--- a/ops/deploy/production-transition-b0-bootstrap.test.sh
+++ b/ops/deploy/production-transition-b0-bootstrap.test.sh
@@ -86,12 +86,17 @@ deploy_control_bootstrap_production_transition_b0 "$B0"
 [[ ! -e $CONTROL/production-transition-b0-host-control.sh ]]
 
 # The current-main deploy state machine invokes bootstrap only after the exact
-# target checkout and before its legacy sync function can install entrypoint.
+# target checkout, only when B0 is not already loaded, and before its legacy
+# sync function can install the entrypoint.
 control_library=$SCRIPT_DIR/deploy-control-lib.sh
 advance_line=$(grep -nF 'advance_integration "$sha"' "$control_library" | tail -1 | cut -d: -f1)
+loaded_guard_line=$(grep -nF \
+  'if ! declare -F production_transition_host_failpoint >/dev/null; then' \
+  "$control_library" | tail -1 | cut -d: -f1)
 bootstrap_line=$(grep -nF 'deploy_control_bootstrap_production_transition_b0 "$sha"' \
   "$control_library" | tail -1 | cut -d: -f1)
 sync_line=$(grep -nF 'sync_control_script "$sha"' "$control_library" | tail -1 | cut -d: -f1)
-((advance_line < bootstrap_line && bootstrap_line < sync_line))
+((advance_line < loaded_guard_line && loaded_guard_line < bootstrap_line && \
+  bootstrap_line < sync_line))
 
 printf 'production transition current-main B0 bootstrap test passed\n'

--- a/ops/deploy/production-transition-b0-bootstrap.test.sh
+++ b/ops/deploy/production-transition-b0-bootstrap.test.sh
@@ -115,10 +115,12 @@ exercise_release_bootstrap() (
   printf 'production_transition_host_failpoint() { :; }\n' > "$authority"
   : > "$events"
   action=deploy
+  # shellcheck source=ops/deploy/deploy-control-lib.sh
   source "$control_library"
   fixed_release=$(declare -f deploy_release)
   if [[ $predecessor == true ]]; then
     # Exact controller loaded by the installed prelude before this fix.
+    # shellcheck source=/dev/null
     source <(git -C "$current_root" show \
       8c402ecadff1db34a9d5991b777a5eb8032282de:ops/deploy/deploy-control-lib.sh)
   fi
@@ -137,12 +139,14 @@ exercise_release_bootstrap() (
   }
   production_forward_install_b0_before_entrypoint() {
     printf 'bootstrap\n' >> "$events"
+    # shellcheck source=/dev/null
     source "$authority"
   }
   sync_control_script() { printf 'sync\n' >> "$events"; }
   deploy_release_runtime_transaction() { printf 'runtime\n' >> "$events"; }
   commit_postgres_pool_bootstrap() { printf 'committed\n' >> "$events"; }
   if [[ $authority_loaded == true ]]; then
+    # shellcheck source=/dev/null
     source "$authority"
     readonly -f production_transition_host_failpoint
   fi

--- a/ops/deploy/production-transition-b0-bootstrap.test.sh
+++ b/ops/deploy/production-transition-b0-bootstrap.test.sh
@@ -173,6 +173,10 @@ exercise_release_bootstrap() (
   local expected=$'advanced\nsync\nruntime\ncommitted'
   if [[ $authority_loaded == false ]]; then
     expected=$'advanced\nbootstrap\nsync\nruntime\ncommitted'
+  elif [[ $predecessor == true ]]; then
+    # Retry is already at the target: neither Git advance nor its legacy
+    # bootstrap side effect may run again.
+    expected=$'sync\nruntime\ncommitted'
   fi
   [[ $(<"$events") == "$expected" ]] || fail 'release bootstrap ordering differs'
   declare -F production_transition_host_failpoint >/dev/null || \

--- a/ops/deploy/production-transition-b0-bootstrap.test.sh
+++ b/ops/deploy/production-transition-b0-bootstrap.test.sh
@@ -99,4 +99,82 @@ sync_line=$(grep -nF 'sync_control_script "$sha"' "$control_library" | tail -1 |
 ((advance_line < loaded_guard_line && loaded_guard_line < bootstrap_line && \
   bootstrap_line < sync_line))
 
+# Exercise the actual release function, not an extracted copy of its guard.
+# All external effects stay inside this disposable Git repository. The fake
+# installer reproduces the frozen function collision seen on the live host.
+exercise_release_bootstrap() (
+  local authority_loaded=$1 predecessor=${2:-false} target current_root fixed_release
+  target=$(git -C "$REPO" rev-parse HEAD)
+  current_root=$(cd "$SCRIPT_DIR/../.." && pwd)
+  STATE=$FIXTURE/release-$authority_loaded-$predecessor
+  STAGING=$STATE/staging RELEASES=$STATE/releases
+  DEPLOY_LOCK=$STATE/deploy.lock POSTGRES_ADMISSION_LOCK=$STATE/postgres.lock
+  install -d "$STATE"
+  local events=$STATE/events authority=$STATE/authority.sh
+  local -a FRONTEND_PATHS=() BACKEND_PATHS=() CONTROL_PATHS=() RUNTIME_CONTROL_PATHS=()
+  printf 'production_transition_host_failpoint() { :; }\n' > "$authority"
+  : > "$events"
+  action=deploy
+  source "$control_library"
+  fixed_release=$(declare -f deploy_release)
+  if [[ $predecessor == true ]]; then
+    # Exact controller loaded by the installed prelude before this fix.
+    source <(git -C "$current_root" show \
+      8c402ecadff1db34a9d5991b777a5eb8032282de:ops/deploy/deploy-control-lib.sh)
+  fi
+  postgres_pool_atomic_legacy_state() { return 1; }
+  load_deploy_control_bridge_library() { :; }
+  acquire_postgres_admission_with_daily_priority() { :; }
+  fetch_main() { :; }
+  validate_main_commit() { [[ $1 == "$target" ]]; }
+  postgres_pool_bootstrap_installed() { return 0; }
+  reconcile_completed_backend_image_rescues() { :; }
+  component_changed() { return 1; }
+  reconcile_github_premidnight_capture_runtime_control() { printf 'false\n'; }
+  advance_integration() {
+    git -C "$REPO" merge --ff-only -q "$1"
+    printf 'advanced\n' >> "$events"
+  }
+  production_forward_install_b0_before_entrypoint() {
+    printf 'bootstrap\n' >> "$events"
+    source "$authority"
+  }
+  sync_control_script() { printf 'sync\n' >> "$events"; }
+  deploy_release_runtime_transaction() { printf 'runtime\n' >> "$events"; }
+  commit_postgres_pool_bootstrap() { printf 'committed\n' >> "$events"; }
+  if [[ $authority_loaded == true ]]; then
+    source "$authority"
+    readonly -f production_transition_host_failpoint
+  fi
+  git -C "$REPO" checkout -q --detach "$B0"
+  if [[ $predecessor == true ]]; then
+    local status=0
+    # Keep errexit enabled within the child, so failure cannot reach runtime.
+    bash -euo pipefail -c "$(declare -f); $(declare -p REPO STATE STAGING RELEASES \
+      DEPLOY_LOCK POSTGRES_ADMISSION_LOCK FRONTEND_PATHS BACKEND_PATHS \
+      CONTROL_PATHS RUNTIME_CONTROL_PATHS target events authority action); \
+      readonly -f production_transition_host_failpoint; deploy_release \"\$target\"" \
+      > "$STATE/predecessor.log" 2>&1 || status=$?
+    ((status != 0)) || fail 'predecessor did not reproduce the readonly failure'
+    grep -F 'readonly function' "$STATE/predecessor.log" >/dev/null
+    [[ $(<"$events") == $'advanced\nbootstrap' ]] || \
+      fail 'predecessor mutated runtime after its bootstrap failure'
+    [[ $(git -C "$REPO" rev-parse HEAD) == "$target" ]] || \
+      fail 'predecessor did not durably advance to the fixed controller'
+    : > "$events"
+    eval "$fixed_release"
+  fi
+  deploy_release "$target" > "$STATE/release.log"
+  local expected=$'advanced\nsync\nruntime\ncommitted'
+  if [[ $authority_loaded == false ]]; then
+    expected=$'advanced\nbootstrap\nsync\nruntime\ncommitted'
+  fi
+  [[ $(<"$events") == "$expected" ]] || fail 'release bootstrap ordering differs'
+  declare -F production_transition_host_failpoint >/dev/null || \
+    fail 'release lost its B0 authority'
+)
+exercise_release_bootstrap false
+exercise_release_bootstrap true
+exercise_release_bootstrap true true
+
 printf 'production transition current-main B0 bootstrap test passed\n'

--- a/ops/deploy/production-transition-b0-bootstrap.test.sh
+++ b/ops/deploy/production-transition-b0-bootstrap.test.sh
@@ -5,6 +5,7 @@ LC_ALL=C
 export PATH LC_ALL
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+python3 -B "$SCRIPT_DIR/b0-controller-repair.test.py"
 FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/production-transition-b0-bootstrap.XXXXXX")
 trap '/usr/bin/find "$FIXTURE" -depth -delete' EXIT
 REPO=$FIXTURE/repo

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -136,7 +136,7 @@ assert_real_bridge_target_assets() {
         expected_digest=d18854822ef36d5571289e72c7691fff8db4a7d5c516787441a733d6960a88a9
         # The ordinary-release controller preserves the frozen B0 authority
         # instead of sourcing its readonly functions for a second time.
-        current_release_digest=2b80efe62990d8eaf6ea79f0ff7d45c153563036e2503bd0a634db813807fc18
+        current_release_digest=c5612b8cd1092ec04bf3d5271e98e0bc58918cc23832f7f57c3947cb91e011eb
         ;;
       ops/deploy/postgres-runtime-deploy-lib.sh)
         expected_digest=261fb030bea2f203564c59e0c22db8058b310fb5d979c7db622938fe6045545a

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -134,7 +134,9 @@ assert_real_bridge_target_assets() {
         ;;
       ops/deploy/deploy-control-lib.sh)
         expected_digest=d18854822ef36d5571289e72c7691fff8db4a7d5c516787441a733d6960a88a9
-        current_release_digest=824d624944de61027e29b51ca5ad86e87c9b9dcac468bb413b63898700fd78e3
+        # The ordinary-release controller preserves the frozen B0 authority
+        # instead of sourcing its readonly functions for a second time.
+        current_release_digest=3caf2f61ef68ef9697d4e2d5dd3eb057abbcc201942670d4e81fba5ab89f20ad
         ;;
       ops/deploy/postgres-runtime-deploy-lib.sh)
         expected_digest=261fb030bea2f203564c59e0c22db8058b310fb5d979c7db622938fe6045545a

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -136,7 +136,7 @@ assert_real_bridge_target_assets() {
         expected_digest=d18854822ef36d5571289e72c7691fff8db4a7d5c516787441a733d6960a88a9
         # The ordinary-release controller preserves the frozen B0 authority
         # instead of sourcing its readonly functions for a second time.
-        current_release_digest=3caf2f61ef68ef9697d4e2d5dd3eb057abbcc201942670d4e81fba5ab89f20ad
+        current_release_digest=f0b717cb29067bae349340c473b924918d790ba1d0c45620a96f7854e54f7c5d
         ;;
       ops/deploy/postgres-runtime-deploy-lib.sh)
         expected_digest=261fb030bea2f203564c59e0c22db8058b310fb5d979c7db622938fe6045545a

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -136,7 +136,7 @@ assert_real_bridge_target_assets() {
         expected_digest=d18854822ef36d5571289e72c7691fff8db4a7d5c516787441a733d6960a88a9
         # The ordinary-release controller preserves the frozen B0 authority
         # instead of sourcing its readonly functions for a second time.
-        current_release_digest=f0b717cb29067bae349340c473b924918d790ba1d0c45620a96f7854e54f7c5d
+        current_release_digest=2b80efe62990d8eaf6ea79f0ff7d45c153563036e2503bd0a634db813807fc18
         ;;
       ops/deploy/postgres-runtime-deploy-lib.sh)
         expected_digest=261fb030bea2f203564c59e0c22db8058b310fb5d979c7db622938fe6045545a

--- a/ops/deploy/social-monitor-production-deploy.test.sh
+++ b/ops/deploy/social-monitor-production-deploy.test.sh
@@ -29,7 +29,7 @@ cp "$SCRIPT_DIR/postgres-runtime-asset-lib.sh" \
   "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR"/postgres-runtime-{weekly-timer-state,daily-c1-readiness,activation-boundary}-lib.sh \
   "$REPO/ops/deploy/"
-cp "$SCRIPT_DIR/deploy-control-lib.sh" "$SCRIPT_DIR/deploy-control-bridge-lib.sh" "$REPO/ops/deploy/"
+cp "$SCRIPT_DIR"/deploy-control-{lib,bridge-lib,current-target-lib}.sh "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/backend-runtime-health-lib.sh" "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/backend-image-rescue-lib.sh" "$REPO/ops/deploy/"
 cp "$SCRIPT_DIR/backend-image-rescue-pin-cleanup-lib.sh" "$REPO/ops/deploy/"

--- a/ops/deploy/x-collector-image-deploy-lib.test.sh
+++ b/ops/deploy/x-collector-image-deploy-lib.test.sh
@@ -218,6 +218,7 @@ CURRENT_ENTRYPOINT_SOURCE_CLOSURE=(
   ops/deploy/social-monitor-production-deploy.sh
   ops/deploy/deploy-control-lib.sh
   ops/deploy/deploy-control-bridge-lib.sh
+  ops/deploy/deploy-control-current-target-lib.sh
   ops/deploy/postgres-runtime-deploy-lib.sh
   ops/deploy/postgres-runtime-asset-lib.sh
   ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
@@ -432,6 +433,7 @@ A_CONTROLLER="$TRANSITION_CONTROL/github-production-deploy.sh" \
       ops/deploy/social-monitor-production-deploy.sh
       ops/deploy/deploy-control-lib.sh
       ops/deploy/deploy-control-bridge-lib.sh
+      ops/deploy/deploy-control-current-target-lib.sh
       ops/deploy/postgres-runtime-deploy-lib.sh
       ops/deploy/postgres-runtime-asset-lib.sh
       ops/deploy/postgres-runtime-weekly-timer-state-lib.sh


### PR DESCRIPTION
Fix the ordinary deployment retry after the authenticated B0 transition without changing the frozen B authority.

## Scope

- Restore historical sealed forward blobs exactly.
- Do not source an already authenticated readonly B0 authority again.
- For a fresh same-target retry, verify the authenticated prelude SHA, initialized SHA, physical control blobs, file modes and all initialized digests before skipping the obsolete first-bootstrap path.
- Keep the existing verification for every other transition.
- Add a one-incident operator recovery for the existing pre-advance deadlock. It admits only the exact protected-main control-only delta from the pinned production preimage, under the existing locks and a reviewed plan digest. It does not deploy an application or write deployment markers.
- Preserve the shared Git directory, linked worktrees, ignored data, installed historical authority, runtime pointers and running container identities. Partial/unknown state fails closed. Rollback is explicit and ends at the ordinary-deployment handoff.

## Evidence

Exact head: 43d16bd2baf89d226ae181242cd200a57df34fac.

Passed in a disposable, network-disabled old-host container:

- 28 recovery tests, including real production Git history, linked worktrees, ignored data, interrupted index/files/ref states, changed runtime, locks, symlinks, failed filesystem flush, native Git line-ending conversion, hidden untracked files, Git status failure and durable receipts.
- Real current-target compatibility and two fresh release invocations up to the publication runtime prebootstrap boundary. This is not application E2E evidence.
- B0 bootstrap regression, RabbitMQ bridge transition, runtime-helper regression and exact forward-target verification.
- Source line cap and review-CI contract checks.

Two independent hosted review passes found six defects, now fixed: restored same-target checkout cleanliness, added a filesystem durability barrier before receipts, raw-byte/mode/index revalidation, common Git device/inode checks at handoff, explicit propagation of Git status failures, and forced enumeration of untracked files independent of Git configuration. Peer closure review and exact-head GitHub CI are in progress. Previous head edfc3fff passed all nine CI jobs; the final two edge-case fixes have focused regression evidence and are getting their exact-head CI. Production has not been changed by this PR's recovery script.

## Delivery order

1. Finish independent review and exact-head CI.
2. Briefly pause only the Production deploy workflow to prevent push-triggered application deployment racing the repair; preserve its initial state.
3. Merge normally, inspect the exact main repair plan and independently verify its digest and unchanged production identities.
4. Apply only the reviewed controller recovery and validate the receipt. No direct application deploy, DB mutation or marker rewrite.
5. Record the handoff, restore Production deploy and run the official workflow. Restore the workflow even if recovery refuses.
6. Verify actual deployed runtime version, health, redacted runtime logs and the bounded subscription-runtime E2E separately.

Known limitation: an unrecognized partial file or outstanding Git lock requires operator investigation; the script never uses reset/clean to conceal it.
