### PR TITLE
fix(delivery): recover historical reader summary ready events safely

### DIFF
--- a/docs/iterations/06-production-hardening/reader-summary-ready-delivery-recovery.md
+++ b/docs/iterations/06-production-hardening/reader-summary-ready-delivery-recovery.md
@@ -171,3 +171,66 @@ real Prisma adapter, concurrent duplicates/channel races, a fresh connection
 after commit, rollback after both writes, RLS/scoped reads and stored diagnostics.
 It proves these tables/transactions, not the entire migration chain or deployed
 broker. Parent acceptance must still validate deployment and real summary data.
+
+## Recovery lifecycle and cancellation follow-up
+
+A historical artifact may now be `SUPERSEDED` while its job and publication
+retain `COMPLETED` or `NO_SIGNAL`. Recovery accepts that lifecycle only with
+unchanged exact event IDs, job/artifact links, scope, period, report and v1 proof
+hashes. It never changes the publication's semantic status. Changed content,
+proof, scope or incompatible job/artifact lifecycle still fails closed.
+
+Recovery uses a dedicated Amqplib channel. Its explicit
+`cancelPendingPublishes()` synchronously and permanently inhibits future sends,
+including continuations waiting for connect, channel creation or exchange
+assertion. The guard runs after awaiting the channel, immediately before the
+amqplib publish call. A separate synchronous `beforePublish` check enforces the
+parent's exclusive window at that boundary. Neither close nor reconnect clears
+cancellation. Shared relay command/event publishers and queue consumers retain
+their default reusable close/reconnect behavior when cancellation is unused.
+
+The deadline is the earlier of 15 seconds and the remaining exclusive window.
+Expiry inhibits future sends before rejecting the wait and recording uncertainty.
+This bounds the confirmation wait; it is **not a hard 15-second wire-delivery
+or broker-settlement guarantee**. Bytes already handed to amqplib may arrive
+later, and event-loop scheduling can delay timers. A late confirm never resumes
+acknowledgement or advances the cohort. Claims stay permanent; there is no
+blind resend. Resource close is best effort with a separate five-second wait;
+its completion is not evidence of cancellation or absence of a send.
+
+`npm run check:reader-summary-ready-recovery-postgres` extends the reviewed
+loopback disposable fixture with native recovery tables, canonical constraints
+and immutability triggers. It creates an additional isolated non-bypass recovery
+role, uses separate bounded Prisma pools (min 0, max 1), and cleans up only its
+new database/roles. It exercises supersession without proof mutation, actual
+recovery persistence, microsecond/xmin CAS, competing writers, the real consumer
+inbox/projection, retained replay, a database trigger failure after confirmation,
+permanent claim retention/no resend, and raw RLS queries. The broker confirm is
+synthetic; the database work is native. It does not run the full migration chain.
+
+Parent must supply `READER_DELIVERY_TEST_ADMIN_DATABASE_URL` for a **new test
+container**, with the same privileges as the reviewed delivery native gate. Run
+from this source workspace with existing generated Prisma client/dependencies,
+after the focused source typecheck. Transpile-only here avoids repeating that
+typecheck inside the native gate deadline; all runtime assertions still execute:
+
+```sh
+mkdir -p .cache/reader-recovery-final/native-tmp
+chmod 700 .cache/reader-recovery-final/native-tmp
+NODE_ENV=test TMPDIR="$PWD/.cache/reader-recovery-final/native-tmp" \
+  TS_NODE_TRANSPILE_ONLY=true TS_NODE_COMPILER_OPTIONS='{"rootDir":"."}' \
+  npm run check:reader-summary-ready-recovery-postgres
+```
+
+The secure receipt tests also require a private TMPDIR whose ancestors are not
+writable by others; shared `/tmp` is deliberately rejected. These test options
+never relax the production filesystem policy.
+
+Frozen exact17 auditing runs separately from any apply manifest. Only database
+columns receive snake-case to camel-case and native Date conversion; JSONB
+report/proof/payload values remain unchanged. Audit artifacts contain identities,
+statuses and hashes only. They prove frozen content compatibility, not current
+outbox/inbox state, deployment, bindings, exclusive access or any other live
+precondition. Parent supplies the chronological exact UUID allowlist. Seventeen
+bounds manifest entry count, never a query selection; a new natural publication
+may add its own separate event and must not broaden this recovery.

--- a/docs/iterations/06-production-hardening/reader-summary-ready-delivery-recovery.md
+++ b/docs/iterations/06-production-hardening/reader-summary-ready-delivery-recovery.md
@@ -74,52 +74,88 @@ unknown earlier attempts. Failures retain the shared-redacted, single-line,
 A database acknowledgement failure can follow a successful broker send, so
 FAILED also requires consumer dedupe before recovery.
 
-## Proposed recovery contract (not executed)
+## One-shot recovery decision (production execution belongs to parent)
 
-There is no canonical scoped EVENT-outbox reset command in this base. Existing
-webhook replay and ReaderSummary job recovery are different operations. The
-minimal proposed operation is `recover-reader-summary-ready-events --manifest
-<reviewed-file> --dry-run`, with a separately authorized `--apply` mode. This
-change documents the contract; it does not add a general recovery platform.
+`npm run recover:reader-summary-ready-events -- --manifest <absolute-file>`
+defaults to `--dry-run`; `--apply` is explicit. This CLI publishes each reviewed
+original envelope once through `RabbitMqEventPublisher`, including mandatory
+routing and confirms. It never changes FAILED to PENDING or selects a cohort
+by count, time or status. The maximum 17 bounds the exact UUID allowlist only.
 
-The manifest must contain an operation id, approved deployment revision,
-operator/reason, exact event UUID allowlist (maximum 17 for the original cohort),
-expected tenant/workspace per row, event type/version, creation timestamp,
-readerSummary/job ids, report/proof hashes and a canonical payload digest.
-The original Aug 30 cohort and the parent's seven-day evidence determine the
-actual UUIDs. A time range, status predicate, or the number 17 alone is never an
-allowlist. Never mutate publication proof, job, artifact or payload to recover.
+The strict v1 JSON manifest has `operationId` (UUID), `deployedSourceSha` (40
+lowercase hex), `window` (`startedAt`, `expiresAt`, canonical UTC, at most one
+hour), `preconditions` (all true: `relayQuiesced`, `exclusiveOperation`,
+`consumerReady`, `bindingsVerified`, `retentionHeld`), and `events` (1–17).
+Every event has `eventId`, `tenantId`, `workspaceId`, `createdAt`, `correlationId`,
+`causationId` (string or null), `readerSummaryId`, `readerSummaryJobId`,
+`messageKind: "EVENT"`, `eventType: "reader_summary.ready"`, `schemaVersion: 1`,
+`expectedStatus: "FAILED"`, `payloadSha256`, `reportSha256`, `proofSha256`.
+Hashes are SHA-256 over UTF-8 `stablePublicationJson` (recursive sorted keys,
+array order preserved), including the entire original payload. The report is
+reconstructed from the immutable artifact; proof content is also rehashed.
+Do not include credentials or raw report/provider content in the manifest.
 
-Preconditions for apply:
+Parent supplies explicit `READER_READY_RECOVERY_DATABASE_URL`,
+`READER_READY_RECOVERY_RABBITMQ_URL` (apply only),
+`READER_READY_RECOVERY_DEPLOYED_SHA`, and
+`READER_READY_RECOVERY_MANIFEST_SHA256` (SHA-256 of the exact reviewed file bytes).
+There is no ambient DATABASE_URL fallback. The source SHA and time-bounded
+quiescence attestation are checked again before every effect. These are trusted
+parent attestations, not independent deployment/broker discovery. Parent must
+verify the deployed consumer revision, both exact bindings, enabled Prisma
+drain loop and DLX, hold relay/other recovery writers and retention quiescent,
+and use one durable evidence volume across invocations/hosts. The consumer
+continues running. Restoring/moving/deleting claims invalidates this procedure.
 
-1. The parent verifies the deployed revision, both exact broker bindings,
-   mandatory publication, enabled shared drain loop, Prisma persistence and
-   DLX settings. Validate the PostgreSQL fixture below, including crash retry.
-2. Reconcile every allowlisted event against immutable publication evidence;
-   validate through the same reader parser. Record existing consumer inbox and
-   realtime projection identities. An inconsistent/missing retained projection
-   or altered payload stops the operation for investigation.
-3. Quiesce the event relay for the bounded operation. In one Serializable
-   transaction, lock only the allowlisted EVENT rows, compare every manifest
-   precondition, and require all still have `FAILED` / version 1 /
-   `reader_summary.ready`. Abort the entire operation on any mismatch. Record
-   immutable before-state audit evidence (including sanitized error, counter
-   and explicit `historicalAttempts: unknown`) before any mutation.
-4. Change only these rows' status to `PENDING`, retain original diagnostics and
-   recorded counters, and atomically append an audit record linking operation
-   id, manifest digest, operator, exact ids and before/after state. Use existing
-   audit persistence if its contract supports an atomic operation; otherwise a
-   narrow maintenance audit entry must be approved before implementing apply.
-5. Resume the normal mandatory relay once. Verify publisher confirmation and
-   exactly one matching durable projection/inbox per event. Record duplicates,
-   fresh projections and failures separately. Stop on failure; never loop a
-   reset or assume PUBLISHED means consumed. Rollback is to halt recovery and
-   retain evidence, not to erase inbox/projections or rewrite publication.
+Inputs and receipts use the existing Linux descriptor-anchored secure evidence
+filesystem: `/var/lib/social-monitor/artifacts`, uid 1000, directories 0700,
+files 0400, no symlinks, exclusive creation, file and parent-directory fsync.
+The manifest is read once and its exact bytes sealed at
+`reader-summary-ready-recovery/<operationId>/claim.json`. An existing claim
+always rejects apply, including after a crash before the first send. Permanent
+per-event claims also prevent overlapping manifests from republishing. No
+claim release, TTL takeover, resume or retry switch is provided. An operator
+must review any uncertain operation before designing a subsequent action.
+This bounded claim plus exclusive parent window avoids a new table/migration.
 
-The parent owns production authorization and these actions. This lane runs no
-recovery command, outbox replay, deployment, push, PR or external notification.
+All exact rows, publication evidence, consumer inbox and replay identities are
+validated before claims/effects. The durable `before.json` records metadata,
+full-payload/report/proof digests, sanitized prior error, starts counter and
+`historicalAttempts: "unknown"`; report/payload bodies are never logged.
+For each event, immutable receipts record `publish_started` (before the DB
+start), `confirmed` (only after mandatory broker confirm), `acknowledged`
+(only after DB acknowledgement), and `consumed` (committed inbox plus matching
+projection). Existing delivered identity is recorded separately; it still
+requires a confirmed original-envelope publication before outbox acknowledgement.
+
+The standard outbox adapter owns recorded starts, markPublished and markFailed.
+Each update compares the previously read PostgreSQL `xmin` tuple version under
+an exact UUID `FOR UPDATE` lock inside a Serializable transaction, then invokes
+the standard adapter update. Any concurrent row mutation aborts the transition.
+This also protects payload, metadata, diagnostics and lease fields without
+comparing microsecond PostgreSQL timestamps to millisecond JavaScript Dates. There is
+no reset of counters and no acknowledgement of an altered row. Broker calls
+are outside all database write retries. A rejected publish records a sanitized
+failure when CAS remains safe; a confirm followed by DB failure stays uncertain.
+Any error stops the remaining events. A started receipt with no terminal
+receipt is also uncertain, including disk/process loss. Never infer send count
+from recorded starts or infer consumption from PUBLISHED/confirmed.
+
+After acknowledgement, at most 20 reads spaced 250 ms apart reconcile the
+committed inbox/projection using the same parser/use case and duplicate identity
+comparison as the consumer. A timeout or retained mismatch stops the operation
+without resending. Dry-run remains available after failures/success/window
+expiry: it inspects current states and claims without changing them and reports
+whether apply is still eligible. It cannot certify a displayed notification.
+Parent retains the production seven-day publication/API/site and consumer
+identity evidence; synthetic tests do not establish those production facts.
 
 ## Focused executable evidence
+
+`scripts/lib/reader-summary-ready-recovery-{run,guards}.spec.ts` exercise the
+one-shot CLI orchestration, original-envelope transport, concurrent claims,
+retained mismatches, CAS, delayed consumption, uncertainty and redaction with
+synthetic data. Run them with the repository Jest config and `--runInBand`.
 
 Sibling use-case/parser tests, `reader-summary-ready-delivery.spec.ts`, and
 `prisma-outbox-store.adapter.spec.ts` cover minimal projections, legacy

--- a/docs/iterations/06-production-hardening/reader-summary-ready-delivery-recovery.md
+++ b/docs/iterations/06-production-hardening/reader-summary-ready-delivery-recovery.md
@@ -110,6 +110,10 @@ continues running. Restoring/moving/deleting claims invalidates this procedure.
 Inputs and receipts use the existing Linux descriptor-anchored secure evidence
 filesystem: `/var/lib/social-monitor/artifacts`, uid 1000, directories 0700,
 files 0400, no symlinks, exclusive creation, file and parent-directory fsync.
+Installation validates each opened child and fsyncs its containing directory
+before descending, including children observed from concurrent creators or
+after mkdir returns EEXIST. Any directory sync failure stops claim installation
+before publication. Real-filesystem fault/order tests do not prove power-loss behavior.
 The manifest is read once and its exact bytes sealed at
 `reader-summary-ready-recovery/<operationId>/claim.json`. An existing claim
 always rejects apply, including after a crash before the first send. Permanent

--- a/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
@@ -475,6 +475,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/check-reader-summary-production-regeneration-smoke.ts
       scripts/check-reader-summary-publication-postgres.ts
       scripts/check-reader-summary-ready-delivery-postgres.ts
+      scripts/check-reader-summary-ready-recovery-postgres.ts
       scripts/check-reader-summary-recovery-candidate-staging-postgres.ts
       scripts/check-reader-summary-source-quality-trace.ts
       scripts/check-reader-summary-top-read-ranking.ts
@@ -518,6 +519,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/lib/reader-summary-quality-eval-support.spec.ts
       scripts/lib/reader-summary-quality-eval-support.ts
       scripts/lib/reader-summary-ready-delivery-postgres-fixture.ts
+      scripts/lib/reader-summary-ready-recovery-postgres-fixture.ts
       scripts/lib/reader-summary-recovery-postgres-contract.ts
       scripts/lib/reader-summary-weekly-atomic-publication-postgres-contract.ts
       scripts/lib/reader-summary-weekly-certification-seal-postgres-contract.ts

--- a/libs/platform/queue/src/adapters/rabbitmq/amqplib-rabbitmq-channel.spec.ts
+++ b/libs/platform/queue/src/adapters/rabbitmq/amqplib-rabbitmq-channel.spec.ts
@@ -3,9 +3,12 @@ import { EventEmitter } from 'node:events';
 import type { ChannelModel, ConfirmChannel, GetMessage } from 'amqplib';
 
 import { AmqplibRabbitMqChannel } from './amqplib-rabbitmq-channel';
+import type { RabbitMqPublishOptions } from './rabbitmq-queue-publisher';
 
 class FakeConfirmChannel extends EventEmitter {
   getCount = 0;
+  publish = jest.fn(() => true);
+  async close(): Promise<void> { this.emit('close'); }
 
   async get(): Promise<GetMessage | false> {
     this.getCount += 1;
@@ -15,6 +18,7 @@ class FakeConfirmChannel extends EventEmitter {
 
 class FakeConnection extends EventEmitter {
   readonly channels: FakeConfirmChannel[] = [];
+  async close(): Promise<void> { this.emit('close'); }
 
   async createConfirmChannel(): Promise<ConfirmChannel> {
     const channel = new FakeConfirmChannel();
@@ -24,6 +28,29 @@ class FakeConnection extends EventEmitter {
 }
 
 describe('AmqplibRabbitMqChannel', () => {
+  const options: RabbitMqPublishOptions = { contentType: 'application/json', deliveryMode: 2, mandatory: true,
+    messageId: 'synthetic', correlationId: 'synthetic', type: 'synthetic', timestamp: 0, headers: {} };
+  it('inhibits a send suspended on an already-created channel, permanently across close', async () => {
+    const connection = new FakeConnection();
+    const channel = new AmqplibRabbitMqChannel({ url: 'amqp://synthetic', connect: async () => connection as unknown as ChannelModel });
+    await channel.get('synthetic', { noAck: false });
+    const pending = channel.publish('synthetic', 'synthetic', Buffer.from('{}'), options);
+    channel.cancelPendingPublishes();
+    await expect(pending).rejects.toThrow('cancelled');
+    expect(connection.channels[0]!.publish).not.toHaveBeenCalled();
+    await channel.close();
+    await expect(channel.publish('synthetic', 'synthetic', Buffer.from('{}'), options)).rejects.toThrow('cancelled');
+    expect(connection.channels).toHaveLength(1);
+  });
+  it('retains reusable close behavior for shared callers that never cancel', async () => {
+    const connection = new FakeConnection();
+    const channel = new AmqplibRabbitMqChannel({ url: 'amqp://synthetic', connect: async () => connection as unknown as ChannelModel });
+    await channel.publish('synthetic', 'synthetic', Buffer.from('{}'), options);
+    await channel.close();
+    await channel.publish('synthetic', 'synthetic', Buffer.from('{}'), options);
+    expect(connection.channels).toHaveLength(2);
+    expect(connection.channels[1]!.publish).toHaveBeenCalledTimes(1);
+  });
   it('reconnects after the broker connection emits an error', async () => {
     const first = new FakeConnection();
     const second = new FakeConnection();

--- a/libs/platform/queue/src/adapters/rabbitmq/amqplib-rabbitmq-channel.ts
+++ b/libs/platform/queue/src/adapters/rabbitmq/amqplib-rabbitmq-channel.ts
@@ -17,6 +17,8 @@ import type {
 export type AmqplibRabbitMqChannelOptions = {
   readonly url: string;
   readonly socketOptions?: SocketOptions;
+  /** Optional synchronous authority check immediately before handing bytes to amqplib. */
+  readonly beforePublish?: () => void;
   readonly connect?: (
     url: string,
     socketOptions?: SocketOptions,
@@ -27,6 +29,7 @@ export class AmqplibRabbitMqChannel implements RabbitMqQueueChannelPort {
   private connectionPromise: Promise<ChannelModel> | undefined;
   private channelPromise: Promise<ConfirmChannel> | undefined;
   private readonly returnedMessages: ReturnedRabbitMqMessage[] = [];
+  private publishesCancelled = false;
 
   constructor(private readonly options: AmqplibRabbitMqChannelOptions) {
     if (options.url.trim().length === 0) {
@@ -67,7 +70,25 @@ export class AmqplibRabbitMqChannel implements RabbitMqQueueChannelPort {
     content: Buffer,
     options: RabbitMqPublishOptions,
   ): Promise<boolean> {
-    return (await this.channel()).publish(exchange, routingKey, content, options);
+    this.assertPublishAllowed();
+    const channel = await this.channel();
+    // No await between this terminal guard and the wire-library call. A send
+    // already handed to amqplib cannot be recalled; its outcome remains uncertain.
+    this.assertPublishAllowed();
+    this.options.beforePublish?.();
+    this.assertPublishAllowed();
+    return channel.publish(exchange, routingKey, content, options);
+  }
+
+  /** Synchronously and permanently inhibits future sends, including pending
+   * connect/assert/channel creation continuations. close/reconnect never resets it.
+   * Does not claim to retract bytes already handed to the wire library. */
+  cancelPendingPublishes(): void {
+    this.publishesCancelled = true;
+  }
+
+  private assertPublishAllowed(): void {
+    if (this.publishesCancelled) throw new Error('RabbitMQ publishing cancelled');
   }
 
   async waitForConfirms(exchange: string, routingKey: string, messageId: string): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -290,6 +290,7 @@
     "check:summary-queue-drain-loop": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-queue-drain-loop-smoke.ts",
     "recover:reader-summary-ready-events": "ts-node -r tsconfig-paths/register scripts/recover-reader-summary-ready-events.ts",
     "check:reader-summary-ready-delivery-postgres": "node scripts/run-with-timeout.mjs --timeout-ms 120000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-reader-summary-ready-delivery-postgres.ts",
+    "check:reader-summary-ready-recovery-postgres": "node scripts/run-with-timeout.mjs --timeout-ms 120000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-reader-summary-ready-recovery-postgres.ts",
     "check:summary-ready-projection-handler": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-ready-projection-handler-smoke.ts",
     "check:summary-ready-event-drain-loop": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-ready-event-drain-loop-smoke.ts",
     "check:summary-worker-command": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-worker-command-smoke.ts",

--- a/package.json
+++ b/package.json
@@ -288,6 +288,7 @@
     "check:summary-job-polling-loop": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-job-polling-loop-smoke.ts",
     "check:auto-summary-scheduler-loop": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-auto-summary-scheduler-loop-smoke.ts",
     "check:summary-queue-drain-loop": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-queue-drain-loop-smoke.ts",
+    "recover:reader-summary-ready-events": "ts-node -r tsconfig-paths/register scripts/recover-reader-summary-ready-events.ts",
     "check:reader-summary-ready-delivery-postgres": "node scripts/run-with-timeout.mjs --timeout-ms 120000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-reader-summary-ready-delivery-postgres.ts",
     "check:summary-ready-projection-handler": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-ready-projection-handler-smoke.ts",
     "check:summary-ready-event-drain-loop": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-summary-ready-event-drain-loop-smoke.ts",

--- a/scripts/check-reader-summary-ready-recovery-postgres.ts
+++ b/scripts/check-reader-summary-ready-recovery-postgres.ts
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client as PgClient } from 'pg';
+import { CryptoIdGenerator, redactSensitiveResponseText } from '@social-monitor/shared-kernel';
+import { loadPrismaRuntimeClient } from '@social-monitor/platform-persistence/prisma-runtime-client';
+import { defaultPostgresRuntimePoolConfig, PostgresRuntimePoolRegistry, type PrismaPgRuntimeClientConstructor } from '@social-monitor/platform-persistence';
+import { RabbitMqEventPublisher } from '@social-monitor/platform-events/adapters/rabbitmq';
+import { InMemoryMetricsRecorder } from '@social-monitor/platform-metrics';
+import { WorkerRuntime } from '@social-monitor/platform-worker';
+import { PrismaDeliveryConnection } from '@social-monitor/delivery/adapters/persistence/prisma/prisma-delivery-connection';
+import { PrismaReaderSummaryReadyProjectionStore } from '@social-monitor/delivery/adapters/persistence/prisma/prisma-reader-summary-ready-projection.store';
+import { ProjectReaderSummaryReadyEventUseCase } from '@social-monitor/delivery/features/project-reader-summary-ready-event/project-reader-summary-ready-event.use-case';
+import { ProjectReaderSummaryReadyEventHandler } from '@social-monitor/delivery/interfaces/events/project-reader-summary-ready-event.handler';
+import { withReaderDeliveryPostgresFixture } from './lib/reader-summary-ready-delivery-postgres-fixture';
+import { seedRecoveryPostgres, protectRecoveryPostgres } from './lib/reader-summary-ready-recovery-postgres-fixture';
+import { readyRecoveryData } from './lib/reader-summary-ready-recovery-data';
+import { recoveryPersistence, type RecoveryDatabase } from './lib/reader-summary-ready-recovery-persistence';
+import { validateRecoveryEvidence } from './lib/reader-summary-ready-recovery-evidence';
+import { bytesSha256, canonicalSha256, type RecoveryManifest } from './lib/reader-summary-ready-recovery-manifest';
+import { createRecoveryEvidenceFilesystemTestHarness } from './lib/reader-summary-recovery-evidence-secure-file';
+import { recoveryReceipts } from './lib/reader-summary-ready-recovery-receipts';
+import { runReadyRecovery } from './lib/reader-summary-ready-recovery-run';
+
+export async function main(): Promise<void> {
+  assert.equal(process.env.NODE_ENV, 'test', 'Native recovery gate requires NODE_ENV=test');
+  // Secure receipt harness keeps all production filesystem guards; use a private
+  // TMPDIR under a non-writable-by-others ancestor, not the shared /tmp directory.
+  const directory = mkdtempSync(join(tmpdir(), 'reader-recovery-pg-'));
+  const files = createRecoveryEvidenceFilesystemTestHarness(directory);
+  try { await withReaderDeliveryPostgresFixture(async ({ runtimeUrl, database }) => {
+    const data = readyRecoveryData(4), { manifest, clock } = data;
+    await seedRecoveryPostgres(database, data.snapshots);
+    const protectedFixture = await protectRecoveryPostgres(database, runtimeUrl);
+    const close: (() => Promise<void>)[] = [protectedFixture.cleanup];
+    try {
+      const Client = loadPrismaRuntimeClient<PrismaPgRuntimeClientConstructor<RecoveryDatabase>>();
+      const config = defaultPostgresRuntimePoolConfig(protectedFixture.recoveryUrl, 'event-relay');
+      const first = await new PostgresRuntimePoolRegistry().acquire(config, Client); close.push(() => first.close());
+      const second = await new PostgresRuntimePoolRegistry().acquire(config, Client); close.push(() => second.close());
+      const persistence = recoveryPersistence(first.client, clock), peer = recoveryPersistence(second.client, clock);
+      const delivery = await PrismaDeliveryConnection.create(defaultPostgresRuntimePoolConfig(runtimeUrl, 'delivery-service'));
+      close.push(() => delivery.close());
+      const runtime = new WorkerRuntime({ serviceName: 'reader-recovery-postgres-fixture' }); runtime.onModuleInit();
+      close.push(() => runtime.onApplicationShutdown('fixture complete'));
+      const handler = new ProjectReaderSummaryReadyEventHandler(new ProjectReaderSummaryReadyEventUseCase(
+        new PrismaReaderSummaryReadyProjectionStore(delivery, new CryptoIdGenerator())), new InMemoryMetricsRecorder(), runtime);
+      const entry = manifest.events[0]!, race = manifest.events[1]!, failure = manifest.events[2]!, rest = manifest.events[3]!;
+      const immutable = async () => (await database.query(`SELECT
+        (SELECT jsonb_agg(to_jsonb(p) ORDER BY p.id) FROM reader_summary_publications p) AS publications,
+        (SELECT jsonb_agg(to_jsonb(e) ORDER BY e.publication_id) FROM reader_summary_weekly_publication_evidence e) AS evidence`)).rows[0];
+      const before = canonicalSha256(await immutable());
+      const systemRole = decodeURIComponent(new URL(runtimeUrl).username).replace(/_runtime$/, '_system');
+      await database.query('BEGIN');
+      try {
+        await database.query(`SET LOCAL ROLE "${systemRole}"; SELECT set_config('social_monitor.system_access','true',true)`);
+        await database.query("UPDATE reader_summary_artifacts SET status='SUPERSEDED' WHERE id=$1", [entry.readerSummaryId]);
+        await database.query('COMMIT');
+      } catch (error) { await database.query('ROLLBACK'); throw error; }
+      const [superseded] = await persistence.read([entry]);
+      assert.equal(superseded!.publication!.readerSummaryArtifact.status, 'SUPERSEDED');
+      assert.equal(await validateRecoveryEvidence(entry, superseded!), null);
+      await assert.rejects(database.query("UPDATE reader_summary_artifacts SET headline='tampered' WHERE id=$1", [entry.readerSummaryId]), /immutable/);
+      await assert.rejects(database.query("UPDATE reader_summary_publications SET exact_proof='{}' WHERE id=$1", [superseded!.publication!.id]), /immutable/);
+      await assert.rejects(database.query("DELETE FROM reader_summary_weekly_publication_evidence WHERE publication_id=$1", [superseded!.publication!.id]), /immutable/);
+
+      // Native microseconds survive a valid transition; a one-microsecond write
+      // invisible to JS Date invalidates xmin CAS and cannot be acknowledged.
+      await database.query("UPDATE outbox_events SET available_at='2026-09-04T00:00:00.000123Z' WHERE id=$1", [race.eventId]);
+      const [initial] = await persistence.read([race]);
+      const started = await persistence.transition(initial!.row, 'start');
+      assert.equal((await database.query("SELECT to_char(available_at,'US') AS micros FROM outbox_events WHERE id=$1", [race.eventId])).rows[0].micros, '000123');
+      await database.query("UPDATE outbox_events SET available_at=available_at+interval '1 microsecond' WHERE id=$1", [race.eventId]);
+      const [changed] = await persistence.read([race]);
+      assert.equal(changed!.row.availableAt.getTime(), started.availableAt.getTime());
+      assert.notEqual(changed!.row.rowVersion, started.rowVersion);
+      await assert.rejects(persistence.transition(started, 'published'), /outbox_concurrent_mutation/);
+      const races = await Promise.allSettled([persistence.transition(changed!.row, 'start'), peer.transition(changed!.row, 'start')]);
+      assert.equal(races.filter(r => r.status === 'fulfilled').length, 1);
+      assert.equal((await persistence.read([race]))[0]!.row.publishAttempts, 2);
+      await persistence.transition((await persistence.read([race]))[0]!.row, 'failed');
+
+      let sends = 0, cancelled = false, envelope: Record<string, unknown>;
+      const publisher = new RabbitMqEventPublisher({
+        assertExchange: async () => undefined, assertQueue: async () => undefined, bindQueue: async () => undefined,
+        publish: async (_exchange, _routing, bytes, options) => {
+          assert(!cancelled); assert.equal(options.mandatory, true); sends += 1;
+          envelope = JSON.parse(bytes.toString()) as Record<string, unknown>; return true;
+        },
+        // Broker outcome is synthetic; consumer inbox/projection is the actual
+        // parser, handler, use case and Prisma transaction on native PostgreSQL.
+        waitForConfirms: async () => { await handler.handle(envelope); },
+      }, { exchange: 'social-monitor.events', mandatory: true });
+      const run = (selected: RecoveryManifest) => {
+        const bytes = Buffer.from(JSON.stringify(selected));
+        return runReadyRecovery({ bytes, reviewedSha256: bytesSha256(bytes), deployedSha: selected.deployedSourceSha,
+          apply: true, clock, persistence, publisher, cancelPendingPublishes: () => { cancelled = true; },
+          receipts: (m, b) => recoveryReceipts(m, b, files), sleep: ms => new Promise(resolve => setTimeout(resolve, ms)) });
+      };
+      await run({ ...manifest, events: [entry] });
+      const [consumed] = await persistence.read([entry]);
+      assert.equal(consumed!.row.status, 'PUBLISHED');
+      assert.equal(consumed!.row.publishAttempts, 1);
+      assert.equal(await validateRecoveryEvidence(entry, consumed!), consumed!.inbox!.id);
+      assert.equal((await handler.handle(envelope!)).duplicate, true);
+      await assert.rejects(handler.handle({ ...envelope!, workspaceId: data.id(903),
+        payload: { ...(envelope!.payload as object), workspaceId: data.id(903) } }));
+      // Fresh registry/client proves retained evidence across a connection restart.
+      await second.close();
+      const restarted = await new PostgresRuntimePoolRegistry().acquire(config, Client); close.push(() => restarted.close());
+      const [retained] = await recoveryPersistence(restarted.client, clock).read([entry]);
+      assert.equal(await validateRecoveryEvidence(entry, retained!), consumed!.inbox!.id);
+      await assert.rejects(run({ ...manifest, events: [entry] }), /apply_precondition_failed/);
+      assert.equal(sends, 1);
+
+      await database.query(`CREATE FUNCTION recovery_fixture_fail_ack() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN
+        IF NEW.id::text=TG_ARGV[0] AND NEW.status='PUBLISHED' THEN RAISE EXCEPTION 'synthetic DB acknowledgement failure'; END IF;
+        RETURN NEW; END $$;
+        CREATE TRIGGER recovery_fixture_fail_ack BEFORE UPDATE ON outbox_events FOR EACH ROW
+        EXECUTE FUNCTION recovery_fixture_fail_ack('${failure.eventId}');`);
+      const failManifest = { ...manifest, operationId: data.id(601), events: [failure, rest] };
+      await assert.rejects(run(failManifest), /synthetic DB acknowledgement failure/);
+      assert.equal(sends, 2);
+      const receipt = JSON.parse(readFileSync(join(directory, 'reader-summary-ready-recovery', failManifest.operationId,
+        `${failure.eventId}.uncertain.json`), 'utf8')) as object;
+      assert.equal((receipt as { confirmed: boolean }).confirmed, true);
+      assert.equal((receipt as { acknowledged: boolean }).acknowledged, false);
+      const [uncertain, untouched] = await persistence.read([failure, rest]);
+      assert.equal(uncertain!.row.status, 'FAILED'); assert.equal(uncertain!.row.publishAttempts, 1);
+      assert(uncertain!.inbox); assert.equal(untouched!.row.publishAttempts, 0); assert.equal(untouched!.inbox, null);
+      await assert.rejects(run(failManifest), /apply_precondition_failed/);
+      await assert.rejects(run({ ...failManifest, operationId: data.id(602) }), /apply_precondition_failed/);
+      assert.equal(sends, 2); assert.equal(canonicalSha256(await immutable()), before);
+
+      const rls = new PgClient({ connectionString: runtimeUrl }); await rls.connect();
+      try {
+        const roles = (await rls.query('SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname=current_user')).rows[0];
+        assert.deepEqual(roles, { rolsuper: false, rolbypassrls: false });
+        await rls.query('BEGIN');
+        for (const [tenant, workspace, visible] of [[entry.tenantId, entry.workspaceId, true],
+          [entry.tenantId, data.id(901), false], [data.id(900), data.id(901), false]] as const) {
+          await rls.query("SELECT set_config('social_monitor.tenant_id',$1,true),set_config('social_monitor.workspace_id',$2,true),set_config('social_monitor.system_access','true',true)", [tenant, workspace]);
+          // Even a forged system setting cannot grant the delivery role capability.
+          for (const table of ['outbox_events', 'reader_summary_artifacts', 'reader_summary_jobs', 'reader_summary_publications',
+            'reader_summary_weekly_publication_evidence', 'realtime_events']) {
+            const rows = await rls.query(`SELECT tenant_id FROM "${table}" WHERE tenant_id=$1 AND workspace_id=$2`, [entry.tenantId, entry.workspaceId]);
+            assert.equal(rows.rows.length > 0, visible, `${table} scoped visibility`);
+          }
+          const inbox = await rls.query('SELECT id FROM inbox_records WHERE tenant_id=$1', [entry.tenantId]);
+          assert.equal(inbox.rows.length > 0, tenant === entry.tenantId, 'inbox uses the canonical tenant-only policy');
+        }
+      } finally { await rls.query('ROLLBACK'); await rls.end(); }
+      console.log('Reader recovery native PostgreSQL PASS: immutable supersession, microsecond xmin CAS, concurrent writers, durable consumer, confirm/DB uncertainty, no resend, RLS');
+    } finally {
+      await closeRecoveryFixture(close);
+    }
+  }); } finally { rmSync(directory, { recursive: true, force: true }); }
+}
+async function closeRecoveryFixture(close: (() => Promise<void>)[]): Promise<void> {
+  const errors: unknown[] = [];
+  for (const cleanup of close.reverse()) { try { await cleanup(); } catch (error) { errors.push(error); } }
+  if (errors.length) throw new AggregateError(errors, 'Recovery fixture cleanup failed');
+}
+if (require.main === module) void main().catch(error => {
+  console.error(redactSensitiveResponseText(error instanceof Error ? error.message : 'Reader recovery PostgreSQL fixture failed'));
+  process.exitCode = 1;
+});

--- a/scripts/lib/reader-summary-ready-recovery-cancellation.spec.ts
+++ b/scripts/lib/reader-summary-ready-recovery-cancellation.spec.ts
@@ -1,0 +1,66 @@
+import { EventEmitter } from 'node:events';
+import type { ChannelModel, ConfirmChannel } from 'amqplib';
+import { AmqplibRabbitMqChannel } from '@social-monitor/platform-queue/adapters/rabbitmq';
+import { RabbitMqEventPublisher } from '@social-monitor/platform-events/adapters/rabbitmq';
+import { readyRecoveryFixture } from './reader-summary-ready-recovery-fixture';
+import { runReadyRecovery } from './reader-summary-ready-recovery-run';
+import { assertRecoveryWindow, originalEnvelope } from './reader-summary-ready-recovery-manifest';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe('recovery terminal pre-wire cancellation', () => {
+  let f: ReturnType<typeof readyRecoveryFixture>;
+  beforeEach(() => { f = readyRecoveryFixture(2); jest.useFakeTimers(); });
+  afterEach(() => { f.cleanup(); jest.useRealTimers(); });
+  it.each(['connect', 'channel', 'assert', 'confirm', 'window'])('inhibits pending %s continuation after deadline, retains claims and never retries', async delay => {
+    const reached = deferred<void>(), release = deferred<void>();
+    const wait = async (phase: string) => { if ((delay === 'window' ? 'assert' : delay) === phase) { reached.resolve(); await release.promise; } };
+    if (delay === 'window') f.manifest.window.expiresAt = new Date(f.options().clock.now().getTime() + 500).toISOString();
+    const native = Object.assign(new EventEmitter(), {
+      assertExchange: async () => { await wait('assert'); }, close: async () => undefined,
+      publish: jest.fn(() => true), waitForConfirms: async () => { await wait('confirm'); },
+    });
+    const connection = Object.assign(new EventEmitter(), {
+      createConfirmChannel: async () => { await wait('channel'); return native as unknown as ConfirmChannel; }, close: async () => undefined,
+    });
+    const connect = jest.fn(async () => { await wait('connect'); return connection as unknown as ChannelModel; });
+    const channel = new AmqplibRabbitMqChannel({ url: 'amqp://synthetic', connect });
+    const options = { ...f.options(), publisher: new RabbitMqEventPublisher(channel, { exchange: 'social-monitor.events', mandatory: true }),
+      cancelPendingPublishes: () => channel.cancelPendingPublishes() };
+    const run = runReadyRecovery(options);
+    const failed = expect(run).rejects.toThrow('publish deadline');
+    await reached.promise;
+    await jest.advanceTimersByTimeAsync(delay === 'window' ? 500 : 15_000); await failed;
+    release.resolve(); await jest.advanceTimersByTimeAsync(0);
+    const sent = delay === 'confirm' ? 1 : 0;
+    expect(native.publish).toHaveBeenCalledTimes(sent);
+    if (sent) expect(native.publish.mock.calls[0]).toEqual(expect.arrayContaining([expect.objectContaining({ mandatory: true })]));
+    expect(JSON.parse(f.receipt(`${f.snapshots[0]!.row.id}.uncertain`))).toMatchObject({ publishing: true, confirmed: false, acknowledged: false });
+    expect(f.snapshots[1]!.row.publishAttempts).toBe(0);
+    await expect(runReadyRecovery(options)).rejects.toThrow('apply_precondition_failed');
+    await channel.close();
+    await expect(options.publisher.publish(originalEnvelope(f.snapshots[0]!.row))).rejects.toThrow();
+    expect(native.publish).toHaveBeenCalledTimes(sent); expect(connect).toHaveBeenCalledTimes(1);
+  });
+  it('checks the exclusive window immediately before the wire call after delayed assertion', async () => {
+    const clock = { now: () => new Date(f.manifest.window.startedAt) };
+    let current = clock.now(); clock.now = () => current;
+    const native = Object.assign(new EventEmitter(), {
+      assertExchange: async () => { current = new Date(f.manifest.window.expiresAt); },
+      publish: jest.fn(() => true), waitForConfirms: async () => undefined, close: async () => undefined,
+    });
+    const connection = Object.assign(new EventEmitter(), {
+      createConfirmChannel: async () => native as unknown as ConfirmChannel, close: async () => undefined,
+    });
+    const channel = new AmqplibRabbitMqChannel({ url: 'amqp://synthetic', connect: async () => connection as unknown as ChannelModel,
+      beforePublish: () => assertRecoveryWindow(f.manifest, f.manifest.deployedSourceSha, clock.now()) });
+    await expect(runReadyRecovery({ ...f.options(), clock,
+      publisher: new RabbitMqEventPublisher(channel, { exchange: 'social-monitor.events' }),
+      cancelPendingPublishes: () => channel.cancelPendingPublishes() })).rejects.toThrow('operation_window_closed');
+    expect(native.publish).not.toHaveBeenCalled(); await channel.close();
+  });
+});

--- a/scripts/lib/reader-summary-ready-recovery-data.ts
+++ b/scripts/lib/reader-summary-ready-recovery-data.ts
@@ -1,0 +1,44 @@
+import { FixedClock } from '@social-monitor/shared-kernel';
+import { readerSummaryReadyFixture } from '@social-monitor/delivery/test-support/reader-summary-ready.fixture';
+import { canonicalSha256, type originalEnvelope, type RecoveryEntry, type RecoveryManifest } from './reader-summary-ready-recovery-manifest';
+import type { RecoverySnapshot } from './reader-summary-ready-recovery-evidence';
+
+// Synthetic publication data shared by focused unit tests and the native PG gate.
+export function readyRecoveryData(count = 1) {
+  const clock = new FixedClock(new Date('2026-09-05T01:00:00.000Z'));
+  const id = (n: number) => `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`;
+  const snapshots: RecoverySnapshot[] = Array.from({ length: count }, (_, index) => {
+    const event = JSON.parse(JSON.stringify(readerSummaryReadyFixture())) as ReturnType<typeof originalEnvelope>;
+    const payload = { ...event.payload, readerSummaryId: id(100 + index), readerSummaryJobId: id(200 + index),
+      userId: 'synthetic-user', subscriptionId: id(300 + index) };
+    const scope = { tenantId: event.tenantId!, workspaceId: event.workspaceId!, scopeType: 'workspace', scopeKey: 'workspace',
+      cadence: 'daily', periodStartedAt: new Date('2026-09-03T00:00:00.000Z'), periodEndedAt: new Date('2026-09-04T00:00:00.000Z'),
+      periodTimezone: 'UTC', periodKey: readerSummaryReadyFixture().payload.period.periodKey };
+    const artifact = { ...scope, id: payload.readerSummaryId, status: 'COMPLETED', modelVersion: 'synthetic', promptVersion: 'fixture',
+      headline: 'Synthetic report', summaryText: 'Synthetic summary', artifactPayload: { fixture: true }, citations: [], qualitySignals: {} };
+    const report = { schemaVersion: 'reader_summary.publication_report.v1', semanticStatus: 'COMPLETED',
+      modelVersion: artifact.modelVersion, promptVersion: artifact.promptVersion, headline: artifact.headline,
+      summaryText: artifact.summaryText, artifactPayload: artifact.artifactPayload, citations: [], qualitySignals: {} };
+    const proof = { schemaVersion: 'reader_summary.publication_proof.v1', reportSha256: canonicalSha256(report), tenantId: scope.tenantId, workspaceId: scope.workspaceId,
+      readerSummaryJobId: payload.readerSummaryJobId, readerSummaryArtifactId: payload.readerSummaryId,
+      semanticStatus: 'COMPLETED', period: event.payload.period };
+    return { row: { id: id(400 + index), tenantId: scope.tenantId, workspaceId: scope.workspaceId, messageKind: 'EVENT', eventType: 'reader_summary.ready', schemaVersion: 1,
+      payload, status: 'FAILED', correlationId: payload.readerSummaryJobId, causationId: payload.readerSummaryJobId,
+      createdAt: new Date(event.occurredAt), availableAt: new Date(event.occurredAt), publishedAt: null, publishAttempts: 0,
+      lastError: 'NO_ROUTE access_token=fixture-secret\n' + 'x'.repeat(600), leaseOwner: null, leasedUntil: null, rowVersion: 'initial' },
+    publication: { ...scope, id: id(500 + index), outboxEventId: id(400 + index), readerSummaryArtifactId: payload.readerSummaryId,
+      readerSummaryJobId: payload.readerSummaryJobId, semanticStatus: 'COMPLETED', publishedAt: new Date(event.occurredAt),
+      reportSha256: canonicalSha256(report), proofSha256: canonicalSha256(proof), exactProof: proof,
+      readerSummaryArtifact: artifact, readerSummaryJob: { ...scope, id: payload.readerSummaryJobId,
+        readerSummaryArtifactId: payload.readerSummaryId, status: 'COMPLETED' } }, inbox: null, projections: [] };
+  });
+  const entries: RecoveryEntry[] = snapshots.map(({ row, publication: p }) => ({ eventId: row.id, tenantId: row.tenantId!,
+    workspaceId: row.workspaceId!, createdAt: row.createdAt.toISOString(), correlationId: row.correlationId, causationId: row.causationId,
+    readerSummaryId: p!.readerSummaryArtifactId, readerSummaryJobId: p!.readerSummaryJobId!, messageKind: 'EVENT',
+    eventType: 'reader_summary.ready', schemaVersion: 1, expectedStatus: 'FAILED', payloadSha256: canonicalSha256(row.payload),
+    reportSha256: p!.reportSha256, proofSha256: p!.proofSha256 }));
+  const manifest: RecoveryManifest = { operationId: id(600), deployedSourceSha: 'a'.repeat(40),
+    window: { startedAt: '2026-09-05T00:59:00.000Z', expiresAt: '2026-09-05T01:59:00.000Z' },
+    preconditions: { relayQuiesced: true, exclusiveOperation: true, consumerReady: true, bindingsVerified: true, retentionHeld: true }, events: entries };
+  return { clock, id, snapshots, manifest };
+}

--- a/scripts/lib/reader-summary-ready-recovery-evidence.spec.ts
+++ b/scripts/lib/reader-summary-ready-recovery-evidence.spec.ts
@@ -1,0 +1,43 @@
+import { readyRecoveryFixture } from './reader-summary-ready-recovery-fixture';
+import { canonicalSha256 } from './reader-summary-ready-recovery-manifest';
+import { validateRecoveryEvidence } from './reader-summary-ready-recovery-evidence';
+
+describe('historical recovery publication lifecycle', () => {
+  let f: ReturnType<typeof readyRecoveryFixture>;
+  beforeEach(() => { f = readyRecoveryFixture(); });
+  afterEach(() => f.cleanup());
+  it.each(['COMPLETED', 'NO_SIGNAL'])('accepts superseded immutable %s without rewriting semantic status', async status => {
+    const s = f.snapshots[0]!, p = s.publication!, a = p.readerSummaryArtifact;
+    a.status = 'SUPERSEDED';
+    p.semanticStatus = status; p.readerSummaryJob!.status = status;
+    s.row = { ...s.row, payload: { ...(s.row.payload as object), status: status.toLowerCase() } };
+    p.reportSha256 = canonicalSha256({ schemaVersion: 'reader_summary.publication_report.v1', semanticStatus: status,
+      modelVersion: a.modelVersion, promptVersion: a.promptVersion, headline: a.headline, summaryText: a.summaryText,
+      artifactPayload: a.artifactPayload, citations: a.citations, qualitySignals: a.qualitySignals });
+    p.exactProof = { ...(p.exactProof as object), semanticStatus: status, reportSha256: p.reportSha256 };
+    p.proofSha256 = canonicalSha256(p.exactProof);
+    Object.assign(f.manifest.events[0]!, { reportSha256: p.reportSha256, proofSha256: p.proofSha256, payloadSha256: canonicalSha256(s.row.payload) });
+    const immutable = canonicalSha256(p);
+    await expect(f.run()).resolves.toMatchObject({ consumed: 1 });
+    expect(canonicalSha256(p)).toBe(immutable);
+    expect(p.semanticStatus).toBe(status);
+  });
+  it.each(['FAILED', 'PENDING', 'QUALITY_REJECTED', 'NO_SIGNAL'])('rejects incompatible artifact lifecycle %s', async status => {
+    f.snapshots[0]!.publication!.readerSummaryArtifact.status = status;
+    await expect(validateRecoveryEvidence(f.manifest.events[0]!, f.snapshots[0]!)).rejects.toThrow('publication_links_mismatch');
+  });
+  it.each(['report', 'proof', 'job-status', 'job-id', 'artifact-id', 'tenant', 'workspace', 'period'])('still rejects superseded %s mutation', async mutation => {
+    const p = f.snapshots[0]!.publication!;
+    p.readerSummaryArtifact.status = 'SUPERSEDED';
+    if (mutation === 'report') p.readerSummaryArtifact.headline = 'Changed content';
+    if (mutation === 'proof') p.exactProof = { ...(p.exactProof as object), changed: true };
+    if (mutation === 'job-status') p.readerSummaryJob!.status = 'SUPERSEDED';
+    if (mutation === 'job-id') p.readerSummaryJob!.id = 'foreign';
+    if (mutation === 'artifact-id') p.readerSummaryArtifact.id = 'foreign';
+    if (mutation === 'tenant') p.readerSummaryArtifact.tenantId = 'foreign';
+    if (mutation === 'workspace') p.readerSummaryArtifact.workspaceId = 'foreign';
+    if (mutation === 'period') p.readerSummaryArtifact.periodKey = 'foreign';
+    await expect(f.run()).rejects.toThrow();
+    expect(f.channel.publish).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/lib/reader-summary-ready-recovery-evidence.ts
+++ b/scripts/lib/reader-summary-ready-recovery-evidence.ts
@@ -37,14 +37,18 @@ export async function validateRecoveryEvidence(entry: RecoveryEntry, snapshot: R
     p.proofSha256 === entry.proofSha256 && canonicalSha256(p.exactProof) === entry.proofSha256 &&
     p.semanticStatus.toLowerCase() === payload.status && p.publishedAt.getTime() === row.createdAt.getTime(), 'publication_mismatch');
   const proof = p.exactProof as Record<string, unknown>;
-  requireRecovery(proof.tenantId === entry.tenantId && proof.workspaceId === entry.workspaceId &&
+  requireRecovery(proof.schemaVersion === 'reader_summary.publication_proof.v1' &&
+    proof.tenantId === entry.tenantId && proof.workspaceId === entry.workspaceId &&
     proof.readerSummaryJobId === entry.readerSummaryJobId && proof.readerSummaryArtifactId === entry.readerSummaryId &&
     proof.reportSha256 === entry.reportSha256 && proof.semanticStatus === p.semanticStatus &&
     canonicalSha256(proof.period) === canonicalSha256(payload.period), 'publication_proof_binding_mismatch');
   const a = p.readerSummaryArtifact;
   const j = p.readerSummaryJob;
+  // Supersession changes artifact visibility only. The original semantic job,
+  // publication, report and proof remain bound to this exact historical event.
   requireRecovery(j !== null && j.id === entry.readerSummaryJobId && j.readerSummaryArtifactId === entry.readerSummaryId &&
-    a.id === entry.readerSummaryId && a.status === p.semanticStatus && j.status === p.semanticStatus, 'publication_links_mismatch');
+    a.id === entry.readerSummaryId && (a.status === p.semanticStatus || a.status === 'SUPERSEDED') &&
+    j.status === p.semanticStatus, 'publication_links_mismatch');
   for (const scoped of [p, a, j]) {
     requireRecovery(scoped.tenantId === entry.tenantId && scoped.workspaceId === entry.workspaceId &&
       scoped.scopeType === payload.scope.type && scoped.scopeKey === (payload.scope.type === 'workspace' ? 'workspace' : `interest:${payload.scope.interestId}`) &&

--- a/scripts/lib/reader-summary-ready-recovery-evidence.ts
+++ b/scripts/lib/reader-summary-ready-recovery-evidence.ts
@@ -1,0 +1,81 @@
+import { redactSensitiveResponseText } from '@social-monitor/shared-kernel';
+import type { PrismaInboxRecord } from '@social-monitor/platform-events/adapters/prisma/prisma-event-store-client';
+import { parseReaderSummaryReadyEvent } from '@social-monitor/delivery/interfaces/events/reader-summary-ready-event.parser';
+import { ProjectReaderSummaryReadyEventUseCase } from '@social-monitor/delivery/features/project-reader-summary-ready-event/project-reader-summary-ready-event.use-case';
+import { assertSameReaderSummaryProjection } from '@social-monitor/delivery/adapters/persistence/reader-summary-projection-identity';
+import { realtimeEventFromPrisma, type PrismaRealtimeEventRecord } from '@social-monitor/delivery/adapters/persistence/prisma/prisma-delivery-records';
+import { encodeRealtimeReplayCursor } from '@social-monitor/delivery/domain';
+import { READER_SUMMARY_READY_CONSUMER } from '@social-monitor/delivery/application/contracts/reader-summary-ready-projection-store';
+import { canonicalSha256, originalEnvelope, requireRecovery, type RecoveryEntry, type RecoveryRow } from './reader-summary-ready-recovery-manifest';
+
+type PublicationScope = {
+  tenantId: string; workspaceId: string; scopeType: string; scopeKey: string; cadence: string;
+  periodStartedAt: Date; periodEndedAt: Date; periodTimezone: string; periodKey: string;
+};
+export type RecoveryPublication = PublicationScope & {
+  id: string; outboxEventId: string | null; readerSummaryArtifactId: string; readerSummaryJobId: string | null;
+  semanticStatus: string; publishedAt: Date; reportSha256: string; proofSha256: string; exactProof: unknown;
+  readerSummaryJob: (PublicationScope & { id: string; readerSummaryArtifactId: string | null; status: string }) | null;
+  readerSummaryArtifact: PublicationScope & { id: string; status: string; modelVersion: string; promptVersion: string;
+    headline: string; summaryText: string | null; artifactPayload: unknown; citations: unknown; qualitySignals: unknown };
+};
+export type RecoverySnapshot = { row: RecoveryRow; publication: RecoveryPublication | null;
+  inbox: PrismaInboxRecord | null; projections: readonly PrismaRealtimeEventRecord[] };
+
+export async function validateRecoveryEvidence(entry: RecoveryEntry, snapshot: RecoverySnapshot): Promise<string | null> {
+  const { row, publication: p, inbox, projections } = snapshot;
+  requireRecovery(row.id === entry.eventId && row.tenantId === entry.tenantId && row.workspaceId === entry.workspaceId &&
+    row.messageKind === entry.messageKind && row.eventType === entry.eventType && row.schemaVersion === entry.schemaVersion &&
+    row.createdAt.toISOString() === entry.createdAt && row.correlationId === entry.correlationId &&
+    row.causationId === entry.causationId && canonicalSha256(row.payload) === entry.payloadSha256, 'outbox_identity_mismatch');
+  const event = parseReaderSummaryReadyEvent(originalEnvelope(row));
+  const payload = event.payload;
+  requireRecovery(payload.readerSummaryId === entry.readerSummaryId && payload.readerSummaryJobId === entry.readerSummaryJobId,
+    'reader_identity_mismatch');
+  requireRecovery(p !== null && p.outboxEventId === row.id && p.readerSummaryArtifactId === entry.readerSummaryId &&
+    p.readerSummaryJobId === entry.readerSummaryJobId && p.reportSha256 === entry.reportSha256 &&
+    p.proofSha256 === entry.proofSha256 && canonicalSha256(p.exactProof) === entry.proofSha256 &&
+    p.semanticStatus.toLowerCase() === payload.status && p.publishedAt.getTime() === row.createdAt.getTime(), 'publication_mismatch');
+  const proof = p.exactProof as Record<string, unknown>;
+  requireRecovery(proof.tenantId === entry.tenantId && proof.workspaceId === entry.workspaceId &&
+    proof.readerSummaryJobId === entry.readerSummaryJobId && proof.readerSummaryArtifactId === entry.readerSummaryId &&
+    proof.reportSha256 === entry.reportSha256 && proof.semanticStatus === p.semanticStatus &&
+    canonicalSha256(proof.period) === canonicalSha256(payload.period), 'publication_proof_binding_mismatch');
+  const a = p.readerSummaryArtifact;
+  const j = p.readerSummaryJob;
+  requireRecovery(j !== null && j.id === entry.readerSummaryJobId && j.readerSummaryArtifactId === entry.readerSummaryId &&
+    a.id === entry.readerSummaryId && a.status === p.semanticStatus && j.status === p.semanticStatus, 'publication_links_mismatch');
+  for (const scoped of [p, a, j]) {
+    requireRecovery(scoped.tenantId === entry.tenantId && scoped.workspaceId === entry.workspaceId &&
+      scoped.scopeType === payload.scope.type && scoped.scopeKey === (payload.scope.type === 'workspace' ? 'workspace' : `interest:${payload.scope.interestId}`) &&
+      scoped.cadence === payload.period.cadence && scoped.periodStartedAt.getTime() === payload.period.startedAt.getTime() &&
+      scoped.periodEndedAt.getTime() === payload.period.endedAt.getTime() && scoped.periodTimezone === payload.period.timezone &&
+      scoped.periodKey === payload.period.periodKey, 'publication_scope_mismatch');
+  }
+  requireRecovery(canonicalSha256({ schemaVersion: 'reader_summary.publication_report.v1', semanticStatus: p.semanticStatus,
+    modelVersion: a.modelVersion, promptVersion: a.promptVersion, headline: a.headline, summaryText: a.summaryText,
+    artifactPayload: a.artifactPayload, citations: a.citations, qualitySignals: a.qualitySignals }) === entry.reportSha256,
+  'publication_report_mismatch');
+  if (inbox === null) { requireRecovery(projections.length === 0, 'orphan_projection'); return null; }
+  requireRecovery(inbox.consumerName === READER_SUMMARY_READY_CONSUMER && inbox.eventId === entry.eventId &&
+    inbox.tenantId === entry.tenantId && inbox.schemaVersion === 1 && projections.length === 1 &&
+    projections[0]?.id === inbox.id, 'retained_inbox_mismatch');
+  const existing = realtimeEventFromPrisma(projections[0]).toSnapshot();
+  requireRecovery(existing.replayCursor === encodeRealtimeReplayCursor(existing.sequence), 'retained_cursor_mismatch');
+  // Reuse the consumer's projection construction without invoking its write store.
+  const result = await new ProjectReaderSummaryReadyEventUseCase({ project: async incoming => {
+    assertSameReaderSummaryProjection(existing, incoming);
+    return { realtimeEventId: existing.id, channel: existing.channel, sequence: existing.sequence, duplicate: true };
+  } }).execute({ event });
+  requireRecovery(result.ok, 'retained_projection_mismatch');
+  return inbox.id;
+}
+export function recoveryBefore(snapshot: RecoverySnapshot, entry: RecoveryEntry): object {
+  const { payload: _payload, lastError, ...metadata } = snapshot.row;
+  void _payload;
+  return { ...metadata, payloadSha256: entry.payloadSha256, reportSha256: entry.reportSha256, proofSha256: entry.proofSha256,
+    lastError: lastError === null ? null : redactSensitiveResponseText(lastError).replace(/[\r\n\t]/g, ' '),
+    historicalAttempts: 'unknown', inbox: snapshot.inbox,
+    projections: snapshot.projections.map(p => ({ id: p.id, sequence: p.sequence, replayCursor: p.replayCursor,
+      identitySha256: canonicalSha256(p) })) };
+}

--- a/scripts/lib/reader-summary-ready-recovery-fixture.ts
+++ b/scripts/lib/reader-summary-ready-recovery-fixture.ts
@@ -1,16 +1,14 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { FixedClock } from '@social-monitor/shared-kernel';
-import { readerSummaryReadyFixture } from '@social-monitor/delivery/test-support/reader-summary-ready.fixture';
 import { ProjectReaderSummaryReadyEventUseCase } from '@social-monitor/delivery/features/project-reader-summary-ready-event/project-reader-summary-ready-event.use-case';
 import { parseReaderSummaryReadyEvent } from '@social-monitor/delivery/interfaces/events/reader-summary-ready-event.parser';
 import { encodeRealtimeReplayCursor } from '@social-monitor/delivery/domain';
 import { READER_SUMMARY_READY_CONSUMER } from '@social-monitor/delivery/application/contracts/reader-summary-ready-projection-store';
 import { RabbitMqEventPublisher } from '@social-monitor/platform-events/adapters/rabbitmq';
-import { canonicalSha256, bytesSha256, originalEnvelope, type RecoveryEntry, type RecoveryManifest } from './reader-summary-ready-recovery-manifest';
+import { canonicalSha256, bytesSha256, originalEnvelope, type RecoveryManifest } from './reader-summary-ready-recovery-manifest';
 import { recoveryPersistence, type RecoveryDatabase } from './reader-summary-ready-recovery-persistence';
-import type { RecoverySnapshot } from './reader-summary-ready-recovery-evidence';
+import { readyRecoveryData } from './reader-summary-ready-recovery-data';
 import { createRecoveryEvidenceFilesystemTestHarness } from './reader-summary-recovery-evidence-secure-file';
 import { recoveryReceipts } from './reader-summary-ready-recovery-receipts';
 import { runReadyRecovery } from './reader-summary-ready-recovery-run';
@@ -18,41 +16,7 @@ import { runReadyRecovery } from './reader-summary-ready-recovery-run';
 export function readyRecoveryFixture(count = 1) {
   const directory = mkdtempSync(join(tmpdir(), 'reader-ready-recovery-'));
   const files = createRecoveryEvidenceFilesystemTestHarness(directory);
-  const clock = new FixedClock(new Date('2026-09-05T01:00:00.000Z'));
-  const id = (n: number) => `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`;
-  const snapshots: RecoverySnapshot[] = Array.from({ length: count }, (_, index) => {
-    const event = JSON.parse(JSON.stringify(readerSummaryReadyFixture())) as ReturnType<typeof originalEnvelope>;
-    const payload = { ...event.payload, readerSummaryId: id(100 + index), readerSummaryJobId: id(200 + index),
-      userId: 'synthetic-user', subscriptionId: id(300 + index) };
-    const scope = { tenantId: event.tenantId!, workspaceId: event.workspaceId!, scopeType: 'workspace', scopeKey: 'workspace',
-      cadence: 'daily', periodStartedAt: new Date('2026-09-03T00:00:00.000Z'), periodEndedAt: new Date('2026-09-04T00:00:00.000Z'),
-      periodTimezone: 'UTC', periodKey: readerSummaryReadyFixture().payload.period.periodKey };
-    const artifact = { ...scope, id: payload.readerSummaryId, status: 'COMPLETED', modelVersion: 'synthetic', promptVersion: 'fixture',
-      headline: 'Synthetic report', summaryText: 'Synthetic summary', artifactPayload: { fixture: true }, citations: [], qualitySignals: {} };
-    const report = { schemaVersion: 'reader_summary.publication_report.v1', semanticStatus: 'COMPLETED',
-      modelVersion: artifact.modelVersion, promptVersion: artifact.promptVersion, headline: artifact.headline,
-      summaryText: artifact.summaryText, artifactPayload: artifact.artifactPayload, citations: [], qualitySignals: {} };
-    const proof = { reportSha256: canonicalSha256(report), tenantId: scope.tenantId, workspaceId: scope.workspaceId,
-      readerSummaryJobId: payload.readerSummaryJobId, readerSummaryArtifactId: payload.readerSummaryId,
-      semanticStatus: 'COMPLETED', period: event.payload.period };
-    return { row: { id: id(400 + index), tenantId: scope.tenantId, workspaceId: scope.workspaceId, messageKind: 'EVENT', eventType: 'reader_summary.ready', schemaVersion: 1,
-      payload, status: 'FAILED', correlationId: payload.readerSummaryJobId, causationId: payload.readerSummaryJobId,
-      createdAt: new Date(event.occurredAt), availableAt: new Date(event.occurredAt), publishedAt: null, publishAttempts: 0,
-      lastError: 'NO_ROUTE access_token=fixture-secret\n' + 'x'.repeat(600), leaseOwner: null, leasedUntil: null, rowVersion: 'initial' },
-    publication: { ...scope, id: id(500 + index), outboxEventId: id(400 + index), readerSummaryArtifactId: payload.readerSummaryId,
-      readerSummaryJobId: payload.readerSummaryJobId, semanticStatus: 'COMPLETED', publishedAt: new Date(event.occurredAt),
-      reportSha256: canonicalSha256(report), proofSha256: canonicalSha256(proof), exactProof: proof,
-      readerSummaryArtifact: artifact, readerSummaryJob: { ...scope, id: payload.readerSummaryJobId,
-        readerSummaryArtifactId: payload.readerSummaryId, status: 'COMPLETED' } }, inbox: null, projections: [] };
-  });
-  const entries: RecoveryEntry[] = snapshots.map(({ row, publication: p }) => ({ eventId: row.id, tenantId: row.tenantId!,
-    workspaceId: row.workspaceId!, createdAt: row.createdAt.toISOString(), correlationId: row.correlationId, causationId: row.causationId,
-    readerSummaryId: p!.readerSummaryArtifactId, readerSummaryJobId: p!.readerSummaryJobId!, messageKind: 'EVENT',
-    eventType: 'reader_summary.ready', schemaVersion: 1, expectedStatus: 'FAILED', payloadSha256: canonicalSha256(row.payload),
-    reportSha256: p!.reportSha256, proofSha256: p!.proofSha256 }));
-  const manifest: RecoveryManifest = { operationId: id(600), deployedSourceSha: 'a'.repeat(40),
-    window: { startedAt: '2026-09-05T00:59:00.000Z', expiresAt: '2026-09-05T01:59:00.000Z' },
-    preconditions: { relayQuiesced: true, exclusiveOperation: true, consumerReady: true, bindingsVerified: true, retentionHeld: true }, events: entries };
+  const { clock, id, snapshots, manifest } = readyRecoveryData(count);
   const db: RecoveryDatabase = {
     $disconnect: async () => undefined, $transaction: async work => work(db),
     $queryRawUnsafe: async <T>(_sql: string, ...values: readonly unknown[]): Promise<T> => {
@@ -87,12 +51,15 @@ export function readyRecoveryFixture(count = 1) {
     } }).execute({ event: parseReaderSummaryReadyEvent(originalEnvelope(s.row)) });
     if (!result.ok) throw result.error;
   };
+  let cancelled = false;
+  const cancelPendingPublishes = () => { cancelled = true; };
   const channel = { assertExchange: jest.fn(async () => undefined), assertQueue: jest.fn(), bindQueue: jest.fn(),
-    publish: jest.fn(async () => true), waitForConfirms: jest.fn(async () => { await consume(); }) };
+    publish: jest.fn(async () => { if (cancelled) throw new Error('Publishing cancelled'); return true; }),
+    waitForConfirms: jest.fn(async () => { await consume(); }) };
   const persistence = recoveryPersistence(db, clock);
   const options = () => { const bytes = Buffer.from(JSON.stringify(manifest)); return { bytes, reviewedSha256: bytesSha256(bytes),
     deployedSha: manifest.deployedSourceSha, apply: true, clock, persistence,
-    publisher: new RabbitMqEventPublisher(channel, { exchange: 'social-monitor.events' }), sleep: async () => undefined,
+    publisher: new RabbitMqEventPublisher(channel, { exchange: 'social-monitor.events' }), cancelPendingPublishes, sleep: async () => undefined,
     receipts: (m: RecoveryManifest, b: Buffer) => recoveryReceipts(m, b, files) }; };
   return { directory, manifest, snapshots, db, persistence, channel, consume, options,
     run: (apply = true) => runReadyRecovery({ ...options(), apply }),

--- a/scripts/lib/reader-summary-ready-recovery-fixture.ts
+++ b/scripts/lib/reader-summary-ready-recovery-fixture.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FixedClock } from '@social-monitor/shared-kernel';
+import { readerSummaryReadyFixture } from '@social-monitor/delivery/test-support/reader-summary-ready.fixture';
+import { ProjectReaderSummaryReadyEventUseCase } from '@social-monitor/delivery/features/project-reader-summary-ready-event/project-reader-summary-ready-event.use-case';
+import { parseReaderSummaryReadyEvent } from '@social-monitor/delivery/interfaces/events/reader-summary-ready-event.parser';
+import { encodeRealtimeReplayCursor } from '@social-monitor/delivery/domain';
+import { READER_SUMMARY_READY_CONSUMER } from '@social-monitor/delivery/application/contracts/reader-summary-ready-projection-store';
+import { RabbitMqEventPublisher } from '@social-monitor/platform-events/adapters/rabbitmq';
+import { canonicalSha256, bytesSha256, originalEnvelope, type RecoveryEntry, type RecoveryManifest } from './reader-summary-ready-recovery-manifest';
+import { recoveryPersistence, type RecoveryDatabase } from './reader-summary-ready-recovery-persistence';
+import type { RecoverySnapshot } from './reader-summary-ready-recovery-evidence';
+import { createRecoveryEvidenceFilesystemTestHarness } from './reader-summary-recovery-evidence-secure-file';
+import { recoveryReceipts } from './reader-summary-ready-recovery-receipts';
+import { runReadyRecovery } from './reader-summary-ready-recovery-run';
+
+export function readyRecoveryFixture(count = 1) {
+  const directory = mkdtempSync(join(tmpdir(), 'reader-ready-recovery-'));
+  const files = createRecoveryEvidenceFilesystemTestHarness(directory);
+  const clock = new FixedClock(new Date('2026-09-05T01:00:00.000Z'));
+  const id = (n: number) => `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`;
+  const snapshots: RecoverySnapshot[] = Array.from({ length: count }, (_, index) => {
+    const event = JSON.parse(JSON.stringify(readerSummaryReadyFixture())) as ReturnType<typeof originalEnvelope>;
+    const payload = { ...event.payload, readerSummaryId: id(100 + index), readerSummaryJobId: id(200 + index),
+      userId: 'synthetic-user', subscriptionId: id(300 + index) };
+    const scope = { tenantId: event.tenantId!, workspaceId: event.workspaceId!, scopeType: 'workspace', scopeKey: 'workspace',
+      cadence: 'daily', periodStartedAt: new Date('2026-09-03T00:00:00.000Z'), periodEndedAt: new Date('2026-09-04T00:00:00.000Z'),
+      periodTimezone: 'UTC', periodKey: readerSummaryReadyFixture().payload.period.periodKey };
+    const artifact = { ...scope, id: payload.readerSummaryId, status: 'COMPLETED', modelVersion: 'synthetic', promptVersion: 'fixture',
+      headline: 'Synthetic report', summaryText: 'Synthetic summary', artifactPayload: { fixture: true }, citations: [], qualitySignals: {} };
+    const report = { schemaVersion: 'reader_summary.publication_report.v1', semanticStatus: 'COMPLETED',
+      modelVersion: artifact.modelVersion, promptVersion: artifact.promptVersion, headline: artifact.headline,
+      summaryText: artifact.summaryText, artifactPayload: artifact.artifactPayload, citations: [], qualitySignals: {} };
+    const proof = { reportSha256: canonicalSha256(report), tenantId: scope.tenantId, workspaceId: scope.workspaceId,
+      readerSummaryJobId: payload.readerSummaryJobId, readerSummaryArtifactId: payload.readerSummaryId,
+      semanticStatus: 'COMPLETED', period: event.payload.period };
+    return { row: { id: id(400 + index), tenantId: scope.tenantId, workspaceId: scope.workspaceId, messageKind: 'EVENT', eventType: 'reader_summary.ready', schemaVersion: 1,
+      payload, status: 'FAILED', correlationId: payload.readerSummaryJobId, causationId: payload.readerSummaryJobId,
+      createdAt: new Date(event.occurredAt), availableAt: new Date(event.occurredAt), publishedAt: null, publishAttempts: 0,
+      lastError: 'NO_ROUTE access_token=fixture-secret\n' + 'x'.repeat(600), leaseOwner: null, leasedUntil: null, rowVersion: 'initial' },
+    publication: { ...scope, id: id(500 + index), outboxEventId: id(400 + index), readerSummaryArtifactId: payload.readerSummaryId,
+      readerSummaryJobId: payload.readerSummaryJobId, semanticStatus: 'COMPLETED', publishedAt: new Date(event.occurredAt),
+      reportSha256: canonicalSha256(report), proofSha256: canonicalSha256(proof), exactProof: proof,
+      readerSummaryArtifact: artifact, readerSummaryJob: { ...scope, id: payload.readerSummaryJobId,
+        readerSummaryArtifactId: payload.readerSummaryId, status: 'COMPLETED' } }, inbox: null, projections: [] };
+  });
+  const entries: RecoveryEntry[] = snapshots.map(({ row, publication: p }) => ({ eventId: row.id, tenantId: row.tenantId!,
+    workspaceId: row.workspaceId!, createdAt: row.createdAt.toISOString(), correlationId: row.correlationId, causationId: row.causationId,
+    readerSummaryId: p!.readerSummaryArtifactId, readerSummaryJobId: p!.readerSummaryJobId!, messageKind: 'EVENT',
+    eventType: 'reader_summary.ready', schemaVersion: 1, expectedStatus: 'FAILED', payloadSha256: canonicalSha256(row.payload),
+    reportSha256: p!.reportSha256, proofSha256: p!.proofSha256 }));
+  const manifest: RecoveryManifest = { operationId: id(600), deployedSourceSha: 'a'.repeat(40),
+    window: { startedAt: '2026-09-05T00:59:00.000Z', expiresAt: '2026-09-05T01:59:00.000Z' },
+    preconditions: { relayQuiesced: true, exclusiveOperation: true, consumerReady: true, bindingsVerified: true, retentionHeld: true }, events: entries };
+  const db: RecoveryDatabase = {
+    $disconnect: async () => undefined, $transaction: async work => work(db),
+    $queryRawUnsafe: async <T>(_sql: string, ...values: readonly unknown[]): Promise<T> => {
+      const s = snapshots.find(s => s.row.id === values[0]);
+      return (s ? [{ version: canonicalSha256({ ...s.row, rowVersion: undefined }) }] : []) as T;
+    },
+    outboxEvent: { findUnique: async args => copy(snapshots.find(s => s.row.id === args.where.id)?.row ?? null),
+      update: jest.fn(async args => {
+        const s = snapshots.find(s => s.row.id === args.where.id)!;
+        const { publishAttempts, ...data } = args.data;
+        s.row = { ...s.row, ...data, publishAttempts: s.row.publishAttempts + (publishAttempts?.increment ?? 0) };
+        return copy(s.row);
+      }) },
+    readerSummaryPublication: { findUnique: async args => copy(snapshots.find(s => s.row.id === args.where.outboxEventId)?.publication ?? null) },
+    inboxRecord: { findUnique: async args => copy(snapshots.find(s => s.row.id === args.where.consumerName_eventId.eventId)?.inbox ?? null) },
+    realtimeEvent: { findMany: async args => copy(snapshots.flatMap(s => s.projections).filter(p => args.where.OR.some(clause => {
+      const c = clause as { id?: string; tenantId?: string; workspaceId?: string; payload?: { equals: string } };
+      return c.id === p.id || (c.tenantId === p.tenantId && c.workspaceId === p.workspaceId && c.payload?.equals ===
+        (p.payload as Record<string, unknown>).readerSummaryId);
+    }))) },
+  };
+  const consume = async (index = 0) => {
+    const s = snapshots[index]!;
+    if (s.inbox !== null) return;
+    const result = await new ProjectReaderSummaryReadyEventUseCase({ project: async incoming => {
+      const { sourceEventId, ...projection } = incoming;
+      const projectionId = id(700 + index);
+      s.inbox = { id: projectionId, consumerName: READER_SUMMARY_READY_CONSUMER, eventId: sourceEventId,
+        tenantId: projection.tenantId, schemaVersion: 1, processedAt: clock.now() };
+      s.projections = [{ ...projection, id: projectionId, sequence: index + 1, replayCursor: encodeRealtimeReplayCursor(index + 1) }];
+      return { realtimeEventId: projectionId, channel: projection.channel, sequence: index + 1, duplicate: false };
+    } }).execute({ event: parseReaderSummaryReadyEvent(originalEnvelope(s.row)) });
+    if (!result.ok) throw result.error;
+  };
+  const channel = { assertExchange: jest.fn(async () => undefined), assertQueue: jest.fn(), bindQueue: jest.fn(),
+    publish: jest.fn(async () => true), waitForConfirms: jest.fn(async () => { await consume(); }) };
+  const persistence = recoveryPersistence(db, clock);
+  const options = () => { const bytes = Buffer.from(JSON.stringify(manifest)); return { bytes, reviewedSha256: bytesSha256(bytes),
+    deployedSha: manifest.deployedSourceSha, apply: true, clock, persistence,
+    publisher: new RabbitMqEventPublisher(channel, { exchange: 'social-monitor.events' }), sleep: async () => undefined,
+    receipts: (m: RecoveryManifest, b: Buffer) => recoveryReceipts(m, b, files) }; };
+  return { directory, manifest, snapshots, db, persistence, channel, consume, options,
+    run: (apply = true) => runReadyRecovery({ ...options(), apply }),
+    receipt: (name: string) => readFileSync(join(directory, 'reader-summary-ready-recovery', manifest.operationId, `${name}.json`), 'utf8'),
+    cleanup: () => rmSync(directory, { recursive: true, force: true }) };
+}
+
+function copy<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value), (key: string, child: unknown) =>
+    typeof child === 'string' && ['createdAt', 'availableAt', 'publishedAt', 'processedAt', 'occurredAt',
+      'periodStartedAt', 'periodEndedAt', 'leasedUntil'].includes(key) ? new Date(child) : child) as T;
+}

--- a/scripts/lib/reader-summary-ready-recovery-guards.spec.ts
+++ b/scripts/lib/reader-summary-ready-recovery-guards.spec.ts
@@ -1,3 +1,5 @@
+import type * as NodeFilesystem from 'node:fs';
+import { join } from 'node:path';
 import { readyRecoveryFixture } from './reader-summary-ready-recovery-fixture';
 import { main, recoveryArguments } from '../recover-reader-summary-ready-events';
 import { runReadyRecovery } from './reader-summary-ready-recovery-run';
@@ -41,6 +43,25 @@ describe('reader ready recovery safety guards', () => {
     expect(f.channel.publish).not.toHaveBeenCalled();
     f.manifest.operationId = '00000000-0000-4000-8000-000000000888';
     await expect(f.run()).rejects.toThrow('apply_precondition_failed');
+  });
+  it.each(['recovery-root', 'operation', 'events'])('never starts a publish when the %s directory entry cannot be synced', async entry => {
+    const fs = jest.requireActual<typeof NodeFilesystem>('node:fs');
+    const realFsync = fs.fsyncSync;
+    const parent = entry === 'recovery-root' ? f.directory : join(f.directory, 'reader-summary-ready-recovery');
+    let parentSyncs = 0;
+    const sync = jest.spyOn(fs, 'fsyncSync').mockImplementation(descriptor => {
+      if (fs.readlinkSync(`/proc/self/fd/${descriptor}`) === parent && ++parentSyncs === (entry === 'events' ? 2 : 1)) {
+        throw new Error('synthetic parent directory fsync failure');
+      }
+      realFsync(descriptor);
+    });
+    try {
+      await expect(f.run()).rejects.toThrow('synthetic parent directory fsync failure');
+      expect(f.db.outboxEvent.update).not.toHaveBeenCalled();
+      expect(f.channel.publish).not.toHaveBeenCalled();
+      expect(f.snapshots[0]!.row.status).toBe('FAILED');
+    } finally { sync.mockRestore(); }
+    if (entry === 'events') await expect(f.run()).rejects.toThrow('apply_precondition_failed');
   });
   it('stops after a receipt failure following confirmation, without acknowledging the outbox', async () => {
     const options = f.options();

--- a/scripts/lib/reader-summary-ready-recovery-guards.spec.ts
+++ b/scripts/lib/reader-summary-ready-recovery-guards.spec.ts
@@ -1,0 +1,63 @@
+import { readyRecoveryFixture } from './reader-summary-ready-recovery-fixture';
+import { main, recoveryArguments } from '../recover-reader-summary-ready-events';
+import { runReadyRecovery } from './reader-summary-ready-recovery-run';
+
+describe('reader ready recovery safety guards', () => {
+  let f: ReturnType<typeof readyRecoveryFixture>;
+  beforeEach(() => { f = readyRecoveryFixture(); });
+  afterEach(() => f.cleanup());
+  it('requires explicit configuration and has no ambient DATABASE_URL fallback', async () => {
+    expect(recoveryArguments(['--manifest', '/synthetic.json'])).toEqual({ manifestPath: '/synthetic.json', apply: false });
+    expect(() => recoveryArguments(['--manifest', '/synthetic.json', '--apply', '--dry-run'])).toThrow();
+    await expect(main(['--manifest', '/synthetic.json'], { DATABASE_URL: 'synthetic-unused' })).rejects.toThrow('explicit_recovery_config_required');
+  });
+  it('rejects wrong deployment SHA and closed windows before any effects, but allows later inspection', async () => {
+    await expect(runReadyRecovery({ ...f.options(), deployedSha: 'b'.repeat(40) })).rejects.toThrow('deployed_source_mismatch');
+    const options = { ...f.options(), clock: { now: () => new Date('2026-09-06T00:00:00.000Z') } };
+    await expect(runReadyRecovery(options)).rejects.toThrow('apply_precondition_failed');
+    expect(await runReadyRecovery({ ...options, apply: false })).toMatchObject({ eligible: false });
+    expect(f.channel.publish).not.toHaveBeenCalled();
+  });
+  it('validates the complete allowlist before sending its first row', async () => {
+    f.cleanup(); f = readyRecoveryFixture(2);
+    f.snapshots[1]!.row = { ...f.snapshots[1]!.row, payload: {} };
+    await expect(f.run()).rejects.toThrow('outbox_identity_mismatch');
+    expect(f.db.outboxEvent.update).not.toHaveBeenCalled(); expect(f.channel.publish).not.toHaveBeenCalled();
+  });
+  it.each(['payload', 'tenant', 'schema', 'orphan', 'duplicate'])('rejects retained %s mismatch and still exposes inspection evidence', async risk => {
+    await f.consume(); const s = f.snapshots[0]!;
+    if (risk === 'payload') s.projections = [{ ...s.projections[0]!, payload: { altered: true } }];
+    if (risk === 'tenant') s.projections = [{ ...s.projections[0]!, tenantId: 'foreign' }];
+    if (risk === 'schema') s.inbox = { ...s.inbox!, schemaVersion: 2 };
+    if (risk === 'orphan') s.inbox = null;
+    if (risk === 'duplicate') s.projections = [...s.projections, { ...s.projections[0]!, id: 'duplicate' }];
+    await expect(f.run()).rejects.toThrow(); expect(f.channel.publish).not.toHaveBeenCalled();
+    expect(await f.run(false)).toMatchObject({ eligible: false, states: [{ eventId: s.row.id, status: 'FAILED' }] });
+  });
+  it('requires durable before evidence and blocks overlapping manifests after any claimed invocation', async () => {
+    const options = f.options();
+    await expect(runReadyRecovery({ ...options, receipts: (m, b) => ({ ...options.receipts(m, b),
+      before: () => { throw new Error('synthetic disk failure'); } }) })).rejects.toThrow('synthetic disk failure');
+    expect(f.channel.publish).not.toHaveBeenCalled();
+    f.manifest.operationId = '00000000-0000-4000-8000-000000000888';
+    await expect(f.run()).rejects.toThrow('apply_precondition_failed');
+  });
+  it('stops after a receipt failure following confirmation, without acknowledging the outbox', async () => {
+    const options = f.options();
+    await expect(runReadyRecovery({ ...options, receipts: (m, b) => {
+      const receipts = options.receipts(m, b);
+      return { ...receipts, stage: (id, phase, evidence) => {
+        if (phase === 'confirmed') throw new Error('synthetic fsync failure');
+        receipts.stage(id, phase, evidence);
+      } };
+    } })).rejects.toThrow('synthetic fsync failure');
+    expect(f.channel.publish).toHaveBeenCalledTimes(1); expect(f.snapshots[0]!.row.status).toBe('FAILED');
+    expect(JSON.parse(f.receipt(`${f.snapshots[0]!.row.id}.uncertain`))).toMatchObject({ confirmed: true, acknowledged: false });
+  });
+  it('accepts asynchronously committed consumption without republishing', async () => {
+    f.channel.waitForConfirms.mockResolvedValue(undefined);
+    const sleep = jest.fn(async () => { await f.consume(); });
+    expect(await runReadyRecovery({ ...f.options(), sleep })).toMatchObject({ consumed: 1 });
+    expect(sleep).toHaveBeenCalledTimes(1); expect(f.channel.publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/lib/reader-summary-ready-recovery-manifest.ts
+++ b/scripts/lib/reader-summary-ready-recovery-manifest.ts
@@ -1,0 +1,63 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+import { causationId, correlationId, eventId, tenantId, workspaceId, type EventEnvelope } from '@social-monitor/shared-kernel';
+import { stablePublicationJson } from '@social-monitor/summary/adapters/persistence/reader-summary-publication-proof';
+import { deepFreezeReaderSummaryWeekly } from '@social-monitor/summary/domain/value-objects/reader-summary-weekly-canonical-json';
+import type { PrismaEventOutboxRecord } from '@social-monitor/platform-events/adapters/prisma/prisma-event-store-client';
+
+const uuid = z.string().regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+const digest = z.string().regex(/^[0-9a-f]{64}$/);
+const timestamp = z.string().refine(v => Number.isFinite(Date.parse(v)) && new Date(v).toISOString() === v);
+const identity = z.string().min(1).max(300).refine(v => v.trim() === v);
+const entry = z.object({
+  eventId: uuid, tenantId: uuid, workspaceId: uuid, createdAt: timestamp,
+  correlationId: identity, causationId: identity.nullable(), readerSummaryId: uuid, readerSummaryJobId: uuid,
+  messageKind: z.literal('EVENT'), eventType: z.literal('reader_summary.ready'), schemaVersion: z.literal(1),
+  expectedStatus: z.literal('FAILED'), payloadSha256: digest, reportSha256: digest, proofSha256: digest,
+}).strict();
+const schema = z.object({
+  operationId: uuid, deployedSourceSha: z.string().regex(/^[0-9a-f]{40}$/),
+  window: z.object({ startedAt: timestamp, expiresAt: timestamp }).strict(),
+  preconditions: z.object({ relayQuiesced: z.literal(true), exclusiveOperation: z.literal(true),
+    consumerReady: z.literal(true), bindingsVerified: z.literal(true), retentionHeld: z.literal(true) }).strict(),
+  events: z.array(entry).min(1).max(17),
+}).strict();
+export type RecoveryManifest = z.infer<typeof schema>;
+export type RecoveryEntry = RecoveryManifest['events'][number];
+export type RecoveryRow = PrismaEventOutboxRecord & {
+  readonly availableAt: Date; readonly leaseOwner: string | null; readonly leasedUntil: Date | null; readonly rowVersion: string;
+};
+export class RecoveryError extends Error {}
+export function requireRecovery(condition: unknown, code: string): asserts condition {
+  if (!condition) throw new RecoveryError(code);
+}
+export const bytesSha256 = (bytes: string | Buffer): string => createHash('sha256').update(bytes).digest('hex');
+export const canonicalSha256 = (value: unknown): string => bytesSha256(stablePublicationJson(value));
+export const failureCode = (error: unknown): string => error instanceof RecoveryError ? error.message : 'dependency_failed';
+
+export function parseRecoveryManifest(bytes: Buffer, reviewedSha256: string): RecoveryManifest {
+  requireRecovery(bytes.length <= 65_536 && bytesSha256(bytes) === reviewedSha256, 'manifest_digest_mismatch');
+  let value: unknown;
+  try { value = JSON.parse(bytes.toString('utf8')); } catch { throw new RecoveryError('manifest_invalid'); }
+  const parsed = schema.safeParse(value);
+  requireRecovery(parsed.success, 'manifest_invalid');
+  const manifest = parsed.data;
+  requireRecovery(new Set(manifest.events.map(e => e.eventId)).size === manifest.events.length, 'duplicate_allowlist');
+  const span = Date.parse(manifest.window.expiresAt) - Date.parse(manifest.window.startedAt);
+  requireRecovery(span > 0 && span <= 3_600_000, 'invalid_operation_window');
+  return deepFreezeReaderSummaryWeekly(manifest);
+}
+export function assertRecoveryWindow(manifest: RecoveryManifest, deployedSha: string, now: Date): void {
+  requireRecovery(manifest.deployedSourceSha === deployedSha, 'deployed_source_mismatch');
+  requireRecovery(now.getTime() >= Date.parse(manifest.window.startedAt) &&
+    now.getTime() < Date.parse(manifest.window.expiresAt), 'operation_window_closed');
+}
+export function originalEnvelope(row: RecoveryRow): EventEnvelope<Readonly<Record<string, unknown>>> {
+  requireRecovery(row.payload !== null && typeof row.payload === 'object' && !Array.isArray(row.payload), 'payload_invalid');
+  requireRecovery(row.tenantId !== null && row.workspaceId !== null, 'scope_missing');
+  return { eventId: eventId(row.id), eventType: row.eventType, schemaVersion: row.schemaVersion,
+    occurredAt: row.createdAt, tenantId: tenantId(row.tenantId), workspaceId: workspaceId(row.workspaceId),
+    correlationId: correlationId(row.correlationId),
+    ...(row.causationId === null ? {} : { causationId: causationId(row.causationId) }),
+    payload: row.payload as Readonly<Record<string, unknown>> };
+}

--- a/scripts/lib/reader-summary-ready-recovery-persistence.ts
+++ b/scripts/lib/reader-summary-ready-recovery-persistence.ts
@@ -1,0 +1,82 @@
+import { PrismaOutboxStoreAdapter } from '@social-monitor/platform-events/adapters/prisma';
+import type { PrismaEventStoreClient, PrismaInboxRecord } from '@social-monitor/platform-events/adapters/prisma/prisma-event-store-client';
+import { runWithSystemDatabaseAccess } from '@social-monitor/platform-persistence';
+import type { Clock } from '@social-monitor/shared-kernel';
+import { READER_SUMMARY_READY_CONSUMER } from '@social-monitor/delivery/application/contracts/reader-summary-ready-projection-store';
+import type { PrismaRealtimeEventRecord } from '@social-monitor/delivery/adapters/persistence/prisma/prisma-delivery-records';
+import { requireRecovery, type RecoveryEntry, type RecoveryRow } from './reader-summary-ready-recovery-manifest';
+import type { RecoveryPublication, RecoverySnapshot } from './reader-summary-ready-recovery-evidence';
+
+type Update = Parameters<PrismaEventStoreClient['outboxEvent']['update']>[0];
+type RecoveryTables = {
+  $queryRawUnsafe<T>(sql: string, ...values: readonly unknown[]): Promise<T>;
+  outboxEvent: {
+    findUnique(args: { where: { id: string } }): Promise<Omit<RecoveryRow, 'rowVersion'> | null>;
+    update(args: Update): Promise<Omit<RecoveryRow, 'rowVersion'>>;
+  };
+  readerSummaryPublication: { findUnique(args: { where: { outboxEventId: string };
+    include: { readerSummaryArtifact: true; readerSummaryJob: true } }): Promise<RecoveryPublication | null> };
+  inboxRecord: Pick<PrismaEventStoreClient['inboxRecord'], 'findUnique'>;
+  realtimeEvent: { findMany(args: { where: { OR: readonly object[] }; take: number }): Promise<readonly PrismaRealtimeEventRecord[]> };
+};
+export type RecoveryDatabase = RecoveryTables & {
+  $disconnect(): Promise<void>;
+  $transaction<T>(work: (tx: RecoveryTables) => Promise<T>, options: { isolationLevel: 'Serializable' }): Promise<T>;
+};
+export type RecoveryPersistence = {
+  read(entries: readonly RecoveryEntry[]): Promise<readonly RecoverySnapshot[]>;
+  transition(row: RecoveryRow, action: 'start' | 'published' | 'failed'): Promise<RecoveryRow>;
+};
+export function recoveryPersistence(db: RecoveryDatabase, clock: Clock): RecoveryPersistence {
+  return {
+    read: entries => runWithSystemDatabaseAccess('reader ready recovery exact evidence read', () => db.$transaction(async tx => {
+      const snapshots: RecoverySnapshot[] = [];
+      for (const entry of entries) {
+        const row = await tx.outboxEvent.findUnique({ where: { id: entry.eventId } });
+        requireRecovery(row !== null, 'allowlisted_row_missing');
+        const publication = await tx.readerSummaryPublication.findUnique({ where: { outboxEventId: entry.eventId },
+          include: { readerSummaryArtifact: true, readerSummaryJob: true } });
+        const inbox: PrismaInboxRecord | null = await tx.inboxRecord.findUnique({ where: {
+          consumerName_eventId: { consumerName: READER_SUMMARY_READY_CONSUMER, eventId: entry.eventId },
+        } });
+        const projections = await tx.realtimeEvent.findMany({ where: { OR: [
+          ...(inbox === null ? [] : [{ id: inbox.id }]),
+          { tenantId: entry.tenantId, workspaceId: entry.workspaceId, eventType: 'reader_summary.status.changed.v1',
+            payload: { path: ['readerSummaryId'], equals: entry.readerSummaryId } },
+        ] }, take: 2 });
+        snapshots.push({ row: { ...row, rowVersion: await readVersion(tx, row.id) }, publication, inbox, projections });
+      }
+      return snapshots;
+    }, { isolationLevel: 'Serializable' })),
+    transition: async (row, action) => {
+      let updated: RecoveryRow | undefined;
+      const unavailable = (): never => { throw new Error('Recovery adapter method unavailable'); };
+      // The standard adapter owns diagnostics and start/ack/failure semantics.
+      // Compare PostgreSQL tuple versions under an exact row lock. Comparing
+      // Date values in Prisma WHERE loses PostgreSQL sub-millisecond precision.
+      const guarded: PrismaEventStoreClient = {
+        outboxEvent: { findMany: unavailable, update: async args => {
+          requireRecovery(args.where.id === row.id, 'transition_id_mismatch');
+          updated = await db.$transaction(async tx => {
+            requireRecovery(await readVersion(tx, row.id, true) === row.rowVersion, 'outbox_concurrent_mutation');
+            const next = await tx.outboxEvent.update(args);
+            return { ...next, rowVersion: await readVersion(tx, row.id) };
+          }, { isolationLevel: 'Serializable' });
+          return updated;
+        } }, inboxRecord: { findUnique: unavailable, create: unavailable },
+      };
+      const outbox = new PrismaOutboxStoreAdapter(guarded, clock);
+      if (action === 'start') await outbox.recordAttempt(row.id);
+      else if (action === 'published') await outbox.markPublished(row.id);
+      else await outbox.markFailed(row.id, 'Reader ready recovery publish uncertain; inspect durable operation receipts.');
+      requireRecovery(updated !== undefined, 'transition_unacknowledged');
+      return updated;
+    },
+  };
+}
+async function readVersion(tx: RecoveryTables, id: string, lock = false): Promise<string> {
+  const rows = await tx.$queryRawUnsafe<readonly { version: string }[]>(
+    `SELECT xmin::text AS version FROM public.outbox_events WHERE id = $1::uuid${lock ? ' FOR UPDATE' : ''}`, id);
+  requireRecovery(rows.length === 1 && rows[0]?.version, 'allowlisted_row_missing');
+  return rows[0].version;
+}

--- a/scripts/lib/reader-summary-ready-recovery-postgres-fixture.ts
+++ b/scripts/lib/reader-summary-ready-recovery-postgres-fixture.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import type { Pool } from 'pg';
+import { canonicalSha256 } from './reader-summary-ready-recovery-manifest';
+import type { RecoverySnapshot } from './reader-summary-ready-recovery-evidence';
+
+const baseline = () => readFileSync('prisma/migrations/20260618143000_baseline/migration.sql', 'utf8');
+const publication = () => readFileSync('prisma/migrations/20260716170000_reader_summary_fail_closed_publication/migration.sql', 'utf8');
+const evidence = () => readFileSync('prisma/migrations/20260724020000_reader_summary_weekly_publication_evidence/migration.sql', 'utf8');
+const required = (sql: string, pattern: RegExp): string => {
+  const value = sql.match(pattern)?.[0];
+  if (!value) throw new Error(`Recovery fixture migration definition missing: ${pattern.source}`);
+  return value;
+};
+export function recoveryFixtureSchema(): readonly string[] {
+  const tables = [
+    [baseline(), 'reader_summary_artifacts'], [baseline(), 'reader_summary_jobs'],
+    [publication(), 'reader_summary_publications'], [publication(), 'reader_summary_publication_slots'],
+    [evidence(), 'reader_summary_weekly_publication_evidence'],
+  ];
+  return [required(baseline(), /CREATE TYPE "SummaryStatus"[^;]+;/), ...tables.flatMap(([sql, table]) => [
+    required(sql!, new RegExp(`CREATE TABLE "${table}" \\([\\s\\S]*?\\n\\);`)),
+    ...Array.from(sql!.matchAll(new RegExp(`CREATE (?:UNIQUE )?INDEX [^;]+\\sON\\s+"${table}"[^;]+;`, 'g')), match => match[0]),
+  ])];
+}
+export async function seedRecoveryPostgres(database: Pool, snapshots: readonly RecoverySnapshot[]): Promise<void> {
+  for (const sql of recoveryFixtureSchema()) await database.query(sql);
+  // Only known synthetic fixture objects/columns enter these parameterized inserts.
+  const insert = async (table: string, row: object) => {
+    const fields = Object.entries(row);
+    const columns = fields.map(([key]) => `"${key.replace(/[A-Z]/g, c => `_${c.toLowerCase()}`)}"`);
+    await database.query(`INSERT INTO "${table}" (${columns.join(',')}) VALUES (${fields.map((_, i) => `$${i + 1}`).join(',')})`,
+      fields.map(([, value]) => value !== null && typeof value === 'object' && !(value instanceof Date) && !Buffer.isBuffer(value)
+        ? JSON.stringify(value) : value));
+  };
+  const slots = new Set<string>();
+  for (const s of snapshots) {
+    const { rowVersion: _version, ...row } = s.row; void _version;
+    const { readerSummaryArtifact: a, readerSummaryJob: j, ...p } = s.publication!;
+    const scope = { tenantId: p.tenantId, workspaceId: p.workspaceId, scopeType: p.scopeType, scopeKey: p.scopeKey,
+      cadence: p.cadence, periodStartedAt: p.periodStartedAt, periodEndedAt: p.periodEndedAt, periodTimezone: p.periodTimezone };
+    const report = { schemaVersion: 'reader_summary.publication_report.v1', semanticStatus: p.semanticStatus,
+      modelVersion: a.modelVersion, promptVersion: a.promptVersion, headline: a.headline, summaryText: a.summaryText,
+      artifactPayload: a.artifactPayload, citations: a.citations, qualitySignals: a.qualitySignals };
+    await insert('outbox_events', row);
+    await insert('reader_summary_artifacts', { ...a, updatedAt: p.publishedAt });
+    await insert('reader_summary_jobs', { ...j, idempotencyKey: j!.id, requestedAt: p.periodStartedAt, updatedAt: p.publishedAt });
+    await insert('reader_summary_publications', { ...p, requestedUtcDate: p.periodStartedAt, requestedAt: p.periodStartedAt,
+      publicationKind: 'EXACT', modelVersion: a.modelVersion, modelAuthority: 1 });
+    if (!slots.has(canonicalSha256(scope))) {
+      await insert('reader_summary_publication_slots', { ...scope, currentPublicationId: p.id, updatedAt: p.publishedAt });
+      slots.add(canonicalSha256(scope));
+    }
+    const providerEvidence = [{ synthetic: true }], canonical = Buffer.from(JSON.stringify({ synthetic: p.id }));
+    await insert('reader_summary_weekly_publication_evidence', { ...scope, publicationId: p.id, requestedUtcDate: p.periodStartedAt,
+      readerSummaryJobId: j!.id, readerSummaryArtifactId: a.id, reportId: `report:${p.id}`, proofId: `proof:${p.id}`,
+      semanticStatus: p.semanticStatus, report, reportSha256: p.reportSha256, exactProof: p.exactProof, proofSha256: p.proofSha256,
+      artifactPayloadSha256: canonicalSha256(a.artifactPayload), providerEvidence, providerEvidenceSha256: canonicalSha256(providerEvidence),
+      githubEvidence: { mode: 'synthetic' }, canonicalRecord: { synthetic: p.id }, canonicalBytes: canonical,
+      canonicalSha256: canonicalSha256({ synthetic: p.id }), identity: `synthetic:${p.id}`, recordedAt: p.publishedAt });
+  }
+}
+export async function protectRecoveryPostgres(database: Pool, runtimeUrl: string): Promise<{ recoveryUrl: string; cleanup: () => Promise<void> }> {
+  const url = new URL(runtimeUrl), runtimeRole = decodeURIComponent(url.username);
+  if (!/^reader_delivery_fixture_[0-9a-f]{16}_runtime$/.test(runtimeRole)) throw new Error('Expected isolated delivery fixture role');
+  const systemRole = runtimeRole.replace(/_runtime$/, '_system'), recoveryRole = runtimeRole.replace(/_runtime$/, '_recovery');
+  const password = decodeURIComponent(url.password);
+  if (!/^[0-9a-f]{48}$/.test(password)) throw new Error('Expected generated fixture password');
+  const rls = readFileSync('prisma/migrations/20260723153000_tenant_row_level_security/migration.sql', 'utf8');
+  await database.query(required(rls, /ALTER TABLE "outbox_events" ENABLE[\s\S]*?\n {2}\);/));
+  for (const name of ['reject_reader_summary_publication_mutation', 'guard_published_reader_summary_artifact_update', 'guard_reader_summary_weekly_publication_evidence']) {
+    const sql = name === 'guard_reader_summary_weekly_publication_evidence' ? evidence() : publication();
+    await database.query(required(sql, new RegExp(`CREATE (?:OR REPLACE )?FUNCTION "${name}"\\(\\)[\\s\\S]*?\\$\\$;`))
+      .replaceAll('social_monitor_reader_summary_publication_owner', systemRole));
+  }
+  for (const [sql, name] of [[publication(), 'reader_summary_publications_immutable'],
+    [publication(), 'reader_summary_artifacts_published_immutable'], [evidence(), 'reader_summary_weekly_publication_evidence_guarded']]) {
+    await database.query(required(sql!, new RegExp(`CREATE TRIGGER "${name}"[\\s\\S]*?;`)));
+  }
+  for (const table of ['reader_summary_artifacts', 'reader_summary_jobs', 'reader_summary_publications', 'reader_summary_weekly_publication_evidence']) {
+    await database.query(`ALTER TABLE "${table}" ENABLE ROW LEVEL SECURITY; ALTER TABLE "${table}" FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON "${table}" USING (public.social_monitor_rls_workspace_match(tenant_id, workspace_id))
+      WITH CHECK (public.social_monitor_rls_workspace_match(tenant_id, workspace_id));`);
+  }
+  await database.query(`CREATE ROLE "${recoveryRole}" LOGIN PASSWORD '${password}' NOSUPERUSER NOBYPASSRLS`);
+  const cleanup = async () => { await database.query(`DROP OWNED BY "${recoveryRole}"; DROP ROLE "${recoveryRole}"`); };
+  try {
+    await database.query(`GRANT "${systemRole}" TO "${recoveryRole}";
+      GRANT SELECT ON ALL TABLES IN SCHEMA public TO "${runtimeRole}", "${recoveryRole}", "${systemRole}";
+      GRANT UPDATE ON outbox_events TO "${recoveryRole}";
+      GRANT UPDATE ON reader_summary_artifacts TO "${systemRole}";`);
+    url.username = recoveryRole;
+    return { recoveryUrl: url.toString(), cleanup };
+  } catch (error) { await cleanup(); throw error; }
+}

--- a/scripts/lib/reader-summary-ready-recovery-postgres.spec.ts
+++ b/scripts/lib/reader-summary-ready-recovery-postgres.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { recoveryFixtureSchema } from './reader-summary-ready-recovery-postgres-fixture';
+import { withReaderDeliveryPostgresFixture } from './reader-summary-ready-delivery-postgres-fixture';
+
+// Wiring/guard checks supplement the native gate; these are not PG evidence.
+describe('native recovery fixture contract', () => {
+  const original = process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL;
+  afterEach(() => {
+    if (original === undefined) delete process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL;
+    else process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL = original;
+  });
+  it.each([undefined, 'postgresql://fixture:fixture@remote.invalid/test',
+    'postgresql://fixture:fixture@127.0.0.1/test?host=remote.invalid'])('fails closed before connecting for %s', async url => {
+    if (url === undefined) delete process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL;
+    else process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL = url;
+    const operation = jest.fn();
+    await expect(withReaderDeliveryPostgresFixture(operation)).rejects.toThrow();
+    expect(operation).not.toHaveBeenCalled();
+  });
+  it('extracts complete native tables, constraints, and indexes from source migrations', () => {
+    const statements = recoveryFixtureSchema();
+    expect(statements.filter(sql => sql.startsWith('CREATE TABLE'))).toHaveLength(5);
+    const source = statements.join('\n');
+    for (const expected of ['TIMESTAMPTZ(6)', 'reader_summary_publications_outbox_key',
+      'reader_summary_weekly_publication_evidence_slot_fkey', 'reader_summary_weekly_publication_evidence_semantics_check']) {
+      expect(source).toContain(expected);
+    }
+  });
+  it('registers a bounded native executable with no skip/fallback', () => {
+    const config = JSON.parse(readFileSync('package.json', 'utf8')) as { scripts: Record<string, string> };
+    expect(config.scripts['check:reader-summary-ready-recovery-postgres']).toContain('--timeout-ms 120000');
+    expect(config.scripts['check:reader-summary-ready-recovery-postgres']).toContain('scripts/check-reader-summary-ready-recovery-postgres.ts');
+  });
+});

--- a/scripts/lib/reader-summary-ready-recovery-postgres.spec.ts
+++ b/scripts/lib/reader-summary-ready-recovery-postgres.spec.ts
@@ -9,8 +9,8 @@ describe('native recovery fixture contract', () => {
     if (original === undefined) delete process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL;
     else process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL = original;
   });
-  it.each([undefined, 'postgresql://fixture:fixture@remote.invalid/test',
-    'postgresql://fixture:fixture@127.0.0.1/test?host=remote.invalid'])('fails closed before connecting for %s', async url => {
+  it.each([undefined, 'postgresql://fixture:password@remote.invalid/test',
+    'postgresql://fixture:password@127.0.0.1/test?host=remote.invalid'])('fails closed before connecting for %s', async url => {
     if (url === undefined) delete process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL;
     else process.env.READER_DELIVERY_TEST_ADMIN_DATABASE_URL = url;
     const operation = jest.fn();

--- a/scripts/lib/reader-summary-ready-recovery-receipts.ts
+++ b/scripts/lib/reader-summary-ready-recovery-receipts.ts
@@ -1,0 +1,40 @@
+import { installSecureRecoveryEvidenceFile, readSecureRecoveryEvidenceFile,
+  type RecoveryEvidenceFilesystemTestHarness } from './reader-summary-recovery-evidence-secure-file';
+import { bytesSha256, requireRecovery, type RecoveryManifest } from './reader-summary-ready-recovery-manifest';
+
+export const recoveryPhases = ['publish_started', 'confirmed', 'acknowledged', 'consumed', 'uncertain'] as const;
+type Phase = typeof recoveryPhases[number];
+export function recoveryReceipts(manifest: RecoveryManifest, bytes: Buffer,
+  files: RecoveryEvidenceFilesystemTestHarness = { read: readSecureRecoveryEvidenceFile, install: installSecureRecoveryEvidenceFile }) {
+  const root = 'reader-summary-ready-recovery';
+  const prefix = `${root}/${manifest.operationId}`;
+  const eventClaim = (id: string) => `${root}/events/${id}.json`;
+  const read = (relativePath: string): Buffer | null => {
+    try { return files.read({ relativePath, label: 'reader ready receipt' }); }
+    catch (error) {
+      if (error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') return null;
+      throw error;
+    }
+  };
+  const install = (relativePath: string, content: Buffer): void => {
+    requireRecovery(files.install({ relativePath, label: 'reader ready receipt', bytes: content }) === 'installed', 'operation_already_claimed');
+  };
+  const write = (name: string, value: object) => install(`${prefix}/${name}.json`, Buffer.from(JSON.stringify(value) + '\n'));
+  return {
+    inspect: () => ({ operationClaimed: read(`${prefix}/claim.json`) !== null,
+      events: manifest.events.map(e => ({ eventId: e.eventId, claimed: read(eventClaim(e.eventId)) !== null,
+        phases: recoveryPhases.filter(phase => read(`${prefix}/${e.eventId}.${phase}.json`) !== null) })) }),
+    claim: () => {
+      install(`${prefix}/claim.json`, bytes);
+      for (const e of manifest.events) install(eventClaim(e.eventId), Buffer.from(JSON.stringify({
+        operationId: manifest.operationId, manifestSha256: bytesSha256(bytes), eventId: e.eventId,
+      }) + '\n'));
+    },
+    before: (snapshots: readonly object[]) => write('before', { manifestSha256: bytesSha256(bytes), snapshots }),
+    stage: (eventId: string, phase: Phase, evidence: object) => {
+      requireRecovery(manifest.events.some(e => e.eventId === eventId), 'event_outside_allowlist');
+      write(`${eventId}.${phase}`, { operationId: manifest.operationId, eventId, phase,
+        manifestSha256: bytesSha256(bytes), ...evidence });
+    },
+  };
+}

--- a/scripts/lib/reader-summary-ready-recovery-run.spec.ts
+++ b/scripts/lib/reader-summary-ready-recovery-run.spec.ts
@@ -1,0 +1,96 @@
+import { readyRecoveryFixture } from './reader-summary-ready-recovery-fixture';
+import { bytesSha256, canonicalSha256, parseRecoveryManifest } from './reader-summary-ready-recovery-manifest';
+import { runReadyRecovery } from './reader-summary-ready-recovery-run';
+
+describe('one-shot reader ready recovery', () => {
+  let f: ReturnType<typeof readyRecoveryFixture>;
+  beforeEach(() => { f = readyRecoveryFixture(); });
+  afterEach(() => f.cleanup());
+
+  it('defaults to inspection and never sends on a precondition error', async () => {
+    expect(await f.run(false)).toMatchObject({ eligible: true, mode: 'dry-run' });
+    f.snapshots[0]!.row = { ...f.snapshots[0]!.row, status: 'PENDING' };
+    await expect(f.run()).rejects.toThrow('apply_precondition_failed');
+    expect(f.channel.publish).not.toHaveBeenCalled(); expect(f.db.outboxEvent.update).not.toHaveBeenCalled();
+  });
+  it.each(['scope', 'payload', 'legacy', 'proof', 'report', 'missing retained projection'])('fails closed before send for %s', async risk => {
+    const s = f.snapshots[0]!;
+    if (risk === 'scope') s.row = { ...s.row, workspaceId: '00000000-0000-4000-8000-000000000099' };
+    if (risk === 'payload') s.row = { ...s.row, payload: { changed: true } };
+    if (risk === 'legacy') s.row = { ...s.row, eventType: 'summary.ready' };
+    if (risk === 'proof') s.publication!.exactProof = { changed: true };
+    if (risk === 'report') s.publication!.readerSummaryArtifact.summaryText = 'changed';
+    if (risk === 'missing retained projection') { await f.consume(); s.projections = []; }
+    await expect(f.run()).rejects.toThrow(); expect(f.channel.publish).not.toHaveBeenCalled();
+  });
+  it('rejects tampered, oversized, duplicate and outside-allowlist manifests', async () => {
+    const options = f.options();
+    expect(() => parseRecoveryManifest(Buffer.from(options.bytes.toString().replace('FAILED', 'PENDING')), options.reviewedSha256)).toThrow('manifest_digest');
+    f.manifest.events[0]!.eventId = '00000000-0000-4000-8000-000000000999';
+    await expect(f.run()).rejects.toThrow('allowlisted_row_missing');
+    f.manifest.events = Array.from({ length: 18 }, () => f.manifest.events[0]!);
+    const bytes = Buffer.from(JSON.stringify(f.manifest));
+    expect(() => parseRecoveryManifest(bytes, bytesSha256(bytes))).toThrow('manifest_invalid');
+    f.manifest.events.pop(); await expect(f.run()).rejects.toThrow('duplicate_allowlist');
+    expect(f.channel.publish).not.toHaveBeenCalled();
+  });
+  it('publishes exact original envelope bytes and records distinct confirmation, acknowledgement and consumption', async () => {
+    const row = structuredClone(f.snapshots[0]!.row);
+    expect(await f.run()).toMatchObject({ consumed: 1 });
+    const expected = Buffer.from(JSON.stringify({ eventId: row.id, eventType: row.eventType, schemaVersion: 1,
+      occurredAt: row.createdAt.toISOString(), tenantId: row.tenantId, workspaceId: row.workspaceId,
+      correlationId: row.correlationId, causationId: row.causationId, payload: row.payload }));
+    expect(f.channel.publish).toHaveBeenCalledWith('social-monitor.events', 'reader_summary.ready', expected,
+      expect.objectContaining({ mandatory: true, messageId: row.id, deliveryMode: 2 }));
+    expect(f.receipt('claim')).toBe(f.options().bytes.toString());
+    for (const phase of ['publish_started', 'confirmed', 'acknowledged', 'consumed']) expect(f.receipt(`${row.id}.${phase}`)).toContain(phase);
+    expect(f.snapshots[0]!.row).toMatchObject({ status: 'PUBLISHED', publishAttempts: 1, lastError: null });
+    await expect(f.run()).rejects.toThrow(); expect(f.channel.publish).toHaveBeenCalledTimes(1);
+    expect(await f.run(false)).toMatchObject({ eligible: false });
+  });
+  it('rejects a simultaneous apply and never releases the durable operation claim', async () => {
+    let release!: () => void; let arrived!: () => void;
+    const blocked = new Promise<void>(resolve => { release = resolve; });
+    const started = new Promise<void>(resolve => { arrived = resolve; });
+    f.channel.waitForConfirms.mockImplementation(async () => { arrived(); await blocked; await f.consume(); });
+    const first = f.run(); await started;
+    await expect(f.run()).rejects.toThrow('apply_precondition_failed');
+    release(); await first; expect(f.channel.publish).toHaveBeenCalledTimes(1);
+  });
+  it('retains uncertainty after broker confirm then DB failure, permits inspection and stops the rest', async () => {
+    f.cleanup(); f = readyRecoveryFixture(2);
+    const transition = f.persistence.transition;
+    f.persistence.transition = async (row, action) => { if (action === 'published') throw new Error('fixture-secret'); return transition(row, action); };
+    await expect(f.run()).rejects.toThrow('fixture-secret');
+    expect(JSON.parse(f.receipt(`${f.snapshots[0]!.row.id}.uncertain`))).toMatchObject({ confirmed: true, acknowledged: false, failure: 'dependency_failed' });
+    expect(f.channel.publish).toHaveBeenCalledTimes(1);
+    expect(await f.run(false)).toMatchObject({ eligible: false });
+    await expect(f.run()).rejects.toThrow(); expect(f.channel.publish).toHaveBeenCalledTimes(1);
+  });
+  it('uses the same retained identity for a duplicate without forging an inbox', async () => {
+    await f.consume(); const before = canonicalSha256(f.snapshots[0]!.projections);
+    await f.run(); expect(canonicalSha256(f.snapshots[0]!.projections)).toBe(before);
+    expect(JSON.parse(f.receipt(`${f.snapshots[0]!.row.id}.consumed`))).toMatchObject({ duplicateBefore: true });
+  });
+  it('stops on a publish failure with no acknowledgement and sanitizes retained diagnostics', async () => {
+    f.channel.waitForConfirms.mockRejectedValue(new Error('access_token=fixture-secret'));
+    await expect(f.run()).rejects.toThrow();
+    expect(f.snapshots[0]!.row.status).toBe('FAILED'); expect(f.snapshots[0]!.row.publishAttempts).toBe(1);
+    expect(f.receipt('before')).not.toContain('fixture-secret');
+    expect(f.receipt(`${f.snapshots[0]!.row.id}.uncertain`)).not.toContain('fixture-secret');
+  });
+  it('bounds consumer delay and never automatically resends a confirmed event', async () => {
+    f.channel.waitForConfirms.mockResolvedValue(undefined);
+    const sleep = jest.fn(async () => undefined);
+    await expect(runReadyRecovery({ ...f.options(), sleep })).rejects.toThrow('consumer_outcome_uncertain');
+    expect(sleep).toHaveBeenCalledTimes(19); expect(f.channel.publish).toHaveBeenCalledTimes(1);
+    await f.consume(); expect(await f.run(false)).toMatchObject({ eligible: false });
+    await expect(f.run()).rejects.toThrow();
+  });
+  it('does not silently acknowledge payload mutation between confirm and DB acknowledgement', async () => {
+    f.channel.waitForConfirms.mockImplementation(async () => { f.snapshots[0]!.row = { ...f.snapshots[0]!.row, payload: { altered: true } }; });
+    await expect(f.run()).rejects.toThrow('outbox_concurrent_mutation');
+    expect(f.snapshots[0]!.row.status).toBe('FAILED');
+    expect(JSON.parse(f.receipt(`${f.snapshots[0]!.row.id}.uncertain`))).toMatchObject({ confirmed: true, acknowledged: false });
+  });
+});

--- a/scripts/lib/reader-summary-ready-recovery-run.spec.ts
+++ b/scripts/lib/reader-summary-ready-recovery-run.spec.ts
@@ -7,6 +7,21 @@ describe('one-shot reader ready recovery', () => {
   beforeEach(() => { f = readyRecoveryFixture(); });
   afterEach(() => f.cleanup());
 
+  it('walks the exact 17-entry parent order and leaves a separate newer event untouched', async () => {
+    f.cleanup(); f = readyRecoveryFixture(18);
+    f.manifest.events = f.manifest.events.slice(0, 17);
+    const outside = canonicalSha256(f.snapshots[17]);
+    f.channel.waitForConfirms.mockImplementation(async () => {
+      const last = f.channel.publish.mock.calls.at(-1) as unknown as [string, string, Buffer];
+      const { eventId } = JSON.parse(last[2].toString()) as { eventId: string };
+      await f.consume(f.snapshots.findIndex(s => s.row.id === eventId));
+    });
+    expect(await f.run()).toMatchObject({ consumed: 17 });
+    expect(f.channel.publish.mock.calls.map(call => JSON.parse((call as unknown as [string, string, Buffer])[2].toString()).eventId))
+      .toEqual(f.manifest.events.map(e => e.eventId));
+    expect(canonicalSha256(f.snapshots[17])).toBe(outside);
+  });
+
   it('defaults to inspection and never sends on a precondition error', async () => {
     expect(await f.run(false)).toMatchObject({ eligible: true, mode: 'dry-run' });
     f.snapshots[0]!.row = { ...f.snapshots[0]!.row, status: 'PENDING' };

--- a/scripts/lib/reader-summary-ready-recovery-run.ts
+++ b/scripts/lib/reader-summary-ready-recovery-run.ts
@@ -8,6 +8,9 @@ import { recoveryReceipts } from './reader-summary-ready-recovery-receipts';
 export async function runReadyRecovery(options: {
   bytes: Buffer; reviewedSha256: string; deployedSha: string; apply: boolean; clock: Clock;
   persistence: RecoveryPersistence; publisher: EventPublisherPort;
+  // Must synchronously inhibit all future pre-wire sends, permanently, even
+  // when publish() is still awaiting a connection, exchange or confirm channel.
+  cancelPendingPublishes: () => void;
   receipts?: typeof recoveryReceipts; sleep: (milliseconds: number) => Promise<void>;
 }): Promise<object> {
   const manifest = parseRecoveryManifest(options.bytes, options.reviewedSha256);
@@ -52,7 +55,8 @@ export async function runReadyRecovery(options: {
       guard(); row = await options.persistence.transition(row, 'start');
       await validateRecoveryEvidence(entry, { ...current, row });
       guard(); publishing = true;
-      await boundedPublish(() => options.publisher.publish(originalEnvelope(row)));
+      await boundedPublish(() => options.publisher.publish(originalEnvelope(row)), options.cancelPendingPublishes,
+        Math.min(15_000, Date.parse(manifest.window.expiresAt) - options.clock.now().getTime()));
       confirmed = true; stage('confirmed');
       guard(); row = await options.persistence.transition(row, 'published');
       acknowledged = true; stage('acknowledged', { recordedStarts: row.publishAttempts });
@@ -68,6 +72,7 @@ export async function runReadyRecovery(options: {
       requireRecovery(consumed !== null, 'consumer_outcome_uncertain');
       stage('consumed', { realtimeEventId: consumed, duplicateBefore: states[index]!.consumed !== null });
     } catch (error) {
+      options.cancelPendingPublishes();
       // Never change a confirmed send into an ordinary failed/no-send outcome.
       // Persist uncertainty BEFORE any best-effort failure diagnostic write.
       stage('uncertain', { publishing, confirmed, acknowledged, failure: failureCode(error) });
@@ -79,11 +84,11 @@ export async function runReadyRecovery(options: {
   }
   return { mode: 'apply', operationId: manifest.operationId, consumed: manifest.events.length };
 }
-async function boundedPublish(work: () => Promise<void>): Promise<void> {
+async function boundedPublish(work: () => Promise<void>, cancel: () => void, milliseconds: number): Promise<void> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     await Promise.race([work(), new Promise<never>((_, reject) => {
-      timer = setTimeout(() => reject(new Error('publish deadline')), 15_000);
+      timer = setTimeout(() => { cancel(); reject(new Error('publish deadline; wire outcome uncertain')); }, milliseconds);
     })]);
   } finally { clearTimeout(timer); }
 }

--- a/scripts/lib/reader-summary-ready-recovery-run.ts
+++ b/scripts/lib/reader-summary-ready-recovery-run.ts
@@ -1,0 +1,89 @@
+import type { Clock } from '@social-monitor/shared-kernel';
+import type { EventPublisherPort } from '@social-monitor/platform-events';
+import { assertRecoveryWindow, canonicalSha256, failureCode, originalEnvelope, parseRecoveryManifest, requireRecovery } from './reader-summary-ready-recovery-manifest';
+import { recoveryBefore, validateRecoveryEvidence } from './reader-summary-ready-recovery-evidence';
+import type { RecoveryPersistence } from './reader-summary-ready-recovery-persistence';
+import { recoveryReceipts } from './reader-summary-ready-recovery-receipts';
+
+export async function runReadyRecovery(options: {
+  bytes: Buffer; reviewedSha256: string; deployedSha: string; apply: boolean; clock: Clock;
+  persistence: RecoveryPersistence; publisher: EventPublisherPort;
+  receipts?: typeof recoveryReceipts; sleep: (milliseconds: number) => Promise<void>;
+}): Promise<object> {
+  const manifest = parseRecoveryManifest(options.bytes, options.reviewedSha256);
+  requireRecovery(manifest.deployedSourceSha === options.deployedSha, 'deployed_source_mismatch');
+  const journal = (options.receipts ?? recoveryReceipts)(manifest, options.bytes);
+  const snapshots = await options.persistence.read(manifest.events);
+  requireRecovery(snapshots.length === manifest.events.length, 'allowlist_read_mismatch');
+  const states = [];
+  for (const [index, entry] of manifest.events.entries()) {
+    const snapshot = snapshots[index]!;
+    let consumed: string | null = null;
+    let validation = 'valid';
+    try { consumed = await validateRecoveryEvidence(entry, snapshot); }
+    catch (error) { if (options.apply) throw error; validation = failureCode(error); }
+    states.push({ eventId: entry.eventId, status: snapshot.row.status, consumed, validation,
+      observedPayloadSha256: canonicalSha256(snapshot.row.payload), evidence: recoveryBefore(snapshot, entry) });
+  }
+  const claims = journal.inspect();
+  const guard = () => assertRecoveryWindow(manifest, options.deployedSha, options.clock.now());
+  let eligible = true;
+  try { guard(); } catch { eligible = false; }
+  eligible = eligible && states.every(s => s.validation === 'valid') && !claims.operationClaimed && claims.events.every(e => !e.claimed) &&
+    snapshots.every(s => s.row.status === 'FAILED' && s.row.leaseOwner === null && s.row.leasedUntil === null);
+  if (!options.apply) return { mode: 'dry-run', eligible, claims, states };
+  requireRecovery(eligible, 'apply_precondition_failed');
+  guard(); journal.claim(); journal.before(states.map(s => s.evidence));
+  for (const [index, entry] of manifest.events.entries()) {
+    let row = snapshots[index]!.row;
+    let publishing = false;
+    let confirmed = false;
+    let acknowledged = false;
+    const stage = (phase: Parameters<typeof journal.stage>[1], evidence: object = {}) =>
+      journal.stage(entry.eventId, phase, { at: options.clock.now().toISOString(), ...evidence });
+    try {
+      guard();
+      // Revalidate evidence immediately before each event; CAS below also catches
+      // mutations since the durable before snapshot, including mutable metadata.
+      const [current] = await options.persistence.read([entry]);
+      requireRecovery(current !== undefined, 'allowlisted_row_missing');
+      await validateRecoveryEvidence(entry, current);
+      stage('publish_started', { historicalAttempts: 'unknown', priorRecordedStarts: row.publishAttempts });
+      guard(); row = await options.persistence.transition(row, 'start');
+      await validateRecoveryEvidence(entry, { ...current, row });
+      guard(); publishing = true;
+      await boundedPublish(() => options.publisher.publish(originalEnvelope(row)));
+      confirmed = true; stage('confirmed');
+      guard(); row = await options.persistence.transition(row, 'published');
+      acknowledged = true; stage('acknowledged', { recordedStarts: row.publishAttempts });
+      let consumed: string | null = null;
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        const [after] = await options.persistence.read([entry]);
+        requireRecovery(after !== undefined, 'allowlisted_row_missing');
+        requireRecovery(canonicalSha256(after.row) === canonicalSha256(row), 'acknowledged_row_changed');
+        consumed = await validateRecoveryEvidence(entry, after);
+        if (consumed !== null) break;
+        if (attempt < 19) await options.sleep(250);
+      }
+      requireRecovery(consumed !== null, 'consumer_outcome_uncertain');
+      stage('consumed', { realtimeEventId: consumed, duplicateBefore: states[index]!.consumed !== null });
+    } catch (error) {
+      // Never change a confirmed send into an ordinary failed/no-send outcome.
+      // Persist uncertainty BEFORE any best-effort failure diagnostic write.
+      stage('uncertain', { publishing, confirmed, acknowledged, failure: failureCode(error) });
+      if (publishing && !confirmed) {
+        try { guard(); await options.persistence.transition(row, 'failed'); } catch { /* CAS/DB uncertainty is retained. */ }
+      }
+      throw error;
+    }
+  }
+  return { mode: 'apply', operationId: manifest.operationId, consumed: manifest.events.length };
+}
+async function boundedPublish(work: () => Promise<void>): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([work(), new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error('publish deadline')), 15_000);
+    })]);
+  } finally { clearTimeout(timer); }
+}

--- a/scripts/lib/reader-summary-recovery-evidence-secure-file.spec.ts
+++ b/scripts/lib/reader-summary-recovery-evidence-secure-file.spec.ts
@@ -8,6 +8,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
+import type * as NodeFilesystem from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -17,6 +18,8 @@ import {
   recoveryEvidenceRoot,
   resolveRecoveryEvidencePath,
 } from "./reader-summary-recovery-evidence-secure-file";
+
+const fs = jest.requireActual<typeof NodeFilesystem>("node:fs");
 
 describe("recovery evidence descriptor-anchored filesystem", () => {
   it("fails closed when a symlink replaces an input after it is opened", () => {
@@ -188,4 +191,168 @@ describe("recovery evidence descriptor-anchored filesystem", () => {
 const secureTemporaryDirectory = (prefix: string): string => {
   const path = mkdtempSync(join(tmpdir(), prefix));
   return path;
+};
+
+describe("recovery evidence directory durability", () => {
+  let root: string;
+  const relativePath = "reader-summary-ready-recovery/operation/events/claim.json";
+  const bytes = Buffer.from("permanent synthetic claim\n");
+  beforeEach(() => { root = secureTemporaryDirectory("evidence-fsync-"); });
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  const install = () => createRecoveryEvidenceFilesystemTestHarness(root).install({
+    relativePath, label: "fixture claim", bytes,
+  });
+
+  it("syncs the entire new directory chain before creating a claim", () => {
+    const trace = traceEvidenceFilesystem(root);
+    expect(install()).toBe("installed");
+    const paths = [root, join(root, "reader-summary-ready-recovery"),
+      join(root, "reader-summary-ready-recovery/operation"),
+      join(root, "reader-summary-ready-recovery/operation/events")];
+    expect(trace.events.filter(event => event.startsWith("sync:"))).toEqual([
+      ...paths.slice(0, -1).map(path => `sync:${path}`),
+      `sync:${join(root, relativePath)}`, `sync:${paths[3]}`,
+    ]);
+    for (let index = 1; index < paths.length; index++) {
+      const child = paths[index]!;
+      const parent = paths[index - 1]!;
+      expect(trace.events.indexOf(`mkdir:${child}`)).toBeLessThan(
+        trace.events.indexOf(`open:${child}`),
+      );
+      expect(trace.events.indexOf(`open:${child}`)).toBeLessThan(
+        trace.events.indexOf(`sync:${parent}`),
+      );
+      expect(trace.events.indexOf(`sync:${parent}`)).toBeLessThan(
+        trace.events.indexOf(`close:${parent}`),
+      );
+      expect(trace.events.indexOf(`sync:${parent}`)).toBeLessThan(
+        trace.events.indexOf(index + 1 < paths.length
+          ? `mkdir:${paths[index + 1]}` : `open:${join(root, relativePath)}`),
+      );
+      expect(statSync(child).mode & 0o7777).toBe(0o700);
+    }
+    expect(fs.readFileSync(join(root, relativePath))).toEqual(bytes);
+    expect(statSync(join(root, relativePath)).mode & 0o7777).toBe(0o400);
+    expect(trace.openDescriptors.size).toBe(0);
+  });
+
+  it("anchors directories already visible from an unfinished sibling creator", () => {
+    mkdirSync(join(root, "reader-summary-ready-recovery/operation/events"), {
+      recursive: true, mode: 0o700,
+    });
+    const trace = traceEvidenceFilesystem(root);
+    expect(install()).toBe("installed");
+    expect(trace.events.filter(event => event.startsWith("mkdir:"))).toEqual([]);
+    expect(trace.events.filter(event => event.startsWith("sync:")).slice(0, 3)).toEqual([
+      `sync:${root}`, `sync:${join(root, "reader-summary-ready-recovery")}`,
+      `sync:${join(root, "reader-summary-ready-recovery/operation")}`,
+    ]);
+    expect(trace.events.indexOf(`sync:${join(root, "reader-summary-ready-recovery/operation")}`))
+      .toBeLessThan(trace.events.indexOf(`open:${join(root, relativePath)}`));
+  });
+
+  it("opens and syncs the exact parent after a concurrent mkdir EEXIST", () => {
+    const realMkdir = fs.mkdirSync;
+    const trace = traceEvidenceFilesystem(root, {
+      beforeMkdir: path => { realMkdir(path, { mode: 0o700 }); },
+    });
+    expect(install()).toBe("installed");
+    expect(trace.events.filter(event => event.startsWith("sync:")).slice(0, 3)).toEqual([
+      `sync:${root}`, `sync:${join(root, "reader-summary-ready-recovery")}`,
+      `sync:${join(root, "reader-summary-ready-recovery/operation")}`,
+    ]);
+    expect(trace.openDescriptors.size).toBe(0);
+  });
+
+  it.each(["", "reader-summary-ready-recovery", "reader-summary-ready-recovery/operation"])(
+    "fails closed and closes both descriptors when parent fsync fails at %s", failedParent => {
+      const trace = traceEvidenceFilesystem(root, { failSync: join(root, failedParent) });
+      expect(install).toThrow("synthetic directory fsync failure");
+      expect(existsSync(join(root, relativePath))).toBe(false);
+      expect(trace.events).not.toContain(`open:${join(root, relativePath)}`);
+      expect(trace.openDescriptors.size).toBe(0);
+    },
+  );
+
+  it("fails closed when a concurrent creator's parent cannot be synced", () => {
+    const realMkdir = fs.mkdirSync;
+    const trace = traceEvidenceFilesystem(root, {
+      beforeMkdir: path => { realMkdir(path, { mode: 0o700 }); }, failSync: root,
+    });
+    expect(install).toThrow("synthetic directory fsync failure");
+    expect(existsSync(join(root, relativePath))).toBe(false);
+    expect(trace.openDescriptors.size).toBe(0);
+  });
+
+  it.each(["symlink", "permissions"])("rejects an EEXIST %s before syncing or advancing", risk => {
+    const realMkdir = fs.mkdirSync;
+    const trace = traceEvidenceFilesystem(root, {
+      beforeMkdir: path => {
+        if (risk === "symlink") symlinkSync(root, path, "dir");
+        else { realMkdir(path, { mode: 0o700 }); chmodSync(path, 0o750); }
+      },
+    });
+    expect(install).toThrow(risk === "symlink"
+      ? /symbolic link|non-directory/u : /permissions must be exactly 0700/u);
+    expect(trace.events.filter(event => event.startsWith("sync:"))).toEqual([]);
+    expect(existsSync(join(root, relativePath))).toBe(false);
+    expect(trace.openDescriptors.size).toBe(0);
+  });
+
+  it("retries a failed directory sync before accepting a subsequent installation", () => {
+    traceEvidenceFilesystem(root, { failSync: root });
+    expect(install).toThrow("synthetic directory fsync failure");
+    jest.restoreAllMocks();
+    const trace = traceEvidenceFilesystem(root);
+    expect(install()).toBe("installed");
+    expect(trace.events).not.toContain(`mkdir:${join(root, "reader-summary-ready-recovery")}`);
+    expect(trace.events).toContain(`sync:${root}`);
+    expect(trace.openDescriptors.size).toBe(0);
+  });
+});
+
+// Real Linux filesystem calls with deterministic interleavings/failures; no power-loss simulation.
+const traceEvidenceFilesystem = (root: string, options: {
+  readonly failSync?: string;
+  readonly beforeMkdir?: (path: NodeFilesystem.PathLike) => void;
+} = {}) => {
+  const realOpen = fs.openSync;
+  const realClose = fs.closeSync;
+  const realMkdir = fs.mkdirSync;
+  const realFsync = fs.fsyncSync;
+  const events: string[] = [];
+  const openDescriptors = new Set<number>();
+  const descriptorPath = (descriptor: number) => fs.readlinkSync(`/proc/self/fd/${descriptor}`);
+  const record = (operation: string, path: string) => {
+    if (path === root || path.startsWith(`${root}/`)) events.push(`${operation}:${path}`);
+  };
+  jest.spyOn(fs, "openSync").mockImplementation((path, flags, mode) => {
+    const descriptor = realOpen(path, flags, mode);
+    openDescriptors.add(descriptor);
+    record("open", descriptorPath(descriptor));
+    return descriptor;
+  });
+  jest.spyOn(fs, "closeSync").mockImplementation(descriptor => {
+    record("close", descriptorPath(descriptor));
+    realClose(descriptor);
+    openDescriptors.delete(descriptor);
+  });
+  jest.spyOn(fs, "mkdirSync").mockImplementation((path, mkdirOptions) => {
+    options.beforeMkdir?.(path);
+    const result = realMkdir(path, mkdirOptions);
+    record("mkdir", fs.realpathSync(path));
+    return result;
+  });
+  jest.spyOn(fs, "fsyncSync").mockImplementation(descriptor => {
+    const path = descriptorPath(descriptor);
+    record("sync", path);
+    if (path === options.failSync) {
+      throw Object.assign(new Error("synthetic directory fsync failure"), { code: "EIO" });
+    }
+    realFsync(descriptor);
+  });
+  return { events, openDescriptors };
 };

--- a/scripts/lib/reader-summary-recovery-evidence-secure-file.ts
+++ b/scripts/lib/reader-summary-recovery-evidence-secure-file.ts
@@ -289,40 +289,53 @@ const openTrustedParent = (
       .filter(Boolean);
     for (const [index, component] of components.entries()) {
       assertSafeName(component);
+      let nextDescriptor: number;
       try {
-        const nextDescriptor = openAnchoredName(
+        nextDescriptor = openAnchoredName(
           descriptor,
           component,
           constants.O_RDONLY |
             constants.O_DIRECTORY |
             constants.O_NOFOLLOW,
         );
-        closeSync(descriptor);
-        descriptor = nextDescriptor;
       } catch (error) {
         if (
           !createMissing ||
           index < evidenceRootComponents.length ||
           errorCode(error) !== "ENOENT"
         ) throw error;
-        mkdirSync(anchoredName(descriptor, component), { mode: 0o700 });
-        const nextDescriptor = openAnchoredName(
+        try {
+          mkdirSync(anchoredName(descriptor, component), { mode: 0o700 });
+        } catch (mkdirError) {
+          if (errorCode(mkdirError) !== "EEXIST") throw mkdirError;
+        }
+        nextDescriptor = openAnchoredName(
           descriptor,
           component,
           constants.O_RDONLY |
             constants.O_DIRECTORY |
             constants.O_NOFOLLOW,
         );
-        closeSync(descriptor);
-        descriptor = nextDescriptor;
       }
       traversed = resolve(traversed, component);
-      assertSecureDirectory(
-        fstatSync(descriptor, { bigint: true }),
-        traversed,
-        index >= evidenceRootComponents.length - 1,
-        policy,
-      );
+      try {
+        assertSecureDirectory(
+          fstatSync(nextDescriptor, { bigint: true }),
+          traversed,
+          index >= evidenceRootComponents.length - 1,
+          policy,
+        );
+        // Existing children may belong to a creator that has not fsynced yet.
+        // Anchor every child below the evidence root before advancing.
+        if (createMissing && index >= evidenceRootComponents.length) {
+          fsyncSync(descriptor);
+        }
+      } catch (error) {
+        closeSync(nextDescriptor);
+        throw error;
+      }
+      closeSync(descriptor);
+      descriptor = nextDescriptor;
     }
     return Object.freeze({
       descriptor,

--- a/scripts/recover-reader-summary-ready-events.ts
+++ b/scripts/recover-reader-summary-ready-events.ts
@@ -5,7 +5,7 @@ import { PostgresRuntimePoolRegistry, defaultPostgresRuntimePoolConfig, type Pri
 import { RabbitMqEventPublisher } from '@social-monitor/platform-events/adapters/rabbitmq';
 import { AmqplibRabbitMqChannel } from '@social-monitor/platform-queue/adapters/rabbitmq';
 import { readSecureRecoveryEvidenceFile, recoveryEvidenceRoot } from './lib/reader-summary-recovery-evidence-secure-file';
-import { failureCode, parseRecoveryManifest, requireRecovery } from './lib/reader-summary-ready-recovery-manifest';
+import { assertRecoveryWindow, failureCode, parseRecoveryManifest, requireRecovery } from './lib/reader-summary-ready-recovery-manifest';
 import { recoveryPersistence, type RecoveryDatabase } from './lib/reader-summary-ready-recovery-persistence';
 import { runReadyRecovery } from './lib/reader-summary-ready-recovery-run';
 
@@ -24,19 +24,28 @@ export async function main(args: readonly string[], env: NodeJS.ProcessEnv): Pro
   const bytes = readSecureRecoveryEvidenceFile({ relativePath: relative(recoveryEvidenceRoot, manifestPath), label: 'reviewed ready manifest' });
   const manifest = parseRecoveryManifest(bytes, reviewedSha256);
   requireRecovery(manifest.deployedSourceSha === deployedSha, 'deployed_source_mismatch');
-  const channel = apply ? new AmqplibRabbitMqChannel({ url: required('READER_READY_RECOVERY_RABBITMQ_URL'), socketOptions: { timeout: 5_000 } }) : undefined;
+  const clock = new SystemClock();
+  const channel = apply ? new AmqplibRabbitMqChannel({ url: required('READER_READY_RECOVERY_RABBITMQ_URL'), socketOptions: { timeout: 5_000 },
+    beforePublish: () => assertRecoveryWindow(manifest, deployedSha, clock.now()) }) : undefined;
   const Client = loadPrismaRuntimeClient<PrismaPgRuntimeClientConstructor<RecoveryDatabase>>();
   const connection = await new PostgresRuntimePoolRegistry().acquire(defaultPostgresRuntimePoolConfig(databaseUrl, 'event-relay'), Client);
   try {
-    const clock = new SystemClock();
     const result = await runReadyRecovery({ bytes, reviewedSha256, deployedSha, apply, clock,
       persistence: recoveryPersistence(connection.client, clock),
       publisher: channel ? new RabbitMqEventPublisher(channel, { exchange: 'social-monitor.events', mandatory: true })
         : { publish: async () => { throw new Error('Dry run cannot publish'); } },
+      cancelPendingPublishes: () => channel?.cancelPendingPublishes(),
       sleep: milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)),
     });
     console.log(JSON.stringify(result));
-  } finally { await channel?.close(); await connection.close(); }
+  } finally {
+    channel?.cancelPendingPublishes();
+    // Resource cleanup is separate from synchronous send inhibition. A stalled
+    // amqplib close must not hold DB resources or be mistaken for send cancellation.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try { await Promise.race([channel?.close(), new Promise<void>(resolve => { timer = setTimeout(resolve, 5_000); })]); }
+    finally { clearTimeout(timer); await connection.close(); }
+  }
 }
 if (require.main === module) void main(process.argv.slice(2), process.env).catch(error => {
   console.error(JSON.stringify({ error: failureCode(error) })); process.exitCode = 1;

--- a/scripts/recover-reader-summary-ready-events.ts
+++ b/scripts/recover-reader-summary-ready-events.ts
@@ -1,0 +1,43 @@
+import { relative } from 'node:path';
+import { SystemClock } from '@social-monitor/shared-kernel';
+import { loadPrismaRuntimeClient } from '@social-monitor/platform-persistence/prisma-runtime-client';
+import { PostgresRuntimePoolRegistry, defaultPostgresRuntimePoolConfig, type PrismaPgRuntimeClientConstructor } from '@social-monitor/platform-persistence';
+import { RabbitMqEventPublisher } from '@social-monitor/platform-events/adapters/rabbitmq';
+import { AmqplibRabbitMqChannel } from '@social-monitor/platform-queue/adapters/rabbitmq';
+import { readSecureRecoveryEvidenceFile, recoveryEvidenceRoot } from './lib/reader-summary-recovery-evidence-secure-file';
+import { failureCode, parseRecoveryManifest, requireRecovery } from './lib/reader-summary-ready-recovery-manifest';
+import { recoveryPersistence, type RecoveryDatabase } from './lib/reader-summary-ready-recovery-persistence';
+import { runReadyRecovery } from './lib/reader-summary-ready-recovery-run';
+
+export function recoveryArguments(args: readonly string[]): { manifestPath: string; apply: boolean } {
+  requireRecovery(args.length === 2 || args.length === 3, 'usage_manifest_dry_run_or_apply');
+  requireRecovery(args[0] === '--manifest' && args[1]?.startsWith('/') &&
+    (args[2] === undefined || args[2] === '--dry-run' || args[2] === '--apply'), 'usage_manifest_dry_run_or_apply');
+  return { manifestPath: args[1]!, apply: args[2] === '--apply' };
+}
+export async function main(args: readonly string[], env: NodeJS.ProcessEnv): Promise<void> {
+  const { manifestPath, apply } = recoveryArguments(args);
+  const required = (key: string): string => { const value = env[key]; requireRecovery(value !== undefined && value.trim(), 'explicit_recovery_config_required'); return value; };
+  const reviewedSha256 = required('READER_READY_RECOVERY_MANIFEST_SHA256');
+  const deployedSha = required('READER_READY_RECOVERY_DEPLOYED_SHA');
+  const databaseUrl = required('READER_READY_RECOVERY_DATABASE_URL');
+  const bytes = readSecureRecoveryEvidenceFile({ relativePath: relative(recoveryEvidenceRoot, manifestPath), label: 'reviewed ready manifest' });
+  const manifest = parseRecoveryManifest(bytes, reviewedSha256);
+  requireRecovery(manifest.deployedSourceSha === deployedSha, 'deployed_source_mismatch');
+  const channel = apply ? new AmqplibRabbitMqChannel({ url: required('READER_READY_RECOVERY_RABBITMQ_URL'), socketOptions: { timeout: 5_000 } }) : undefined;
+  const Client = loadPrismaRuntimeClient<PrismaPgRuntimeClientConstructor<RecoveryDatabase>>();
+  const connection = await new PostgresRuntimePoolRegistry().acquire(defaultPostgresRuntimePoolConfig(databaseUrl, 'event-relay'), Client);
+  try {
+    const clock = new SystemClock();
+    const result = await runReadyRecovery({ bytes, reviewedSha256, deployedSha, apply, clock,
+      persistence: recoveryPersistence(connection.client, clock),
+      publisher: channel ? new RabbitMqEventPublisher(channel, { exchange: 'social-monitor.events', mandatory: true })
+        : { publish: async () => { throw new Error('Dry run cannot publish'); } },
+      sleep: milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)),
+    });
+    console.log(JSON.stringify(result));
+  } finally { await channel?.close(); await connection.close(); }
+}
+if (require.main === module) void main(process.argv.slice(2), process.env).catch(error => {
+  console.error(JSON.stringify({ error: failureCode(error) })); process.exitCode = 1;
+});


### PR DESCRIPTION
Reader Summary publications can have a valid immutable artifact while their reader_summary.ready outbox event remains FAILED. Add an explicit, hash-reviewed one-shot recovery command for an exact allowlist of up to 17 original event IDs, preserving their envelopes and existing publication/report/proof identities. Legitimately superseded historical artifacts remain recoverable.

Durable operation and per-event claims are installed with descriptor-anchored filesystem validation and parent-directory fsync before any effect. Dispatch uses mandatory RabbitMQ confirms, cancellation and a bounded exclusive window; standard outbox transitions compare PostgreSQL xmin. Recovery then verifies the consumer inbox and matching realtime replay projection. Unknown outcomes stop the cohort without automatic resend. Dry-run is the default.

Validation on head 5d38cbc2661cb0559558cdca02671bbd087138e0:
- All 10 CI jobs passed in run 33993983531.
- Focused recovery/delivery/filesystem tests: 331 tests in 36 suites passed.
- Native PostgreSQL 18 recovery fixture passed in 7.923 seconds, including supersession, microsecond/xmin races, actual inbox/projection persistence, post-confirm DB failure and permanent claims.
- Independent hosted final review APPROVE; 24 additional in-memory checks verified directory durability and no effects after claim failure. The prior P1 directory fsync defect is resolved.
- CodeRabbit minor observations checked: private TMPDIR is an explicit documented fixture prerequisite; indexed projection is narrowed by the assertion signature and equality guard.

Production recovery and seven-day historical metric/summary refresh are separate operator acceptance steps. This PR does not claim those effects have happened.
