### PR TITLE
fix(runtime): restore image permissions and daily continuity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ COPY libs ./libs
 ARG PRISMA_GENERATE_DATABASE_URL=postgresql://social_monitor:social_monitor_local_password@localhost:5432/social_monitor
 RUN DATABASE_URL="${PRISMA_GENERATE_DATABASE_URL}" npm run prisma:generate && npm run build
 
+# Host checkouts may use umask 077. Keep public image assets root-owned and
+# readable by node, preserving executable tools and directory traversal.
+RUN chmod -R u=rwX,go=rX \
+  apps libs prisma scripts vendor dist \
+  tsconfig.json tsconfig.build.json prisma.config.ts
+
 ARG SERVICE=api
 ENV NODE_ENV=production
 ENV SERVICE=${SERVICE}

--- a/ops/deploy/backend-image-rescue-lib.sh
+++ b/ops/deploy/backend-image-rescue-lib.sh
@@ -73,7 +73,8 @@ backend_image_rescue_snapshot_otel_config() (
   git -C "$REPO" show \
     "$from:ops/observability/otel-collector.yml" > "$partial" || return 1
   [[ -s $partial && ! -L $partial ]] || return 1
-  chmod 0600 "$partial" || return 1
+  # Tracked public configuration is mounted read-only by the non-root collector.
+  chmod 0644 "$partial" || return 1
   mv -f "$partial" "$path"
 )
 
@@ -831,7 +832,7 @@ rollback_backend_images() {
   local state_file=$1
   [[ -e $state_file || -L $state_file ]] || return 0
   local record service policy source_kind source_ref image_id rescue_tag extra
-  local phase target_sha api_rolled_back=false otel_image='' otel_config=''
+  local phase target_sha api_rolled_back=false otel_image='' otel_config='' otel_mode
   local -a rollback_services=() remove_services=()
 
   phase=$(backend_image_rescue_read_phase "$state_file") || return 1
@@ -861,6 +862,9 @@ rollback_backend_images() {
       otel_config=$(backend_image_rescue_otel_config_path \
         "$target_sha") || return 1
       [[ -f $otel_config && ! -L $otel_config && -s $otel_config ]] || return 1
+      otel_mode=$(stat -c '%a' "$otel_config" 2>/dev/null) ||
+        otel_mode=$(stat -f '%Lp' "$otel_config") || return 1
+      [[ $otel_mode == 644 ]] || return 1
     fi
   done < "$state_file"
   if ((${#remove_services[@]} > 0)); then

--- a/ops/deploy/otel-collector-deploy-lifecycle.test.sh
+++ b/ops/deploy/otel-collector-deploy-lifecycle.test.sh
@@ -33,7 +33,7 @@ cmp -s "$REPO/ops/observability/otel-collector.yml" "$CONFIG_SNAPSHOT"
 if ! snapshot_mode=$(stat -f '%Lp' "$CONFIG_SNAPSHOT" 2>/dev/null); then
   snapshot_mode=$(stat -c '%a' "$CONFIG_SNAPSHOT")
 fi
-[[ $snapshot_mode == 600 ]]
+[[ $snapshot_mode == 644 ]]
 
 STATE_FILE=$STATE/backend-image-rescue-$TARGET_SHA.tsv
 EVENT_LOG=$FIXTURE/events.log
@@ -60,7 +60,27 @@ grep -F 'compose:--profile app --profile daily rm -sf otel-collector' \
 printf 'image\totel-collector\trecreate\trunning-image\tcollector-container\t%s\t%s\n' \
   'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
   "$(backend_image_rescue_tag "$TARGET_SHA" otel-collector)" > "$STATE_FILE"
+for invalid_mode in 600 666; do
+  chmod "$invalid_mode" "$CONFIG_SNAPSHOT"
+  if rollback_backend_images "$STATE_FILE"; then
+    printf 'unsafe collector snapshot mode was accepted: %s\n' "$invalid_mode" >&2
+    exit 1
+  fi
+  [[ ! -s $EVENT_LOG && -f $CONFIG_SNAPSHOT ]]
+done
+chmod 0644 "$CONFIG_SNAPSHOT"
+mv "$CONFIG_SNAPSHOT" "$CONFIG_SNAPSHOT.saved"
+ln -s "$CONFIG_SNAPSHOT.saved" "$CONFIG_SNAPSHOT"
+if rollback_backend_images "$STATE_FILE"; then
+  printf 'symlink collector snapshot was accepted\n' >&2
+  exit 1
+fi
+[[ ! -s $EVENT_LOG ]]
+rm "$CONFIG_SNAPSHOT"
+mv "$CONFIG_SNAPSHOT.saved" "$CONFIG_SNAPSHOT"
 rollback_backend_images "$STATE_FILE"
+# A successful rollback must keep the live bind source for future restarts.
+[[ -f $CONFIG_SNAPSHOT && ! -L $CONFIG_SNAPSHOT ]]
 grep -F 'compose:--profile app up -d --no-deps --force-recreate otel-collector' \
   "$EVENT_LOG" >/dev/null
 grep -F "image=$(backend_image_rescue_tag "$TARGET_SHA" otel-collector)" \

--- a/ops/deploy/production-runtime/reader-promotion-v2-production-canary.sh
+++ b/ops/deploy/production-runtime/reader-promotion-v2-production-canary.sh
@@ -40,6 +40,14 @@ else
     READER_PROMOTION_V2_CANARY_HOST_TEST_FLOCK
 fi
 
+database_ca=$root/secrets/db/ca-certificate.crt
+[[ -f $database_ca && ! -L $database_ca && -s $database_ca ]] || exit 75
+[[ $(readlink -f -- "$database_ca") == "$database_ca" ]] || exit 75
+[[ $(stat -c '%a' "$database_ca") == 644 ]] || exit 75
+if [[ $root == /var/data/social-monitor ]]; then
+  [[ $(stat -c '%u:%g' "$database_ca") == 0:0 ]] || exit 75
+fi
+
 read_marker() {
   local path=$1 expected_root=$2 real
   [[ -f $path && ! -L $path ]] || return 1
@@ -117,6 +125,7 @@ exec "$docker_command" run --rm --read-only --cap-drop ALL \
   --env AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT=/run/social-monitor-codex-auth-pool \
   --env AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST=current.json \
   --volume "$auth_pool:/run/social-monitor-codex-auth-pool:ro" \
+  --volume "$database_ca:/run/social-monitor-db/ca-certificate.crt:ro" \
   --volume "$integration:/app/verified-checkout:ro" \
   "$image_id" node -r /app/node_modules/ts-node/register \
   -r /app/node_modules/tsconfig-paths/register "${args[@]}"

--- a/ops/deploy/production-runtime/reader-promotion-v2-production-canary.test.sh
+++ b/ops/deploy/production-runtime/reader-promotion-v2-production-canary.test.sh
@@ -17,7 +17,10 @@ root=$(mktemp -d "$test_tmp/reader-promotion-canary-host.XXXXXX")
 trap 'find "$root" -depth -delete' EXIT HUP INT TERM
 mkdir -p "$root/control/deploy-state" \
   "$root/control/postgres-runtime-releases" "$root/integration" \
-  "$root/secrets" "$root/bin" "$root/auth-pool"
+  "$root/secrets/db" "$root/bin" "$root/auth-pool"
+database_ca=$root/secrets/db/ca-certificate.crt
+printf 'Synthetic CA fixture, never used for a TLS connection\n' > "$database_ca"
+chmod 0644 "$database_ca"
 touch "$root/control/production-deploy.lock"
 git -C "$root/integration" init -q
 git -C "$root/integration" config user.name 'Canary Test'
@@ -64,6 +67,7 @@ printf '%s\n' "$*" > "$READER_PROMOTION_CANARY_ARGS"
 [[ " $* " == *" --env NODE_PATH=/app/node_modules "* ]]
 [[ " $* " == *" --env TS_NODE_PROJECT=/app/verified-checkout/tsconfig.json "* ]]
 [[ " $* " == *" $READER_PROMOTION_CANARY_CHECKOUT:/app/verified-checkout:ro "* ]]
+[[ " $* " == *" $READER_PROMOTION_CANARY_DATABASE_CA:/run/social-monitor-db/ca-certificate.crt:ro "* ]]
 [[ " $* " == *" sha256:0000000000000000000000000000000000000000000000000000000000000001 node "* ]]
 grep -Fx 'sha256:0000000000000000000000000000000000000000000000000000000000000002' \
   "$READER_PROMOTION_CANARY_TAG_STATE" >/dev/null
@@ -76,6 +80,7 @@ printf 'entrypoint-and-manifest-resolved\n' > "$READER_PROMOTION_CANARY_STARTED"
 EOF
 chmod +x "$fake_docker"
 export READER_PROMOTION_CANARY_ARGS=$root/args \
+  READER_PROMOTION_CANARY_DATABASE_CA=$database_ca \
   READER_PROMOTION_CANARY_CHECKOUT=$root/integration \
   READER_PROMOTION_CANARY_DEPLOY_LOCK=$root/control/production-deploy.lock \
   READER_PROMOTION_CANARY_BACKEND_MARKER=$root/control/deploy-state/backend.sha \
@@ -95,6 +100,29 @@ grep -F -- '--runtime-command /app/apps/agent-runtime/bin/run-codex-subscription
   "$root/args" >/dev/null
 grep -Fx 'entrypoint-and-manifest-resolved' "$root/started" >/dev/null
 grep -F -- "$root/integration:/app/verified-checkout:ro" "$root/args" >/dev/null
+
+# Refuse missing, redirected or unsafe CA files before starting the canary.
+for ca_case in missing symlink private writable; do
+  mv "$database_ca" "$database_ca.saved"
+  case $ca_case in
+    missing) ;;
+    symlink) ln -s "$database_ca.saved" "$database_ca" ;;
+    private) cp "$database_ca.saved" "$database_ca"; chmod 0600 "$database_ca" ;;
+    writable) cp "$database_ca.saved" "$database_ca"; chmod 0666 "$database_ca" ;;
+  esac
+  : > "$root/args"
+  set +e
+  READER_PROMOTION_V2_CANARY_HOST_TEST_ROOT=$root \
+  READER_PROMOTION_V2_CANARY_HOST_TEST_DOCKER=$fake_docker \
+    bash "$host" "$sha" reader-promotion-v2-production-canary 100 1 \
+      0123456789abcdef0123456789abcdef "$confirmation" \
+      >/dev/null 2>"$root/error"
+  status=$?
+  set -e
+  [[ $status == 75 && ! -s $root/args ]]
+  rm -f "$database_ca"
+  mv "$database_ca.saved" "$database_ca"
+done
 
 # Repository-local Git settings cannot conceal unreviewed build inputs.
 git -C "$root/integration" config status.showUntrackedFiles no

--- a/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
+++ b/ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh
@@ -183,7 +183,9 @@ assert_real_bridge_target_assets() {
       ops/deploy/backend-image-rescue-lib.sh)
         expected_digest=68f13213e6d1662d943185df7cdd1c11678261e76977021f74493c4e6c643b59
         alternate_digest=c8d363b8d64402ee77e42d62aac67ce9d4543135e328255557d2036c8ef3a398
-        current_release_digest=02ab92e562ce8d612e0a068260bd63262c13c0142f34a6bb6973d0d96eeea13a
+        # Current release keeps the public collector snapshot readable and
+        # rejects unsafe snapshot modes before a rollback recreate.
+        current_release_digest=85ef1cf10c357ee3a40004ccd677bfbafa2e2fe5553ea5963fe879d050643884
         ;;
       ops/deploy/deploy-control-bridge-lib.sh)
         expected_digest=e6f958555966b77d02b85da8d0b9195e13a200dcb2b19c8afc010fab6d28b65d

--- a/ops/deploy/runtime-source-permissions.test.py
+++ b/ops/deploy/runtime-source-permissions.test.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import time
 import unittest
+from unittest import mock
 
 
 REPO = Path(__file__).resolve().parents[2]
@@ -73,7 +74,17 @@ def offline_dockerfile(base):
             "/permission-negative/contract.cjs\n")
 
 
+def remove_test_image(image_id):
+    run(["docker", "image", "rm", "--no-prune", image_id])
+
+
 class LocalPermissions(unittest.TestCase):
+    def test_cleanup_preserves_existing_parent_images(self):
+        with mock.patch(__name__ + ".run") as command:
+            remove_test_image("sha256:" + "a" * 64)
+        command.assert_called_once_with(["docker", "image", "rm", "--no-prune",
+                                         "sha256:" + "a" * 64])
+
     def test_offline_build_preserves_source_instructions(self):
         generated = offline_dockerfile("sha256:" + "a" * 64)
         self.assertNotIn("--chmod", generated)
@@ -191,7 +202,7 @@ def image_regression(base):
         finally:
             if image_id is not None:
                 # Only the untagged image created by this test; never prune caches.
-                run(["docker", "image", "rm", image_id])
+                remove_test_image(image_id)
 
 
 if __name__ == "__main__":

--- a/ops/deploy/runtime-source-permissions.test.py
+++ b/ops/deploy/runtime-source-permissions.test.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Run --local, or pass an immutable, sandbox app image ID for one offline build.
+
+The image supplies installed dependencies and already-normalized manifests
+(both manifest hashes and modes must match). Source COPY, generation,
+compilation, permission and runtime instructions from the real Dockerfile
+are exercised with 0600 files / 0700 directories and tools.
+No image is pulled, package installed, service started or provider contacted.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[2]
+DOCKERFILE = (REPO / "Dockerfile").read_text()
+INSTRUCTIONS = DOCKERFILE.replace("\\\n", " ").splitlines()
+COPIES = [shlex.split(line)[1:] for line in INSTRUCTIONS if line.startswith("COPY ")]
+SOURCES = [part for copy in COPIES for part in copy[:-1] if not part.startswith("--")]
+GIB = 1024 ** 3
+
+
+def run(args, **kwargs):
+    return subprocess.run(args, check=True, timeout=60, **kwargs)
+
+
+def context(root):
+    """Copy tracked public Docker inputs only; never include local credentials."""
+    entries = run(["git", "ls-files", "-s", "-z", "--", *SOURCES], cwd=REPO,
+                  capture_output=True).stdout.decode().split("\0")
+    expected = {}
+    for entry in filter(None, entries):
+        metadata, name = entry.split("\t", 1)
+        mode = metadata.split()[0]
+        assert mode in ("100644", "100755"), f"unexpected input type: {name}"
+        assert not any(part.startswith(".env") and part != ".env.example"
+                       for part in Path(name).parts), f"private input: {name}"
+        assert not (REPO / name).is_symlink(), f"symlink input: {name}"
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        content = (REPO / name).read_bytes()
+        target.write_bytes(content)
+        target.chmod(0o700 if mode == "100755" else 0o600)
+        expected[name] = {"sha256": hashlib.sha256(content).hexdigest(),
+                          "mode": 0o755 if mode == "100755" else 0o644}
+    for directory, _, _ in os.walk(root):
+        Path(directory).chmod(0o700)
+    assert (root / "apps/agent-runtime/bin/reader-promotion-v2-canary-contract.cjs").stat().st_mode & 0o777 == 0o600
+    return expected
+
+
+def offline_dockerfile(base):
+    prefix, runtime = DOCKERFILE.split("RUN npm ci\n", 1)
+    # Legacy builds support resource limits but not COPY --chmod. Reuse only
+    # the manifests validated in the base image; all source copies stay exact.
+    manifests = "COPY --chmod=0644 package.json package-lock.json ./"
+    assert manifests in prefix.splitlines(), "manifest COPY contract changed"
+    copies = "\n".join(line for line in prefix.splitlines()
+                       if line.startswith("COPY ") and line != manifests)
+    return (f"FROM {base} AS app\nWORKDIR /app\nUSER root\n{copies}\n{runtime}"
+            # COPY preserves the root-owned source-context mode 0600.
+            "\nCOPY apps/agent-runtime/bin/reader-promotion-v2-canary-contract.cjs "
+            "/permission-negative/contract.cjs\n")
+
+
+class LocalPermissions(unittest.TestCase):
+    def test_offline_build_preserves_source_instructions(self):
+        generated = offline_dockerfile("sha256:" + "a" * 64)
+        self.assertNotIn("--chmod", generated)
+        self.assertNotIn("RUN npm ci", generated)
+        self.assertIn(DOCKERFILE.split("RUN npm ci\n", 1)[1], generated)
+        for line in INSTRUCTIONS:
+            if line.startswith("COPY ") and "package.json package-lock.json" not in line:
+                self.assertIn(line, generated.replace("\\\n", " "))
+
+    def test_public_asset_modes_from_restrictive_context(self):
+        with tempfile.TemporaryDirectory(prefix="runtime-source-permissions-") as path:
+            root = Path(path)
+            expected = context(root)
+            # Generated output is checked too; the image test compiles real output.
+            (root / "dist").mkdir(mode=0o700)
+            (root / "dist/output.json").write_text("{}")
+            (root / "dist/output.json").chmod(0o600)
+            permissions = [shlex.split(line)[1:] for line in INSTRUCTIONS
+                           if line.startswith("RUN chmod ")]
+            self.assertEqual(len(permissions), 1)
+            run(permissions[0], cwd=root)
+            # The existing manifest COPY has its own permission normalization.
+            for copy in COPIES:
+                if "--chmod=0644" in copy:
+                    for name in copy[1:-1]:
+                        (root / name).chmod(0o644)
+            for name, entry in expected.items():
+                self.assertEqual((root / name).stat().st_mode & 0o777, entry["mode"], name)
+                self.assertEqual(hashlib.sha256((root / name).read_bytes()).hexdigest(),
+                                 entry["sha256"], name)
+            for directory, _, _ in os.walk(root):
+                if Path(directory) != root:
+                    self.assertEqual(Path(directory).stat().st_mode & 0o777, 0o755, directory)
+            self.assertEqual((root / "dist/output.json").stat().st_mode & 0o777, 0o644)
+
+    def test_reviewed_daily_runner_inherits_app_assets(self):
+        # The actual daily Dockerfile is control-owned, not present in this repo.
+        # Verify the existing reviewed fixture against the controller's digest;
+        # do not invent a Dockerfile or modify the controller/provenance pin.
+        fixture = (REPO / "ops/deploy/daily-runner-image-bootstrap-lib.test.sh").read_text()
+        daily = fixture.split("<<'DOCKERFILE'\n", 1)[1].split("\nDOCKERFILE", 1)[0] + "\n"
+        library = (REPO / "ops/deploy/daily-runner-image-bootstrap-lib.sh").read_text()
+        digest = re.search(r"^DAILY_RUNNER_BOOTSTRAP_DOCKERFILE_SHA256=(\w+)$",
+                           library, re.MULTILINE).group(1)
+        self.assertEqual(hashlib.sha256(daily.encode()).hexdigest(), digest)
+        self.assertTrue(daily.startswith("FROM social-monitor-prod-intelligence-worker:latest\n"))
+        self.assertTrue(daily.endswith("USER node\n"))
+        self.assertEqual([line for line in daily.splitlines() if line.startswith("COPY ")],
+                         [f"COPY --chown=node:node {name} /app/{name}"
+                          for name in ("scripts", "ops", "test", "docs")])
+
+
+def image_regression(base):
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", base), "pass an immutable sandbox app image ID"
+    run(["docker", "version", "--format", "{{.Server.Version}}"])
+    available = int(re.search(r"MemAvailable:\s+(\d+)", Path("/proc/meminfo").read_text()).group(1)) * 1024
+    free = shutil.disk_usage(tempfile.gettempdir()).free
+    load = os.getloadavg()[0]
+    print(json.dumps({"cpus": os.cpu_count(), "load1": load,
+                      "availableRamBytes": available, "freeDiskBytes": free}), flush=True)
+    assert free >= 10 * GIB and available >= 4 * GIB, "insufficient build headroom"
+    assert load <= os.cpu_count(), "host CPU is busy; defer the single build"
+    isolation = ["--rm", "--read-only", "--network", "none", "--cap-drop", "ALL",
+                 "--security-opt", "no-new-privileges", "--memory", "1g", "--cpus", "1",
+                 "--workdir", "/app", "--entrypoint", "node"]
+    manifests = {name: hashlib.sha256((REPO / name).read_bytes()).hexdigest()
+                 for name in ("package.json", "package-lock.json")}
+    run(["docker", "run", *isolation, base, "-e",
+         "const assert = require('node:assert/strict'), fs = require('node:fs');"
+         "for (const [name, hash] of Object.entries(JSON.parse(process.argv[1]))) {"
+         "const path = '/app/' + name, stats = fs.statSync(path);"
+         "assert.equal(stats.uid, 0); assert.equal(stats.mode & 0o777, 0o644);"
+         "assert.equal(require('node:crypto').createHash('sha256')"
+         ".update(fs.readFileSync(path)).digest('hex'), hash); }",
+         json.dumps(manifests)])
+    with tempfile.TemporaryDirectory(prefix="runtime-source-permissions-image-") as path:
+        root = Path(path)
+        build_context = root / "context"
+        build_context.mkdir()
+        expected = context(build_context)
+        (build_context / "Dockerfile").write_text(offline_dockerfile(base))
+        iidfile = root / "image.id"
+        image_id = None
+        try:
+            # Legacy builder exposes per-step memory/CPU limits on OLD.
+            command = ["docker", "build", "--pull=false", "--force-rm", "--network", "none",
+                       "--memory", "3g", "--memory-swap", "3g", "--cpu-period", "100000",
+                       "--cpu-quota", "200000", "--iidfile", str(iidfile), str(build_context)]
+            with subprocess.Popen(command, env={**os.environ, "DOCKER_BUILDKIT": "0"}) as build:
+                deadline = time.monotonic() + 600
+                try:
+                    while build.poll() is None:
+                        assert time.monotonic() < deadline, "offline build exceeded 600 seconds"
+                        assert shutil.disk_usage(root).free >= 6 * GIB, "disk reserve reached; stopping build"
+                        time.sleep(1)
+                finally:
+                    if build.poll() is None:
+                        build.terminate()
+                        try:
+                            build.wait(timeout=15)
+                        except subprocess.TimeoutExpired:
+                            build.kill()
+                            build.wait(timeout=5)
+                assert build.returncode == 0, "offline image build failed"
+            image_id = iidfile.read_text().strip()
+            assert re.fullmatch(r"sha256:[0-9a-f]{64}", image_id)
+            user = run(["docker", "image", "inspect", "--format", "{{.Config.User}}", image_id],
+                       capture_output=True, text=True).stdout.strip()
+            assert user == "node", f"unexpected runtime user: {user}"
+            probe = (REPO / "ops/deploy/support/runtime-source-permissions-image-probe.mjs").read_text()
+            run(["docker", "run", "-i", *isolation, image_id, "--input-type=module", "-"],
+                input="const expected = " + json.dumps(expected) + ";\n" + probe, text=True)
+            print(json.dumps({"image": image_id, "sourceFiles": len(expected),
+                              "offlineImagePermissions": "passed"}))
+        finally:
+            if image_id is not None:
+                # Only the untagged image created by this test; never prune caches.
+                run(["docker", "image", "rm", image_id])
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--local"]:
+        unittest.main(argv=[sys.argv[0]], verbosity=2)
+    elif len(sys.argv) == 2:
+        image_regression(sys.argv[1])
+    else:
+        sys.exit("usage: runtime-source-permissions.test.py --local | sha256:SANDBOX_APP_IMAGE_ID")

--- a/ops/deploy/support/runtime-source-permissions-image-probe.mjs
+++ b/ops/deploy/support/runtime-source-permissions-image-probe.mjs
@@ -1,0 +1,55 @@
+// Fed on stdin by runtime-source-permissions.test.py, which defines expected.
+// Inspect actual /app assets, without a checkout mount or service/provider start.
+/* global expected */
+import assert from "node:assert/strict";
+import console from "node:console";
+import { createHash } from "node:crypto";
+import { accessSync, constants, readFileSync, readdirSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import process from "node:process";
+
+assert.equal(process.getuid(), 1000);
+assert.equal(process.getgid(), 1000);
+assert.equal(process.cwd(), "/app");
+const require = createRequire("/app/package.json");
+assert.throws(() => require("/permission-negative/contract.cjs"), { code: "EACCES" });
+
+let filesRead = 0;
+function inspect(path) {
+  const stats = statSync(path);
+  assert.equal(stats.uid, 0, `public app asset must stay root-owned: ${path}`);
+  assert.equal(stats.mode & 0o022, 0, `group/other write permission: ${path}`);
+  accessSync(path, constants.R_OK);
+  if (stats.isDirectory()) {
+    accessSync(path, constants.X_OK);
+    for (const name of readdirSync(path)) inspect(`${path}/${name}`);
+  } else {
+    readFileSync(path);
+    filesRead++;
+  }
+}
+for (const name of ["apps", "libs", "prisma", "scripts", "vendor", "dist",
+  "package.json", "package-lock.json", "tsconfig.json", "tsconfig.build.json", "prisma.config.ts"]) {
+  inspect(`/app/${name}`);
+}
+// Check bytes and executable bits against the restrictive source context.
+for (const [name, entry] of Object.entries(expected)) {
+  const path = `/app/${name}`;
+  assert.equal(createHash("sha256").update(readFileSync(path)).digest("hex"), entry.sha256, path);
+  assert.equal(statSync(path).mode & 0o777, entry.mode, path);
+}
+
+// Exercise the exact compiled-to-source import that restart-looped in production.
+const compiled = require("/app/dist/apps/agent-runtime/src/reader-promotion-v2-canary-contract.js");
+const source = require("/app/apps/agent-runtime/bin/reader-promotion-v2-canary-contract.cjs");
+assert.equal(compiled.readerPromotionV2CanaryOutputSchema, source.readerPromotionV2CanaryOutputSchema);
+const policy = await import("/app/apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.mjs");
+assert.equal(policy.readerPromotionV2CanaryPurpose, source.readerPromotionV2CanaryPurpose);
+JSON.parse(readFileSync("/app/tsconfig.json", "utf8"));
+JSON.parse(readFileSync("/app/tsconfig.build.json", "utf8"));
+for (const tool of ["/app/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs",
+  "/app/node_modules/.bin/codex", "/app/node_modules/.bin/ts-node", "/app/node_modules/.bin/prisma"]) {
+  accessSync(tool, constants.R_OK | constants.X_OK);
+}
+console.log(JSON.stringify({ uid: process.getuid(), filesRead, compiledContractLoaded: true,
+  purposePolicyLoaded: true, restrictiveControlDenied: true, providerCalled: false }));

--- a/scripts/check-container.mjs
+++ b/scripts/check-container.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 
 const policyPath = 'ops/security/container-release-policy.json';
@@ -84,4 +85,7 @@ if (violations.length > 0) {
   process.exit(1);
 }
 
+execFileSync('python3', ['ops/deploy/runtime-source-permissions.test.py', '--local'], {
+  stdio: 'inherit',
+});
 console.log('Container release contract OK');

--- a/scripts/check-reader-summary-production-day-publication-gap.spec.ts
+++ b/scripts/check-reader-summary-production-day-publication-gap.spec.ts
@@ -1,8 +1,55 @@
-import { publicationGapDates } from "./check-reader-summary-production-day-publication-gap";
+import { strict as assert } from "node:assert";
+
+import { dailyGapPublicationBindingsQuery } from "./lib/reader-summary-daily-gap-query";
+import { dailyGapTestDates, dailyGapTestDatabaseUrl, dailyGapTestRows, dailyGapTestScope } from "./lib/reader-summary-daily-gap-test-fixtures";
+
+const mockCalls: { operation: string; args: readonly unknown[] }[] = [];
+let mockRows = dailyGapTestRows();
+let mockQueryFailure: Error | undefined;
+jest.mock("@social-monitor/platform-persistence", () => ({
+  defaultPostgresRuntimePoolConfig: (...args: unknown[]) => ({ args }),
+  runWithSystemDatabaseAccess: async (reason: string, operation: () => Promise<unknown>) => {
+    mockCalls.push({ operation: "system-access", args: [reason] });
+    return operation();
+  },
+  acquirePrismaPgRuntimeConnection: async () => ({
+    client: {
+      $transaction: async (operation: (transaction: unknown) => Promise<unknown>, options: unknown) => {
+        mockCalls.push({ operation: "transaction", args: [options] });
+        return operation({
+          $executeRawUnsafe: async (...args: unknown[]) => {
+            mockCalls.push({ operation: "execute", args });
+            return 0;
+          },
+          $queryRawUnsafe: async (...args: unknown[]) => {
+            mockCalls.push({ operation: "query", args });
+            if (mockQueryFailure !== undefined) throw mockQueryFailure;
+            return mockRows;
+          },
+        });
+      },
+    },
+    close: async () => { mockCalls.push({ operation: "close", args: [] }); },
+  }),
+}));
+jest.mock("@social-monitor/platform-persistence/prisma-runtime-client", () => ({
+  loadPrismaRuntimeClient: () => class {},
+}));
+jest.mock("./lib/reader-summary-production-day-scope", () => ({
+  readerSummaryProductionDayScope: {
+    tenantId: "00000000-0000-4000-8000-000000009201",
+    workspaceId: "00000000-0000-4000-8000-000000009202",
+  },
+}));
+
+import { publicationGapDates, verifyPublishedProductionDayGap } from "./check-reader-summary-production-day-publication-gap";
+const verify = () => verifyPublishedProductionDayGap({
+  afterDate: "2026-08-29", targetDate: "2026-09-04", databaseUrl: dailyGapTestDatabaseUrl,
+});
 
 describe("production-day publication cursor gap", () => {
   it("returns every intervening UTC date and excludes both endpoints", () => {
-    expect(publicationGapDates("2026-08-14", "2026-08-18")).toEqual([
+    assert.deepEqual(publicationGapDates("2026-08-14", "2026-08-18"), [
       "2026-08-15",
       "2026-08-16",
       "2026-08-17",
@@ -10,18 +57,60 @@ describe("production-day publication cursor gap", () => {
   });
 
   it("accepts an ordinary consecutive transition without a database gap", () => {
-    expect(publicationGapDates("2026-08-27", "2026-08-28")).toEqual([]);
+    assert.deepEqual(publicationGapDates("2026-08-27", "2026-08-28"), []);
   });
 
   it("fails closed for malformed or non-forward transitions", () => {
-    expect(() => publicationGapDates("not-a-date", "2026-08-28")).toThrow(
-      "publication cursor date is invalid",
+    assert.throws(() => publicationGapDates("not-a-date", "2026-08-28"),
+      /publication cursor date is invalid/u,
     );
-    expect(() => publicationGapDates("2026-08-28", "2026-08-28")).toThrow(
-      "must follow the current cursor",
+    assert.throws(() => publicationGapDates("2026-08-28", "2026-08-28"),
+      /must follow the current cursor/u,
     );
-    expect(() => publicationGapDates("2026-08-29", "2026-08-28")).toThrow(
-      "must follow the current cursor",
+    assert.throws(() => publicationGapDates("2026-08-29", "2026-08-28"),
+      /must follow the current cursor/u,
     );
+  });
+
+  it("validates the synthetic mixed gap in one bounded repeatable-read snapshot", async () => {
+    mockCalls.length = 0;
+    mockRows = dailyGapTestRows();
+    assert.deepEqual(await verify(), dailyGapTestDates);
+    assert.deepEqual(mockCalls.map((call) => call.operation), [
+      "system-access", "transaction", "execute", "query", "close",
+    ]);
+    assert.deepEqual(mockCalls[1]?.args, [{ isolationLevel: "RepeatableRead", maxWait: 30_000, timeout: 180_000 }]);
+    assert.deepEqual(mockCalls[2]?.args, ["SET LOCAL statement_timeout = '60s'"]);
+    assert.deepEqual(mockCalls[3]?.args, [dailyGapPublicationBindingsQuery,
+      dailyGapTestScope.tenantId, dailyGapTestScope.workspaceId, "workspace", dailyGapTestDates]);
+  });
+
+  it("does not connect for a consecutive day", async () => {
+    mockCalls.length = 0;
+    assert.deepEqual(await verifyPublishedProductionDayGap({
+      afterDate: "2026-09-03", targetDate: "2026-09-04", databaseUrl: dailyGapTestDatabaseUrl,
+    }), []);
+    assert.deepEqual(mockCalls, []);
+  });
+
+  it("fails closed and closes the connection for a missing or tampered terminal", async () => {
+    for (const rows of [dailyGapTestRows().slice(0, 4), dailyGapTestRows().map((row, i) =>
+      i === 4 ? { ...row, proofSha256: "f".repeat(64) } : row)]) {
+      mockRows = rows;
+      mockCalls.length = 0;
+      await assert.rejects(verify());
+      assert.equal(mockCalls.at(-1)?.operation, "close");
+    }
+  });
+
+  it("propagates database failure and closes the connection", async () => {
+    mockCalls.length = 0;
+    mockQueryFailure = new Error("Synthetic database unavailable");
+    try {
+      await assert.rejects(verify(), /Synthetic database unavailable/u);
+      assert.equal(mockCalls.at(-1)?.operation, "close");
+    } finally {
+      mockQueryFailure = undefined;
+    }
   });
 });

--- a/scripts/check-reader-summary-production-day-publication-gap.ts
+++ b/scripts/check-reader-summary-production-day-publication-gap.ts
@@ -7,9 +7,10 @@ import {
 import { loadPrismaRuntimeClient } from "@social-monitor/platform-persistence/prisma-runtime-client";
 
 import {
-  buildCurrentPublicArtifactSnapshot,
-  currentPublicArtifactBindingsQuery,
-} from "./lib/reader-summary-current-publication-bindings";
+  assertDailyGapPublicationBindings,
+  type DailyGapPublicationRow,
+} from "./lib/reader-summary-daily-gap-bindings";
+import { dailyGapPublicationBindingsQuery } from "./lib/reader-summary-daily-gap-query";
 import { readerSummaryProductionDayScope } from "./lib/reader-summary-production-day-scope";
 import { yesterdaySocialQualityDatabaseUrl } from "./lib/yesterday-social-replay-support";
 
@@ -58,27 +59,19 @@ export async function verifyPublishedProductionDayGap(params: {
             await transaction.$executeRawUnsafe(
               "SET LOCAL statement_timeout = '60s'",
             );
-            for (const collectionDate of dates) {
-              const rows = await transaction.$queryRawUnsafe<
-                Parameters<typeof buildCurrentPublicArtifactSnapshot>[0]["rows"]
-              >(
-                currentPublicArtifactBindingsQuery,
-                readerSummaryProductionDayScope.tenantId,
-                readerSummaryProductionDayScope.workspaceId,
-                "workspace",
-                [collectionDate],
-              );
-              buildCurrentPublicArtifactSnapshot({
-                rows,
-                databaseUrl: params.databaseUrl,
-                scope: {
-                  ...readerSummaryProductionDayScope,
-                  scopeType: "workspace",
-                  scopeKey: "workspace",
-                },
-                collectionDates: [collectionDate],
-              });
-            }
+            const rows = await transaction.$queryRawUnsafe<readonly DailyGapPublicationRow[]>(
+              dailyGapPublicationBindingsQuery,
+              readerSummaryProductionDayScope.tenantId,
+              readerSummaryProductionDayScope.workspaceId,
+              "workspace",
+              dates,
+            );
+            assertDailyGapPublicationBindings({
+              rows,
+              databaseUrl: params.databaseUrl,
+              scope: readerSummaryProductionDayScope,
+              collectionDates: dates,
+            });
           },
           {
             isolationLevel: "RepeatableRead",
@@ -122,7 +115,7 @@ async function main(): Promise<void> {
     databaseUrl: yesterdaySocialQualityDatabaseUrl(),
   });
   console.log(
-    `Verified completed exact production publications for cursor gap ${afterDate}..${targetDate} (${dates.length} dates)`,
+    `Verified terminal exact production publications for cursor gap ${afterDate}..${targetDate} (${dates.length} dates)`,
   );
 }
 

--- a/scripts/lib/reader-summary-daily-gap-bindings.spec.ts
+++ b/scripts/lib/reader-summary-daily-gap-bindings.spec.ts
@@ -1,0 +1,198 @@
+import { strict as assert } from "node:assert";
+
+import { buildCurrentPublicArtifactSnapshot, currentPublicArtifactBindingsQuery } from "./reader-summary-current-publication-bindings";
+import { assertDailyGapPublicationBindings, type DailyGapPublicationRow } from "./reader-summary-daily-gap-bindings";
+import { dailyGapPublicationBindingsQuery } from "./reader-summary-daily-gap-query";
+import {
+  dailyGapTestDatabaseUrl, dailyGapTestDates, dailyGapTestRecord as record,
+  dailyGapTestRows, dailyGapTestScope, rehashDailyGapTestRow,
+} from "./reader-summary-daily-gap-test-fixtures";
+import { canonicalJsonSha256 } from "./reader-summary-quality-eval-support";
+
+const verify = (rows: readonly DailyGapPublicationRow[]) => assertDailyGapPublicationBindings({
+  rows, collectionDates: dailyGapTestDates,
+  databaseUrl: dailyGapTestDatabaseUrl, scope: dailyGapTestScope,
+});
+const noSignal = () => dailyGapTestRows()[4]!;
+const verifyLast = (row: DailyGapPublicationRow) => verify([...dailyGapTestRows().slice(0, 4), row]);
+
+describe("daily gap terminal publication bindings", () => {
+  it("accepts the Aug30..Sep3 gap with four COMPLETED and one canonical NO_SIGNAL", () => {
+    const rows = dailyGapTestRows();
+    const before = JSON.stringify(rows);
+    verify(rows);
+    assert.equal(JSON.stringify(rows), before);
+    assert.deepEqual(rows.map((row) => [row.semanticStatus, row.status]), [
+      ["COMPLETED", "COMPLETED"], ["COMPLETED", "COMPLETED"],
+      ["COMPLETED", "COMPLETED"], ["COMPLETED", "COMPLETED"], ["NO_SIGNAL", "NO_SIGNAL"],
+    ]);
+  });
+
+  it("also accepts an all-COMPLETED gap", () => {
+    const rows = dailyGapTestRows().slice(0, 4);
+    assertDailyGapPublicationBindings({
+      rows, collectionDates: dailyGapTestDates.slice(0, 4),
+      databaseUrl: dailyGapTestDatabaseUrl, scope: dailyGapTestScope,
+    });
+  });
+
+  it("supports exact historical request dates as well as invocation-day dates", () => {
+    const row = noSignal();
+    const exactProof = { ...record(row.exactProof), requestedUtcDate: row.collectionDate };
+    verifyLast({ ...row, publicationRequestedUtcDate: row.collectionDate,
+      exactProof, proofSha256: canonicalJsonSha256(exactProof) });
+  });
+
+  it("keeps the shared SQL and successful-summary snapshot COMPLETED-only", () => {
+    assert.match(currentPublicArtifactBindingsQuery, /publication\.semantic_status = 'COMPLETED'/u);
+    assert.match(currentPublicArtifactBindingsQuery, /artifact\.status = 'COMPLETED'/u);
+    assert.doesNotMatch(currentPublicArtifactBindingsQuery, /NO_SIGNAL/u);
+    assert.throws(() => buildCurrentPublicArtifactSnapshot({
+      rows: dailyGapTestRows(), collectionDates: dailyGapTestDates,
+      databaseUrl: dailyGapTestDatabaseUrl,
+      scope: { ...dailyGapTestScope, scopeType: "workspace", scopeKey: "workspace" },
+    }), /scope drifted/u);
+  });
+
+  it("preserves every existing SQL binding except the two successful-only status filters", () => {
+    const predicates = currentPublicArtifactBindingsQuery.split("\n")
+      .map((line) => line.trim())
+      .filter((line) => /^(?:on|and) /u.test(line))
+      .filter((line) => !["and publication.semantic_status = 'COMPLETED'", "and artifact.status = 'COMPLETED'"].includes(line));
+    for (const predicate of predicates) assert.ok(dailyGapPublicationBindingsQuery.includes(predicate), predicate);
+    assert.match(dailyGapPublicationBindingsQuery, /publication\.semantic_status in \('COMPLETED', 'NO_SIGNAL'\)/u);
+    assert.match(dailyGapPublicationBindingsQuery, /artifact\.status = publication\.semantic_status/u);
+  });
+
+  for (const [label, change] of [
+    ["missing date", (rows) => rows.slice(0, 4)],
+    ["empty result", () => []],
+    ["extra duplicate", (rows) => [...rows, rows[4]!]],
+    ["duplicate instead of missing day", (rows) => [...rows.slice(0, 4), rows[3]!]],
+    ["unsorted result", (rows) => [...rows].reverse()],
+    ["mixed capture timestamps", (rows) => rows.map((row, i) => i === 4 ? { ...row, capturedAt: "2026-09-05T00:00:01.000Z" } : row)],
+  ] satisfies readonly [string, (rows: DailyGapPublicationRow[]) => DailyGapPublicationRow[]][]) {
+    it(`rejects ${label}`, () => assert.throws(() => verify(change(dailyGapTestRows()))));
+  }
+
+  for (const [field, value] of [
+    ["tenantId", "wrong-tenant"], ["workspaceId", "wrong-workspace"],
+    ["scopeType", "interest"], ["scopeKey", "other"], ["cadence", "weekly"],
+    ["periodTimezone", "Europe/London"], ["periodKey", "wrong-period"],
+    ["collectionDate", "2026-09-02"], ["periodStartedAt", new Date("2026-09-02T00:00:00Z")],
+    ["periodEndedAt", new Date("2026-09-05T00:00:00Z")],
+    ["publicationKind", "LEGACY"], ["currentPublicationId", null],
+    ["currentPublicationId", "00000000-0000-4000-8000-000000009999"],
+    ["publicationArtifactId", "00000000-0000-4000-8000-000000009999"],
+    ["publicationModelVersion", "other-model"], ["semanticStatus", "COMPLETED"],
+    ["modelVersion", undefined], ["promptVersion", ""],
+    ["status", "COMPLETED"], ["status", "FAILED"], ["status", "REJECTED"],
+    ["publicationReaderSummaryJobId", ""], ["publicationRequestedAt", "invalid"],
+    ["publicationRequestedAt", null], ["publicationRequestedUtcDate", "2026-09-02"],
+    ["reportSha256", "f".repeat(64)], ["reportSha256", "invalid"],
+    ["proofSha256", "f".repeat(64)], ["proofSha256", "invalid"],
+    ["exactProof", null], ["headline", "Tampered headline"],
+    ["summaryText", "Tampered text"], ["promptVersion", "tampered-prompt"],
+    ["artifactPayload", {}], ["citations", []], ["qualitySignals", {}],
+  ] as const) {
+    // Empty citations are the original NO_SIGNAL value; exercise that report
+    // mutation on a successful row instead.
+    it(`rejects persisted ${field}=${String(value)} drift`, () => {
+      const rows = dailyGapTestRows();
+      const index = field === "citations" ? 0 : 4;
+      rows[index] = { ...rows[index]!, [field]: value } as DailyGapPublicationRow;
+      assert.throws(() => verify(rows));
+    });
+  }
+
+  for (const [path, value] of [
+    [["schemaVersion"], "reader_summary.publication_proof.v2"],
+    [["tenantId"], "other"], [["workspaceId"], "other"],
+    [["scope", "type"], "interest"], [["scope", "key"], "other"],
+    [["scope", "extra"], true], [["period", "cadence"], "weekly"],
+    [["period", "timezone"], "other"], [["period", "periodKey"], "other"],
+    [["period", "startedAt"], "2026-09-02T00:00:00.000Z"],
+    [["period", "endedAt"], "2026-09-05T00:00:00.000Z"],
+    [["period", "extra"], true], [["requestedUtcDate"], "2026-09-02"],
+    [["requestedAt"], "2026-09-04T01:00:00.000Z"],
+    [["readerSummaryJobId"], "other"], [["readerSummaryArtifactId"], "other"],
+    [["semanticStatus"], "COMPLETED"], [["modelVersion"], "other"],
+    [["reportSha256"], "e".repeat(64)], [["extra"], true],
+  ] as const) {
+    it(`rejects rehashed exact proof ${path.join(".")} drift`, () => {
+      const row = noSignal();
+      let target = record(row.exactProof);
+      for (const key of path.slice(0, -1)) target = record(target[key]);
+      target[path.at(-1)!] = value;
+      assert.throws(() => verifyLast({ ...row, proofSha256: canonicalJsonSha256(row.exactProof) }), /exact proof drifted/u);
+    });
+  }
+
+  it("rejects every missing exact-proof key even when its hash is recomputed", () => {
+    for (const key of Object.keys(record(noSignal().exactProof))) {
+      const row = noSignal();
+      delete record(row.exactProof)[key];
+      assert.throws(() => verifyLast({ ...row, proofSha256: canonicalJsonSha256(row.exactProof) }));
+    }
+  });
+
+  for (const [label, mutate] of [
+    ["no flag", (p) => { p.qualityFlags = []; }],
+    ["no reason", (p) => { delete p.noSignalReason; }],
+    ["empty reason", (p) => { p.noSignalReason = " "; }],
+    ["payload tenant", (p) => { p.tenantId = "wrong"; }],
+    ["payload workspace", (p) => { p.workspaceId = "wrong"; }],
+    ["payload artifact", (p) => { p.readerSummaryId = "wrong"; }],
+    ["payload period", (p) => { record(p.period).periodKey = "wrong"; }],
+    ["payload scope", (p) => { p.scope = { type: "interest", interestId: "wrong" }; }],
+    ["payload model", (p) => { record(p.lineage).modelVersion = "wrong"; }],
+    ["payload prompt", (p) => { record(p.lineage).promptVersion = "wrong"; }],
+    ["payload headline", (p) => { p.headline = "wrong"; }],
+    ["payload text", (p) => { p.executiveSummary = "wrong"; }],
+    ["provider evidence", (p) => { p.citationMap = [{ citationId: "synthetic", feedItemId: "synthetic", sourceItemId: "synthetic", providerKey: "hacker-news", field: "title" }]; }],
+    ["missing GitHub audit", (_p, q) => { delete q.githubProjectionAudit; }],
+    ["rejected GitHub audit", (_p, q) => { record(q.githubProjectionAudit).status = "rejected"; }],
+    ["wrong-day GitHub audit", (_p, q) => { record(q.githubProjectionAudit).requestedUtcDay = "2026-09-02"; }],
+    ["GitHub repository", (_p, q) => { record(q.githubProjectionAudit).bindings = [{}]; }],
+    ["no GitHub scan", (_p, q) => { record(q.githubProjectionAudit).pageCount = 0; }],
+    ["missing publication decision", (_p, q) => { delete q.publicationDecision; }],
+    ["rejected publication decision", (_p, q) => { record(q.publicationDecision).status = "rejected"; }],
+    ["failed quality decision", (_p, q) => { record(q.publicationDecision).qualityPassed = false; }],
+  ] satisfies readonly [string, (payload: Record<string, unknown>, quality: Record<string, unknown>) => void][]) {
+    it(`rejects rehashed NO_SIGNAL with ${label}`, () => {
+      const row = noSignal();
+      mutate(record(row.artifactPayload), record(row.qualitySignals));
+      assert.throws(() => verifyLast(rehashDailyGapTestRow(row)));
+    });
+  }
+
+  it("rejects FAILED/FAILED and duplicate identities even with otherwise coherent rows", () => {
+    assert.throws(() => verifyLast({ ...noSignal(), semanticStatus: "FAILED", status: "FAILED" }));
+    const rows = dailyGapTestRows();
+    rows[4] = { ...rows[4]!, publicationId: rows[0]!.publicationId, currentPublicationId: rows[0]!.publicationId };
+    assert.throws(() => verify(rows));
+  });
+
+  it("rejects a fully rehashed NO_SIGNAL report containing provider citations", () => {
+    const row = noSignal();
+    const citations = dailyGapTestRows()[0]!.citations;
+    record(row.artifactPayload).citationMap = citations;
+    assert.throws(() => verifyLast(rehashDailyGapTestRow({ ...row, citations })), /NO_SIGNAL evidence is invalid/u);
+  });
+
+  it("rejects coherent wrong-day requests even with a matching recomputed proof hash", () => {
+    const row = noSignal();
+    const exactProof = { ...record(row.exactProof), requestedUtcDate: "2026-09-02" };
+    assert.throws(() => verifyLast({ ...row, exactProof,
+      publicationRequestedUtcDate: "2026-09-02", proofSha256: canonicalJsonSha256(exactProof),
+    }), /exact proof drifted/u);
+  });
+
+  it("keeps completed report and exact-proof validation active", () => {
+    for (const change of [{ headline: "tampered" }, { proofSha256: "f".repeat(64) }]) {
+      const rows = dailyGapTestRows();
+      rows[0] = { ...rows[0]!, ...change };
+      assert.throws(() => verify(rows));
+    }
+  });
+});

--- a/scripts/lib/reader-summary-daily-gap-bindings.ts
+++ b/scripts/lib/reader-summary-daily-gap-bindings.ts
@@ -1,0 +1,170 @@
+import { readerSummaryArtifactFromPrisma } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-records";
+import {
+  readerSummaryHasVerifiedGitHubProjection,
+  readerSummaryIsOrdinaryNoSignalWithoutEvidence,
+  type ReaderSummaryGitHubProjectionAudit,
+} from "@social-monitor/summary/domain/policies/reader-summary-github-projection-audit";
+
+import { buildCurrentPublicArtifactSnapshot } from "./reader-summary-current-publication-bindings";
+import {
+  canonicalJson,
+  canonicalJsonSha256,
+  dailyPeriodKey,
+} from "./reader-summary-quality-eval-support";
+
+export type DailyGapPublicationRow =
+  Parameters<typeof buildCurrentPublicArtifactSnapshot>[0]["rows"][number] & {
+    readonly currentPublicationId: string;
+    readonly publicationKind: string;
+    readonly semanticStatus: string;
+    readonly publicationArtifactId: string;
+    readonly publicationModelVersion: string;
+  };
+
+export function assertDailyGapPublicationBindings(params: {
+  readonly rows: readonly DailyGapPublicationRow[];
+  readonly collectionDates: readonly string[];
+  readonly databaseUrl: string;
+  readonly scope: { readonly tenantId: string; readonly workspaceId: string };
+}): void {
+  const { rows, collectionDates } = params;
+  if (rows.length !== collectionDates.length || rows.length === 0 ||
+      new Set(collectionDates).size !== collectionDates.length ||
+      new Set(rows.map((row) => row.publicationId)).size !== rows.length ||
+      new Set(rows.map((row) => row.id)).size !== rows.length) {
+    throw new Error("Daily gap publications do not cover every requested date exactly once");
+  }
+  const capturedAt = timestamp(rows[0]!.capturedAt);
+  for (const [index, row] of rows.entries()) {
+    const date = collectionDates[index]!;
+    const start = `${date}T00:00:00.000Z`;
+    const end = new Date(Date.parse(start) + 86_400_000).toISOString();
+    if (row.collectionDate !== date ||
+        (index > 0 && collectionDates[index - 1]! >= date) ||
+        timestamp(row.capturedAt) !== capturedAt ||
+        row.tenantId !== params.scope.tenantId ||
+        row.workspaceId !== params.scope.workspaceId ||
+        row.scopeType !== "workspace" || row.scopeKey !== "workspace" ||
+        row.cadence !== "daily" || row.periodTimezone !== "UTC" ||
+        row.periodKey !== dailyPeriodKey(date) ||
+        timestamp(row.periodStartedAt) !== start ||
+        timestamp(row.periodEndedAt) !== end ||
+        row.publicationKind !== "EXACT" ||
+        row.currentPublicationId !== row.publicationId ||
+        row.publicationArtifactId !== row.id ||
+        row.publicationModelVersion !== row.modelVersion ||
+        typeof row.modelVersion !== "string" || row.modelVersion.trim().length === 0 ||
+        typeof row.promptVersion !== "string" || row.promptVersion.trim().length === 0 ||
+        row.semanticStatus !== row.status ||
+        !["COMPLETED", "NO_SIGNAL"].includes(row.status)) {
+      throw new Error(`Daily gap publication binding drifted for ${date}`);
+    }
+    for (const id of [row.publicationId, row.id, row.publicationReaderSummaryJobId]) {
+      if (typeof id !== "string" || !/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/u.test(id)) {
+        throw new Error(`Daily gap publication identity is invalid for ${date}`);
+      }
+    }
+    if (row.status === "COMPLETED") {
+      // Preserve every existing successful-summary/projection check per day.
+      buildCurrentPublicArtifactSnapshot({
+        rows: [row],
+        collectionDates: [date],
+        databaseUrl: params.databaseUrl,
+        scope: { ...params.scope, scopeType: "workspace", scopeKey: "workspace" },
+      });
+    } else {
+      assertNoSignalProof(row, date, start, end);
+      assertNoSignalSemantics(row, date);
+    }
+  }
+}
+
+function assertNoSignalProof(
+  row: DailyGapPublicationRow, date: string, start: string, end: string,
+): void {
+  const requestedAt = timestamp(row.publicationRequestedAt);
+  const report = {
+    schemaVersion: "reader_summary.publication_report.v1",
+    semanticStatus: row.status,
+    modelVersion: row.modelVersion,
+    promptVersion: row.promptVersion,
+    headline: row.headline,
+    summaryText: row.summaryText,
+    artifactPayload: row.artifactPayload,
+    citations: row.citations,
+    qualitySignals: row.qualitySignals,
+  };
+  if (!/^[0-9a-f]{64}$/u.test(row.reportSha256) ||
+      canonicalJsonSha256(report) !== row.reportSha256) {
+    throw new Error(`Daily gap publication report hash drifted for ${date}`);
+  }
+  // Equality to the complete v1 proof also rejects missing and extra keys,
+  // including nested scope/period keys. Keep both supported request-date modes.
+  const expectedProof = {
+    schemaVersion: "reader_summary.publication_proof.v1",
+    tenantId: row.tenantId,
+    workspaceId: row.workspaceId,
+    scope: { type: "workspace", key: "workspace" },
+    period: {
+      cadence: "daily", startedAt: start, endedAt: end,
+      timezone: "UTC", periodKey: row.periodKey,
+    },
+    requestedUtcDate: row.publicationRequestedUtcDate,
+    requestedAt,
+    readerSummaryJobId: row.publicationReaderSummaryJobId,
+    readerSummaryArtifactId: row.id,
+    semanticStatus: "NO_SIGNAL",
+    modelVersion: row.modelVersion,
+    reportSha256: row.reportSha256,
+  };
+  if ((row.publicationRequestedUtcDate !== requestedAt.slice(0, 10) &&
+        !(row.publicationRequestedUtcDate === date && requestedAt >= end)) ||
+      !/^[0-9a-f]{64}$/u.test(row.proofSha256) ||
+      canonicalJson(row.exactProof) !== canonicalJson(expectedProof) ||
+      canonicalJsonSha256(row.exactProof) !== row.proofSha256) {
+    throw new Error(`Daily gap publication exact proof drifted for ${date}`);
+  }
+}
+
+function assertNoSignalSemantics(row: DailyGapPublicationRow, date: string): void {
+  const payload = record(row.artifactPayload);
+  const quality = record(row.qualitySignals);
+  const decision = record(quality.publicationDecision);
+  const lineage = record(payload.lineage);
+  const artifact = readerSummaryArtifactFromPrisma(row);
+  const audit = quality.githubProjectionAudit as ReaderSummaryGitHubProjectionAudit | undefined;
+  if (payload.readerSummaryId !== row.id ||
+      payload.tenantId !== row.tenantId || payload.workspaceId !== row.workspaceId ||
+      canonicalJson(payload.scope) !== canonicalJson({ type: "workspace" }) ||
+      canonicalJson(payload.period) !== canonicalJson(record(row.exactProof).period) ||
+      lineage.modelVersion !== row.modelVersion ||
+      lineage.promptVersion !== row.promptVersion ||
+      payload.headline !== row.headline || payload.executiveSummary !== row.summaryText ||
+      canonicalJson(payload.citationMap) !== canonicalJson(row.citations) ||
+      canonicalJson(payload.qualityFlags) !== canonicalJson(quality.qualityFlags) ||
+      decision.status !== "published" || decision.qualityPassed !== true ||
+      !Array.isArray(row.citations) || row.citations.length !== 0 ||
+      !readerSummaryIsOrdinaryNoSignalWithoutEvidence(artifact) ||
+      !readerSummaryHasVerifiedGitHubProjection({ artifact, audit }) ||
+      audit?.status !== "not_required" || audit.bindings.length !== 0) {
+    throw new Error(`Daily gap NO_SIGNAL evidence is invalid for ${date}`);
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Daily gap publication evidence must be a JSON object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function timestamp(value: Date | string): string {
+  if (!(value instanceof Date) && typeof value !== "string") {
+    throw new Error("Daily gap publication timestamp is invalid");
+  }
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new Error("Daily gap publication timestamp is invalid");
+  }
+  return parsed.toISOString();
+}

--- a/scripts/lib/reader-summary-daily-gap-query.ts
+++ b/scripts/lib/reader-summary-daily-gap-query.ts
@@ -1,0 +1,84 @@
+// Cursor continuity includes terminal NO_SIGNAL publications. Keep this query
+// separate from the COMPLETED-only multi-day successful-summary snapshot.
+export const dailyGapPublicationBindingsQuery = `
+  with requested_days as (
+    select requested_date
+    from unnest($4::date[]) as requested(requested_date)
+  )
+  select
+    requested_days.requested_date::text as "collectionDate",
+    transaction_timestamp() as "capturedAt",
+    slot.current_publication_id::text as "currentPublicationId",
+    publication.id::text as "publicationId",
+    publication.publication_kind::text as "publicationKind",
+    publication.semantic_status::text as "semanticStatus",
+    publication.reader_summary_artifact_id::text as "publicationArtifactId",
+    publication.model_version as "publicationModelVersion",
+    publication.report_sha256::text as "reportSha256",
+    publication.proof_sha256::text as "proofSha256",
+    publication.exact_proof as "exactProof",
+    publication.requested_utc_date::text as "publicationRequestedUtcDate",
+    publication.requested_at as "publicationRequestedAt",
+    publication.reader_summary_job_id::text as "publicationReaderSummaryJobId",
+    artifact.id::text as "id",
+    artifact.tenant_id::text as "tenantId",
+    artifact.workspace_id::text as "workspaceId",
+    artifact.scope_type as "scopeType",
+    artifact.scope_key as "scopeKey",
+    artifact.interest_id::text as "interestId",
+    artifact.cadence as "cadence",
+    artifact.period_started_at as "periodStartedAt",
+    artifact.period_ended_at as "periodEndedAt",
+    artifact.period_timezone as "periodTimezone",
+    artifact.period_key as "periodKey",
+    artifact.user_id::text as "userId",
+    artifact.subscription_id::text as "subscriptionId",
+    artifact.status::text as "status",
+    artifact.schema_version as "schemaVersion",
+    artifact.model_version as "modelVersion",
+    artifact.prompt_version as "promptVersion",
+    artifact.headline as "headline",
+    artifact.summary_text as "summaryText",
+    artifact.artifact_payload as "artifactPayload",
+    artifact.citations as "citations",
+    artifact.quality_signals as "qualitySignals",
+    artifact.created_at as "createdAt",
+    artifact.updated_at as "updatedAt"
+  from requested_days
+  join reader_summary_publication_slots slot
+    on slot.tenant_id = $1::uuid
+    and slot.workspace_id = $2::uuid
+    and slot.scope_type = 'workspace'
+    and slot.scope_key = $3
+    and slot.cadence = 'daily'
+    and slot.period_started_at = requested_days.requested_date::timestamp at time zone 'UTC'
+    and slot.period_ended_at = (requested_days.requested_date + 1)::timestamp at time zone 'UTC'
+    and slot.period_timezone = 'UTC'
+    and slot.current_publication_id is not null
+  join reader_summary_publications publication
+    on publication.id = slot.current_publication_id
+    and publication.tenant_id = slot.tenant_id
+    and publication.workspace_id = slot.workspace_id
+    and publication.scope_type = slot.scope_type
+    and publication.scope_key = slot.scope_key
+    and publication.cadence = slot.cadence
+    and publication.period_started_at = slot.period_started_at
+    and publication.period_ended_at = slot.period_ended_at
+    and publication.period_timezone = slot.period_timezone
+    and publication.publication_kind = 'EXACT'
+    and publication.semantic_status in ('COMPLETED', 'NO_SIGNAL')
+  join reader_summary_artifacts artifact
+    on artifact.id = publication.reader_summary_artifact_id
+    and artifact.tenant_id = publication.tenant_id
+    and artifact.workspace_id = publication.workspace_id
+    and artifact.scope_type = publication.scope_type
+    and artifact.scope_key = publication.scope_key
+    and artifact.cadence = publication.cadence
+    and artifact.period_started_at = publication.period_started_at
+    and artifact.period_ended_at = publication.period_ended_at
+    and artifact.period_timezone = publication.period_timezone
+    and artifact.period_key = publication.period_key
+    and artifact.status = publication.semantic_status
+    and artifact.model_version = publication.model_version
+  order by requested_days.requested_date asc
+`;

--- a/scripts/lib/reader-summary-daily-gap-test-fixtures.ts
+++ b/scripts/lib/reader-summary-daily-gap-test-fixtures.ts
@@ -1,0 +1,143 @@
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { buildReaderSummaryPublicationPayload } from "@social-monitor/summary/adapters/persistence/reader-summary-publication-proof";
+import { ReaderSummaryArtifact, ReaderSummaryJob, buildReaderSummaryPeriod } from "@social-monitor/summary/domain";
+import type { ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
+
+import type { DailyGapPublicationRow } from "./reader-summary-daily-gap-bindings";
+import { canonicalJsonSha256 } from "./reader-summary-quality-eval-support";
+
+export const dailyGapTestScope = {
+  tenantId: "00000000-0000-4000-8000-000000009201",
+  workspaceId: "00000000-0000-4000-8000-000000009202",
+};
+export const dailyGapTestDatabaseUrl = "postgresql://gap.example.test/synthetic_gap";
+export const dailyGapTestDates = [
+  "2026-08-30", "2026-08-31", "2026-09-01", "2026-09-02", "2026-09-03",
+];
+
+export function dailyGapTestRows(): DailyGapPublicationRow[] {
+  return dailyGapTestDates.map((date, index) => dailyGapTestRow(
+    date, index === 4 ? "NO_SIGNAL" : "COMPLETED", index,
+  ));
+}
+
+export function dailyGapTestRow(
+  date: string, status: "COMPLETED" | "NO_SIGNAL", index = 0,
+): DailyGapPublicationRow {
+  const noSignal = status === "NO_SIGNAL";
+  const period = buildReaderSummaryPeriod({
+    cadence: "daily", timezone: "UTC",
+    startedAt: new Date(`${date}T00:00:00.000Z`),
+    endedAt: new Date(Date.parse(`${date}T00:00:00.000Z`) + 86_400_000),
+  });
+  const id = `00000000-0000-4000-8000-${String(9300 + index).padStart(12, "0")}`;
+  const jobId = `00000000-0000-4000-8000-${String(9400 + index).padStart(12, "0")}`;
+  const requestedAt = new Date(period.endedAt.getTime() + 1_000);
+  const completedAt = new Date(period.endedAt.getTime() + 2_000);
+  const scope = {
+    tenantId: tenantId(dailyGapTestScope.tenantId),
+    workspaceId: workspaceId(dailyGapTestScope.workspaceId),
+  };
+  const artifact = ReaderSummaryArtifact.create({
+    schemaVersion: "reader_summary.artifact.v1", readerSummaryId: id,
+    ...scope, scope: { type: "workspace" }, period, generatedAt: completedAt,
+    sourceWindow: {
+      windowId: `synthetic-window-${date}`, startedAt: period.startedAt,
+      endedAt: period.endedAt,
+      selectedFeedItemIds: noSignal ? [] : ["synthetic-feed"],
+      storyClusterIds: noSignal ? [] : ["synthetic-story"],
+    },
+    storyClusters: noSignal ? [] : [{
+      id: "synthetic-story", storyKey: "synthetic-story", representativeFeedItemId: "synthetic-feed",
+      duplicateFeedItemIds: [], interestIds: ["synthetic-interest"], providerKeys: ["hacker-news"],
+      score: 1, observedAtRange: { startedAt: period.startedAt, endedAt: period.endedAt },
+      whyImportant: ["Synthetic test evidence."],
+    }], contextArtifacts: [],
+    headline: noSignal ? "No qualifying signal" : "Synthetic daily publication",
+    executiveSummary: noSignal ? "No evidence passed selection." : "Synthetic publication text.",
+    topStories: noSignal ? [] : [{
+      storyClusterId: "synthetic-story", title: "Synthetic story", summary: "Synthetic evidence summary.",
+      interestIds: ["synthetic-interest"], providerKeys: ["hacker-news"], citationIds: ["synthetic-citation"],
+    }], interestHighlights: [], repeatedSignals: [], risksAndUnknowns: [],
+    citationMap: noSignal ? [] : [{
+      citationId: "synthetic-citation", feedItemId: "synthetic-feed",
+      sourceItemId: "synthetic-source", providerKey: "hacker-news", field: "title",
+    }],
+    qualityFlags: noSignal ? ["no_signal"] : [],
+    confidence: { level: noSignal ? "none" : "high", score: noSignal ? 0 : 0.9, rationale: "Synthetic fixture." },
+    lineage: {
+      promptVersion: "synthetic-prompt-v1", schemaVersion: "reader_summary.artifact.v1",
+      modelVersion: "synthetic-model-v1", providerVersion: "fixture",
+      rulesVersion: "synthetic-rules-v1", evalDatasetVersion: "synthetic-eval-v1",
+      rankingPolicyVersion: "synthetic-ranking-v1",
+    },
+    usage: { inputTokens: 0, outputTokens: 0, estimatedCostUsd: 0 },
+    ...(noSignal ? { noSignalReason: "No eligible provider evidence." } : {}),
+  });
+  const finalJob = ReaderSummaryJob.rehydrate({
+    id: jobId, ...scope, scope: { type: "workspace" }, period,
+    status: noSignal ? "no_signal" : "completed", idempotencyKey: `synthetic-${date}`,
+    requestedAt, startedAt: requestedAt, completedAt, readerSummaryId: id,
+  });
+  const command: ReaderSummaryPublicationCommand = {
+    artifact, finalJob,
+    publicationDecision: {
+      status: "published", qualityPassed: true, canonicalScore: 1, reasons: [],
+      shadow: { mode: "shadow", policyVersion: "reader_summary_publication_shadow_v1", riskScore: 0, signals: [] },
+    },
+    githubProjectionAudit: {
+      schemaVersion: "reader_summary.github_projection.v1", status: "not_required",
+      requestedUtcDay: date, pageCount: noSignal ? 1 : 0, scannedItemCount: 0,
+      eligibleBindingIds: [], bindings: [], violationCodes: [], reasons: [],
+      ...(noSignal ? {} : { historicalOmission: {
+        mode: "github_projection_unavailable_historical" as const,
+        reason: "Synthetic fixture omits GitHub.", authorizedAt: requestedAt.toISOString(),
+      } }),
+    },
+    readyEvent: {
+      eventId: `synthetic-event-${date}`, eventType: "reader_summary.ready", schemaVersion: 1,
+      occurredAt: completedAt, ...scope, correlationId: jobId, causationId: jobId,
+      payload: {
+        readerSummaryJobId: jobId, readerSummaryId: id, ...scope,
+        scope: { type: "workspace" }, period, status: noSignal ? "no_signal" : "completed",
+      },
+    } as ReaderSummaryPublicationCommand["readyEvent"],
+  };
+  // Produce real v1 report/proof bindings through the canonical publisher,
+  // entirely in memory; no database, provider, or production fixture is used.
+  const publication = buildReaderSummaryPublicationPayload(command);
+  return {
+    collectionDate: date, capturedAt: new Date("2026-09-05T00:00:00.000Z"),
+    currentPublicationId: id, publicationId: id, publicationKind: "EXACT",
+    semanticStatus: status, publicationArtifactId: id,
+    publicationModelVersion: publication.modelVersion,
+    reportSha256: publication.reportSha256, proofSha256: publication.proofSha256,
+    exactProof: publication.exactProof,
+    publicationRequestedUtcDate: publication.requestedUtcDate,
+    publicationRequestedAt: requestedAt, publicationReaderSummaryJobId: jobId,
+    id, ...dailyGapTestScope, scopeType: "workspace", scopeKey: "workspace",
+    interestId: null, cadence: "daily", periodStartedAt: period.startedAt,
+    periodEndedAt: period.endedAt, periodTimezone: "UTC", periodKey: period.periodKey,
+    userId: null, subscriptionId: null, status, schemaVersion: 1,
+    modelVersion: publication.modelVersion, promptVersion: "synthetic-prompt-v1",
+    headline: publication.report.headline as string,
+    summaryText: publication.report.summaryText as string,
+    artifactPayload: publication.report.artifactPayload, citations: publication.report.citations,
+    qualitySignals: publication.report.qualitySignals, createdAt: completedAt, updatedAt: completedAt,
+  };
+}
+
+export function dailyGapTestRecord(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+export function rehashDailyGapTestRow(row: DailyGapPublicationRow): DailyGapPublicationRow {
+  const reportSha256 = canonicalJsonSha256({
+    schemaVersion: "reader_summary.publication_report.v1", semanticStatus: row.status,
+    modelVersion: row.modelVersion, promptVersion: row.promptVersion,
+    headline: row.headline, summaryText: row.summaryText, artifactPayload: row.artifactPayload,
+    citations: row.citations, qualitySignals: row.qualitySignals,
+  });
+  const exactProof = { ...dailyGapTestRecord(row.exactProof), reportSha256 };
+  return { ...row, reportSha256, exactProof, proofSha256: canonicalJsonSha256(exactProof) };
+}


### PR DESCRIPTION
## Purpose

Restore the existing daily E2E delivery path after two reproduced production permission failures, without changing summary model selection or weakening publication quality/proof gates. One coherent follow-up PR avoids two consecutive backend deployments.

## Changes

- Normalize public application assets after build for non-root runtime access; preserve root ownership and executability without group/other write access.
- Keep the public OTel rollback snapshot readable by UID10001; reject unsafe modes/symlinks before recreate and retain its live bind source after rollback.
- Let the daily cursor continuity checker validate coherent exact NO_SIGNAL terminals alongside COMPLETED publications. The shared successful-summary snapshot remains COMPLETED-only. NO_SIGNAL is not counted as a generated summary.
- Mount the verified database CA read-only into the isolated production canary. No TLS weakening, database provisioning, provider call or production publication in this PR.

## Evidence and remaining verification

- Exact base: fff87384f753684501331f677b0768dbd6f82af2.
- One offline image regression rebuilt source from 0600/0700 context. UID1000 read9060 files, loaded the exact failing compiled-to-CJS import and model-purpose MJS, and rejected the negative EACCES control. Provider called:false.
- Four local permission tests plus the existing check:container gate passed. Cleanup uses --no-prune to preserve existing ancestor images.
- OTel lifecycle assertions passed. The OLD host cleanup wrapper rejected removal of the newly created test Git fixture; clean GitHub CI must validate the complete test exit.
- Gap writer ran100 synthetic tests. Standard Jest/lint/typecheck were unavailable inside its sandbox and remain required exact-head CI checks, not claimed passed here.
- Independent component review found no blocking defect. Final exact-head hosted review and full CI are required before merge. Product collection/summary/publication E2E is still pending deployment.

## Preserved ownership / rollback

Component commits are preserved separately for targeted revert. Worker patch hashes: permission0325a3a16bfe0f640b5accb685e48ded3b11d0e8919a2c07a09606c0366a1df7; gap2e974df3b3d79757e83aa276b2d3b8f91c0ae6b4596bfc454589d8169c33aa4f. No local dirty user worktree was staged or modified. No history cursor, production receipts, quality thresholds or account policy was manually advanced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Reliability**
  - Improved container file permissions so application assets remain readable at runtime, including from restrictive host checkouts.
  - Added validation for database CA certificates before production startup and mounted them read-only.
  - Strengthened rollback safeguards by requiring secure, regular collector configuration files.

- **Bug Fixes**
  - Improved production publication-gap verification across multiple dates, including completed and no-signal outcomes.

- **Tests**
  - Expanded coverage for container permissions, certificate validation, rollback safety, and publication integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->