### PR TITLE
fix(deploy): recover stale production controller before deployment

### DIFF
--- a/ops/deploy/deploy-control-lib.sh
+++ b/ops/deploy/deploy-control-lib.sh
@@ -705,7 +705,10 @@ reconcile_current_postgres_pool_bootstrap() {
   local commit_mode=normal
   local force_advance=false
   validate_current_postgres_pool_bootstrap_recovery "$current"
-  postgres_pool_bootstrap_installed "$current" && return 0
+  # An ancestor marker can be valid while its entrypoint still predates HEAD.
+  # A no-op must also prove the current commit's installed controller bytes.
+  if postgres_pool_bootstrap_installed "$current" && \
+      postgres_pool_bootstrap_physically_installed "$current" "$current"; then return 0; fi
   [[ -f $installed && ! -L $installed ]] || \
     fail 'installed deploy entrypoint is not a regular non-symlink file'
   if [[ -n $expected_backend ]]; then

--- a/ops/deploy/github-production-deploy-client.sh
+++ b/ops/deploy/github-production-deploy-client.sh
@@ -732,7 +732,7 @@ reconcile_deploy_plan() {
 }
 
 deploy_once() {
-  local sha=$1
+  local sha=$1 reconciliation_sha=${2:-$1}
   local status
   if run_remote deploy "$sha"; then
     status=0
@@ -743,7 +743,8 @@ deploy_once() {
   if ((status == 255)); then
     printf 'deploy-client: SSH disconnected after deploy; the deploy will not be rerun\n' >&2
   fi
-  reconcile_deploy_plan "$sha"
+  # A control-only bridge can require reconciliation through its main target.
+  reconcile_deploy_plan "$reconciliation_sha"
 }
 
 deploy_release() {

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -344,9 +344,10 @@ prepare_production_forward_bridge() {
     (
       # shellcheck disable=SC2329 # Called by deploy_once reconciliation.
       plan_is_fully_reconciled() {
-        production_forward_plan_is_fully_reconciled "$PRODUCTION_FORWARD_RECOVERY_BRIDGE"
+        plan_is_exact_production_forward_recovery true "$PRODUCTION_FORWARD_RECOVERY_BRIDGE" || \
+          plan_is_exact_production_forward_recovery false "$PRODUCTION_FORWARD_RECOVERY_BRIDGE" "$target"
       }
-      deploy_once "$PRODUCTION_FORWARD_RECOVERY_BRIDGE"
+      deploy_once "$PRODUCTION_FORWARD_RECOVERY_BRIDGE" "$target"
     )
     return
   fi

--- a/ops/deploy/github-production-forward-bridge-client-lib.sh
+++ b/ops/deploy/github-production-forward-bridge-client-lib.sh
@@ -238,7 +238,7 @@ plan_is_approved_production_forward_handoff() {
 
 # Exact incident authority: the side commit changes only the entrypoint.
 PRODUCTION_FORWARD_RECOVERY_BASE=7e800e90d3295cc881e21a3e81b611fa57eb5b2a
-PRODUCTION_FORWARD_RECOVERY_BRIDGE=8df8f3ba4e028e7fa7f837484541e58caf44a3f9
+PRODUCTION_FORWARD_RECOVERY_BRIDGE=77a24e22e8b56e4919ba06fd7ee844bac1dabc59
 
 production_forward_controller_paths() {
   printf '%s\n' \
@@ -278,7 +278,7 @@ production_forward_validate_recovery() {
      "$bridge $PRODUCTION_FORWARD_RECOVERY_BASE" ]] || return 1
   delta=$(production_forward_git diff-tree --no-commit-id --name-only --no-renames \
     -r "$PRODUCTION_FORWARD_RECOVERY_BASE" "$bridge") || return 1
-  [[ $delta == ops/deploy/social-monitor-production-deploy.sh ]] || return 1
+  [[ $delta == $'ops/deploy/deploy-control-lib.sh\nops/deploy/social-monitor-production-deploy.sh' ]] || return 1
   production_forward_controller_is_compatible "$bridge" "$target"
 }
 

--- a/ops/deploy/production-forward-stale-controller.test.sh
+++ b/ops/deploy/production-forward-stale-controller.test.sh
@@ -196,6 +196,9 @@ if [[ $mode == --reproduce ]]; then source "$fixture/old-client"; fi
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
 capture_plan() {
   printf '%s\n' "$1" >> "$fixture/plans"
+  if declare -F fixture_host_preflight >/dev/null; then
+    fixture_host_preflight plan "$1" || return $?
+  fi
   PLAN_FRONTEND=false PLAN_BACKEND=true PLAN_CONTROL=true PLAN_X_COLLECTOR=false
   PLAN_BACKEND_BASE=$(cat "$STATE/backend.sha")
   PLAN_POSTGRES_POOL_BOOTSTRAP=$POSTGRES_POOL_BOOTSTRAP_VERSION
@@ -224,6 +227,24 @@ export GIT_AUTHOR_NAME=stale-test GIT_AUTHOR_EMAIL=stale@example.invalid
 export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 TARGET=$(production_forward_git commit-tree "$TARGET^{tree}" -p "$TARGET" -p "$C" -m 'test: retain recovery controller')
 production_forward_validate_recovery "$TARGET"
+production_forward_git update-ref refs/remotes/origin/main "$TARGET"
+# Keep the real committed host preflight, terminal-state parser and ordinary
+# deploy guard in the transport fixture. Only the network fetch is replaced.
+fixture_host_preflight() (
+  REPO=$fixture/repo
+  SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
+  source_reviewed_deploy_library "$MARKER" \
+    ops/deploy/production-transition-b0-host-control.sh 'committed host prelude'
+  fetch_main() { [[ $(production_forward_git rev-parse origin/main) == "$TARGET" ]]; }
+  validate_main_commit() { production_forward_git merge-base --is-ancestor "$1" origin/main; }
+  production_transition_host_preflight_prelude "$1" "$2"
+  if [[ $1 == deploy ]]; then production_transition_host_require_ordinary_deploy "$2"; fi
+  production_transition_host_release_lock
+)
+printf 'version=production-transition-b0-host-state-v1\nstatus=terminal\ntrusted-base=%s\ntarget=%s\ntarget-tree=%s\n' \
+  "$MARKER" "$MARKER" "$(production_forward_git rev-parse "$MARKER^{tree}")" \
+  > "$STATE/production-transition-b0-host.state"
+chmod 0600 "$STATE/production-transition-b0-host.state"
 # The real host classifier and interrupted-entrypoint validator must accept C,
 # not merely the client's read-only plan stub.
 (
@@ -246,12 +267,24 @@ production_forward_validate_recovery "$TARGET"
 RECONCILE_ATTEMPTS=2 RECONCILE_INTERVAL_SECONDS=0
 run_remote() {
   [[ $1 == deploy && $2 == "$C" ]] || fail 'unexpected remote mutation'
+  fixture_host_preflight deploy "$2" || return $?
   printf '%s\n' "$2" >> "$fixture/deploys"
+  production_forward_git update-ref HEAD "$C"
+  printf '%s\n' "$C" > "$STATE/control.sha"
   printf '%s\n' "$C" > "$STATE/postgres-pool-bootstrap.sha"
   return 255
 }
 prepare_production_forward_bridge "$TARGET"
 prepare_production_forward_bridge "$TARGET"
+# Once C is current, only the descendant target remains host-admitted for
+# reconciliation; neither planning nor replaying deploy C is permitted.
+for action in plan deploy; do
+  if fixture_host_preflight "$action" "$C" > "$fixture/current-c.log" 2>&1; then
+    fail "current C unexpectedly admitted $action C"
+  fi
+  grep -Fx 'deploy-client-error: production prelude target is not exact origin main' \
+    "$fixture/current-c.log" >/dev/null
+done
 # A completed backend transaction can precede the final pool marker write.
 # Resuming this exact target must keep C and avoid another bridge deployment.
 printf '%s\n' "$TARGET" > "$STATE/backend.sha"

--- a/ops/deploy/production-forward-stale-controller.test.sh
+++ b/ops/deploy/production-forward-stale-controller.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Incident regression against real history and the initialized host controller.
 # shellcheck disable=SC1091,SC2034,SC2329 # Dynamic host/client fixture callbacks.
+# shellcheck disable=SC2030,SC2031 # Partial-recovery state is intentionally subshell-isolated.
 set -Eeuo pipefail
 export LC_ALL=C GIT_NO_LAZY_FETCH=1 GIT_NO_REPLACE_OBJECTS=1
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -225,7 +226,20 @@ fi
 C=$PRODUCTION_FORWARD_RECOVERY_BRIDGE
 export GIT_AUTHOR_NAME=stale-test GIT_AUTHOR_EMAIL=stale@example.invalid
 export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
-TARGET=$(production_forward_git commit-tree "$TARGET^{tree}" -p "$TARGET" -p "$C" -m 'test: retain recovery controller')
+# Carry both reviewed control fixes into the fixture target, retaining real C
+# ancestry. All unrelated target files remain the protected main snapshot.
+GIT_INDEX_FILE=$fixture/recovery-target.index production_forward_git read-tree "$TARGET"
+for path in ops/deploy/deploy-control-lib.sh ops/deploy/social-monitor-production-deploy.sh; do
+  blob=$(production_forward_git rev-parse "$C:$path")
+  [[ $(git -C "$PROJECT_ROOT" hash-object "$PROJECT_ROOT/$path") == "$blob" ]]
+  GIT_INDEX_FILE=$fixture/recovery-target.index production_forward_git \
+    update-index --cacheinfo "100644,$blob,$path"
+done
+tree=$(GIT_INDEX_FILE=$fixture/recovery-target.index production_forward_git write-tree --missing-ok)
+old_c=8df8f3ba4e028e7fa7f837484541e58caf44a3f9
+legacy_target=$(production_forward_git commit-tree "$TARGET^{tree}" -p "$TARGET" -p "$old_c" -m 'test: preserve previous review ancestry')
+TARGET=$(production_forward_git commit-tree "$tree" -p "$legacy_target" -p "$C" -m 'test: retain recovery controller')
+production_forward_git merge-base --is-ancestor "$old_c" "$TARGET"
 production_forward_validate_recovery "$TARGET"
 production_forward_git update-ref refs/remotes/origin/main "$TARGET"
 # Keep the real committed host preflight, terminal-state parser and ordinary
@@ -245,6 +259,95 @@ printf 'version=production-transition-b0-host-state-v1\nstatus=terminal\ntrusted
   "$MARKER" "$MARKER" "$(production_forward_git rev-parse "$MARKER^{tree}")" \
   > "$STATE/production-transition-b0-host.state"
 chmod 0600 "$STATE/production-transition-b0-host.state"
+# A crash after advancing HEAD to C is deliberately fail-closed in the client.
+# Prove the bounded operator repair through the existing authenticated ancestor
+# command, not a new host authority or a transport stub that rewrites markers.
+verify_partial_controller_operator_recovery() (
+  local phase=$1 partial=$fixture/partial-$1 path initial_pool installed_identity
+  mkdir -p "$partial/state" "$partial/control"
+  git -c gc.autoDetach=false clone -q --shared --no-checkout "$fixture/repo" "$partial/repo"
+  REPO=$partial/repo GITHUB_WORKSPACE=$partial/repo STATE=$partial/state CONTROL=$partial/control
+  git -C "$REPO" config core.hooksPath /dev/null
+  git -C "$REPO" sparse-checkout set --no-cone --no-sparse-index \
+    /ops/deploy/social-monitor-production-deploy.sh \
+    /ops/deploy/postgres-runtime-deploy-lib.sh \
+    /ops/deploy/verify-postgres-runtime-topology.py \
+    /ops/deploy/production-runtime/compose.postgres-runtime.yml
+  git -C "$REPO" checkout -q --detach "$C"
+  git -C "$REPO" update-ref refs/remotes/origin/main "$TARGET"
+  [[ -z $(git -C "$REPO" status --porcelain) ]]
+  for path in backend control frontend postgres-pool-bootstrap; do
+    printf '%s\n' "$MARKER" > "$STATE/$path.sha"
+    chmod 0600 "$STATE/$path.sha"
+  done
+  cp "$fixture/state/production-transition-b0-host.state" "$STATE/production-transition-b0-host.state"
+  production_forward_git show "$phase:ops/deploy/social-monitor-production-deploy.sh" > \
+    "$CONTROL/github-production-deploy.sh"
+  production_forward_git show "$MARKER:ops/deploy/social-monitor-production-ssh-wrapper.sh" > \
+    "$CONTROL/github-production-deploy-wrapper.sh"
+  chmod 0755 "$CONTROL/"*.sh
+  source_reviewed_deploy_library "$C" ops/deploy/deploy-control-lib.sh 'partial-C recovery implementation'
+  source_reviewed_deploy_library "$C" ops/deploy/production-transition-b0-host-control.sh 'partial-C host prelude'
+  source_reviewed_deploy_library "$C" ops/deploy/production-transition-marker-lib.sh 'partial-C marker publication'
+  source /dev/stdin < <(sed -n '/^FRONTEND_PATHS=(/,/^COMPOSE=(/p' "$fixture/target-entrypoint" | sed '$d')
+  source /dev/stdin < <(sed -n '/^marker_value() {/,/^validate_frontend_archive() {/p' "$fixture/target-entrypoint" | sed '$d')
+  source /dev/stdin < <(sed -n '/^sync_control_entrypoint() {/,/^sync_control_script() {/p' "$fixture/target-entrypoint" | sed '$d')
+  SOCIAL_MONITOR_DEPLOY_TEST_MODE=1
+  DEPLOY_LOCK=$partial/deploy.lock POSTGRES_ADMISSION_LOCK=$partial/admission.lock
+  DAILY_SINGLETON_LOCK=$partial/daily.lock STAGING=$partial/staging RELEASES=$partial/releases
+  fetch_main() { [[ $(git -C "$REPO" rev-parse origin/main) == "$TARGET" ]]; }
+  validate_main_commit() { git -C "$REPO" merge-base --is-ancestor "$1" origin/main; }
+  # Normalize only OS ownership for unprivileged CI; real install/rename,
+  # committed source validation, marker publication and host locks still run.
+  install() {
+    local -a args=()
+    while (($#)); do
+      case $1 in -o|-g) shift 2 ;; *) args+=("$1"); shift ;; esac
+    done
+    command install "${args[@]}"
+    [[ ${args[${#args[@]}-1]} != "$CONTROL/github-production-deploy.sh.next" ]] || \
+      printf 'entrypoint-sync\n' >> "$partial/effects"
+  }
+  advance_integration() { fail 'operator repair replayed integration advancement'; }
+  deploy_release_runtime_transaction() { fail 'operator repair replayed application deployment'; }
+  deploy_frontend() { fail 'operator repair replayed frontend deployment'; }
+  sync_control_script() { fail 'operator repair replayed full control deployment'; }
+  operator_repair() (
+    production_transition_host_preflight_prelude deploy "$MARKER"
+    production_transition_host_require_ordinary_deploy "$MARKER"
+    deploy_release "$MARKER"
+    production_transition_host_release_lock
+  )
+  initial_pool=$(stat -c '%d:%i:%s:%y:%z' "$STATE/postgres-pool-bootstrap.sha")
+  operator_repair
+  [[ $(cat "$STATE/postgres-pool-bootstrap.sha") == "$C" ]]
+  [[ $(cat "$partial/effects") == entrypoint-sync ]]
+  [[ $(stat -c '%d:%i:%s:%y:%z' "$STATE/postgres-pool-bootstrap.sha") != "$initial_pool" ]]
+  initial_pool=$(stat -c '%d:%i:%s:%y:%z' "$STATE/postgres-pool-bootstrap.sha")
+  installed_identity=$(stat -c '%d:%i:%s:%y:%z' "$CONTROL/github-production-deploy.sh")
+  operator_repair
+  [[ $(stat -c '%d:%i:%s:%y:%z' "$STATE/postgres-pool-bootstrap.sha") == "$initial_pool" ]]
+  [[ $(stat -c '%d:%i:%s:%y:%z' "$CONTROL/github-production-deploy.sh") == "$installed_identity" ]]
+  [[ $(cat "$partial/effects") == entrypoint-sync ]]
+  # Ancestor repair seals the installed pool only. The next normal deployment
+  # owns control.sha advancement; fabricating it here would hide pending work.
+  for path in backend control frontend; do [[ $(cat "$STATE/$path.sha") == "$MARKER" ]]; done
+  [[ $(git -C "$REPO" rev-parse HEAD) == "$C" ]]
+  cmp "$CONTROL/github-production-deploy.sh" "$REPO/ops/deploy/social-monitor-production-deploy.sh"
+  [[ $(find_postgres_pool_bootstrap_installed_control_commit \
+    "$MARKER" "$C" "$CONTROL/github-production-deploy.sh") == "$C" ]]
+  (
+    production_transition_host_preflight_prelude plan "$TARGET"
+    print_plan "$TARGET"
+    production_transition_host_release_lock
+  ) > "$partial/target.plan"
+  grep -Fx "postgres_pool_bootstrap_sha=$C" "$partial/target.plan" >/dev/null
+  grep -Fx "backend_base=$MARKER" "$partial/target.plan" >/dev/null
+  grep -Fx 'backend=true' "$partial/target.plan" >/dev/null
+  grep -Fx 'control=true' "$partial/target.plan" >/dev/null
+)
+verify_partial_controller_operator_recovery "$C"
+verify_partial_controller_operator_recovery "$MARKER"
 # The real host classifier and interrupted-entrypoint validator must accept C,
 # not merely the client's read-only plan stub.
 (
@@ -358,7 +461,7 @@ for drift in absent symlink mode; do
   bad_target=$(production_forward_git commit-tree "$tree" -p "$TARGET" -m "test: $drift")
   if production_forward_validate_recovery "$bad_target"; then fail "controller drift admitted: $drift"; fi
 done
-# Parent count and one-path delta checks are independent of byte compatibility.
+# Parent count and exact two-path delta checks are independent of byte compatibility.
 for drift in parent merge delta; do
   tree=$(production_forward_git rev-parse "$C^{tree}")
   parents=(-p "$MARKER")

--- a/ops/deploy/production-release-a-transition.test.sh
+++ b/ops/deploy/production-release-a-transition.test.sh
@@ -268,12 +268,16 @@ echo 'Canonical E/A2/B2 target transition tests passed'
 # client must install only the reviewed bridge, then let the normal target
 # deploy own the descendant itself.
 source "$PROJECT_ROOT/ops/deploy/github-production-forward-bridge-client-lib.sh"
+fail() { printf 'forward-preparation-test: %s\n' "$*" >&2; exit 1; }
 POSTGRES_POOL_BOOTSTRAP_VERSION=postgres-pool-v1
 verify_production_forward_target_identity() {
   PRODUCTION_FORWARD_ANCHOR=anchor
   PRODUCTION_FORWARD_DERIVED_BRIDGE=bridge
 }
 production_forward_bridge_is_installed() { return 1; }
+# This orchestration-only fixture uses symbolic graph identities. Real
+# controller blobs and modes are exercised by production-forward-bridge.test.sh.
+production_forward_controller_is_compatible() { [[ $1 == bridge && $2 == bridge ]]; }
 capture_plan() {
   local requested=$1
   PLAN_FRONTEND=true PLAN_BACKEND=true PLAN_CONTROL=true PLAN_X_COLLECTOR=false
@@ -312,6 +316,7 @@ capture_plan() {
     PLAN_FRONTEND=false
     PLAN_BACKEND=false
     PLAN_CONTROL=false
+    PLAN_POSTGRES_POOL_BOOTSTRAP_SHA=bridge
   fi
 }
 print_plan() { :; }

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -172,8 +172,8 @@ assert_real_bridge_target_assets() {
       ops/deploy/deploy-control-lib.sh)
         expected_digest=d18854822ef36d5571289e72c7691fff8db4a7d5c516787441a733d6960a88a9
         # The ordinary-release controller preserves the frozen B0 authority
-        # instead of sourcing its readonly functions for a second time.
-        current_release_digest=c5612b8cd1092ec04bf3d5271e98e0bc58918cc23832f7f57c3947cb91e011eb
+        # and verifies current installed bytes before treating recovery as a no-op.
+        current_release_digest=78e9a52cf2c4775160a959e8dd695cb1fc35e745066e221bec473cf5ad861b57
         ;;
       ops/deploy/postgres-runtime-deploy-lib.sh)
         expected_digest=261fb030bea2f203564c59e0c22db8058b310fb5d979c7db622938fe6045545a

--- a/ops/deploy/social-monitor-production-deploy.sh
+++ b/ops/deploy/social-monitor-production-deploy.sh
@@ -579,11 +579,11 @@ upload_frontend() (
   [[ $(df -Pk "$STAGING" | awk 'NR == 2 {print $4}') -ge 1048576 ]] || fail 'less than 1 GiB is free for frontend extraction'
   install -d -m 0755 "$extracted"
   if command -v timeout >/dev/null; then
-    timeout 180 tar --no-same-owner --no-same-permissions -xzf "$temp" -C "$extracted"
+    (umask 022; timeout 180 tar --no-same-owner --no-same-permissions -xzf "$temp" -C "$extracted")
   elif ((EUID == 0)); then
     fail 'timeout is required for production extraction'
   else
-    tar --no-same-owner --no-same-permissions -xzf "$temp" -C "$extracted"
+    (umask 022; tar --no-same-owner --no-same-permissions -xzf "$temp" -C "$extracted")
   fi
   test -s "$extracted/public/index.html"
   test -s "$extracted/public/main.dart.js"


### PR DESCRIPTION
Production at `7e800e90` skipped the control bridge because the client treated marker ancestry as proof that the installed controller was compatible. The host then rejected the backend release, leaving the manifest-permission fix in main undeployed.

This change validates the controller's Git entries before accepting it and deploys the pinned, control-only bridge once for the observed production state. Retries recognize both a completed bridge and the later state where backend activation completed before the final marker write. Mixed or unrelated markers remain rejected.

The current bridge C2 is `77a24e22e8b56e4919ba06fd7ee844bac1dabc59`, with sole parent `7e800e90d3295cc881e21a3e81b611fa57eb5b2a` and exactly two changed paths: the deploy entrypoint's previously reviewed extraction permissions, and the controller's recovery no-op check. The client verifies exact ancestry, path delta, Git modes and all11 compatible controller entries. Review history is preserved by fast-forward updates; the target retains C2. Merge with a merge commit: squash/rebase would discard required bridge ancestry.

Validation: bash syntax, ShellCheck on changed implementation/new regression, source line cap, complete forward-bridge fixture (including the new stale-controller regression), deployment-client tests, and bootstrap-marker resume tests passed on the old host. The interrupted-backend regression failed before the fix and passed afterward. The old symbolic release-A fixture was updated to model the exact committed bridge marker and passed independently.

The hosted read-only review found a real P1 at head6648: after C becomes current, `plan C` is rejected by the unchanged exact-origin host preflight. Head `5136db4ea5da01cff73097b8c35d15c0fc6893c8` fixes this by deploying C but reconciling the host-admitted main target with exact C-state predicates. Ordinary deploy callers retain the same reconciliation target by default. The regression now runs the committed host preflight, terminal-state parser and ordinary-deploy guard. It failed before this fix and passed afterward.

The real partial-install fixture found another gap: a valid ancestor pool marker with an old installed entrypoint incorrectly satisfied the current-controller no-op. C2 now also requires the existing physical-install helper to verify the current commit's bytes. The committed fixture uses real host preflight, terminal state, locks, deploy_release, recovery and atomic marker helpers for both interrupted phases. A bounded operator `deploy <base>` repairs installed bytes and pool once; a repeat changes neither inode/time identity. Backend/frontend/control markers remain at base until the normal target deployment. No application deployment is replayed. The normal client stays fail-closed in this partial phase, without a new recovery protocol or weaker host authority. A fixture target containing both old C1 and C2 proves the first-parent introducing lookup returns C2 only.

Current head: `f2ffc34ea4f14abc33d81089556833f7abb9c563`. Exact CI33934783525 passed all10 jobs, including production lifecycle and backend E2E. Independent hosted review R8 (gpt-6-astra/xhigh, one attempt) returned ACCEPT with no actionable P0/P1/P2 findings for this exact commit. Review inspected Git objects only and left the existing worktree unchanged. Previous CI33934386920 caught a stale current-release digest pin; the final commit binds that pin to the verified C2 library bytes. The full forward/client suites and exact partial-C2 proof passed. The separate legacy deploy-control-lib test fails identically on unchanged main421a and this branch because its systemctl mock lacks UnitFileState; this was not counted as PASS or weakened. Hosted cleanup policy blocks the local rabbit test's existing /tmp cleanup; the successful exact-head CI proves that lifecycle gate in its reproducible environment.

Code review and exact-head CI are complete. PR remains draft as a delivery HOLD: main push automatically triggers production deployment, while the owner's continuous35GiB disk floor would be violated by the normal build peak at current free space. No merge or production deployment has been performed by this PR. The natural Sep5 daily trigger authenticated successfully but failed on the old image's package.json EACCES; CI is not production E2E proof.
