### PR TITLE
fix(ingestion): allow bounded multi-pass X RPC completion

### DIFF
--- a/libs/ingestion/adapters/source/x-twitter-experimental-daily/x-collector-runtime-config.spec.ts
+++ b/libs/ingestion/adapters/source/x-twitter-experimental-daily/x-collector-runtime-config.spec.ts
@@ -1,0 +1,53 @@
+import { resolveXCollectorRuntimeConfig } from './x-collector-runtime-config';
+
+describe('resolveXCollectorRuntimeConfig', () => {
+  const enabled = {
+    X_COLLECTOR_ENABLED: '1',
+    X_COLLECTOR_GRPC_ADDRESS: ' x-collector.test:50051 ',
+  };
+
+  it('allows a bounded multi-pass collection to finish beyond one minute', () => {
+    expect(resolveXCollectorRuntimeConfig(enabled)).toEqual({
+      address: 'x-collector.test:50051',
+      timeoutMs: 180_000,
+      serviceToken: undefined,
+    });
+  });
+
+  it.each(['', ' ', '0', '-1', '1.5', 'invalid', 'Infinity'])(
+    'uses the bounded default for invalid timeout %j',
+    (timeout) => {
+      expect(resolveXCollectorRuntimeConfig({
+        ...enabled,
+        X_COLLECTOR_GRPC_TIMEOUT_MS: timeout,
+      })?.timeoutMs).toBe(180_000);
+    },
+  );
+
+  it.each(['60000', '240000'])(
+    'preserves an explicitly configured timeout %s',
+    (timeout) => {
+      expect(resolveXCollectorRuntimeConfig({
+        ...enabled,
+        X_COLLECTOR_GRPC_TIMEOUT_MS: timeout,
+      })?.timeoutMs).toBe(Number(timeout));
+    },
+  );
+
+  it('keeps a disabled or unaddressed collector disabled', () => {
+    expect(resolveXCollectorRuntimeConfig({})).toBeNull();
+    expect(resolveXCollectorRuntimeConfig({
+      X_COLLECTOR_ENABLED: '1',
+    })).toBeNull();
+    expect(resolveXCollectorRuntimeConfig({
+      X_COLLECTOR_GRPC_ADDRESS: 'x-collector.test:50051',
+    })).toBeNull();
+  });
+
+  it('uses the same default for the existing experimental enable flag', () => {
+    expect(resolveXCollectorRuntimeConfig({
+      X_COLLECTOR_EXPERIMENTAL_ENABLED: '1',
+      X_COLLECTOR_GRPC_ADDRESS: 'x-collector.test:50051',
+    })?.timeoutMs).toBe(180_000);
+  });
+});

--- a/libs/ingestion/adapters/source/x-twitter-experimental-daily/x-collector-runtime-config.ts
+++ b/libs/ingestion/adapters/source/x-twitter-experimental-daily/x-collector-runtime-config.ts
@@ -4,6 +4,10 @@ export type XCollectorRuntimeConfig = {
   readonly serviceToken?: string;
 };
 
+// A multi-pass collection can take two minutes before ranking and returning.
+// Keep the RPC bounded while allowing that result to reach the scan caller.
+export const DEFAULT_X_COLLECTOR_GRPC_TIMEOUT_MS = 180_000;
+
 export const resolveXCollectorRuntimeConfig = (
   env: NodeJS.ProcessEnv,
 ): XCollectorRuntimeConfig | null => {
@@ -18,7 +22,10 @@ export const resolveXCollectorRuntimeConfig = (
 
   return {
     address,
-    timeoutMs: readPositiveEnvInteger(env.X_COLLECTOR_GRPC_TIMEOUT_MS, 60_000),
+    timeoutMs: readPositiveEnvInteger(
+      env.X_COLLECTOR_GRPC_TIMEOUT_MS,
+      DEFAULT_X_COLLECTOR_GRPC_TIMEOUT_MS,
+    ),
     serviceToken: readOptionalEnvString(env.X_COLLECTOR_SERVICE_TOKEN),
   };
 };

--- a/scripts/lib/clean-real-day-provider-acquisition.ts
+++ b/scripts/lib/clean-real-day-provider-acquisition.ts
@@ -24,6 +24,7 @@ import { RssSourceProvider } from "@social-monitor/ingestion/adapters/source/rss
 import { SocialResearchSourceQueryPlannerAdapter } from "@social-monitor/ingestion/adapters/source/social-research-source-query-planner.adapter";
 import { sourceReadinessProfiles } from "@social-monitor/ingestion/adapters/source/source-readiness-profiles";
 import { GrpcXDailyCollectorClient } from "@social-monitor/ingestion/adapters/source/x-twitter-experimental-daily/grpc-x-daily-collector-client";
+import { DEFAULT_X_COLLECTOR_GRPC_TIMEOUT_MS } from "@social-monitor/ingestion/adapters/source/x-twitter-experimental-daily/x-collector-runtime-config";
 import { XTwitterSourceProvider } from "@social-monitor/ingestion/adapters/source/x-twitter-experimental-daily/x-twitter-experimental-daily-source.provider";
 import { ExecuteScanUseCase } from "@social-monitor/ingestion/features/execute-scan/execute-scan.use-case";
 import {
@@ -487,7 +488,7 @@ const buildProviders = (
           options: {
             timeoutMs: positiveIntegerEnv(
               process.env.X_COLLECTOR_GRPC_TIMEOUT_MS,
-              60_000,
+              DEFAULT_X_COLLECTOR_GRPC_TIMEOUT_MS,
             ),
             serviceToken: optionalEnv(process.env.X_COLLECTOR_SERVICE_TOKEN),
           },


### PR DESCRIPTION
## Problem

The real production collection on 2026-09-05 persisted no X posts even though the collector recorded 34 accepted candidates in each of two multi-pass requests. Both callers failed with a 60-second gRPC deadline; the second request continued completing passes for almost two minutes. A subsequent retry encountered a busy account pool. Raising account quotas is not the fix: the configured per-account quotas are already large.

## Change

- Give X collection a bounded 180-second default RPC deadline.
- Share that default between normal ingestion runtime configuration and the real-day collection composition.
- Preserve explicitly configured positive timeouts, enable flags and provider quality policy.
- Add regressions for the new default, invalid values, overrides, disabled configuration and the existing experimental flag.

## Scope and evidence

- Base: `13b2b58e75e249add34e817758b73388affd7932`.
- No account/auth changes, quota increases, quality-gate changes, provider retries or manual data writes.
- This is a bounded timeout correction, not a claim that server-side cancellation is solved.
- OLD isolated clone at exact `e3f1cc9e551462e987f1be344ee83724d667ac91`: 26/26 focused tests passed (3 suites, 4.228s); runtime-profile guards, source certification (7 deterministic providers), source/test line cap, architecture and code-quality checks passed.
- Independent exact-diff review passed with no P0/P1. It explicitly notes that the timeout fix does not establish server-side cancellation or lease-cleanup correctness. Exact-head CI is still required before merge.
- Full AI-summary/publication E2E remains pending; neither these tests nor the earlier persistence proof replace it.
