### PR TITLE
fix(ingestion): preserve partial X query results

### DIFF
--- a/libs/ingestion/adapters/source/x-twitter-experimental-daily/x-twitter-experimental-daily-source.provider.spec.ts
+++ b/libs/ingestion/adapters/source/x-twitter-experimental-daily/x-twitter-experimental-daily-source.provider.spec.ts
@@ -356,9 +356,14 @@ describe("XTwitterSourceProvider", () => {
     ).toEqual([12, 6, 10]);
   });
 
-  it("returns collected posts when a later configured query is rate limited", async () => {
+  it.each([
+    [status.RESOURCE_EXHAUSTED, "x-twitter.partial_rate_limit"],
+    [status.UNAVAILABLE, "x-twitter.partial_provider_failure"],
+    [status.DEADLINE_EXCEEDED, "x-twitter.partial_provider_failure"],
+  ] as const)("retains posts and query cursors after retryable gRPC %s", async (code, warningCode) => {
+    const collector = new FailingSecondQueryCollector(errorWithCode(code));
     const provider = new XTwitterSourceProvider(
-      new RateLimitedSecondQueryCollector(),
+      collector,
       {
         now: () => new Date("2026-06-27T00:00:00.000Z"),
       },
@@ -370,7 +375,7 @@ describe("XTwitterSourceProvider", () => {
       scanJobId: "scan-1",
       correlationId: "corr-1",
       config: {
-        searchQueries: ["mcp server"],
+        searchQueries: ["mcp server", "cursor ai"],
       },
     };
 
@@ -380,6 +385,7 @@ describe("XTwitterSourceProvider", () => {
         cursor: JSON.stringify({
           queries: {
             "mcp server": "previous-mcp-cursor",
+            "cursor ai": "previous-cursor-ai-cursor",
           },
         }),
       },
@@ -390,15 +396,51 @@ describe("XTwitterSourceProvider", () => {
       "x-twitter:ai-agents",
     ]);
     expect(result.warnings).toEqual([
-      "mcp server: x-twitter.partial_rate_limit: grpc 8",
+      `mcp server: ${warningCode}: grpc ${code}`,
     ]);
     expect(result.nextCursor).toBe(
       JSON.stringify({
         queries: {
+          "ai agents": "next-ai-cursor",
           "mcp server": "previous-mcp-cursor",
+          "cursor ai": "previous-cursor-ai-cursor",
         },
       }),
     );
+    expect(collector.requests.map((request) => request.query)).toEqual([
+      "ai agents",
+      "mcp server",
+    ]);
+  });
+
+  it.each([
+    [status.UNAVAILABLE, false, 0],
+    [status.DEADLINE_EXCEEDED, false, 0],
+    [status.RESOURCE_EXHAUSTED, false, 0],
+    [status.UNAVAILABLE, true, 30],
+    [status.UNAUTHENTICATED, true, 0],
+    [status.PERMISSION_DENIED, true, 0],
+    [status.INVALID_ARGUMENT, true, 0],
+    [status.INTERNAL, true, 0],
+  ] as const)("propagates gRPC %s with posts=%s and minLikes=%s when partial recovery is unsafe", async (code, includePosts, minLikes) => {
+    const failure = errorWithCode(code);
+    const provider = new XTwitterSourceProvider(
+      new FailingSecondQueryCollector(failure, includePosts),
+      { now: () => new Date("2026-06-27T00:00:00.000Z") },
+    );
+    const context = {
+      tenantId: tenantId("tenant-1"),
+      workspaceId: workspaceId("workspace-1"),
+      sourceBindingId: "binding-1",
+      scanJobId: "scan-1",
+      correlationId: "corr-1",
+      config: { searchQueries: ["mcp server"], minLikes },
+    };
+
+    await expect(provider.scan(
+      provider.planScan({ mode: "search", query: "ai agents" }, context),
+      context,
+    )).rejects.toBe(failure);
   });
 
   it("keeps invalid bindings non-retryable through validation", () => {
@@ -544,8 +586,13 @@ class MultiQueryCollector implements XDailyCollectorClientPort {
   }
 }
 
-class RateLimitedSecondQueryCollector implements XDailyCollectorClientPort {
+class FailingSecondQueryCollector implements XDailyCollectorClientPort {
   readonly requests: XDailyCollectorRequest[] = [];
+
+  constructor(
+    private readonly failure: Error,
+    private readonly includePosts = true,
+  ) {}
 
   async collectDailySearch(
     request: XDailyCollectorRequest,
@@ -554,18 +601,19 @@ class RateLimitedSecondQueryCollector implements XDailyCollectorClientPort {
   > {
     this.requests.push(request);
     if (this.requests.length > 1) {
-      throw errorWithCode(status.RESOURCE_EXHAUSTED);
+      throw this.failure;
     }
 
     return {
-      posts: [
+      posts: this.includePosts ? [
         xPost({
           tweetId: "ai-agents",
           text: "AI agents broad post",
           likes: 20,
           trendScore: 20,
         }),
-      ],
+      ] : [],
+      nextCursor: "next-ai-cursor",
       warnings: [],
     };
   }

--- a/libs/ingestion/adapters/source/x-twitter-experimental-daily/x-twitter-experimental-daily-source.provider.ts
+++ b/libs/ingestion/adapters/source/x-twitter-experimental-daily/x-twitter-experimental-daily-source.provider.ts
@@ -197,10 +197,17 @@ export class XTwitterSourceProvider implements SourceProviderPort {
         );
       } catch (error) {
         const failure = this.classifyError(error);
-        if (failure.kind === "rate_limited" && postsByExternalId.size > 0) {
+        if (
+          postsByExternalId.size > 0 &&
+          failure.retryable &&
+          (failure.kind === "rate_limited" || failure.kind === "unavailable")
+        ) {
+          const warningCode = failure.kind === "rate_limited"
+            ? "x-twitter.partial_rate_limit"
+            : "x-twitter.partial_provider_failure";
           warnings.push(
             redactSensitiveText(
-              `${searchQuery}: x-twitter.partial_rate_limit: ${failure.message}`,
+              `${searchQuery}: ${warningCode}: ${failure.message}`,
             ),
           );
           break;


### PR DESCRIPTION
## Problem

The production collection on 2026-09-05 returned posts from earlier configured X queries, but a later gRPC UNAVAILABLE made the TypeScript provider throw and discard its accumulated results. Its existing partial recovery handled only RESOURCE_EXHAUSTED.

## Change

- Preserve previously accepted posts on retryable UNAVAILABLE/DEADLINE_EXCEEDED, with an explicit redacted `x-twitter.partial_provider_failure` warning.
- Keep the existing distinct rate-limit warning, stop further queries, and retain successful, failed, and unvisited query cursor semantics.
- Continue throwing for empty/filtered-out accumulated results, authentication/permission/invalid-query failures, and unknown failures. Metric thresholds, output budgets, account limits and quality gates are unchanged.

## Evidence

- Exact base: `4a3bf1b45fbdeaea6c01223fce0e8b1aba627f85`.
- RED on OLD at `8cbd9086`: the two new UNAVAILABLE/DEADLINE recovery cases fail; 19 pass.
- GREEN on OLD at `bc1150d9`: 59 tests across 8 provider, gRPC, config, output-budget and registry suites pass.
- OLD source certification (7 providers), architecture, code quality and source/test line cap (3949 files) all pass. Independent exact-head read-only review found no P0/P1. Exact-head CI is required before merge.
- No local heavy tests, production mutation, provider rerun or account change was performed for this patch.

## Scope / rollback

This fixes the observed configured-query boundary only. Recovery inside a single query's later adaptive page is a separate limitation and is not claimed solved. This does not restore unavailable AI credentials or prove summary publication. Revert this two-file change independently if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery for interrupted X/Twitter scans caused by temporary rate limits or provider availability issues.
  - When partial results are available, scans now preserve those results and provide a warning instead of failing completely.
  - Other unrecoverable errors continue to be reported normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->