### PR TITLE
fix(collection): persist fresh engagement across repeat scans

### DIFF
--- a/libs/ingestion/features/execute-scan/source-engagement-sample-coordinator.ts
+++ b/libs/ingestion/features/execute-scan/source-engagement-sample-coordinator.ts
@@ -21,6 +21,9 @@ export const prepareSourceEngagementSamples = (params: {
   const persistedByExternalId = new Map(
     params.persistedItems.map((item) => [item.toSnapshot().externalId, item]),
   );
+  const fetchedByExternalId = new Map(
+    params.candidateScreening.itemsToProcess.map((item) => [item.externalId, item]),
+  );
   const classificationByExternalId = new Map(
     params.candidateScreening.classifications.map((classification) => [
       classification.externalId,
@@ -40,7 +43,12 @@ export const prepareSourceEngagementSamples = (params: {
   const engagementSamples = [
     ...[...persistedByExternalId.values()].map((item): SourceEngagementSample | undefined => {
       const snapshot = item.toSnapshot();
-      const engagement = reliableEngagement(params.providerKey, snapshot.metadata);
+      const fetched = fetchedByExternalId.get(snapshot.externalId);
+      // Persistence intentionally retains metadata when content is unchanged.
+      // Bind identity to the saved row, but observe metrics from this fetch.
+      const engagement = reliableEngagement(
+        params.providerKey, fetched === undefined ? snapshot.metadata : fetched.metadata,
+      );
       const ref = savedRefByExternalId.get(snapshot.externalId);
       const classification = classificationByExternalId.get(
         snapshot.externalId,
@@ -58,9 +66,8 @@ export const prepareSourceEngagementSamples = (params: {
             sourceItemId: snapshot.id,
             publishedAt: snapshot.publishedAt,
             ...engagement,
-            refreshReadModels: !fullProjectionExternalIds.has(
-              snapshot.externalId,
-            ),
+            refreshReadModels: ref.mutationKind === "unchanged" ||
+              !fullProjectionExternalIds.has(snapshot.externalId),
           };
     }),
     ...[...engagementRefreshByExternalId.values()].map(

--- a/libs/ingestion/features/execute-scan/source-engagement-sample-coordinator.ts
+++ b/libs/ingestion/features/execute-scan/source-engagement-sample-coordinator.ts
@@ -66,7 +66,7 @@ export const prepareSourceEngagementSamples = (params: {
             sourceItemId: snapshot.id,
             publishedAt: snapshot.publishedAt,
             ...engagement,
-            refreshReadModels: ref.mutationKind === "unchanged" ||
+            refreshReadModels: (fetched !== undefined && ref.mutationKind === "unchanged") ||
               !fullProjectionExternalIds.has(snapshot.externalId),
           };
     }),

--- a/scripts/lib/clean-real-day-engagement.spec-support.ts
+++ b/scripts/lib/clean-real-day-engagement.spec-support.ts
@@ -1,0 +1,97 @@
+import { currentDatabaseAccess } from "@social-monitor/platform-persistence";
+import type { PrismaIngestionWorkerConnection } from
+  "../../apps/ingestion-worker/src/adapters/persistence/prisma-ingestion-worker-connection";
+
+type Row = Record<string, unknown>;
+type Args = { where?: Row; data?: Row; create?: Row; update?: Row };
+
+// Deterministic persistence double, not an imitation of the acquisition wiring.
+// The real source/feed/engagement/scan repositories execute against these tables.
+export class AcquisitionDatabaseFixture {
+  readonly tables = Object.fromEntries([
+    "sourceItem", "feedItem", "feedSignalBaselineSample", "sourceCandidateMemory",
+    "sourceItemEngagementSnapshot", "sourceItemEngagementObservation",
+    "sourceItemEngagementDailyRollup", "scanAttempt", "cursorCheckpoint",
+    "scanLeaseEntry", "scanJob", "scanFailureQueueEntry", "conversationUnit",
+    "conversationSignalBaselineSample",
+  ].map((name) => [name, new FixtureTable()]));
+  readonly accesses: ReturnType<typeof currentDatabaseAccess>[] = [];
+  failSnapshots = false;
+
+  readonly connection = {
+    ...this.tables,
+    $transaction: async <T>(operation: (connection: unknown) => Promise<T>) => {
+      this.accesses.push(currentDatabaseAccess());
+      const before = Object.fromEntries(Object.entries(this.tables).map(
+        ([name, table]) => [name, structuredClone(table.rows)],
+      ));
+      this.tables.sourceItemEngagementSnapshot!.failWrites = this.failSnapshots;
+      try {
+        return await operation(this.connection);
+      } catch (error) {
+        for (const [name, rows] of Object.entries(before)) this.tables[name]!.rows = rows;
+        throw error;
+      }
+    },
+  } as unknown as PrismaIngestionWorkerConnection;
+
+  rows(name: string): Row[] { return this.tables[name]!.rows; }
+}
+
+class FixtureTable {
+  rows: Row[] = [];
+  failWrites = false;
+
+  async findMany(args: Args = {}) {
+    return this.rows.filter((row) => matches(row, args.where));
+  }
+  async findFirst(args: Args) { return (await this.findMany(args))[0] ?? null; }
+  async findUnique(args: Args) { return this.findFirst(args); }
+  async count(args: Args) { return (await this.findMany(args)).length; }
+  async create(args: Args) {
+    this.requireWrites();
+    const row = { createdAt: new Date(), updatedAt: new Date(), seenCount: 1, ...args.data };
+    this.rows.push(row);
+    return row;
+  }
+  async createMany(args: { data: readonly Row[] }) {
+    for (const data of args.data) await this.create({ data });
+    return { count: args.data.length };
+  }
+  async update(args: Args) {
+    this.requireWrites();
+    const row = await this.findFirst(args);
+    if (row === null) throw new Error("Fixture update target is missing");
+    for (const [key, value] of Object.entries(args.data ?? {})) {
+      row[key] = isRecord(value) && typeof value.increment === "number"
+        ? Number(row[key] ?? 0) + value.increment : value;
+    }
+    return row;
+  }
+  async upsert(args: Args) {
+    return await this.findFirst(args) === null
+      ? this.create({ data: args.create })
+      : this.update({ where: args.where, data: args.update });
+  }
+  async deleteMany(args: Args) {
+    const before = this.rows.length;
+    this.rows = this.rows.filter((row) => !matches(row, args.where));
+    return { count: before - this.rows.length };
+  }
+  private requireWrites() {
+    if (this.failWrites) throw new Error("Fixture engagement persistence unavailable");
+  }
+}
+
+function matches(row: Row, where: Row = {}): boolean {
+  return Object.entries(where).every(([key, expected]) => {
+    if (!isRecord(expected)) return row[key] === expected;
+    if ("in" in expected) return (expected.in as unknown[]).includes(row[key]);
+    if ("lt" in expected) return Number(row[key]) < Number(expected.lt);
+    if ("lte" in expected) return Number(row[key]) <= Number(expected.lte);
+    return matches(row, expected); // Prisma compound unique selector.
+  });
+}
+function isRecord(value: unknown): value is Row {
+  return typeof value === "object" && value !== null && !(value instanceof Date);
+}

--- a/scripts/lib/clean-real-day-engagement.spec-support.ts
+++ b/scripts/lib/clean-real-day-engagement.spec-support.ts
@@ -42,6 +42,8 @@ class FixtureTable {
   rows: Row[] = [];
   failWrites = false;
 
+  constructor() { this.update = this.update.bind(this); }
+
   async findMany(args: Args = {}) {
     return this.rows.filter((row) => matches(row, args.where));
   }

--- a/scripts/lib/clean-real-day-engagement.spec.ts
+++ b/scripts/lib/clean-real-day-engagement.spec.ts
@@ -38,6 +38,7 @@ describe("live acquisition durable engagement composition", () => {
 
   it("writes source-bound snapshots and observations through the real composition", async () => {
     const results = await run();
+    expect(db.rows("scanAttempt").map((row) => row.failureReason).filter(Boolean)).toEqual([]);
     expect(results[0]?.status).toBe("succeeded");
     const source = db.rows("sourceItem")[0]!;
     expect(db.rows("sourceItemEngagementSnapshot")).toEqual([

--- a/scripts/lib/clean-real-day-engagement.spec.ts
+++ b/scripts/lib/clean-real-day-engagement.spec.ts
@@ -1,0 +1,90 @@
+import { CircuitBreakerSourceFetcherAdapter } from
+  "@social-monitor/ingestion/adapters/source/circuit-breaker-source-fetcher.adapter";
+import { SystemClock } from "@social-monitor/shared-kernel";
+import type { GitHubTrendingDurableSnapshotReader } from
+  "./github-trending-durable-snapshot-reuse";
+import { executeCleanRealDayProviderAcquisition, type CleanRealDaySourceBindingTarget } from
+  "./clean-real-day-provider-acquisition";
+import { AcquisitionDatabaseFixture } from "./clean-real-day-engagement.spec-support";
+
+describe("live acquisition durable engagement composition", () => {
+  let db: AcquisitionDatabaseFixture;
+  let score: number;
+  let now: Date;
+  beforeEach(() => {
+    db = new AcquisitionDatabaseFixture();
+    score = 42;
+    now = new Date("2026-09-04T12:00:00.000Z");
+    jest.spyOn(SystemClock.prototype, "now").mockImplementation(() => new Date(now));
+    jest.spyOn(CircuitBreakerSourceFetcherAdapter.prototype, "fetch")
+      .mockImplementation(async () => ({
+        items: [{
+          externalId: "reddit:test-engagement",
+          canonicalUrl: "https://example.test/reddit/engagement",
+          title: "A relevant AI research result", body: "Sandbox source evidence.",
+          publishedAt: new Date("2026-09-04T11:00:00.000Z"),
+          metadata: { kind: "reddit_post", providerScore: score, subreddit: "sandbox" },
+        }],
+      }));
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  const run = () => executeCleanRealDayProviderAcquisition({
+    targets: [target], connection: db.connection,
+    durableSnapshotReader: {} as GitHubTrendingDurableSnapshotReader,
+    requestedUtcDay: "2026-09-04", targetWindowEndedAt: new Date("2026-09-05T00:00:00Z"),
+    runStartedAt: now, waitForXReadiness: false,
+  });
+
+  it("writes source-bound snapshots and observations through the real composition", async () => {
+    const results = await run();
+    expect(results[0]?.status).toBe("succeeded");
+    const source = db.rows("sourceItem")[0]!;
+    expect(db.rows("sourceItemEngagementSnapshot")).toEqual([
+      expect.objectContaining({
+        tenantId: target.tenantId, workspaceId: target.workspaceId,
+        sourceItemId: source.id, providerKey: "reddit", score: 42n,
+      }),
+    ]);
+    expect(db.rows("sourceItemEngagementObservation")[0]).toMatchObject({
+      tenantId: target.tenantId, workspaceId: target.workspaceId,
+      sourceItemId: source.id, sourceBindingId: target.sourceBindingId,
+      providerKey: "reddit", score: 42n,
+    });
+    expect(db.accesses.length).toBeGreaterThan(0);
+    expect(db.accesses.every((access) => access?.kind === "tenant" &&
+      access.tenantId === target.tenantId && access.workspaceId === target.workspaceId)).toBe(true);
+  });
+
+  it("refreshes a duplicate from fresh provider metrics without inserting another post", async () => {
+    await run();
+    score = 90;
+    now = new Date("2026-09-04T16:00:00.000Z");
+    await run();
+    expect(db.rows("sourceItem")).toHaveLength(1);
+    expect(db.rows("feedItem")).toHaveLength(1);
+    expect(db.rows("sourceItemEngagementSnapshot")[0]).toMatchObject({
+      score: 90n, lastObservedAt: now,
+    });
+    expect(db.rows("feedItem")[0]?.providerMetadata).toMatchObject({ providerScore: 90 });
+  });
+
+  it("reports failed collection when durable engagement cannot be persisted", async () => {
+    db.failSnapshots = true;
+    const results = await run();
+    expect(results[0]?.status).toBe("failed");
+    expect(db.rows("sourceItemEngagementSnapshot")).toEqual([]);
+    expect(db.rows("sourceItemEngagementObservation")).toEqual([]);
+    expect(db.rows("scanAttempt").every((row) => row.status === "FAILED")).toBe(true);
+  });
+});
+
+const target: CleanRealDaySourceBindingTarget = {
+  tenantId: "11111111-1111-4111-8111-111111111111",
+  workspaceId: "22222222-2222-4222-8222-222222222222",
+  interestId: "33333333-3333-4333-8333-333333333333", interestQuery: "AI research",
+  sourceBindingId: "44444444-4444-4444-8444-444444444444",
+  scanPolicyId: "55555555-5555-4555-8555-555555555555",
+  providerKey: "reddit", config: { mode: "search", limit: 1 },
+  sourceQuery: { mode: "search", query: "AI research" },
+};

--- a/scripts/lib/clean-real-day-engagement.spec.ts
+++ b/scripts/lib/clean-real-day-engagement.spec.ts
@@ -57,8 +57,13 @@ describe("live acquisition durable engagement composition", () => {
       access.tenantId === target.tenantId && access.workspaceId === target.workspaceId)).toBe(true);
   });
 
-  it("refreshes a duplicate from fresh provider metrics without inserting another post", async () => {
+  it.each(["warm", "cold", "read_failed"])("refreshes duplicate metrics with %s memory", async (memory) => {
     await run();
+    if (memory === "cold") db.tables.sourceCandidateMemory!.rows = [];
+    if (memory === "read_failed") {
+      jest.spyOn(db.tables.sourceCandidateMemory!, "findMany")
+        .mockRejectedValue(new Error("Fixture memory read unavailable"));
+    }
     score = 90;
     now = new Date("2026-09-04T16:00:00.000Z");
     await run();
@@ -68,6 +73,12 @@ describe("live acquisition durable engagement composition", () => {
       score: 90n, lastObservedAt: now,
     });
     expect(db.rows("feedItem")[0]?.providerMetadata).toMatchObject({ providerScore: 90 });
+    expect(db.rows("sourceItem")[0]?.metadata).toMatchObject({ providerScore: 90 });
+    now = new Date("2026-09-04T16:05:00.000Z");
+    await run();
+    expect(db.rows("sourceItemEngagementSnapshot")[0]?.score).toBe(90n);
+    expect(db.rows("sourceItemEngagementObservation")).toHaveLength(2);
+    expect(db.rows("feedItem")).toHaveLength(1);
   });
 
   it("reports failed collection when durable engagement cannot be persisted", async () => {

--- a/scripts/lib/clean-real-day-provider-acquisition.ts
+++ b/scripts/lib/clean-real-day-provider-acquisition.ts
@@ -7,6 +7,7 @@ import { PrismaScanCursorRepository } from "@social-monitor/ingestion/adapters/p
 import { PrismaScanFailureQueueAdapter } from "@social-monitor/ingestion/adapters/persistence/prisma/prisma-scan-failure-queue.adapter";
 import { PrismaScanLeaseAdapter } from "@social-monitor/ingestion/adapters/persistence/prisma/prisma-scan-lease.adapter";
 import { PrismaSourceItemRepository } from "@social-monitor/ingestion/adapters/persistence/prisma/prisma-source-item.repository";
+import { PrismaSourceCandidateMemoryRepository } from "@social-monitor/ingestion/adapters/persistence/prisma/prisma-source-candidate-memory.repository";
 import { CircuitBreakerSourceFetcherAdapter } from "@social-monitor/ingestion/adapters/source/circuit-breaker-source-fetcher.adapter";
 import { GitHubTrendingPageSourceProvider } from "@social-monitor/ingestion/adapters/source/github-trending-page/github-trending-page-source.provider";
 import { HttpGitHubTrendingPageClient } from "@social-monitor/ingestion/adapters/source/github-trending-page/http-github-trending-page-client";
@@ -320,7 +321,7 @@ const buildLiveRuntime = (params: {
       new PrismaConversationUnitRepository(params.connection, ids),
       ids,
     ),
-    undefined,
+    new PrismaSourceCandidateMemoryRepository(params.connection, ids),
     new PrismaSourceEngagementProjectionAdapter(params.connection, ids),
   );
   return { executeScan, scanJobReporter };

--- a/scripts/lib/clean-real-day-provider-acquisition.ts
+++ b/scripts/lib/clean-real-day-provider-acquisition.ts
@@ -1,6 +1,7 @@
 import { ConversationUnitProjectionAdapter } from "@social-monitor/conversation/adapters/ingestion/conversation-unit-projection.adapter";
 import { PrismaConversationUnitRepository } from "@social-monitor/conversation/adapters/persistence/prisma/prisma-conversation-unit.repository";
 import { PrismaFeedProjectionAdapter } from "@social-monitor/feed/adapters/persistence/prisma/prisma-feed-projection.adapter";
+import { PrismaSourceEngagementProjectionAdapter } from "@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-projection.adapter";
 import { PrismaScanAttemptRepository } from "@social-monitor/ingestion/adapters/persistence/prisma/prisma-scan-attempt.repository";
 import { PrismaScanCursorRepository } from "@social-monitor/ingestion/adapters/persistence/prisma/prisma-scan-cursor.repository";
 import { PrismaScanFailureQueueAdapter } from "@social-monitor/ingestion/adapters/persistence/prisma/prisma-scan-failure-queue.adapter";
@@ -319,6 +320,8 @@ const buildLiveRuntime = (params: {
       new PrismaConversationUnitRepository(params.connection, ids),
       ids,
     ),
+    undefined,
+    new PrismaSourceEngagementProjectionAdapter(params.connection, ids),
   );
   return { executeScan, scanJobReporter };
 };


### PR DESCRIPTION
## Production defects
The live daily/rolling acquisition composition omitted canonical source-engagement projection. Connecting it alone exposed a second bug: a duplicate fetch returning score90 persisted old score42 with the new observation time.

## Fix
Wire existing durable candidate-memory and engagement adapters. Keep canonical persisted source identity, but use metrics from the exact current fetched candidate. Refresh duplicate read models when content persistence retains older metadata. No eligibility/quality threshold changes.

## Verification
- OLD sandbox, exact9fe3a286b01ef45e9659bd67987ab051c6cd6a5b:5 suites/41 tests PASS; focused ESLint PASS.
- Real acquisition composition, ExecuteScan and source/feed/engagement/scan adapters; only provider fetch and underlying persistence tables are deterministic test doubles.
- New post persistence; warm/cold/failed-memory duplicate refresh; identical followup; tenant/source binding; durable-projection failure without success reporting.
- Regression first failed with stale42 instead of90, then passed after the coordinator fix.
- Independent review requested on exact head.

## Boundary
No production writes/deploy or real publication claim. Complements PR279 historical V1 readback and PR280 non-root runtime manifest permissions. Production deploy remains capacity-blocked; account admission and actual summary publication still need proof.