### PR TITLE
fix(deploy): inspect retained marker links without mutation

### DIFF
--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -220,11 +220,23 @@ class ControllerRepair:
                        '{{.Id}} {{.Image}} {{.State.Running}} {{.State.Pid}} '
                        '{{if index .State "Health"}}{{index (index .State "Health") "Status"}}'
                        '{{else}}none{{end}} {{.State.StartedAt}} {{.RestartCount}} {{json .Mounts}}', *names)
-        rows = [row.split(maxsplit=5) for row in data.decode().splitlines()]
-        require(len(rows) == len(names) and all(len(row) == 6 and row[2] == 'true'
+        rows = [row.split(maxsplit=7) for row in data.decode().splitlines()]
+        require(len(rows) == len(names) and all(len(row) == 8 and row[2] == 'true'
                 and row[3].isdigit() and int(row[3]) > 0 and row[4] in ('healthy', 'none') for row in rows),
                 'production containers are not stably running')
-        return digest(data)
+        normalized = []
+        for row in rows:
+            try:
+                mounts = json.loads(row[7])
+            except ValueError as error:
+                raise RuntimeError('container mounts are unreadable') from error
+            require(isinstance(mounts, list) and all(isinstance(mount, dict) for mount in mounts),
+                    'container mounts have unexpected shape')
+            # Docker may emit its mount map in a different order on each read.
+            # Preserve every field, but compare the semantic snapshot, not that
+            # presentation order. Runtime identity/state fields remain ordered.
+            normalized.append([*row[:7], sorted(mounts, key=canonical)])
+        return digest(canonical(normalized))
 
     def plan(self, target: str) -> dict:
         require(re.fullmatch('[0-9a-f]{40}', target) is not None, 'full target SHA required')

--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -217,7 +217,9 @@ class ControllerRepair:
             'api', 'agent-runtime', 'ingestion-worker', 'intelligence-worker',
             'delivery-service', 'event-relay', 'frontend', 'x-collector', 'rabbitmq', 'redis', 'otel-collector', 'caddy')]
         data = execute('/usr/bin/docker', 'inspect', '--format',
-                       '{{.Id}} {{.Image}} {{.State.Running}} {{.State.Pid}} {{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} {{.State.StartedAt}} {{.RestartCount}} {{json .Mounts}}', *names)
+                       '{{.Id}} {{.Image}} {{.State.Running}} {{.State.Pid}} '
+                       '{{if index .State "Health"}}{{index (index .State "Health") "Status"}}'
+                       '{{else}}none{{end}} {{.State.StartedAt}} {{.RestartCount}} {{json .Mounts}}', *names)
         rows = [row.split(maxsplit=5) for row in data.decode().splitlines()]
         require(len(rows) == len(names) and all(len(row) == 6 and row[2] == 'true'
                 and row[3].isdigit() and int(row[3]) > 0 and row[4] in ('healthy', 'none') for row in rows),

--- a/ops/deploy/b0-controller-repair.py
+++ b/ops/deploy/b0-controller-repair.py
@@ -68,15 +68,29 @@ def execute(*args: str) -> bytes:
     return result.stdout
 
 
-def regular(path: Path) -> tuple[bytes, list[int]]:
+def regular(path: Path, *, retained_marker: bool = False) -> tuple[bytes, list[int]]:
     with os.fdopen(os.open(path, os.O_RDONLY | os.O_NOFOLLOW), 'rb') as stream:
         before = os.fstat(stream.fileno())
-        require(stat.S_ISREG(before.st_mode) and before.st_nlink == 1
+        require(stat.S_ISREG(before.st_mode)
+                and before.st_nlink in ((1, 2) if retained_marker else (1,))
                 and before.st_uid == os.geteuid() and not before.st_mode & 0o022,
                 f'unsafe file: {path}')
         data = stream.read()
+        identity = lambda s: [s.st_dev, s.st_ino, s.st_mode, s.st_size, s.st_mtime_ns,
+                              s.st_ctime_ns, s.st_uid, s.st_gid, s.st_nlink]
+        if before.st_nlink == 2:
+            # The deployed marker protocol retains the committed .next inode
+            # at this content-addressed name. Inspect it without changing either
+            # link; arbitrary hardlinks and unfinished .next files stay refused.
+            require(not os.path.lexists(path.with_name(path.name + '.next')),
+                    f'unfinished marker: {path}')
+            receipt = path.with_name(path.name + '.next.retired.' + digest(data))
+            with os.fdopen(os.open(receipt, os.O_RDONLY | os.O_NOFOLLOW), 'rb') as retained:
+                require(identity(os.fstat(retained.fileno())) == identity(before)
+                        and retained.read() == data
+                        and identity(receipt.lstat()) == identity(before),
+                        f'unaccounted marker hardlink: {path}')
         after = os.fstat(stream.fileno())
-        identity = lambda s: [s.st_dev, s.st_ino, s.st_mode, s.st_size, s.st_mtime_ns, s.st_ctime_ns]
         require(identity(before) == identity(after) == identity(path.lstat()),
                 f'file changed during read: {path}')
         return data, identity(after)
@@ -174,7 +188,7 @@ class ControllerRepair:
         result = {}
         for name in STATE_FILES:
             path = self.control / 'deploy-state' / name
-            data, identity = regular(path)
+            data, identity = regular(path, retained_marker=True)
             if name in MARKERS:
                 require(data == (self.live + '\n').encode(), f'live marker drift: {name}')
             result[str(path.relative_to(self.root))] = [digest(data), identity]

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -306,14 +306,30 @@ class RepairTests(unittest.TestCase):
                 output = (f'id image {running} {pid} {health} started 0 []\n' * 12).encode()
                 with patch.object(repair_module, 'execute', return_value=output) as inspect:
                     if accepted:
+                        expected = [['id', 'image', running, pid, health, 'started', '0', []]] * 12
                         self.assertEqual(repair_module.ControllerRepair.runtime_identity(self.repair),
-                                         repair_module.digest(output))
+                                         repair_module.digest(repair_module.canonical(expected)))
                     else:
                         with self.assertRaisesRegex(RuntimeError, 'not stably running'):
                             repair_module.ControllerRepair.runtime_identity(self.repair)
                     template = inspect.call_args.args[3]
                     self.assertIn('index .State "Health"', template)
                     self.assertNotIn('.State.Health', template)
+
+    def test_runtime_mount_order_is_stable_without_ignoring_mount_changes(self):
+        first = {'Destination': '/first', 'Source': '/source-a', 'RW': False}
+        second = {'Destination': '/second', 'Source': '/source-b', 'RW': True}
+
+        def snapshot(mounts):
+            encoded = repair_module.canonical(mounts).decode().strip()
+            output = (f'id image true 123 none started 0 {encoded}\n' * 12).encode()
+            with patch.object(repair_module, 'execute', return_value=output):
+                return repair_module.ControllerRepair.runtime_identity(self.repair)
+
+        original = snapshot([first, second])
+        self.assertEqual(original, snapshot([second, first]))
+        for changed in ({**first, 'Source': '/changed'}, {**first, 'RW': True}):
+            self.assertNotEqual(original, snapshot([changed, second]))
 
     def test_marker_unknown_or_forged_retired_links_are_refused_before_writes(self):
         marker = self.control / 'deploy-state/control.sha'

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -298,6 +298,23 @@ class RepairTests(unittest.TestCase):
             self.assertEqual(marker.stat().st_nlink, 2)
         self.assert_preserved()
 
+    def test_runtime_snapshot_accepts_absent_health_but_refuses_failed_containers(self):
+        for running, pid, health, accepted in (
+                ('true', '123', 'none', True), ('true', '123', 'healthy', True),
+                ('false', '0', 'none', False), ('true', '123', 'unhealthy', False)):
+            with self.subTest(running=running, health=health):
+                output = (f'id image {running} {pid} {health} started 0 []\n' * 12).encode()
+                with patch.object(repair_module, 'execute', return_value=output) as inspect:
+                    if accepted:
+                        self.assertEqual(repair_module.ControllerRepair.runtime_identity(self.repair),
+                                         repair_module.digest(output))
+                    else:
+                        with self.assertRaisesRegex(RuntimeError, 'not stably running'):
+                            repair_module.ControllerRepair.runtime_identity(self.repair)
+                    template = inspect.call_args.args[3]
+                    self.assertIn('index .State "Health"', template)
+                    self.assertNotIn('.State.Health', template)
+
     def test_marker_unknown_or_forged_retired_links_are_refused_before_writes(self):
         marker = self.control / 'deploy-state/control.sha'
         receipt = marker.with_name(marker.name + '.next.retired.' + repair_module.digest(marker.read_bytes()))

--- a/ops/deploy/b0-controller-repair.test.py
+++ b/ops/deploy/b0-controller-repair.test.py
@@ -279,6 +279,68 @@ class RepairTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'plan drifted'):
             self.repair.apply(self.target, '0' * 64)
         self.assertFalse(self.repair.run_path(self.target).exists())
+        self.assert_preserved()
+
+    def test_retired_marker_links_are_preserved_through_apply_and_handoff(self):
+        linked = []
+        for name in ('control.sha', 'postgres-pool-bootstrap.sha',
+                     'production-transition-activated.sha', 'production-transition-review-consumption.v2'):
+            marker = self.control / 'deploy-state' / name
+            receipt = marker.with_name(name + '.next.retired.' + repair_module.digest(marker.read_bytes()))
+            os.link(marker, receipt)
+            linked.append((marker, receipt, marker.stat().st_ino))
+        self.plan = self.repair.plan(self.target)
+        self.approved = repair_module.digest(repair_module.canonical(self.plan))
+        self.repair.apply(self.target, self.approved)
+        self.repair.handoff(self.target, self.approved)
+        for marker, receipt, inode in linked:
+            self.assertEqual((marker.stat().st_ino, receipt.stat().st_ino), (inode, inode))
+            self.assertEqual(marker.stat().st_nlink, 2)
+        self.assert_preserved()
+
+    def test_marker_unknown_or_forged_retired_links_are_refused_before_writes(self):
+        marker = self.control / 'deploy-state/control.sha'
+        receipt = marker.with_name(marker.name + '.next.retired.' + repair_module.digest(marker.read_bytes()))
+        unknown = self.root / 'unexpected-link'
+        os.link(marker, unknown)
+        for forged in ('missing', 'same-bytes-different-inode', 'symlink'):
+            with self.subTest(forged=forged):
+                if forged == 'same-bytes-different-inode':
+                    receipt.write_bytes(marker.read_bytes())
+                elif forged == 'symlink':
+                    receipt.symlink_to(marker)
+                with self.assertRaises((RuntimeError, OSError)):
+                    self.repair.apply(self.target, self.approved)
+                self.assertFalse(self.repair.run_path(self.target).exists())
+                if os.path.lexists(receipt):
+                    receipt.unlink()
+
+    def test_marker_retained_link_change_after_plan_is_refused(self):
+        marker = self.control / 'deploy-state/control.sha'
+        receipt = marker.with_name(marker.name + '.next.retired.' + repair_module.digest(marker.read_bytes()))
+        os.link(marker, receipt)
+        self.plan = self.repair.plan(self.target)
+        self.approved = repair_module.digest(repair_module.canonical(self.plan))
+        receipt.unlink()
+        with self.assertRaisesRegex(RuntimeError, 'plan drifted'):
+            self.repair.apply(self.target, self.approved)
+        self.assertFalse(self.repair.run_path(self.target).exists())
+
+    def test_nonmarker_hardlinks_and_unfinished_marker_are_refused(self):
+        for path in (self.repo / repair_module.CONTROLLER,
+                     self.control / 'github-production-deploy.sh',
+                     self.control / 'production-deploy.lock'):
+            with self.subTest(path=path):
+                sibling = self.root / 'unexpected-link'
+                os.link(path, sibling)
+                with self.assertRaisesRegex(RuntimeError, 'unsafe file'):
+                    self.repair.apply(self.target, self.approved)
+                sibling.unlink()
+        marker = self.control / 'deploy-state/control.sha'
+        os.link(marker, marker.with_name(marker.name + '.next'))
+        with self.assertRaisesRegex(RuntimeError, 'unfinished marker'):
+            self.repair.apply(self.target, self.approved)
+        self.assertFalse(self.repair.run_path(self.target).exists())
 
     def test_plan_refuses_untracked_files_hidden_by_git_configuration(self):
         self.git('config', 'status.showUntrackedFiles', 'no')


### PR DESCRIPTION
Follow-up to #274, based on exact production preflight. Accept only canonical content-addressed retired marker hardlinks for read-only snapshots; mutable files still require one link. Read optional Docker Health safely and canonicalize mount ordering without dropping fields. Adds regression cases for retained markers, forged/symlink/unaccounted links, state drift, stopped/unhealthy containers and mount metadata changes.

Evidence: exact head 028a1aaf25ede16fa521fff6f383061682cb7ec8 passed all 9 CI jobs in run 33876312603, 34/34 focused tests in an isolated no-network container on OLD, and independent peer review. Full read-only production plan passed twice with identical protected identities.

Production control recovery: merged main eb0dd332924e35f10b174e7528d37f04d7406fd7; verified script SHA256 68210ef76f93c5d240c649a706bf9011f09d89023d1bdd3c955f11b2a08105a5. Apply and handoff succeeded with plan SHA256 1390417153a3a1c453572b7e151a71332c6de2fefec8a78df694d38f002e4b81. Receipts are in control/b0-controller-repair-eb0dd332924e35f10b174e7528d37f04d7406fd7. Common Git directory, installed authority, marker bytes/inodes, runtime pointer and container identities were preserved. Four public tracked control files had their mode normalized from 0600 to Git 0644 with incident audit; no marker rewrite or application deploy was performed by the repair.

Official application rollout is separate: https://github.com/777genius/social-monitor/actions/runs/33877147094 . Plan phase passed; final production acceptance was pending when this evidence was written. Do not interpret a control recovery receipt as an application deployment receipt.