### PR TITLE
fix(rolling): use verified topic labeling

### DIFF
--- a/ops/deploy/production-runtime/rolling-run.test.sh
+++ b/ops/deploy/production-runtime/rolling-run.test.sh
@@ -38,6 +38,8 @@ prior_alias=$TEST_ROOT/artifacts/evals/reader-summary-clean-real-day-collection.
 printf '%s\n' '{"run":{"collectionDate":"2026-08-14"},"sentinel":"prior-day"}' > "$prior_alias"
 prior_alias_bytes=$(sha256sum "$prior_alias" | cut -d' ' -f1)
 
+DURABLE_READER_SUMMARY_TOPIC_LABELER=deterministic \
+DURABLE_READER_SUMMARY_REJECTED_TOPIC_MAP_PATH=/tmp/stale-topic-map.json \
 SOCIAL_MONITOR_ROLLING_RUN_TEST_MODE=1 \
 SOCIAL_MONITOR_ROLLING_RUN_TEST_ROOT=$TEST_ROOT \
 SOCIAL_MONITOR_ROLLING_RUN_TEST_DOCKER=$fake_docker \
@@ -63,7 +65,7 @@ grep -Fx 'collection-created 20260815T081500000Z 2026-08-15' "$TEST_ROOT/docker.
 grep -F -- "--providers \"\$required_providers\"" "$CONTAINER_RUNNER" >/dev/null
 grep -F -- 'npm run capture:durable-reader-summary' "$CONTAINER_RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_MODEL=agent-runtime' "$CONTAINER_RUNNER" >/dev/null
-grep -F -- 'DURABLE_READER_SUMMARY_TOPIC_LABELER=deterministic' "$CONTAINER_RUNNER" >/dev/null
+grep -Fx 'topic-labeler-config 20260815T081500000Z agent-runtime' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_MAX_EVIDENCE_ITEMS=120' "$CONTAINER_RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_PERIOD_ENDED_AT' "$CONTAINER_RUNNER" >/dev/null
 grep -F -- 'DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF' "$CONTAINER_RUNNER" >/dev/null
@@ -196,6 +198,7 @@ SOCIAL_MONITOR_ROLLING_RUN_TEST_NOW=2026-08-15T16:15:00.000Z \
 SOCIAL_MONITOR_ROLLING_RUNTIME=containerd \
   bash "$RUNNER"
 grep -Fx 'collection-created 20260815T161500000Z 2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
+grep -Fx 'topic-labeler-config 20260815T161500000Z agent-runtime' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '-n moby run --rm --net-host' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '--env ROLLING_COLLECTION_DATE=2026-08-15' "$TEST_ROOT/docker.log" >/dev/null
 grep -F -- '--env ROLLING_AUTH_READY=true' "$TEST_ROOT/docker.log" >/dev/null

--- a/ops/deploy/production-runtime/rolling-summary-container-run.sh
+++ b/ops/deploy/production-runtime/rolling-summary-container-run.sh
@@ -83,6 +83,9 @@ if [ "$ROLLING_AUTH_READY" != true ]; then
   exit 75
 fi
 
+export DURABLE_READER_SUMMARY_TOPIC_LABELER=agent-runtime
+export DURABLE_READER_SUMMARY_REJECTED_TOPIC_MAP_PATH="$artifact_root/rolling-summary.$ROLLING_RUN_ID.rejected-topic-map.v1.json"
+
 if [ "${SOCIAL_MONITOR_ROLLING_CONTAINER_TEST_MODE:-0}" = 1 ]; then
   "$SOCIAL_MONITOR_ROLLING_CONTAINER_TEST_SUMMARY_COMMAND" \
     "$evidence_path" "$frontend_path"
@@ -95,7 +98,6 @@ else
   export DURABLE_READER_SUMMARY_PERIOD_ENDED_AT
   export DURABLE_READER_SUMMARY_LIVE_OBSERVATION_CUTOFF="$rolling_observation_cutoff"
   export DURABLE_READER_SUMMARY_MODEL=agent-runtime
-  export DURABLE_READER_SUMMARY_TOPIC_LABELER=deterministic
   export DURABLE_READER_SUMMARY_MAX_EVIDENCE_ITEMS=120
   export DURABLE_READER_SUMMARY_EVIDENCE_PATH="$evidence_path"
   export DURABLE_READER_SUMMARY_FRONTEND_FIXTURE_PATH="$frontend_path"

--- a/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-summary.sh
+++ b/ops/deploy/production-runtime/test-fixtures/rolling-run-fake-summary.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 evidence_path=${1:?summary evidence path is required}
 frontend_path=${2:?summary frontend path is required}
+[[ ${DURABLE_READER_SUMMARY_TOPIC_LABELER:-} == agent-runtime ]] || {
+  echo 'rolling summary must use verified agent-runtime topic labeling' >&2
+  exit 1
+}
+expected_rejection_path=${evidence_path%.evidence.v1.json}.rejected-topic-map.v1.json
+[[ ${DURABLE_READER_SUMMARY_REJECTED_TOPIC_MAP_PATH:-} == "$expected_rejection_path" ]] || {
+  echo 'rolling rejected topic map audit must belong to the current run' >&2
+  exit 1
+}
+printf 'topic-labeler-config %s %s\n' "$ROLLING_RUN_ID" \
+  "$DURABLE_READER_SUMMARY_TOPIC_LABELER" >> "$SOCIAL_MONITOR_ROLLING_RUN_TEST_LOG"
 fixture_root=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
 node "$fixture_root/rolling-run-fake-artifact.mjs" evidence \
   "$evidence_path" "$ROLLING_RUN_ID" "$ROLLING_COLLECTION_DATE" \


### PR DESCRIPTION
Rolling Reader Summary generation could succeed and then fail publication because the runtime forced deterministic topic labels, leaving related stories without supported semantic groups. Use the existing verified agent-runtime labeler and save rejected topic-map diagnostics at a path scoped to the rolling run.

The shared summary branch supplies the same effective configuration to production and the Docker/containerd fixtures. Strict quality checks, attestations, provenance, retry bounds, selection thresholds, and gpt-5.6-sol/high model policy remain unchanged.

Validation: regression proved RED then GREEN; rolling receipts, shell syntax, ShellCheck, architecture, code quality, source line cap, and runtime profile guards passed. Independent hosted review approved exact commit 0b069095d49c7e293ff55df26275a61c90737ba1. Production publication will be verified after deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rolling summary runs now use verified agent-runtime topic labeling.
  * Rejected-topic mapping is recorded to a per-run audit artifact.
  * Runtime checks now validate topic-labeling configuration through execution logs and evidence artifacts.

* **Tests**
  * Added coverage to verify topic-labeling configuration and rejected-topic audit paths across runtime modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->