### PR TITLE
fix(runtime): make npm manifests readable by non-root runners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates openssl \
   && rm -rf /var/lib/apt/lists/*
 
-COPY package.json package-lock.json ./
+COPY --chmod=0644 package.json package-lock.json ./
 COPY vendor ./vendor
 RUN npm ci
 

--- a/ops/deploy/runtime-manifest-file-modes.test.mjs
+++ b/ops/deploy/runtime-manifest-file-modes.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { randomUUID } from 'node:crypto';
+
+const dockerfile = readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
+const copyManifests = dockerfile.split('\n').filter((line) =>
+  /^COPY\s/u.test(line) && /package\.json/u.test(line));
+
+test('npm manifests have deterministic read permissions for the node runtime', () => {
+  assert.deepEqual(copyManifests, ['COPY --chmod=0644 package.json package-lock.json ./']);
+  assert.match(dockerfile, /^USER node$/mu);
+});
+
+test('a restrictive build context still permits non-root npm execution', {
+  skip: process.env.SOCIAL_MONITOR_TEST_IMAGE_FILE_MODES !== '1',
+  timeout: 180_000,
+}, () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'sm-manifest-modes-test-'));
+  const image = `sm-manifest-modes-test:${randomUUID()}`;
+  const base = process.env.SOCIAL_MONITOR_TEST_NODE_IMAGE ?? 'node:22-bookworm-slim';
+  assert.match(base, /^[a-zA-Z0-9][a-zA-Z0-9./:_@-]+$/u);
+  try {
+    writeFileSync(join(fixture, 'package.json'), JSON.stringify({
+      name: 'isolated-manifest-permission-fixture', version: '1.0.0', private: true,
+      scripts: { probe: 'node -e "process.exit(0)"' },
+    }), { mode: 0o600 });
+    writeFileSync(join(fixture, 'package-lock.json'), '{}', { mode: 0o600 });
+    chmodSync(join(fixture, 'package.json'), 0o600);
+    chmodSync(join(fixture, 'package-lock.json'), 0o600);
+    writeFileSync(join(fixture, 'Dockerfile'), [
+      `FROM ${base}`, 'USER root', 'WORKDIR /app', copyManifests[0], 'USER node',
+      'CMD ["npm", "run", "probe"]', '',
+    ].join('\n'));
+    docker(['build', '--network=none', '--pull=false', '-t', image, fixture]);
+    docker(['run', '--rm', '--network=none', '--entrypoint=node', image, '-e', [
+      "const fs=require('fs');",
+      'if(process.getuid()===0)throw Error("probe must not run as root");',
+      'for(const f of ["/app/package.json","/app/package-lock.json"]){',
+      'const s=fs.statSync(f);',
+      'if((s.mode&0o777)!==0o644||s.uid!==0)throw Error("wrong manifest ownership or mode");',
+      'JSON.parse(fs.readFileSync(f,"utf8"));}',
+    ].join('')]);
+    docker(['run', '--rm', '--network=none', image]);
+  } finally {
+    spawnSync('docker', ['image', 'rm', image], { encoding: 'utf8', timeout: 30_000 });
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+function docker(args) {
+  const result = spawnSync('docker', args, { encoding: 'utf8', timeout: 150_000 });
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, `${args[0]} failed: ${result.stdout}\n${result.stderr}`);
+}

--- a/ops/deploy/runtime-manifest-file-modes.test.mjs
+++ b/ops/deploy/runtime-manifest-file-modes.test.mjs
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import { randomUUID } from 'node:crypto';
+import process from 'node:process';
+import { URL } from 'node:url';
 
 const dockerfile = readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
 const copyManifests = dockerfile.split('\n').filter((line) =>

--- a/scripts/check-container.mjs
+++ b/scripts/check-container.mjs
@@ -31,6 +31,12 @@ for (const required of ['FROM node:22', 'npm ci', 'npm run prisma:generate', 'np
   }
 }
 
+// A root-owned checkout may have umask 077. npm runs as node in daily-runner,
+// so the manifests must be readable independently of build-context modes.
+if (!/^COPY --chmod=0644 package\.json package-lock\.json \.\/\s*$/m.test(dockerfile)) {
+  violations.push(`${policy.dockerfile}: copy npm manifests with explicit non-root-readable modes`);
+}
+
 const npmCiIndex = dockerfile.indexOf('RUN npm ci');
 const nodeEnvIndex = dockerfile.indexOf('ENV NODE_ENV=production');
 const buildIndex = dockerfile.indexOf('npm run build');


### PR DESCRIPTION
## Fix
Production rolling 16:15 UTC failed with npm EACCES on /app/package.json. Root-owned checkout manifests were mode0600 and COPY retained those modes. Daily-runner inherits these layers and runs as node.

Normalize only the two non-secret npm manifests at COPY with --chmod=0644. Keep USER node; no recursive chmod, root-runtime fallback or production hotpatch.

## Evidence
- Exact candidate6244c1470f4a6299b4939683674ab4889e46ecf7.
- Existing container contract passes and now enforces explicit readable manifest modes.
- OLD isolated Docker fixture:2/2 tests passed,0 skipped. Source fixtures intentionally0600, actual Dockerfile COPY instruction, non-root stat/read of both files and npm execution verified. No production data/auth mounts or network during test execution.
- New fixture is opt-in with SOCIAL_MONITOR_TEST_IMAGE_FILE_MODES=1; ordinary container contract still runs in CI.

This is separate from PR279 historical confidence and pending collection engagement wiring. Full production E2E remains unproven until deployment and publication.