### PR TITLE
test(deploy): expect same-target bootstrap without readvance

### DIFF
--- a/ops/deploy/postgres-pool-bootstrap-transition.test.sh
+++ b/ops/deploy/postgres-pool-bootstrap-transition.test.sh
@@ -628,11 +628,11 @@ normal_control_output=$(run_current_control_deploy)
 grep -F "deployed=$CURRENT_SHA" <<< "$normal_control_output" >/dev/null
 grep -F 'backend=true' <<< "$normal_control_output" >/dev/null
 grep -F 'control=true' <<< "$normal_control_output" >/dev/null
-[[ $(sed -n '1p' "$NORMAL_CONTROL_LOG") == integration ]]
-[[ $(sed -n '2p' "$NORMAL_CONTROL_LOG") == load-backend ]]
-[[ $(sed -n '3p' "$NORMAL_CONTROL_LOG") == control ]]
+# Same-target control repair must not fast-forward/re-bootstrap the checkout.
+[[ $(sed -n '1p' "$NORMAL_CONTROL_LOG") == load-backend ]]
+[[ $(sed -n '2p' "$NORMAL_CONTROL_LOG") == control ]]
 grep -Ex 'transaction:true:(true|false)' "$NORMAL_CONTROL_LOG" >/dev/null
-[[ $(wc -l < "$NORMAL_CONTROL_LOG") == 4 ]]
+[[ $(wc -l < "$NORMAL_CONTROL_LOG") == 3 ]]
 [[ $(<"$STATE/control.sha") == "$CURRENT_SHA" ]]
 [[ $(<"$STATE/postgres-pool-bootstrap.sha") == "$CURRENT_SHA" ]]
 assert_release_a_non_activation


### PR DESCRIPTION
Production run 33877147094 failed only at postgres-pool-bootstrap-transition.test.sh phase already-newer-normal-control-deploy line 631. The fixture expected advance_integration for target==HEAD, which #274 intentionally removed while retaining an explicit fail-closed clean checkout check. This four-line test-only correction checks the exact three-event sequence load-backend, control, transaction. Runtime code and gates are unchanged.

Evidence: full historical PostgreSQL bootstrap transition fixture and publication bridge transition fixture both passed on OLD in isolated, read-only, network-none containers. Exact head 98cbe46371ad963207408e91943349e1c272530e independently reviewed and passed all 9 CI jobs in run 33877982138.

Merged main 7e800e90d3295cc881e21a3e81b611fa57eb5b2a. Installed production plan passes with backend/frontend/control=true against live c055, not against the repaired controller checkout. The old production run finished with successful frontend and mandatory publication-boundary jobs; only this corrected fixture failed. Next official push-triggered deploy: https://github.com/777genius/social-monitor/actions/runs/33878601111 . Application deployment and separate acceptance still pending.