### PR TITLE
feat(summary): refresh historical summaries from new observed inputs

### DIFF
--- a/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
@@ -431,6 +431,15 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
     `));
   });
 
+  it('keeps the historical refresh race writer reachable only from its native test gate', () => {
+    const helper = 'scripts/lib/reader-summary-new-input-refresh-native-concurrency.ts';
+    const consumers = completeDatabaseSourceFiles.filter((path) =>
+      path !== helper && !path.endsWith('.spec.ts') &&
+      readSource(path).includes('reader-summary-new-input-refresh-native-concurrency'),
+    );
+    expect(consumers).toEqual(['scripts/check-reader-summary-new-input-refresh-postgres.ts']);
+  });
+
   it('fails on every future raw database-client dependency bypass', () => {
     const rawDependencyFiles = completeDatabaseSourceFiles
       .filter((path) => {
@@ -504,6 +513,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/lib/reader-summary-daily-terminal-runtime-connection.ts
       scripts/lib/reader-summary-large-daily-publication-postgres-contract.ts
       scripts/lib/reader-summary-linear-utf16-postgres-contract.ts
+      scripts/lib/reader-summary-new-input-refresh-native-concurrency.ts
       scripts/lib/reader-summary-production-day-scope.spec.ts
       scripts/lib/reader-summary-production-day-scope.ts
       scripts/lib/reader-summary-promotion-v2-historical-postgres.ts

--- a/libs/summary/application/contracts/reader-summary-new-input-refresh-authority.ts
+++ b/libs/summary/application/contracts/reader-summary-new-input-refresh-authority.ts
@@ -1,0 +1,8 @@
+import type { ReaderSummaryJobProps } from "../../domain";
+
+export const readerSummaryNewInputRefreshPrefix = "new-input-refresh:v1:";
+
+/** A consumed, reviewed operation; never supplied by ordinary queue composition. */
+export interface ReaderSummaryNewInputRefreshAuthority {
+  claim(job: ReaderSummaryJobProps): Promise<Date>;
+}

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.ts
@@ -1,3 +1,4 @@
+import { readerSummaryNewInputRefreshPrefix, type ReaderSummaryNewInputRefreshAuthority } from "../../application/contracts/reader-summary-new-input-refresh-authority";
 import {
   type Clock,
   DomainError,
@@ -88,6 +89,7 @@ export class ExecuteReaderSummaryJobUseCase {
     private readonly historicalGitHubOmission?: ReaderSummaryHistoricalGitHubOmission,
     private readonly recoveryProvenance?: ReaderSummaryDailyCanonicalRecoveryV4ProvenancePort,
     private readonly executionLease: ReaderSummaryExecutionLeasePolicy = new ReaderSummaryExecutionLeasePolicy(),
+    private readonly newInputRefresh?: ReaderSummaryNewInputRefreshAuthority,
   ) {}
 
   async execute(
@@ -120,6 +122,22 @@ export class ExecuteReaderSummaryJobUseCase {
     }
 
     const snapshot = existingJob.toSnapshot();
+    let observedThrough: Date | undefined;
+    if (snapshot.idempotencyKey.startsWith(readerSummaryNewInputRefreshPrefix)) {
+      try {
+        if (this.newInputRefresh === undefined) {
+          return err(new DomainError("operation.conflict", "Historical new-input refresh requires reviewed authority"));
+        }
+        observedThrough = await this.newInputRefresh.claim(snapshot);
+        if (!Number.isFinite(observedThrough.getTime()) ||
+            observedThrough.getTime() > this.clock.now().getTime()) {
+          return err(new DomainError("validation.failed", "Historical new-input refresh cutoff is invalid"));
+        }
+      } catch {
+        return err(new DomainError("operation.conflict",
+          "Historical new-input refresh requires reconciliation or valid authority"));
+      }
+    }
     if (snapshot.status === "completed" || snapshot.status === "no_signal") {
       return ok({
         readerSummaryJobId: snapshot.id,
@@ -154,6 +172,7 @@ export class ExecuteReaderSummaryJobUseCase {
       const result = await this.runModelPipeline(
         runningJob,
         command.maxEvidenceItems ?? defaultReaderSummaryMaxEvidenceItems,
+        observedThrough,
       );
 
       if (!result.ok) {
@@ -187,7 +206,7 @@ export class ExecuteReaderSummaryJobUseCase {
         editorialEvidence: result.value.editorialEvidence,
         publicationPolicy: this.publicationPolicy,
         githubProjectionReader: this.githubProjectionReader,
-        observedThrough: this.clock.now(),
+        observedThrough: observedThrough ?? this.clock.now(),
         historicalGitHubOmission: this.historicalGitHubOmission,
         recoveryProvenance: this.recoveryProvenance,
       });
@@ -283,6 +302,7 @@ export class ExecuteReaderSummaryJobUseCase {
   private async runModelPipeline(
     job: ReaderSummaryJob,
     maxEvidenceItems: number,
+    observedThrough?: Date,
   ): Promise<ReaderSummaryModelPipelineResult> {
     const snapshot = job.toSnapshot();
     const generatedAt = this.clock.now();
@@ -294,7 +314,7 @@ export class ExecuteReaderSummaryJobUseCase {
       userId: snapshot.userId,
       subscriptionId: snapshot.subscriptionId,
       maxItems: maxEvidenceItems,
-      observedThrough: generatedAt,
+      observedThrough: observedThrough ?? generatedAt,
     });
     const readerSummaryId = this.ids.generate();
     const admittedSelection = admitReaderPostPromotionEvidence(selectedEvidence);

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-new-input-refresh.spec.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-new-input-refresh.spec.ts
@@ -1,0 +1,94 @@
+import type { ReaderSummaryEvidenceSelectorPort } from "../../ports";
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { ReaderSummaryJob } from "../../domain";
+import { ExecuteReaderSummaryJobUseCase } from "./execute-reader-summary-job.use-case";
+import { FakeReaderSummaryJobRepository } from "./execute-reader-summary-job.spec-support";
+import { PromotionControlArtifactRepository, PromotionControlTrendingModel, PromotionControlEventPublisher,
+  PromotionControlIdGenerator, PromotionControlPolicyRepository, PromotionControlPublication,
+  promotionControlEmptyTopicMapBuilder } from "./execute-reader-summary-job-promotion-control.spec-support";
+import { readerSummaryPromotionControl, NOOP_READER_SUMMARY_PROMOTION_METRICS } from "./reader-summary-promotion-control";
+import { makeReaderEvidenceSelection, withReaderPromotionEditorialSlate, githubEvidence } from "../../test-fixtures/execute-reader-summary-job-promotion-fixtures";
+import type { ReaderSummaryNewInputRefreshAuthority } from "../../application/contracts/reader-summary-new-input-refresh-authority";
+
+const scope = { tenantId: tenantId("00000000-0000-7000-8000-000000006101"), workspaceId: workspaceId("00000000-0000-7000-8000-000000006102") };
+const cutoff = new Date("2026-09-05T21:59:00.000Z");
+const now = new Date("2026-09-05T22:10:00.000Z");
+async function scenario(admitted = true, empty = false) {
+  const jobs = new FakeReaderSummaryJobRepository();
+  const old = ReaderSummaryJob.request({ ...scope, id: "prior-job", scope: { type: "workspace" },
+    period: { cadence: "daily", startedAt: new Date("2026-09-03T00:00:00Z"), endedAt: new Date("2026-09-04T00:00:00Z"),
+      timezone: "UTC", periodKey: "daily:2026-09-03T00:00:00.000Z:2026-09-04T00:00:00.000Z:UTC" },
+    idempotencyKey: "prior-normal-key", requestedAt: new Date("2026-09-04T00:01:00Z") });
+  await jobs.save(old.start({ startedAt: new Date("2026-09-04T00:02:00Z") }).markNoSignal({ completedAt: new Date("2026-09-04T00:03:00Z"), readerSummaryId: "prior-artifact" }));
+  const oldBefore = JSON.stringify(await jobs.findById({ ...scope, readerSummaryJobId: "prior-job" }));
+  const job = ReaderSummaryJob.request({ ...old.toSnapshot(), id: "new-job", idempotencyKey: "new-input-refresh:v1:2026-09-03:operation", requestedAt: now });
+  await jobs.save(job);
+  const artifacts = new PromotionControlArtifactRepository();
+  const model = new PromotionControlTrendingModel();
+  const githubItems = Array.from({ length: 10 }, (_, index) => ({
+    feedItemId: `github-feed-${index + 1}`, sourceItemId: `github-source-${index + 1}`,
+    sourceBindingId: "github-binding-daily", providerKey: "github-trending-page",
+    metadataKind: "github_trending_page_repository", scanJobId: "github-scan-daily",
+    canonicalUrl: `https://github.com/owner/repo-${index + 1}`, repositoryFullName: `owner/repo-${index + 1}`,
+    rank: index + 1, starsGained: index < 3 ? 1_101 : 100 + index, window: "daily",
+    fetchStartedAt: new Date("2026-09-03T07:19:00Z"), checkedAt: new Date("2026-09-03T07:20:00Z"),
+    publishedAt: new Date("2026-09-03T07:20:00Z"), observedAt: new Date("2026-09-03T07:30:00Z"),
+    sourceContentHash: "a".repeat(64), sourceProviderContentHash: "b".repeat(64),
+  }));
+  const select = jest.fn(async (_query: Parameters<ReaderSummaryEvidenceSelectorPort["select"]>[0]) => {
+    void _query;
+    const evidence = shift(makeReaderEvidenceSelection());
+    const item = evidence.selectedEvidence[0]!;
+    return withReaderPromotionEditorialSlate({ ...evidence,
+      sourceWindow: { ...evidence.sourceWindow, ingestionCutoff: cutoff,
+        selectedFeedItemIds: empty ? [] : [item.feedItemId], storyClusterIds: empty ? [] : [evidence.clusters[0]!.id] },
+      selectedEvidence: empty ? [] : [{ ...item, promotionFacts: { ...item.promotionFacts!,
+        engagementAuthority: { observedAt: new Date("2026-09-05T21:55:00Z"), regressionState: "stable" },
+        freshnessProvenance: { status: "observed", publishedAt: item.publishedAt, observedAt: item.observedAt, ingestionCutoff: cutoff },
+      } }, ...githubItems.map((item) => ({ ...shift(githubEvidence()), ...item,
+        providerMetricLabels: [{ label: "GitHub Trending today", value: `#${item.rank} · +${item.starsGained} stars today` }],
+      }))], clusters: empty ? [] : [evidence.clusters[0]!],
+    });
+  });
+  const github = { read: jest.fn(async (_query: unknown) => {
+    void _query;
+    return { eligibleBindingIds: ["github-binding-daily"], pageCount: 1, items: githubItems };
+  }) };
+  const authority: ReaderSummaryNewInputRefreshAuthority = { claim: jest.fn(async () => cutoff) };
+  const execute = new ExecuteReaderSummaryJobUseCase(jobs, artifacts, new PromotionControlPolicyRepository(), { select }, model,
+    new PromotionControlPublication(jobs, artifacts, new PromotionControlEventPublisher()), new PromotionControlIdGenerator(), new FixedClock(now),
+    readerSummaryPromotionControl(NOOP_READER_SUMMARY_PROMOTION_METRICS), undefined, undefined,
+    promotionControlEmptyTopicMapBuilder(), undefined, github, undefined, undefined, undefined, admitted ? authority : undefined);
+  const result = await execute.execute({ ...scope, readerSummaryJobId: "new-job" });
+  return { result, jobs, model, select, github, artifacts, oldBefore };
+}
+describe("canonical execution admission for historical new inputs", () => {
+  it("keeps an ordinary worker from executing a reserved operation", async () => {
+    const s = await scenario(false);
+    expect(s.result).toMatchObject({ ok: false });
+    expect(s.select).not.toHaveBeenCalled();
+    expect(s.model.generatedEvidenceIds()).toEqual([]);
+  });
+  it("threads the accepted cutoff to selection and GitHub checks while generation stays real", async () => {
+    const s = await scenario();
+    expect(s.result).toMatchObject({ ok: true, value: { status: "completed" } });
+    expect((await s.jobs.findById({ ...scope, readerSummaryJobId: "prior-job" }))?.toSnapshot().status).toBe("no_signal");
+    expect(s.select.mock.calls[0]?.[0]).toMatchObject({ observedThrough: cutoff });
+    expect(s.github.read.mock.calls[0]?.[0]).toMatchObject({ observedThrough: cutoff });
+    expect(s.artifacts.all()[0]?.toSnapshot().generatedAt).toEqual(now);
+    expect(JSON.stringify(await s.jobs.findById({ ...scope, readerSummaryJobId: "prior-job" }))).toBe(s.oldBefore);
+    expect(s.model.generatedEvidenceIds()).toHaveLength(1);
+  });
+  it("empty current input produces truthful NO_SIGNAL without a model", async () => {
+    const s = await scenario(true, true);
+    expect(s.result).toMatchObject({ ok: true, value: { status: "no_signal" } });
+    expect(s.model.generatedEvidenceIds()).toEqual([]);
+  });
+});
+
+function shift<T>(value: T): T {
+  if (value instanceof Date) return new Date(value.getTime() + Date.parse("2026-09-03T00:00:00Z") - Date.parse("2026-06-26T00:00:00Z")) as T;
+  if (Array.isArray(value)) return value.map(shift) as T;
+  if (value !== null && typeof value === "object") return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, shift(v)])) as T;
+  return value;
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Backend/API-first social monitoring MVP platform.",
   "license": "Apache-2.0",
   "scripts": {
+    "check:reader-summary-new-input-refresh:postgres": "node scripts/run-with-timeout.mjs --timeout-ms 180000 --node-options --max-old-space-size=1024 -- ts-node -P tsconfig.build.json -r tsconfig-paths/register scripts/check-reader-summary-new-input-refresh-postgres.ts",
+    "run:reader-summary-new-input-refresh": "ts-node -P tsconfig.build.json -r tsconfig-paths/register scripts/run-reader-summary-new-input-refresh.ts",
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "check:agent-quality-rules": "node scripts/check-agent-quality-rules.mjs",
     "check:claude-hooks": "node scripts/check-claude-hooks.mjs",

--- a/scripts/check-reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/check-reader-summary-new-input-refresh-postgres.ts
@@ -1,0 +1,149 @@
+/** Parent-only native gate: a migrated disposable fixture, never a server,
+ * provider, model, or production connection. Uses the actual Prisma publisher. */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { runWithTenantDatabaseAccess, resolvePostgresRuntimePoolConfig, getPostgresRuntimePoolDiagnostics } from "@social-monitor/platform-persistence";
+import { PrismaFeedConnection } from "@social-monitor/feed/adapters/persistence/prisma/prisma-feed-connection";
+import { PrismaFeedItemReadRepository } from "@social-monitor/feed/adapters/persistence/prisma/prisma-feed-item-read.repository";
+import { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
+import { PrismaReaderSummaryPublication } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-publication";
+import { PrismaReaderSummaryJobRepository } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-job.repository";
+import { normalizeReaderSummaryArtifactPayload } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-artifact-payload";
+import { buildReaderSummaryPublicationPayload, type ReaderSummaryPublicationPayload } from "@social-monitor/summary/adapters/persistence/reader-summary-publication-proof";
+import { ReaderSummaryArtifact } from "@social-monitor/summary/domain";
+import type { ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { SystemClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { refreshScope, assertRefreshManifest, refreshBytesHash } from "./lib/reader-summary-new-input-refresh-manifest";
+import { readRefreshPrior, readRefreshJobs, readRefreshCounts } from "./lib/reader-summary-new-input-refresh-postgres";
+import { assertRefreshEqual, reconcileRefresh } from "./lib/reader-summary-new-input-refresh-guard";
+import { captureRefreshAuthority, preflightRefreshSelection, assertRefreshHasNewInput } from "./lib/reader-summary-new-input-refresh-capture";
+import { assertRefreshTransactionAuthority, refreshPublicationGuard } from "./lib/reader-summary-new-input-refresh-execution";
+import { readReviewedRefresh } from "./lib/reader-summary-new-input-refresh-files";
+
+const required = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required; this native gate never skips`);
+  return value;
+};
+async function main() {
+  const url = required("READER_SUMMARY_REFRESH_TEST_DATABASE_URL");
+  assert.match(decodeURIComponent(new URL(url).pathname.slice(1)), /^reader_summary_refresh_test_[a-z0-9]+$/u);
+  const m = readReviewedRefresh(required("READER_SUMMARY_REFRESH_TEST_MANIFEST_PATH"),
+    required("READER_SUMMARY_REFRESH_TEST_MANIFEST_SHA256"));
+  const clock = new SystemClock();
+  assertRefreshManifest(m, clock.now());
+  const bytes = readFileSync(required("READER_SUMMARY_REFRESH_TEST_CANDIDATE_PATH"));
+  assert.equal(refreshBytesHash(bytes), required("READER_SUMMARY_REFRESH_TEST_CANDIDATE_SHA256"));
+  const candidate = JSON.parse(bytes.toString("utf8")) as ReaderSummaryPublicationPayload;
+  assert.equal(candidate.tenantId, refreshScope.tenantId);
+  assert.equal(candidate.workspaceId, refreshScope.workspaceId);
+  assert.equal(candidate.periodStartedAt, m.startedAt);
+  assert.equal(candidate.modelVersion, "codex:gpt-5.6-sol:high");
+  assert(candidate.requestedAt >= m.observedThrough && candidate.requestedAt <= clock.now().toISOString());
+  assert.notEqual(candidate.requestedUtcDate, m.date, "fixture must use a historical content date and a real operation date");
+  const config = resolvePostgresRuntimePoolConfig({ DATABASE_URL: url, POSTGRES_RUNTIME_PROCESS: "daily-runner",
+    POSTGRES_RUNTIME_POOL_MIN: "0", POSTGRES_RUNTIME_POOL_MAX: "2" });
+  const summary = await PrismaSummaryConnection.create(config);
+  const feedConnection = await PrismaFeedConnection.create(config);
+  const feed = new PrismaFeedItemReadRepository(feedConnection);
+  try {
+    await runWithTenantDatabaseAccess(refreshScope, async () => {
+      assert.deepEqual(getPostgresRuntimePoolDiagnostics(), {
+        poolInstances: 1, prismaClientInstances: 1, activeConnectionLeases: 2, closing: false,
+      });
+      const before = await readRefreshPrior(summary, m.date);
+      assertRefreshEqual(before, m.prior, "fixture prior");
+      await assertRefreshHasNewInput(summary, m.date, before.observedThrough, m.observedThrough);
+      assertRefreshEqual(await captureRefreshAuthority({ client: summary, feed, date: m.date,
+        observedThrough: new Date(m.observedThrough), clock }), m.authority, "fixture full current input");
+      const originalSelection = await preflightRefreshSelection({ feed, date: m.date, clock, observedThrough: new Date(before.observedThrough) });
+      const newSelection = await preflightRefreshSelection({ feed, date: m.date, clock, observedThrough: new Date(m.observedThrough) });
+      if (before.status === "NO_SIGNAL") assert.equal(originalSelection, 0, "original cutoff has no eligible metric authority");
+      assert(newSelection > 0, "new cutoff selects current full canonical inputs");
+      const command = await fixtureCommand(summary, candidate);
+      assertRefreshEqual(buildReaderSummaryPublicationPayload(command), candidate, "normal Prisma command roundtrip");
+      assert.throws(() => reconcileRefresh(m, [{ operation: m.operation, jobId: candidate.readerSummaryJobId,
+        artifactId: null, status: "RUNNING" }], before), /consumed/);
+      const local = () => assertRefreshManifest(m, clock.now());
+      const current = (tx: PrismaReaderSummaryClient) => assertRefreshTransactionAuthority(tx, m, candidate.readerSummaryJobId, clock);
+      const guard = refreshPublicationGuard({ assertLocal: local, assertCurrent: current, manifest: m, jobId: candidate.readerSummaryJobId });
+      for (const phase of ["before-generation", "before-publication"]) {
+        for (const mutation of ["engagement", "config", "slot", "input"] as const) {
+          if (phase === "before-generation") {
+            await assert.rejects(summary.$transaction(async (tx) => {
+              await mutateFixture(tx, mutation, m.date);
+              await current(tx);
+            }, { isolationLevel: "Serializable" }), /drifted|canonical prior/);
+          } else {
+            const publisher = new PrismaReaderSummaryPublication(summary, async (tx, value) => {
+              await mutateFixture(tx, mutation, m.date);
+              await guard(tx, value);
+            });
+            await assert.rejects(publisher.publish(command), /drifted|canonical prior/);
+          }
+        }
+      }
+      const countsBefore = await readRefreshCounts(summary, m.date);
+      const started = Date.now();
+      assert.equal(await new PrismaReaderSummaryPublication(summary, guard).publish(command), "published");
+      const publicationMs = Date.now() - started;
+      assert(publicationMs < 30_000, "publisher guard must finish with the shared max2 pool, no nested/root reads");
+      const after = await readRefreshPrior(summary, m.date);
+      assert.equal(after.status, "COMPLETED");
+      assert.equal(after.observedThrough, m.observedThrough);
+      assert.notEqual(after.publicationId, before.publicationId);
+      assertRefreshEqual(await readRefreshPrior(summary, m.date, before.publicationId), before, "immutable prior report/proof/job");
+      assert.equal(reconcileRefresh(m, await readRefreshJobs(summary, m.date), after), "published");
+      const countsAfter = await readRefreshCounts(summary, m.date);
+      for (const key of ["publications", "outbox", "artifacts"] as const) assert.equal(countsAfter[key] - countsBefore[key], 1);
+      assert.equal(countsAfter.jobs, countsBefore.jobs, "fixture already owns the one consumed job");
+      assert.equal((await readRefreshJobs(summary, m.date)).length, 1);
+      assert.equal(await new PrismaReaderSummaryPublication(summary).publish(command), "replayed");
+      assertRefreshEqual(await readRefreshCounts(summary, m.date), countsAfter, "replay zero delta");
+      console.log(JSON.stringify({ status: "passed", date: m.date, priorStatus: before.status,
+        originalSelection, newSelection, before, after, countsBefore, countsAfter, publicationMs,
+        scenarios: ["actual-cutoff", "changed-input", "engagement-config-slot-input-drift-both-boundaries",
+          "consumed-no-repeat", "normal-prisma-publisher-max2", "preserved-original", "replay-zero-delta"] }));
+    });
+  } finally { await feedConnection.close(); await summary.close(); }
+}
+async function fixtureCommand(summary: PrismaSummaryConnection, p: ReaderSummaryPublicationPayload): Promise<ReaderSummaryPublicationCommand> {
+  const job = await new PrismaReaderSummaryJobRepository(summary).findById({ tenantId: tenantId(p.tenantId),
+    workspaceId: workspaceId(p.workspaceId), readerSummaryJobId: p.readerSummaryJobId });
+  assert(job !== null && job.toSnapshot().status === "running");
+  const artifact = ReaderSummaryArtifact.rehydrate(normalizeReaderSummaryArtifactPayload(p.report.artifactPayload, {
+    id: p.readerSummaryArtifactId, tenantId: p.tenantId, workspaceId: p.workspaceId, scopeType: "workspace",
+    interestId: null, cadence: "daily", periodStartedAt: new Date(p.periodStartedAt), periodEndedAt: new Date(p.periodEndedAt),
+    periodTimezone: "UTC", userId: null, subscriptionId: null, headline: String(p.report.headline),
+    summaryText: String(p.report.summaryText), createdAt: new Date(p.publishedAt),
+  }));
+  const generatedAt = artifact.toSnapshot().generatedAt;
+  assert(generatedAt !== undefined && generatedAt >= job.toSnapshot().requestedAt);
+  const quality = p.report.qualitySignals as Record<string, unknown>;
+  return { artifact, finalJob: job.complete({ completedAt: new Date(p.publishedAt), readerSummaryId: p.readerSummaryArtifactId }),
+    publicationDecision: quality.publicationDecision as ReaderSummaryPublicationCommand["publicationDecision"],
+    githubProjectionAudit: quality.githubProjectionAudit as ReaderSummaryPublicationCommand["githubProjectionAudit"],
+    readyEvent: p.readyEvent as unknown as ReaderSummaryPublicationCommand["readyEvent"] };
+}
+async function mutateFixture(tx: PrismaReaderSummaryClient, kind: "engagement" | "config" | "slot" | "input", date: string) {
+  // Fixed SQL, fixture only, always rolled back by the rejected guard.
+  const db = tx as PrismaReaderSummaryClient & { $executeRaw(s: TemplateStringsArray, ...v: unknown[]): Promise<number> };
+  const count = kind === "engagement" ? await db.$executeRaw`update source_item_engagement_snapshots
+    set last_observed_at = last_observed_at + interval '1 millisecond'
+    where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid`
+    : kind === "config" ? await db.$executeRaw`update reader_summary_policies set tone = case when tone='analytical' then 'neutral' else 'analytical' end
+      where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid and scope_key='workspace'`
+    : kind === "slot" ? await db.$executeRaw`update reader_summary_publication_slots set current_publication_id=null
+      where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid
+        and period_started_at=${date}::date::timestamp at time zone 'UTC'`
+    : await db.$executeRaw`update feed_items set title=title || ' fixture drift'
+      where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid
+        and published_at >= ${date}::date::timestamp at time zone 'UTC'
+        and published_at < (${date}::date + 1)::timestamp at time zone 'UTC'`;
+  assert(count > 0, `fixture must exercise ${kind}`);
+}
+if (require.main === module) void main().catch(() => {
+  console.error("Native new-input refresh fixture gate failed; inspect the disposable fixture. No raw payload is logged.");
+  process.exitCode = 1;
+});

--- a/scripts/check-reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/check-reader-summary-new-input-refresh-postgres.ts
@@ -18,7 +18,8 @@ import { refreshScope, assertRefreshManifest, refreshBytesHash } from "./lib/rea
 import { readRefreshPrior, readRefreshJobs, readRefreshCounts } from "./lib/reader-summary-new-input-refresh-postgres";
 import { assertRefreshEqual, reconcileRefresh } from "./lib/reader-summary-new-input-refresh-guard";
 import { captureRefreshAuthority, preflightRefreshSelection, assertRefreshHasNewInput } from "./lib/reader-summary-new-input-refresh-capture";
-import { assertRefreshTransactionAuthority, refreshPublicationGuard } from "./lib/reader-summary-new-input-refresh-execution";
+import { assertRefreshTransactionAuthority } from "./lib/reader-summary-new-input-refresh-execution";
+import { runRefreshNativeConcurrency } from "./lib/reader-summary-new-input-refresh-native-concurrency";
 import { readReviewedRefresh } from "./lib/reader-summary-new-input-refresh-files";
 
 const required = (name: string): string => {
@@ -65,30 +66,17 @@ async function main() {
       assertRefreshEqual(buildReaderSummaryPublicationPayload(command), candidate, "normal Prisma command roundtrip");
       assert.throws(() => reconcileRefresh(m, [{ operation: m.operation, jobId: candidate.readerSummaryJobId,
         artifactId: null, status: "RUNNING" }], before), /consumed/);
-      const local = () => assertRefreshManifest(m, clock.now());
       const current = (tx: PrismaReaderSummaryClient) => assertRefreshTransactionAuthority(tx, m, candidate.readerSummaryJobId, clock);
-      const guard = refreshPublicationGuard({ assertLocal: local, assertCurrent: current, manifest: m, jobId: candidate.readerSummaryJobId });
-      for (const phase of ["before-generation", "before-publication"]) {
-        for (const mutation of ["engagement", "config", "slot", "input"] as const) {
-          if (phase === "before-generation") {
-            await assert.rejects(summary.$transaction(async (tx) => {
-              await mutateFixture(tx, mutation, m.date);
-              await current(tx);
-            }, { isolationLevel: "Serializable" }), /drifted|canonical prior/);
-          } else {
-            const publisher = new PrismaReaderSummaryPublication(summary, async (tx, value) => {
-              await mutateFixture(tx, mutation, m.date);
-              await guard(tx, value);
-            });
-            await assert.rejects(publisher.publish(command), /drifted|canonical prior/);
-          }
-        }
+      for (const mutation of ["engagement", "config", "slot", "input"] as const) {
+        await assert.rejects(summary.$transaction(async (tx) => {
+          await mutateFixture(tx, mutation, m.date);
+          await current(tx);
+        }, { isolationLevel: "Serializable" }), /drifted|canonical prior/);
       }
       const countsBefore = await readRefreshCounts(summary, m.date);
-      const started = Date.now();
-      assert.equal(await new PrismaReaderSummaryPublication(summary, guard).publish(command), "published");
-      const publicationMs = Date.now() - started;
-      assert(publicationMs < 30_000, "publisher guard must finish with the shared max2 pool, no nested/root reads");
+      const { publicationMs, writerConflicts, acquisitionMs } = await runRefreshNativeConcurrency({
+        url, summary, manifest: m, command, clock,
+      });
       const after = await readRefreshPrior(summary, m.date);
       assert.equal(after.status, "COMPLETED");
       assert.equal(after.observedThrough, m.observedThrough);
@@ -102,8 +90,9 @@ async function main() {
       assert.equal(await new PrismaReaderSummaryPublication(summary).publish(command), "replayed");
       assertRefreshEqual(await readRefreshCounts(summary, m.date), countsAfter, "replay zero delta");
       console.log(JSON.stringify({ status: "passed", date: m.date, priorStatus: before.status,
-        originalSelection, newSelection, before, after, countsBefore, countsAfter, publicationMs,
-        scenarios: ["actual-cutoff", "changed-input", "engagement-config-slot-input-drift-both-boundaries",
+        originalSelection, newSelection, before, after, countsBefore, countsAfter, publicationMs, writerConflicts, acquisitionMs,
+        scenarios: ["actual-cutoff", "changed-input", "engagement-config-slot-input-drift", "independent-writer-commit-before-validation",
+          "writer-blocked-after-publication-snapshot", "all-relation-orders-nowait",
           "consumed-no-repeat", "normal-prisma-publisher-max2", "preserved-original", "replay-zero-delta"] }));
     });
   } finally { await feedConnection.close(); await summary.close(); }
@@ -134,14 +123,35 @@ async function mutateFixture(tx: PrismaReaderSummaryClient, kind: "engagement" |
     where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid`
     : kind === "config" ? await db.$executeRaw`update reader_summary_policies set tone = case when tone='analytical' then 'neutral' else 'analytical' end
       where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid and scope_key='workspace'`
-    : kind === "slot" ? await db.$executeRaw`update reader_summary_publication_slots set current_publication_id=null
-      where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid
-        and period_started_at=${date}::date::timestamp at time zone 'UTC'`
+    : kind === "slot" ? await mutateFixtureSlot(db, date)
     : await db.$executeRaw`update feed_items set title=title || ' fixture drift'
       where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid
         and published_at >= ${date}::date::timestamp at time zone 'UTC'
         and published_at < (${date}::date + 1)::timestamp at time zone 'UTC'`;
   assert(count > 0, `fixture must exercise ${kind}`);
+}
+
+async function mutateFixtureSlot(
+  db: PrismaReaderSummaryClient & { $executeRaw(s: TemplateStringsArray, ...v: unknown[]): Promise<number> },
+  date: string,
+): Promise<number> {
+  // The production trigger permits only the publication owner. The disposable
+  // fixture grants SET on its own random owner; no production role is changed.
+  const roles = await db.$queryRaw<readonly { runtime_role: string; owner_role: string }[]>`
+    select current_user as runtime_role, pg_catalog.pg_get_userbyid(c.relowner) as owner_role
+    from pg_catalog.pg_class c join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public' and c.relname = 'reader_summary_publication_slots'`;
+  assert.equal(roles.length, 1, "fixture slot owner must be unambiguous");
+  const role = roles[0]!;
+  assert.notEqual(role.runtime_role, role.owner_role, "guard must execute as fixture runtime");
+  await db.$queryRaw`select pg_catalog.set_config('role', ${role.owner_role}, true)`;
+  const count = await db.$executeRaw`update reader_summary_publication_slots set current_publication_id=null
+    where tenant_id=${refreshScope.tenantId}::uuid and workspace_id=${refreshScope.workspaceId}::uuid
+      and period_started_at=${date}::date::timestamp at time zone 'UTC'`;
+  // Restore before the authority guard. SQL errors abort/roll back the whole
+  // fixture transaction and are never accepted as a successful drift check.
+  await db.$queryRaw`select pg_catalog.set_config('role', ${role.runtime_role}, true)`;
+  return count;
 }
 if (require.main === module) void main().catch(() => {
   console.error("Native new-input refresh fixture gate failed; inspect the disposable fixture. No raw payload is logged.");

--- a/scripts/check-reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/check-reader-summary-new-input-refresh-postgres.ts
@@ -7,6 +7,7 @@ import { PrismaFeedConnection } from "@social-monitor/feed/adapters/persistence/
 import { PrismaFeedItemReadRepository } from "@social-monitor/feed/adapters/persistence/prisma/prisma-feed-item-read.repository";
 import { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
 import { PrismaReaderSummaryPublication } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-publication";
+import { PrismaReaderSummaryArtifactRepository } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-artifact.repository";
 import { PrismaReaderSummaryJobRepository } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-job.repository";
 import { normalizeReaderSummaryArtifactPayload } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-artifact-payload";
 import { buildReaderSummaryPublicationPayload, type ReaderSummaryPublicationPayload } from "@social-monitor/summary/adapters/persistence/reader-summary-publication-proof";
@@ -75,6 +76,12 @@ async function main() {
         }, { isolationLevel: "Serializable" }), /drifted|canonical prior/);
       }
       const countsBefore = await readRefreshCounts(summary, m.date);
+      // The normal execution use case stages the RUNNING artifact before its
+      // publisher. Include that real repository write in the measured delta.
+      await new PrismaReaderSummaryArtifactRepository(summary).save(command.artifact, {
+        publicationDecision: command.publicationDecision,
+        githubProjectionAudit: command.githubProjectionAudit,
+      });
       const { publicationMs, writerConflicts, acquisitionMs } = await runRefreshNativeConcurrency({
         url, summary, manifest: m, command, clock,
       });

--- a/scripts/check-reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/check-reader-summary-new-input-refresh-postgres.ts
@@ -153,7 +153,10 @@ async function mutateFixtureSlot(
   await db.$queryRaw`select pg_catalog.set_config('role', ${role.runtime_role}, true)`;
   return count;
 }
-if (require.main === module) void main().catch(() => {
-  console.error("Native new-input refresh fixture gate failed; inspect the disposable fixture. No raw payload is logged.");
+if (require.main === module) void main().catch((error: unknown) => {
+  // Keep only source locations, never database errors, SQL or candidate payloads.
+  const frames = error instanceof Error ? error.stack?.split("\n").slice(1)
+    .filter((line) => /^\s+at /.test(line)).slice(0, 8) : [];
+  console.error(JSON.stringify({ status: "failed", frames }));
   process.exitCode = 1;
 });

--- a/scripts/check-reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/check-reader-summary-new-input-refresh-postgres.ts
@@ -82,7 +82,7 @@ async function main() {
         publicationDecision: command.publicationDecision,
         githubProjectionAudit: command.githubProjectionAudit,
       });
-      const { publicationMs, writerConflicts, acquisitionMs } = await runRefreshNativeConcurrency({
+      const { publicationMs, writerConflicts, acquisitionMs, holderLossRejected } = await runRefreshNativeConcurrency({
         url, summary, manifest: m, command, clock,
       });
       const after = await readRefreshPrior(summary, m.date);
@@ -98,9 +98,9 @@ async function main() {
       assert.equal(await new PrismaReaderSummaryPublication(summary).publish(command), "replayed");
       assertRefreshEqual(await readRefreshCounts(summary, m.date), countsAfter, "replay zero delta");
       console.log(JSON.stringify({ status: "passed", date: m.date, priorStatus: before.status,
-        originalSelection, newSelection, before, after, countsBefore, countsAfter, publicationMs, writerConflicts, acquisitionMs,
+        originalSelection, newSelection, before, after, countsBefore, countsAfter, publicationMs, writerConflicts, acquisitionMs, holderLossRejected,
         scenarios: ["actual-cutoff", "changed-input", "engagement-config-slot-input-drift", "independent-writer-commit-before-validation",
-          "writer-blocked-after-publication-snapshot", "all-relation-orders-nowait",
+          "writer-blocked-after-publication-snapshot", "actual-holder-loss-stale-snapshot-rejected", "all-relation-orders-nowait",
           "consumed-no-repeat", "normal-prisma-publisher-max2", "preserved-original", "replay-zero-delta"] }));
     });
   } finally { await feedConnection.close(); await summary.close(); }

--- a/scripts/check-reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/check-reader-summary-new-input-refresh-postgres.ts
@@ -28,6 +28,7 @@ const required = (name: string): string => {
   return value;
 };
 async function main() {
+  Error.stackTraceLimit = 20;
   const url = required("READER_SUMMARY_REFRESH_TEST_DATABASE_URL");
   assert.match(decodeURIComponent(new URL(url).pathname.slice(1)), /^reader_summary_refresh_test_[a-z0-9]+$/u);
   const m = readReviewedRefresh(required("READER_SUMMARY_REFRESH_TEST_MANIFEST_PATH"),
@@ -156,7 +157,14 @@ async function mutateFixtureSlot(
 if (require.main === module) void main().catch((error: unknown) => {
   // Keep only source locations, never database errors, SQL or candidate payloads.
   const frames = error instanceof Error ? error.stack?.split("\n").slice(1)
-    .filter((line) => /^\s+at /.test(line)).slice(0, 8) : [];
-  console.error(JSON.stringify({ status: "failed", frames }));
+    .filter((line) => /^\s+at /.test(line)).slice(0, 16) : [];
+  const value = error as { code?: unknown; meta?: { code?: unknown;
+    driverAdapterError?: { cause?: { originalCode?: unknown; originalMessage?: unknown } } } };
+  const safeCode = (code: unknown) => typeof code === "string" && /^[A-Z0-9]{5}$/.test(code) ? code : undefined;
+  const message = String(value?.meta?.driverAdapterError?.cause?.originalMessage ?? "");
+  const categories = ["permission denied", "serialize", "timeout", "immutable", "publication",
+    "current", "slot", "tenant", "scope", "artifact", "constraint"].filter((word) => message.includes(word));
+  console.error(JSON.stringify({ status: "failed", code: safeCode(value?.code),
+    sqlState: safeCode(value?.meta?.code ?? value?.meta?.driverAdapterError?.cause?.originalCode), categories, frames }));
   process.exitCode = 1;
 });

--- a/scripts/lib/reader-summary-daily-story-relation-verifier.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-verifier.ts
@@ -28,6 +28,7 @@ export const createReaderSummaryDailyCapturePublicationWiring = (
     agentRuntimeClient,
     env,
     summaryModelMode,
+    storyRelationVerifierGuard,
     ...publicationInput
   } = input;
   return createReaderSummaryDailyPublicationExecutionWiring({
@@ -38,6 +39,7 @@ export const createReaderSummaryDailyCapturePublicationWiring = (
       env,
       agentRuntimeClient,
       attestationSink: publicationInput.attestationSink,
+      storyRelationVerifierGuard,
     }),
   });
 };
@@ -51,6 +53,10 @@ type StoryRelationCompositionInput = {
   readonly env: NodeJS.ProcessEnv;
   readonly agentRuntimeClient: AgentRuntimeClientPort | null;
   readonly attestationSink: VerifiedReaderSummaryExecutionAttestationSink;
+  readonly storyRelationVerifierGuard?: {
+    assertUsable(): void;
+    invalidateAdapter(taskRole: "story_relation" | "related_topic_relation"): void;
+  };
 };
 
 const buildReaderSummaryDailyStoryRelationVerifier = (
@@ -64,11 +70,29 @@ const buildReaderSummaryDailyStoryRelationVerifier = (
       "Fresh agent-runtime daily publication requires a story relation verifier client",
     );
   }
-  return new AgentRuntimeReaderSummaryStoryRelationVerifier({
+  const verifier = new AgentRuntimeReaderSummaryStoryRelationVerifier({
     ...resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions(
       input.env,
       input.agentRuntimeClient,
     ),
     verifiedAttestationSink: input.attestationSink,
   });
+  const guard = input.storyRelationVerifierGuard;
+  if (guard === undefined) return verifier;
+  return {
+    verify: async (query) => {
+      try {
+        guard.assertUsable();
+        const decisions = await verifier.verify(query);
+        guard.assertUsable();
+        return decisions;
+      } catch (error) {
+        // Refresh authority must be poisoned before selector fallback catches
+        // adapter exceptions. Accepted decisions retain their normal reconciliation.
+        guard.invalidateAdapter(query.verificationLane === "related_topic"
+          ? "related_topic_relation" : "story_relation");
+        throw error;
+      }
+    },
+  };
 };

--- a/scripts/lib/reader-summary-new-input-refresh-admission.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-admission.spec.ts
@@ -1,0 +1,52 @@
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { ReaderSummaryJob } from "@social-monitor/summary/domain";
+import { RequestReaderSummaryUseCase } from "@social-monitor/summary/features/request-reader-summary/request-reader-summary.use-case";
+import { FakeReaderSummaryJobRepository } from "@social-monitor/summary/features/execute-reader-summary-job/execute-reader-summary-job.spec-support";
+import { createRefreshAdmission } from "./reader-summary-new-input-refresh-admission";
+import { refreshPeriod } from "./reader-summary-new-input-refresh-capture";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+
+it("canonical admission gives terminal NO_SIGNAL a distinct job, then replays without a second grant", async () => {
+  const m = refreshManifest();
+  const scope = { tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId) };
+  const jobs = new FakeReaderSummaryJobRepository();
+  const old = ReaderSummaryJob.request({ ...scope, id: m.prior.jobId, scope: { type: "workspace" },
+    period: refreshPeriod(m.date), idempotencyKey: "old-canonical-request", requestedAt: refreshNow })
+    .start({ startedAt: refreshNow }).markNoSignal({ completedAt: refreshNow, readerSummaryId: m.prior.artifactId });
+  await jobs.save(old);
+  const check = jest.fn(async () => undefined);
+  const admission = createRefreshAdmission(m, { assertCurrent: check });
+  const request = new RequestReaderSummaryUseCase(jobs, admission.queue, admission.quota,
+    { generate: () => "refresh-job" }, new FixedClock(refreshNow));
+  const command = { ...scope, scope: { type: "workspace" as const }, cadence: "daily" as const,
+    period: refreshPeriod(m.date), idempotencyKey: m.operation, correlationId: m.operation };
+  expect(await request.execute(command)).toMatchObject({ ok: true, value: { created: true, readerSummaryJobId: "refresh-job" } });
+  expect(await request.execute(command)).toMatchObject({ ok: true, value: { created: false, readerSummaryJobId: "refresh-job" } });
+  expect(check).toHaveBeenCalledTimes(2);
+  expect(await jobs.findById({ ...scope, readerSummaryJobId: old.toSnapshot().id })).toEqual(old);
+  expect(await request.execute({ ...command, idempotencyKey: "new-path" })).toMatchObject({ ok: false });
+});
+it("operator grant rejects wrong scope, operation, ID and reused reservations", async () => {
+  const m = refreshManifest();
+  const check = jest.fn(async () => undefined);
+  const { queue, quota } = createRefreshAdmission(m, { assertCurrent: check });
+  const command = { tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId),
+    readerSummaryJobId: "new-job", causationId: m.operation, correlationId: m.operation };
+  expect(await queue.canAccept({ ...command, tenantId: tenantId("wrong") })).toBe(false);
+  expect(await queue.canAccept({ ...command, causationId: "wrong" })).toBe(false);
+  const reserve = { tenantId: command.tenantId, workspaceId: command.workspaceId, scopeKey: "workspace", operation: "reader_summary.request" as const };
+  expect(await quota.reserveSummaryJob(reserve)).toMatchObject({ ok: false });
+  expect(await queue.canAccept(command)).toBe(true);
+  expect(await quota.reserveSummaryJob({ ...reserve, scopeKey: "interest:other" })).toMatchObject({ ok: false });
+  expect(await quota.reserveSummaryJob(reserve)).toMatchObject({ ok: true, value: { remaining: 0 } });
+  expect(await quota.reserveSummaryJob(reserve)).toMatchObject({ ok: false });
+  await expect(queue.enqueue({ ...command, readerSummaryJobId: "other" })).rejects.toThrow(/mismatch/);
+  await queue.enqueue(command);
+  await expect(queue.enqueue(command)).rejects.toThrow(/mismatch/);
+});
+it("checks current durable budget and authority immediately before reservation", async () => {
+  const m = refreshManifest();
+  const grant = createRefreshAdmission(m, { assertCurrent: async () => { throw new Error("consumed"); } });
+  await expect(grant.queue.canAccept({ tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId),
+    readerSummaryJobId: "new", causationId: m.operation, correlationId: m.operation })).rejects.toThrow(/consumed/);
+});

--- a/scripts/lib/reader-summary-new-input-refresh-admission.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-admission.ts
@@ -1,0 +1,45 @@
+import { DomainError, err, ok } from "@social-monitor/shared-kernel";
+import type { ReaderSummaryJobQueuePort, SummaryQuotaPort } from "@social-monitor/summary/ports";
+import type { RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
+
+/** Operator-owned one-date grant, not the user request quota. The canonical
+ * request persists the consumed job before execution; every resume checks that
+ * durable row under the same global/date fences, regardless of file location. */
+export function createRefreshAdmission(m: RefreshManifest, deps: {
+  assertCurrent(): Promise<void>;
+}): { queue: ReaderSummaryJobQueuePort; quota: SummaryQuotaPort } {
+  let jobId: string | undefined;
+  let reserved = false;
+  let enqueued = false;
+  const scoped = (command: { tenantId: string; workspaceId: string }) =>
+    command.tenantId === m.tenantId && command.workspaceId === m.workspaceId;
+  return {
+    queue: {
+      canAccept: async (command) => {
+        if (jobId !== undefined || !scoped(command) || command.causationId !== m.operation ||
+            command.correlationId !== m.operation) return false;
+        await deps.assertCurrent();
+        jobId = command.readerSummaryJobId;
+        return true;
+      },
+      enqueue: async (command) => {
+        if (!reserved || enqueued || !scoped(command) || command.readerSummaryJobId !== jobId ||
+            command.causationId !== m.operation || command.correlationId !== m.operation) {
+          throw new Error("Refresh synchronous request admission mismatch");
+        }
+        enqueued = true; // Caller executes exactly this persisted job in-process.
+      },
+    },
+    quota: {
+      reserveSummaryJob: async (command) => {
+        if (reserved || jobId === undefined || !scoped(command) || command.scopeKey !== "workspace" ||
+            command.interestId !== undefined || command.operation !== "reader_summary.request") {
+          return err(new DomainError("operation.conflict", "Refresh one-date grant unavailable"));
+        }
+        await deps.assertCurrent();
+        reserved = true;
+        return ok({ remaining: 0, resetAt: m.preparedAt }); // Never replenishes on expiry.
+      },
+    },
+  };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-capture.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-capture.ts
@@ -1,0 +1,75 @@
+import type { FeedItemReadRepositoryPort, PromotionFeedItemSnapshotRepositoryPort } from "@social-monitor/feed/ports";
+import { InMemoryUserRelevanceProfileRepository } from "@social-monitor/relevance/adapters/persistence/in-memory-user-relevance-profile.repository";
+import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
+import { RelevanceReaderSummaryEvidenceSelector } from "@social-monitor/summary/adapters/evidence/relevance-reader-summary-evidence.selector";
+import { buildReaderSummaryPeriod, primaryReaderSummaryEvidence, admitReaderPostPromotionEvidence } from "@social-monitor/summary/domain";
+import type { PrismaSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-client";
+import { tenantId, workspaceId, type Clock } from "@social-monitor/shared-kernel";
+import { captureReaderSummaryDayDatasetManifest } from "./reader-summary-day-dataset-manifest";
+import { readRefreshMutableAuthority } from "./reader-summary-new-input-refresh-postgres";
+import { refreshScope, refreshHash } from "./reader-summary-new-input-refresh-manifest";
+
+export const refreshPeriod = (date: string) => buildReaderSummaryPeriod({
+  cadence: "daily", startedAt: new Date(`${date}T00:00:00.000Z`),
+  endedAt: new Date(Date.parse(`${date}T00:00:00.000Z`) + 86_400_000), timezone: "UTC",
+});
+export async function captureRefreshAuthority(input: {
+  client: Pick<PrismaSummaryClient, "$queryRaw">;
+  feed: FeedItemReadRepositoryPort & PromotionFeedItemSnapshotRepositoryPort;
+  date: string; observedThrough: Date; clock: Clock;
+}) {
+  const period = refreshPeriod(input.date);
+  const database = await captureRefreshDatabaseAuthority(input);
+  const snapshot = await input.feed.readPromotionSnapshot({
+    tenantId: tenantId(refreshScope.tenantId), workspaceId: workspaceId(refreshScope.workspaceId),
+    windowStartedAt: period.startedAt, windowEndedAt: period.endedAt,
+    timestampPolicy: "published_at", observedThrough: input.observedThrough,
+  });
+  if (!snapshot.ok || !snapshot.exhausted) throw new Error("Refresh canonical promotion snapshot is incomplete");
+  return { ...database, canonicalInputSha256: refreshHash(snapshot),
+    eligibleCount: snapshot.candidates.length };
+}
+// Complete backing rows are revalidated on the publisher's transaction. This
+// avoids a nested read-only feed transaction on the shared bounded runtime pool.
+export async function captureRefreshDatabaseAuthority(input: {
+  client: Pick<PrismaSummaryClient, "$queryRaw">; date: string; clock: Clock;
+}) {
+  const period = refreshPeriod(input.date);
+  const mutable = await readRefreshMutableAuthority(input.client, input.date);
+  const dataset = await captureReaderSummaryDayDatasetManifest({
+    client: input.client, ...refreshScope, startedAt: period.startedAt, endedAt: period.endedAt,
+    generatedAt: input.clock.now(), timestampPolicy: "published_at",
+  });
+  return { ...mutable, datasetSha256: dataset.dataset.aggregateSha256,
+    feedCount: dataset.dataset.feedRowCount };
+}
+// This uses the current selector on the complete repository. No paid relation
+// verifier is composed for preparation. Apply uses the normal agent verifier.
+export async function preflightRefreshSelection(input: {
+  feed: FeedItemReadRepositoryPort; date: string; observedThrough: Date; clock: Clock;
+}): Promise<number> {
+  const selector = new RelevanceReaderSummaryEvidenceSelector(new RankFeedItemsUseCase(
+    input.feed, new InMemoryUserRelevanceProfileRepository(), input.clock,
+  ), input.feed, input.clock);
+  const selection = await selector.select({
+    tenantId: tenantId(refreshScope.tenantId), workspaceId: workspaceId(refreshScope.workspaceId),
+    scope: { type: "workspace" }, period: refreshPeriod(input.date),
+    observedThrough: input.observedThrough, maxItems: 120,
+  });
+  return primaryReaderSummaryEvidence(admitReaderPostPromotionEvidence(selection)).selectedEvidence.length;
+}
+export async function assertRefreshHasNewInput(client: Pick<PrismaSummaryClient, "$queryRaw">,
+  date: string, previous: string, cutoff: string): Promise<void> {
+  const rows = await client.$queryRaw<readonly { count: number }[]>`
+    select count(*)::int as count from feed_items f
+    where f.tenant_id = ${refreshScope.tenantId}::uuid and f.workspace_id = ${refreshScope.workspaceId}::uuid
+      and f.status = 'VISIBLE' and f.published_at >= ${date}::date::timestamp at time zone 'UTC'
+      and f.published_at < (${date}::date + 1)::timestamp at time zone 'UTC'
+      and (f.observed_at > ${previous}::timestamptz and f.observed_at <= ${cutoff}::timestamptz
+        or exists (select 1 from source_item_engagement_observations o
+          where o.tenant_id = f.tenant_id and o.workspace_id = f.workspace_id
+            and o.source_item_id = f.source_item_id and o.provider_key = f.provider_key
+            and o.observed_at > ${previous}::timestamptz and o.observed_at <= ${cutoff}::timestamptz))
+  `;
+  if (rows[0]?.count === undefined || rows[0].count < 1) throw new Error("Refresh has no new canonical input or observation");
+}

--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -107,6 +107,7 @@ export async function executeNewInputRefresh(input: {
   const canonical = createReaderSummaryDailyCapturePublicationWiring({
     replay: null, feedItems: feed, summaryClient: summary, clock, attestationSink: sink,
     summaryModelMode: "agent-runtime", env: input.env, agentRuntimeClient: runtime,
+    storyRelationVerifierGuard: runtime,
   });
   const model = buildRefreshModelWiring(input.env, runtime, sink);
   const publication: ReaderSummaryPublicationPort = {

--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -16,8 +16,9 @@ import { createReaderSummaryDailyCapturePublicationWiring } from "./reader-summa
 import { assertRefreshManifest, refreshScope, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
 import { NewInputRefreshGuard, assertRefreshEqual, reconcileRefresh } from "./reader-summary-new-input-refresh-guard";
 import { captureRefreshAuthority, captureRefreshDatabaseAuthority, refreshPeriod, assertRefreshHasNewInput, preflightRefreshSelection } from "./reader-summary-new-input-refresh-capture";
-import { lockRefreshAuthority, readRefreshJobs, readRefreshPrior, readRefreshCounts } from "./reader-summary-new-input-refresh-postgres";
+import { readRefreshJobs, readRefreshPrior, readRefreshCounts } from "./reader-summary-new-input-refresh-postgres";
 import { createRefreshAdmission } from "./reader-summary-new-input-refresh-admission";
+import { withRefreshPublicationLocks, type RefreshSnapshotProtection } from "./reader-summary-new-input-refresh-publication-lock";
 import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
 
 export async function executeNewInputRefresh(input: {
@@ -76,6 +77,7 @@ export async function executeNewInputRefresh(input: {
       assertRefreshManifest(m, clock.now());
       await assertCurrent();
       if ((await readRefreshJobs(summary, m.date)).length !== 0) throw new Error("Refresh date budget consumed");
+      input.assertSource(); input.assertFences(); assertRefreshManifest(m, clock.now());
     },
   });
   const request = await new RequestReaderSummaryUseCase(jobRepo,
@@ -96,23 +98,30 @@ export async function executeNewInputRefresh(input: {
     },
   });
   const runtime = guardedRefreshRuntime({ delegate: input.runtime, manifest: m,
+    assertLocal: () => { input.assertSource(); guard.assertLocal(); },
     assertCurrent: async () => { await input.assertRuntime(); await guard.assertCurrent(); }, record: input.record });
-  const sink = { record: (attestation: unknown) => input.record({ status: "verified_attestation", attestation }) };
+  const sink = { record: (attestation: unknown) => {
+    try { runtime.assertUsable(); input.record({ status: "verified_attestation", attestation }); }
+    catch (error) { guard.invalidate(); throw error; }
+  } };
   const canonical = createReaderSummaryDailyCapturePublicationWiring({
     replay: null, feedItems: feed, summaryClient: summary, clock, attestationSink: sink,
     summaryModelMode: "agent-runtime", env: input.env, agentRuntimeClient: runtime,
   });
   const model = buildRefreshModelWiring(input.env, runtime, sink);
-  const publisher = new PrismaReaderSummaryPublication(summary, refreshPublicationGuard({
-    assertLocal: () => { guard.assertLocal(); input.assertSource(); },
-    assertCurrent: (tx) => assertRefreshTransactionAuthority(tx, m, request.value.readerSummaryJobId, clock),
-    manifest: m, jobId: request.value.readerSummaryJobId,
-  }));
   const publication: ReaderSummaryPublicationPort = {
     publish: async (command) => {
-      await guard.assertCurrent(); // Full canonical snapshot outside the transaction.
+      await guard.assertCurrent(); // Full canonical snapshot before taking a pool slot.
       await input.assertRuntime();
-      return publisher.publish(command);
+      runtime.assertUsable();
+      return withRefreshPublicationLocks(summary, (assertProtected) => {
+        runtime.assertUsable(); // Lock acquisition may outlive the evidence/fence.
+        return new PrismaReaderSummaryPublication(summary, refreshPublicationGuard({
+          assertLocal: () => { runtime.assertUsable(); guard.assertLocal(); },
+          assertCurrent: (tx) => assertRefreshTransactionAuthority(tx, m, request.value.readerSummaryJobId, clock),
+          assertProtected, manifest: m, jobId: request.value.readerSummaryJobId,
+        })).publish(command);
+      });
     },
   };
   const execution = await new ExecuteReaderSummaryJobUseCase(jobRepo,
@@ -143,11 +152,13 @@ export async function executeNewInputRefresh(input: {
 
 export function refreshPublicationGuard(input: {
   assertLocal(): void;
+  assertProtected: RefreshSnapshotProtection;
   assertCurrent(client: PrismaReaderSummaryClient): Promise<void>;
   manifest: RefreshManifest; jobId: string;
 }): ReaderSummaryPublicationTransactionGuard {
   return async (tx, command) => {
-    await lockRefreshAuthority(tx);
+    input.assertLocal();
+    await input.assertProtected(tx);
     input.assertLocal();
     await input.assertCurrent(tx);
     input.assertLocal();
@@ -156,6 +167,7 @@ export function refreshPublicationGuard(input: {
         command.finalJob.toSnapshot().id !== input.jobId) {
       throw new Error("Refresh publisher lost operation/cutoff authority");
     }
+    input.assertLocal();
   };
 }
 
@@ -172,4 +184,5 @@ export async function assertRefreshTransactionAuthority(
   void canonicalInputSha256; void eligibleCount;
   assertRefreshEqual(await captureRefreshDatabaseAuthority({ client: tx, date: m.date, clock }),
     database, "complete canonical rows/engagement/config");
+  assertRefreshManifest(m, clock.now());
 }

--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -1,0 +1,175 @@
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { InMemoryMetricsRecorder } from "@social-monitor/platform-metrics";
+import type { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
+import { PrismaReaderSummaryArtifactRepository } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-artifact.repository";
+import { PrismaReaderSummaryJobRepository } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-job.repository";
+import { PrismaReaderSummaryPolicyRepository } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-policy.repository";
+import { PrismaReaderSummaryPublication, type ReaderSummaryPublicationTransactionGuard } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-publication";
+import { ReaderSummaryPromotionMetricsRecorder } from "@social-monitor/summary/adapters/metrics/reader-summary-promotion-metrics.recorder";
+import { ExecuteReaderSummaryJobUseCase } from "@social-monitor/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case";
+import { RequestReaderSummaryUseCase } from "@social-monitor/summary/features/request-reader-summary/request-reader-summary.use-case";
+import { readerSummaryPromotionControl } from "@social-monitor/summary/features/execute-reader-summary-job/reader-summary-promotion-control";
+import { CryptoIdGenerator, tenantId, workspaceId, type Clock } from "@social-monitor/shared-kernel";
+import type { AgentRuntimeClientPort, ReaderSummaryPublicationPort } from "@social-monitor/summary/ports";
+import type { FeedItemReadRepositoryPort, PromotionFeedItemSnapshotRepositoryPort } from "@social-monitor/feed/ports";
+import { createReaderSummaryDailyCapturePublicationWiring } from "./reader-summary-daily-story-relation-verifier";
+import { assertRefreshManifest, refreshScope, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
+import { NewInputRefreshGuard, assertRefreshEqual, reconcileRefresh } from "./reader-summary-new-input-refresh-guard";
+import { captureRefreshAuthority, captureRefreshDatabaseAuthority, refreshPeriod, assertRefreshHasNewInput, preflightRefreshSelection } from "./reader-summary-new-input-refresh-capture";
+import { lockRefreshAuthority, readRefreshJobs, readRefreshPrior, readRefreshCounts } from "./reader-summary-new-input-refresh-postgres";
+import { createRefreshAdmission } from "./reader-summary-new-input-refresh-admission";
+import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+
+export async function executeNewInputRefresh(input: {
+  manifest: RefreshManifest; summary: PrismaSummaryConnection;
+  feed: FeedItemReadRepositoryPort & PromotionFeedItemSnapshotRepositoryPort;
+  clock: Clock; env: NodeJS.ProcessEnv;
+  runtime: AgentRuntimeClientPort;
+  assertFences(): void; assertSource(): void; assertRuntime(): Promise<void>;
+  record(event: unknown): void;
+}) {
+  const { manifest: m, summary, feed, clock } = input;
+  input.assertFences(); input.assertSource();
+  const countsBefore = await readRefreshCounts(summary, m.date);
+  const current = await readRefreshPrior(summary, m.date);
+  const prior = await readRefreshPrior(summary, m.date, m.prior.publicationId);
+  assertRefreshEqual(prior, m.prior, "preserved prior");
+  input.record({ status: "before", operation: m.operation, observedThrough: m.observedThrough, prior, countsBefore });
+  const jobs = await readRefreshJobs(summary, m.date);
+  if (reconcileRefresh(m, jobs, current) === "published") {
+    const countsAfter = await readRefreshCounts(summary, m.date);
+    assertRefreshEqual(countsAfter, countsBefore, "replay counts");
+    return { status: "verified_noop", before: prior, after: current, countsBefore, countsAfter,
+      publicationDelta: countsAfter.publications - countsBefore.publications, outboxDelta: countsAfter.outbox - countsBefore.outbox };
+  }
+  const assertCurrent = async (client = summary as Pick<PrismaSummaryConnection, "$queryRaw">) => {
+    input.assertFences(); input.assertSource();
+    assertRefreshEqual(await readRefreshPrior(client, m.date), m.prior, "old slot/content/proof");
+    assertRefreshEqual(await captureRefreshAuthority({ client, feed, date: m.date,
+      observedThrough: new Date(m.observedThrough), clock }), m.authority, "input/engagement/config");
+  };
+  assertRefreshManifest(m, clock.now());
+  await assertCurrent();
+  await assertRefreshHasNewInput(summary, m.date, m.prior.observedThrough, m.observedThrough);
+  await input.assertRuntime();
+  const selectedCount = await preflightRefreshSelection({ feed, date: m.date,
+    observedThrough: new Date(m.observedThrough), clock });
+  input.record({ status: "preflight", operation: m.operation, selectedCount,
+    plannedSummaryGenerations: selectedCount === 0 ? 0 : 1 });
+  if (selectedCount === 0) {
+    await assertCurrent();
+    const countsAfter = await readRefreshCounts(summary, m.date);
+    assertRefreshEqual(countsAfter, countsBefore, "empty input counts");
+    return { status: "no_eligible_input", before: prior, after: current, countsBefore, countsAfter,
+      publicationDelta: 0, outboxDelta: 0 };
+  }
+  const policies = new PrismaReaderSummaryPolicyRepository(summary);
+  const policy = await policies.findByScope({ tenantId: tenantId(m.tenantId),
+    workspaceId: workspaceId(m.workspaceId), scope: { type: "workspace" } });
+  if (policy === null) throw new Error("Refresh cannot fall back to a default policy");
+  await assertCurrent();
+  const jobRepo = new PrismaReaderSummaryJobRepository(summary);
+  const ids = new CryptoIdGenerator();
+  const period = refreshPeriod(m.date);
+  const admission = createRefreshAdmission(m, {
+    assertCurrent: async () => {
+      assertRefreshManifest(m, clock.now());
+      await assertCurrent();
+      if ((await readRefreshJobs(summary, m.date)).length !== 0) throw new Error("Refresh date budget consumed");
+    },
+  });
+  const request = await new RequestReaderSummaryUseCase(jobRepo,
+    admission.queue, admission.quota, ids, clock).execute({
+    tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId), scope: { type: "workspace" },
+    cadence: "daily", period, idempotencyKey: m.operation, correlationId: m.operation,
+  });
+  if (!request.ok || !request.value.created) throw new Error("Refresh request requires original-job reconciliation");
+  input.record({ status: "operation_consumed", operation: m.operation, jobId: request.value.readerSummaryJobId });
+  const guard = new NewInputRefreshGuard(m, request.value.readerSummaryJobId, {
+    now: () => clock.now(), assertFences: input.assertFences, assertCurrent: async () => {
+      const owned = await readRefreshJobs(summary, m.date);
+      if (owned.length !== 1 || owned[0]?.jobId !== request.value.readerSummaryJobId || owned[0].operation !== m.operation ||
+          !["REQUESTED", "RUNNING"].includes(owned[0].status) || owned[0].artifactId !== null) {
+        throw new Error("Refresh date has conflicting consumed operations");
+      }
+      await assertCurrent();
+    },
+  });
+  const runtime = guardedRefreshRuntime({ delegate: input.runtime, manifest: m,
+    assertCurrent: async () => { await input.assertRuntime(); await guard.assertCurrent(); }, record: input.record });
+  const sink = { record: (attestation: unknown) => input.record({ status: "verified_attestation", attestation }) };
+  const canonical = createReaderSummaryDailyCapturePublicationWiring({
+    replay: null, feedItems: feed, summaryClient: summary, clock, attestationSink: sink,
+    summaryModelMode: "agent-runtime", env: input.env, agentRuntimeClient: runtime,
+  });
+  const model = buildRefreshModelWiring(input.env, runtime, sink);
+  const publisher = new PrismaReaderSummaryPublication(summary, refreshPublicationGuard({
+    assertLocal: () => { guard.assertLocal(); input.assertSource(); },
+    assertCurrent: (tx) => assertRefreshTransactionAuthority(tx, m, request.value.readerSummaryJobId, clock),
+    manifest: m, jobId: request.value.readerSummaryJobId,
+  }));
+  const publication: ReaderSummaryPublicationPort = {
+    publish: async (command) => {
+      await guard.assertCurrent(); // Full canonical snapshot outside the transaction.
+      await input.assertRuntime();
+      return publisher.publish(command);
+    },
+  };
+  const execution = await new ExecuteReaderSummaryJobUseCase(jobRepo,
+    new PrismaReaderSummaryArtifactRepository(summary), {
+      findByScope: async () => { await guard.assertCurrent(); return policy; },
+      listScheduled: (query) => policies.listScheduled(query),
+      save: async () => { throw new Error("Refresh policy mutation is prohibited"); },
+    },
+    guard.selector(canonical.evidenceSelector), model.model, publication, ids, clock,
+    readerSummaryPromotionControl(new ReaderSummaryPromotionMetricsRecorder(new InMemoryMetricsRecorder())),
+    undefined, undefined, model.topicMap, undefined, canonical.githubProjectionReader,
+    undefined, undefined, undefined, guard,
+  ).execute({ tenantId: tenantId(refreshScope.tenantId), workspaceId: workspaceId(refreshScope.workspaceId),
+    readerSummaryJobId: request.value.readerSummaryJobId, maxEvidenceItems: 120 });
+  if (!execution.ok) throw new Error("Refresh execution failed; reconcile the consumed job");
+  const after = await readRefreshPrior(summary, m.date);
+  if (reconcileRefresh(m, await readRefreshJobs(summary, m.date), after) !== "published") {
+    throw new Error("Refresh publication requires reconciliation");
+  }
+  assertRefreshEqual(await readRefreshPrior(summary, m.date, m.prior.publicationId), m.prior, "preserved prior");
+  const countsAfter = await readRefreshCounts(summary, m.date);
+  for (const key of ["publications", "outbox", "jobs", "artifacts"] as const) {
+    if (countsAfter[key] - countsBefore[key] !== 1) throw new Error("Refresh counts require reconciliation");
+  }
+  return { status: "published", before: prior, after, countsBefore, countsAfter,
+    publicationDelta: countsAfter.publications - countsBefore.publications, outboxDelta: countsAfter.outbox - countsBefore.outbox };
+}
+
+export function refreshPublicationGuard(input: {
+  assertLocal(): void;
+  assertCurrent(client: PrismaReaderSummaryClient): Promise<void>;
+  manifest: RefreshManifest; jobId: string;
+}): ReaderSummaryPublicationTransactionGuard {
+  return async (tx, command) => {
+    await lockRefreshAuthority(tx);
+    input.assertLocal();
+    await input.assertCurrent(tx);
+    input.assertLocal();
+    const artifact = command.artifact.toSnapshot();
+    if (artifact.sourceWindow.ingestionCutoff?.toISOString() !== input.manifest.observedThrough ||
+        command.finalJob.toSnapshot().id !== input.jobId) {
+      throw new Error("Refresh publisher lost operation/cutoff authority");
+    }
+  };
+}
+
+export async function assertRefreshTransactionAuthority(
+  tx: Pick<PrismaSummaryConnection, "$queryRaw">, m: RefreshManifest, jobId: string, clock: Clock,
+): Promise<void> {
+  assertRefreshManifest(m, clock.now());
+  const jobs = await readRefreshJobs(tx, m.date);
+  if (jobs.length !== 1 || jobs[0]?.jobId !== jobId || jobs[0].operation !== m.operation || jobs[0].status !== "RUNNING") {
+    throw new Error("Refresh transaction lost consumed job authority");
+  }
+  assertRefreshEqual(await readRefreshPrior(tx, m.date), m.prior, "old slot/content/proof");
+  const { canonicalInputSha256, eligibleCount, ...database } = m.authority;
+  void canonicalInputSha256; void eligibleCount;
+  assertRefreshEqual(await captureRefreshDatabaseAuthority({ client: tx, date: m.date, clock }),
+    database, "complete canonical rows/engagement/config");
+}

--- a/scripts/lib/reader-summary-new-input-refresh-files.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-files.spec.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { readReviewedRefresh, readRefreshFenceAuthority } from "./reader-summary-new-input-refresh-files";
+import { refreshBytesHash } from "./reader-summary-new-input-refresh-manifest";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+
+describe("reviewed immutable refresh files and real locks", () => {
+  const roots: string[] = [];
+  const root = () => { const p = mkdtempSync(join(tmpdir(), "summary-refresh-test-")); roots.push(p); return p; };
+  afterEach(() => { for (const p of roots.splice(0)) rmSync(p, { recursive: true, force: true }); });
+  it("rejects tampered, mutable and symlinked manifests", () => {
+    const dir = root(), path = join(dir, "manifest.json");
+    const bytes = Buffer.from(JSON.stringify(refreshManifest()));
+    writeFileSync(path, bytes, { mode: 0o400 });
+    expect(readReviewedRefresh(path, refreshBytesHash(bytes))).toEqual(refreshManifest());
+    expect(() => readReviewedRefresh(path, "f".repeat(64))).toThrow(/hash/);
+    symlinkSync(path, join(dir, "alias"));
+    expect(() => readReviewedRefresh(join(dir, "alias"), refreshBytesHash(bytes))).toThrow();
+    chmodSync(path, 0o600);
+    expect(() => readReviewedRefresh(path, refreshBytesHash(bytes))).toThrow(/immutable/);
+  });
+  it("requires canonical global/date flocks and detects counter drift", () => {
+    const dir = root();
+    const paths = { globalLock: join(dir, "global.lock"), dateDirectory: join(dir, "dates"), fenceDirectory: join(dir, "fences") };
+    writeFileSync(paths.globalLock, ""); mkdirSync(paths.dateDirectory); mkdirSync(paths.fenceDirectory);
+    const authority = readRefreshFenceAuthority(paths);
+    const code = `require('ts-node').register({ transpileOnly: true, project: 'tsconfig.build.json' }); require('tsconfig-paths/register');
+      const { assertRefreshFences } = require('./scripts/lib/reader-summary-new-input-refresh-files');
+      const fs = require('node:fs'); const paths = JSON.parse(process.env.TEST_REFRESH_FENCES);
+      const expected = JSON.parse(process.env.TEST_REFRESH_FENCE_AUTHORITY);
+      assertRefreshFences('2026-09-03', paths, process.env.READER_SUMMARY_DATE_FENCE_TOKEN, expected);
+      fs.writeFileSync(paths.fenceDirectory + '/2026-09-03.counter', '2');
+      let rejected = false;
+      try { assertRefreshFences('2026-09-03', paths, process.env.READER_SUMMARY_DATE_FENCE_TOKEN, expected); }
+      catch { rejected = true; }
+      if (!rejected) throw new Error('counter drift accepted');`;
+    execFileSync("bash", ["ops/deploy/production-runtime/reader-summary-date-lock.sh", "--date", "2026-09-03",
+      "--global-lock", paths.globalLock, "--date-lock-dir", paths.dateDirectory, "--fence-dir", paths.fenceDirectory,
+      "--require-preexisting-authority", "--canonical-global-lock", paths.globalLock,
+      "--canonical-date-lock-dir", paths.dateDirectory, "--canonical-fence-dir", paths.fenceDirectory,
+      "--", process.execPath, "-e", code], { env: { ...process.env, TEST_REFRESH_FENCES: JSON.stringify(paths),
+      TEST_REFRESH_FENCE_AUTHORITY: JSON.stringify(authority) }, timeout: 30_000, stdio: "pipe" });
+    expect(readFileSync(join(paths.fenceDirectory, "2026-09-03.counter"), "utf8")).toBe("2");
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-files.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-files.ts
@@ -1,14 +1,65 @@
-import { execFileSync } from "node:child_process";
-import { fstatSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { closeSync, constants, fstatSync, lstatSync, openSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { refreshBytesHash, refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
 
-export function refreshSourceSha256(): string {
-  const paths = execFileSync("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard",
-    "libs", "scripts", "prisma", "package.json", "package-lock.json"], { encoding: "utf8" })
-    .split("\0").filter((p) => p && !p.includes(".spec.") && !p.includes("test-fixtures/") &&
-      !p.includes("test-support/") && !p.startsWith("prisma/generated/"));
-  return refreshHash([...new Set(paths)].sort().map((p) => [p, refreshBytesHash(readFileSync(p))]));
+// These source roots exist in both the checkout and the canonical daily-runner
+// image. Admission imports src policy and bin/reader-promotion-v2-canary-contract.cjs.
+// Root dist/build/coverage/node_modules/.cache and Git metadata are not source.
+const refreshSourceRoots = ["libs", "scripts", "prisma", "apps/agent-runtime"] as const;
+const refreshSourceConfig = ["package.json", "package-lock.json", "tsconfig.json", "tsconfig.build.json",
+  "prisma.config.ts"] as const;
+const refreshRequiredSource = [
+  "libs/shared-kernel/src/index.ts",
+  "libs/summary/application/contracts/reader-summary-new-input-refresh-authority.ts",
+  "libs/contracts/generated/grpc/agent_runtime/v1/agent_runtime.ts",
+  "scripts/run-reader-summary-new-input-refresh.ts",
+  "scripts/lib/reader-summary-new-input-refresh-files.ts",
+  "scripts/lib/reader-summary-new-input-refresh-model.ts",
+  "apps/agent-runtime/src/subscription-runtime-purpose-model-policy.ts",
+  "apps/agent-runtime/bin/reader-promotion-v2-canary-contract.cjs",
+  "prisma/schema.prisma",
+] as const;
+
+export function refreshSourceSha256(root = process.cwd()): string {
+  const absoluteRoot = resolve(root);
+  if (realpathSync(absoluteRoot) !== absoluteRoot) throw new Error("Refresh source root must not contain symlinks");
+  const paths: string[] = [];
+  const walk = (path: string): void => {
+    const absolute = join(absoluteRoot, path);
+    const stat = lstatSync(absolute);
+    if (stat.isSymbolicLink() || realpathSync(absolute) !== absolute) {
+      throw new Error(`Refresh source must not contain symlinks: ${path}`);
+    }
+    if (!stat.isDirectory() && !stat.isFile()) throw new Error(`Refresh source must be regular: ${path}`);
+    // Preserve the test-only exclusions. Only Prisma's generated dependency is
+    // excluded: libs/contracts/generated contains imported runtime contracts.
+    // Do not ignore extensions or nested build/cache/node_modules directories:
+    // e.g. an untracked sibling .js or package.json can change Node resolution.
+    if (path === "prisma/generated" || path.includes(".spec.") ||
+        path.split("/").some((part) => part === "test-fixtures" || part === "test-support")) return;
+    if (stat.isDirectory()) {
+      for (const name of readdirSync(absolute).sort()) walk(`${path}/${name}`);
+    } else paths.push(path);
+  };
+  for (const path of refreshSourceRoots) {
+    if (!lstatSync(join(absoluteRoot, path)).isDirectory()) throw new Error(`Refresh source root missing: ${path}`);
+    walk(path);
+  }
+  for (const path of refreshSourceConfig) {
+    if (!lstatSync(join(absoluteRoot, path)).isFile()) throw new Error(`Refresh source config missing: ${path}`);
+    walk(path);
+  }
+  for (const path of refreshRequiredSource) {
+    if (!paths.includes(path)) throw new Error(`Refresh required source missing: ${path}`);
+  }
+  const files = paths.sort().map((path) => {
+    const fd = openSync(join(absoluteRoot, path), constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    try {
+      if (!fstatSync(fd).isFile()) throw new Error(`Refresh source must be regular: ${path}`);
+      return [path, refreshBytesHash(readFileSync(fd))];
+    } finally { closeSync(fd); }
+  });
+  return refreshHash({ format: "reader-summary-source-inventory-v2", files });
 }
 export function readReviewedRefresh(path: string, sha256: string): RefreshManifest {
   const absolute = resolve(path);

--- a/scripts/lib/reader-summary-new-input-refresh-files.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-files.ts
@@ -1,0 +1,51 @@
+import { execFileSync } from "node:child_process";
+import { fstatSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { refreshBytesHash, refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
+
+export function refreshSourceSha256(): string {
+  const paths = execFileSync("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard",
+    "libs", "scripts", "prisma", "package.json", "package-lock.json"], { encoding: "utf8" })
+    .split("\0").filter((p) => p && !p.includes(".spec.") && !p.includes("test-fixtures/") &&
+      !p.includes("test-support/") && !p.startsWith("prisma/generated/"));
+  return refreshHash([...new Set(paths)].sort().map((p) => [p, refreshBytesHash(readFileSync(p))]));
+}
+export function readReviewedRefresh(path: string, sha256: string): RefreshManifest {
+  const absolute = resolve(path);
+  if (realpathSync(absolute) !== absolute || !lstatSync(absolute).isFile() ||
+      lstatSync(absolute).nlink !== 1 || (lstatSync(absolute).mode & 0o222) !== 0) throw new Error("Refresh manifest must be a regular immutable file");
+  const bytes = readFileSync(absolute);
+  if (refreshBytesHash(bytes) !== sha256) throw new Error("Reviewed refresh manifest hash differs");
+  return JSON.parse(bytes.toString("utf8")) as RefreshManifest;
+}
+export type RefreshFenceAuthority = Readonly<{
+  globalLock: string; dateDirectory: string; fenceDirectory: string;
+}>;
+export function readRefreshFenceAuthority(paths: RefreshFenceAuthority): RefreshManifest["fenceAuthority"] {
+  const identify = (path: string) => {
+    if (!path.startsWith("/") || realpathSync(path) !== path) throw new Error("Refresh requires existing canonical fence paths");
+    const stat = lstatSync(path);
+    return `${stat.dev}:${stat.ino}`;
+  };
+  return { global: identify(paths.globalLock), dates: identify(paths.dateDirectory), fences: identify(paths.fenceDirectory) };
+}
+export function assertRefreshFences(date: string, paths: RefreshFenceAuthority,
+  token: string | undefined, expected: RefreshManifest["fenceAuthority"]): void {
+  if (refreshHash(readRefreshFenceAuthority(paths)) !== refreshHash(expected)) throw new Error("Refresh reviewed fence authority drifted");
+  for (const [fd, path] of [[8, paths.globalLock], [6, paths.dateDirectory],
+    [5, paths.fenceDirectory], [7, join(paths.dateDirectory, `${date}.lock`)]] as const) {
+    if (!path.startsWith("/") || realpathSync(path) !== path) throw new Error("Refresh canonical fence path invalid");
+    const actual = fstatSync(fd), expected = statSync(path);
+    if (actual.dev !== expected.dev || actual.ino !== expected.ino) throw new Error("Refresh fence inode drifted");
+    if ((fd === 7 || fd === 8) &&
+        !/lock:\s+\d+: FLOCK\s+ADVISORY\s+WRITE/u.test(readFileSync(`/proc/self/fdinfo/${fd}`, "utf8"))) {
+      throw new Error("Refresh requires held global and date flocks");
+    }
+  }
+  const counterPath = join(paths.fenceDirectory, `${date}.counter`);
+  if (lstatSync(counterPath).isSymbolicLink()) throw new Error("Refresh fence counter is a symlink");
+  const counter = readFileSync(counterPath, "utf8").trim();
+  if (!/^[1-9]\d*$/u.test(counter) || token !== `reader-summary-date:${date}:${counter}`) {
+    throw new Error("Refresh fence token drifted");
+  }
+}

--- a/scripts/lib/reader-summary-new-input-refresh-guard.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-guard.spec.ts
@@ -1,0 +1,116 @@
+import { ReaderSummaryJob } from "@social-monitor/summary/domain";
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { refreshPeriod } from "./reader-summary-new-input-refresh-capture";
+import { NewInputRefreshGuard } from "./reader-summary-new-input-refresh-guard";
+import { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import type { AgentRuntimeTaskCommand, AgentRuntimeTaskResult } from "@social-monitor/summary/ports";
+
+const makeJob = () => {
+  const m = refreshManifest();
+  return ReaderSummaryJob.request({ id: "new-job", tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId),
+    scope: { type: "workspace" }, period: refreshPeriod(m.date), idempotencyKey: m.operation, requestedAt: refreshNow });
+};
+describe("new-input refresh consumed authority", () => {
+  it("claims once and threads the real cutoff, independently of the later operational clock", async () => {
+    const m = refreshManifest();
+    const check = jest.fn(async () => undefined);
+    const fence = jest.fn();
+    const guard = new NewInputRefreshGuard(m, "new-job", { now: () => refreshNow, assertFences: fence, assertCurrent: check });
+    expect(await guard.claim(makeJob().toSnapshot())).toEqual(new Date(m.observedThrough));
+    await expect(guard.claim(makeJob().toSnapshot())).rejects.toThrow(/consumed/);
+    const select = jest.fn(async () => ({ sourceWindow: { ingestionCutoff: new Date(m.observedThrough) } }));
+    const selector = guard.selector({ select } as never);
+    await selector.select({ observedThrough: new Date(m.observedThrough) } as never);
+    expect(select).toHaveBeenCalledWith({ observedThrough: new Date(m.observedThrough) });
+    expect(check).toHaveBeenCalledTimes(3);
+    expect(fence).toHaveBeenCalledTimes(3);
+    await expect(selector.select({ observedThrough: refreshNow } as never)).rejects.toThrow(/cutoff/);
+  });
+  it.each(["old slot", "engagement", "config", "fence"])("fails closed on %s drift", async (kind) => {
+    const guard = new NewInputRefreshGuard(refreshManifest(), "new-job", {
+      now: () => refreshNow,
+      assertFences: () => { if (kind === "fence") throw new Error(kind); },
+      assertCurrent: async () => { throw new Error(kind); },
+    });
+    await expect(guard.claim(makeJob().toSnapshot())).rejects.toThrow(kind);
+  });
+  it("cannot reuse started authority after review or execution lease expiry", async () => {
+    const job = makeJob().start({ startedAt: refreshNow });
+    const guard = new NewInputRefreshGuard(refreshManifest(), "new-job", {
+      now: () => new Date("2026-09-06T00:00:00.000Z"), assertFences: () => undefined, assertCurrent: async () => undefined,
+    });
+    await expect(guard.claim(job.toSnapshot())).rejects.toThrow(/consumed/);
+    await expect(guard.claim(makeJob().toSnapshot())).rejects.toThrow(/stale/);
+  });
+  it("rechecks after selection so a mid-read change cannot reach a model", async () => {
+    let drift = false;
+    const m = refreshManifest();
+    const guard = new NewInputRefreshGuard(m, "new-job", { now: () => refreshNow, assertFences: () => undefined,
+      assertCurrent: async () => { if (drift) throw new Error("engagement drift"); } });
+    await guard.claim(makeJob().toSnapshot());
+    const selector = guard.selector({ select: async () => {
+      drift = true;
+      return { sourceWindow: { ingestionCutoff: new Date(m.observedThrough) } };
+    } } as never);
+    await expect(selector.select({ observedThrough: new Date(m.observedThrough) } as never)).rejects.toThrow(/drift/);
+  });
+});
+
+describe("new-input refresh model admission", () => {
+  const command = (): AgentRuntimeTaskCommand => ({
+    requestId: "test-summary", correlationId: "test-correlation", tenantId: tenantId(refreshManifest().tenantId),
+    workspaceId: workspaceId(refreshManifest().workspaceId), provider: "codex", purpose: "social_monitor.reader_summary.generate.v2",
+    prompt: "Synthetic test prompt", systemPrompt: "Synthetic test instruction", outputSchema: {}, timeoutMs: 1000,
+    controls: { model: "gpt-5.6-sol", reasoningEffort: "high" }, metadata: { attempt: "primary" },
+  });
+  it("records consumption before provider start and poisons retries after an ambiguous result", async () => {
+    const events: unknown[] = [];
+    const runTask = jest.fn(async () => { expect(events).toHaveLength(1); throw new Error("ambiguous transport"); });
+    const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() }, manifest: refreshManifest(),
+      assertCurrent: async () => undefined, record: (e) => events.push(e) });
+    await expect(runtime.runTask(command())).rejects.toThrow(/ambiguous/);
+    await expect(runtime.runTask({ ...command(), requestId: "new-path-new-attempt" })).rejects.toThrow(/budget/);
+    expect(runTask).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([expect.objectContaining({ status: "invocation_consumed" }),
+      expect.objectContaining({ status: "requires_reconciliation" })]);
+  });
+  it.each(["engagement", "config", "slot"])("checks %s at the actual provider boundary", async (kind) => {
+    const runTask = jest.fn();
+    const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() }, manifest: refreshManifest(),
+      assertCurrent: async () => { throw new Error(kind); }, record: jest.fn() });
+    await expect(runtime.runTask(command())).rejects.toThrow(kind);
+    expect(runTask).not.toHaveBeenCalled();
+  });
+  it("consumes the generation before an awaited authority check, blocking concurrent starts", async () => {
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    const runTask = jest.fn(async () => { throw new Error("ambiguous transport"); });
+    const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() },
+      manifest: refreshManifest(), assertCurrent: () => pending, record: jest.fn() });
+    const first = runtime.runTask(command());
+    await expect(runtime.runTask({ ...command(), requestId: "concurrent-other-id" })).rejects.toThrow(/budget/);
+    release();
+    await expect(first).rejects.toThrow(/ambiguous/);
+    expect(runTask).toHaveBeenCalledTimes(1);
+  });
+  it("persists token/identity evidence and blocks duplicate and repair generation", async () => {
+    const m = refreshManifest();
+    const events: unknown[] = [];
+    const result: AgentRuntimeTaskResult = { status: "completed", warnings: [],
+      usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5, estimatedCostUsd: 0 },
+      executionAttestation: { schemaVersion: 1, requestId: "test-summary", purpose: "social_monitor.reader_summary.generate.v2",
+        canonicalRequestSha256: "a".repeat(64), provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "high",
+        runtimeEngine: "subscription-runtime-cli", runtimePackageVersion: m.runtime.packageVersion,
+        launcherSha256: m.runtime.launcherSha256, selectedOutputKind: "structured_output", selectedOutputSha256: "b".repeat(64) } };
+    const runTask = jest.fn(async () => result);
+    const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() }, manifest: m,
+      assertCurrent: async () => undefined, record: (e) => events.push(e) });
+    await runtime.runTask(command());
+    await expect(runtime.runTask(command())).rejects.toThrow(/budget/);
+    await expect(runtime.runTask({ ...command(), requestId: "alternate-summary-id" })).rejects.toThrow(/budget/);
+    await expect(runtime.runTask({ ...command(), requestId: "repair", metadata: { attempt: "repair" } })).rejects.toThrow(/budget/);
+    expect(runTask).toHaveBeenCalledTimes(1);
+    expect(events[2]).toMatchObject({ tokens: result.usage, outputSha256: "b".repeat(64) });
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-guard.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-guard.spec.ts
@@ -1,3 +1,4 @@
+import { canonicalJsonSha256 } from "@social-monitor/contracts/grpc/agent_runtime/v1/execution-attestation";
 import { ReaderSummaryJob } from "@social-monitor/summary/domain";
 import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
 import { refreshPeriod } from "./reader-summary-new-input-refresh-capture";
@@ -24,7 +25,7 @@ describe("new-input refresh consumed authority", () => {
     await selector.select({ observedThrough: new Date(m.observedThrough) } as never);
     expect(select).toHaveBeenCalledWith({ observedThrough: new Date(m.observedThrough) });
     expect(check).toHaveBeenCalledTimes(3);
-    expect(fence).toHaveBeenCalledTimes(3);
+    expect(fence).toHaveBeenCalledTimes(6);
     await expect(selector.select({ observedThrough: refreshNow } as never)).rejects.toThrow(/cutoff/);
   });
   it.each(["old slot", "engagement", "config", "fence"])("fails closed on %s drift", async (kind) => {
@@ -68,7 +69,7 @@ describe("new-input refresh model admission", () => {
     const events: unknown[] = [];
     const runTask = jest.fn(async () => { expect(events).toHaveLength(1); throw new Error("ambiguous transport"); });
     const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() }, manifest: refreshManifest(),
-      assertCurrent: async () => undefined, record: (e) => events.push(e) });
+      assertLocal: () => undefined, assertCurrent: async () => undefined, record: (e) => events.push(e) });
     await expect(runtime.runTask(command())).rejects.toThrow(/ambiguous/);
     await expect(runtime.runTask({ ...command(), requestId: "new-path-new-attempt" })).rejects.toThrow(/budget/);
     expect(runTask).toHaveBeenCalledTimes(1);
@@ -78,8 +79,8 @@ describe("new-input refresh model admission", () => {
   it.each(["engagement", "config", "slot"])("checks %s at the actual provider boundary", async (kind) => {
     const runTask = jest.fn();
     const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() }, manifest: refreshManifest(),
-      assertCurrent: async () => { throw new Error(kind); }, record: jest.fn() });
-    await expect(runtime.runTask(command())).rejects.toThrow(kind);
+      assertLocal: () => undefined, assertCurrent: async () => { throw new Error(kind); }, record: jest.fn() });
+    await expect(runtime.runTask(command())).rejects.toThrow(/ambiguous/);
     expect(runTask).not.toHaveBeenCalled();
   });
   it("consumes the generation before an awaited authority check, blocking concurrent starts", async () => {
@@ -87,7 +88,7 @@ describe("new-input refresh model admission", () => {
     const pending = new Promise<void>((resolve) => { release = resolve; });
     const runTask = jest.fn(async () => { throw new Error("ambiguous transport"); });
     const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() },
-      manifest: refreshManifest(), assertCurrent: () => pending, record: jest.fn() });
+      manifest: refreshManifest(), assertLocal: () => undefined, assertCurrent: () => pending, record: jest.fn() });
     const first = runtime.runTask(command());
     await expect(runtime.runTask({ ...command(), requestId: "concurrent-other-id" })).rejects.toThrow(/budget/);
     release();
@@ -97,20 +98,20 @@ describe("new-input refresh model admission", () => {
   it("persists token/identity evidence and blocks duplicate and repair generation", async () => {
     const m = refreshManifest();
     const events: unknown[] = [];
-    const result: AgentRuntimeTaskResult = { status: "completed", warnings: [],
+    const result: AgentRuntimeTaskResult = { status: "completed", warnings: [], structuredOutput: { synthetic: true },
       usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5, estimatedCostUsd: 0 },
       executionAttestation: { schemaVersion: 1, requestId: "test-summary", purpose: "social_monitor.reader_summary.generate.v2",
         canonicalRequestSha256: "a".repeat(64), provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "high",
         runtimeEngine: "subscription-runtime-cli", runtimePackageVersion: m.runtime.packageVersion,
-        launcherSha256: m.runtime.launcherSha256, selectedOutputKind: "structured_output", selectedOutputSha256: "b".repeat(64) } };
+        launcherSha256: m.runtime.launcherSha256, selectedOutputKind: "structured_output", selectedOutputSha256: canonicalJsonSha256({ synthetic: true }) } };
     const runTask = jest.fn(async () => result);
     const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() }, manifest: m,
-      assertCurrent: async () => undefined, record: (e) => events.push(e) });
+      assertLocal: () => undefined, assertCurrent: async () => undefined, record: (e) => events.push(e) });
     await runtime.runTask(command());
     await expect(runtime.runTask(command())).rejects.toThrow(/budget/);
     await expect(runtime.runTask({ ...command(), requestId: "alternate-summary-id" })).rejects.toThrow(/budget/);
     await expect(runtime.runTask({ ...command(), requestId: "repair", metadata: { attempt: "repair" } })).rejects.toThrow(/budget/);
     expect(runTask).toHaveBeenCalledTimes(1);
-    expect(events[2]).toMatchObject({ tokens: result.usage, outputSha256: "b".repeat(64) });
+    expect(events[2]).toMatchObject({ tokens: result.usage, outputSha256: canonicalJsonSha256({ synthetic: true }) });
   });
 });

--- a/scripts/lib/reader-summary-new-input-refresh-guard.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-guard.spec.ts
@@ -5,7 +5,8 @@ import { refreshPeriod } from "./reader-summary-new-input-refresh-capture";
 import { NewInputRefreshGuard } from "./reader-summary-new-input-refresh-guard";
 import { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
 import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
-import type { AgentRuntimeTaskCommand, AgentRuntimeTaskResult } from "@social-monitor/summary/ports";
+import { completedRefreshModelRequest } from "./reader-summary-new-input-refresh-model.spec-support";
+import type { AgentRuntimeTaskCommand } from "@social-monitor/summary/ports";
 
 const makeJob = () => {
   const m = refreshManifest();
@@ -98,12 +99,7 @@ describe("new-input refresh model admission", () => {
   it("persists token/identity evidence and blocks duplicate and repair generation", async () => {
     const m = refreshManifest();
     const events: unknown[] = [];
-    const result: AgentRuntimeTaskResult = { status: "completed", warnings: [], structuredOutput: { synthetic: true },
-      usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5, estimatedCostUsd: 0 },
-      executionAttestation: { schemaVersion: 1, requestId: "test-summary", purpose: "social_monitor.reader_summary.generate.v2",
-        canonicalRequestSha256: "a".repeat(64), provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "high",
-        runtimeEngine: "subscription-runtime-cli", runtimePackageVersion: m.runtime.packageVersion,
-        launcherSha256: m.runtime.launcherSha256, selectedOutputKind: "structured_output", selectedOutputSha256: canonicalJsonSha256({ synthetic: true }) } };
+    const result = await completedRefreshModelRequest(command(), { synthetic: true });
     const runTask = jest.fn(async () => result);
     const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() }, manifest: m,
       assertLocal: () => undefined, assertCurrent: async () => undefined, record: (e) => events.push(e) });

--- a/scripts/lib/reader-summary-new-input-refresh-guard.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-guard.ts
@@ -16,15 +16,23 @@ export type RefreshGuardDependencies = Readonly<{
  * start requires reconciliation; lease expiry can never authorize a paid retry. */
 export class NewInputRefreshGuard implements ReaderSummaryNewInputRefreshAuthority {
   private claimed = false;
+  private invalid = false;
   constructor(readonly manifest: RefreshManifest, private readonly jobId: string,
     private readonly deps: RefreshGuardDependencies) {}
+  invalidate(): void { this.invalid = true; }
   assertLocal(): void {
-    this.deps.assertFences();
-    assertRefreshManifest(this.manifest, this.deps.now());
+    if (this.invalid) throw new Error("Refresh authority requires reconciliation");
+    try {
+      this.deps.assertFences();
+      assertRefreshManifest(this.manifest, this.deps.now());
+    } catch (error) { this.invalid = true; throw error; }
   }
   async assertCurrent(): Promise<void> {
-    this.assertLocal();
-    await this.deps.assertCurrent();
+    try {
+      this.assertLocal();
+      await this.deps.assertCurrent();
+      this.assertLocal();
+    } catch (error) { this.invalid = true; throw error; }
   }
   async claim(job: ReaderSummaryJobProps): Promise<Date> {
     if (this.claimed || job.id !== this.jobId || job.idempotencyKey !== this.manifest.operation ||

--- a/scripts/lib/reader-summary-new-input-refresh-guard.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-guard.ts
@@ -1,0 +1,73 @@
+import type { ReaderSummaryNewInputRefreshAuthority } from
+  "@social-monitor/summary/application/contracts/reader-summary-new-input-refresh-authority";
+import type { ReaderSummaryJobProps } from "@social-monitor/summary/domain";
+import type { ReaderSummaryEvidenceSelectorPort } from "@social-monitor/summary/ports";
+import { assertRefreshManifest, refreshHash, type RefreshManifest } from
+  "./reader-summary-new-input-refresh-manifest";
+import type { RefreshJobState } from "./reader-summary-new-input-refresh-postgres";
+
+export type RefreshGuardDependencies = Readonly<{
+  now(): Date;
+  assertFences(): void;
+  assertCurrent(): Promise<void>;
+}>;
+
+/** Requested is already consumed for this bounded route. Even a crash before
+ * start requires reconciliation; lease expiry can never authorize a paid retry. */
+export class NewInputRefreshGuard implements ReaderSummaryNewInputRefreshAuthority {
+  private claimed = false;
+  constructor(readonly manifest: RefreshManifest, private readonly jobId: string,
+    private readonly deps: RefreshGuardDependencies) {}
+  assertLocal(): void {
+    this.deps.assertFences();
+    assertRefreshManifest(this.manifest, this.deps.now());
+  }
+  async assertCurrent(): Promise<void> {
+    this.assertLocal();
+    await this.deps.assertCurrent();
+  }
+  async claim(job: ReaderSummaryJobProps): Promise<Date> {
+    if (this.claimed || job.id !== this.jobId || job.idempotencyKey !== this.manifest.operation ||
+        job.status !== "requested" || job.startedAt !== undefined ||
+        job.tenantId !== this.manifest.tenantId || job.workspaceId !== this.manifest.workspaceId ||
+        job.scope.type !== "workspace" || job.userId !== undefined || job.subscriptionId !== undefined ||
+        job.period.cadence !== "daily" || job.period.timezone !== "UTC" ||
+        job.period.startedAt.toISOString() !== this.manifest.startedAt ||
+        job.period.endedAt.toISOString() !== this.manifest.endedAt) {
+      throw new Error("Refresh operation is consumed or has wrong job authority");
+    }
+    this.claimed = true;
+    await this.assertCurrent();
+    return new Date(this.manifest.observedThrough);
+  }
+  selector(delegate: ReaderSummaryEvidenceSelectorPort): ReaderSummaryEvidenceSelectorPort {
+    return { select: async (query) => {
+      if (!this.claimed || query.observedThrough?.toISOString() !== this.manifest.observedThrough) {
+        throw new Error("Refresh selector did not receive the frozen cutoff");
+      }
+      await this.assertCurrent();
+      const selected = await delegate.select(query);
+      if (selected.sourceWindow.ingestionCutoff?.toISOString() !== this.manifest.observedThrough) {
+        throw new Error("Refresh selector changed the observation cutoff");
+      }
+      await this.assertCurrent();
+      return selected;
+    } };
+  }
+}
+export function reconcileRefresh(m: RefreshManifest, jobs: readonly RefreshJobState[],
+  current: { publicationId: string; artifactId: string; jobId: string },
+): "unconsumed" | "published" {
+  if (jobs.length === 0) return "unconsumed";
+  const job = jobs[0];
+  if (jobs.length !== 1 || job?.operation !== m.operation ||
+      !["COMPLETED", "NO_SIGNAL"].includes(job.status) ||
+      current.jobId !== job.jobId || current.artifactId !== job.artifactId ||
+      current.publicationId !== job.artifactId) {
+    throw new Error("Refresh generation budget is consumed; reconcile the original job");
+  }
+  return "published";
+}
+export const assertRefreshEqual = (actual: unknown, expected: unknown, label: string): void => {
+  if (refreshHash(actual) !== refreshHash(expected)) throw new Error(`Refresh ${label} drifted`);
+};

--- a/scripts/lib/reader-summary-new-input-refresh-manifest.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-manifest.spec.ts
@@ -1,0 +1,49 @@
+import { assertRefreshManifest, refreshOperation } from "./reader-summary-new-input-refresh-manifest";
+import { parseRefreshCommand } from "../run-reader-summary-new-input-refresh";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import { reconcileRefresh } from "./reader-summary-new-input-refresh-guard";
+
+describe("bounded new-input refresh authority", () => {
+  it("admits a real newer observation for a terminal NO_SIGNAL on the fixed seven dates", () => {
+    expect(() => assertRefreshManifest(refreshManifest(), refreshNow)).not.toThrow();
+    expect(parseRefreshCommand([])).toMatchObject({ mode: "prepare", dates: expect.any(Array) });
+    expect(parseRefreshCommand(["--prepare", "--date", "2026-09-03"])).toEqual({ mode: "prepare", dates: ["2026-09-03"] });
+    expect(() => assertRefreshManifest(refreshManifest(), new Date("2026-09-06T00:00:00Z"), false)).not.toThrow();
+  });
+  it.each([
+    { tenantId: "other" }, { workspaceId: "other" }, { date: "2026-08-29" }, { date: "2026-09-06" },
+    { timezone: "Europe/Kyiv" }, { startedAt: "2026-09-02T00:00:00.000Z" },
+    { model: "gpt-5.5" }, { reasoningEffort: "xhigh" }, { sourceSha256: "b".repeat(64) },
+    { observedThrough: "2026-09-06T00:00:00.000Z" }, { observedThrough: "2026-09-03T00:00:00.000Z" },
+  ])("rejects wrong scope/date/policy/cutoff %j", (patch) => {
+    const m = { ...refreshManifest(), ...patch } as ReturnType<typeof refreshManifest>;
+    expect(() => assertRefreshManifest({ ...m, operation: refreshOperation(m) }, refreshNow)).toThrow();
+  });
+  it("enforces 30 minute review age independently of content date", () => {
+    expect(() => assertRefreshManifest(refreshManifest(), new Date("2026-09-05T22:30:00.001Z"))).toThrow(/stale/);
+  });
+  it("cannot launder an expired observation through a newer preparedAt", () => {
+    const m = { ...refreshManifest(), preparedAt: "2026-09-05T22:29:00.000Z" };
+    expect(() => assertRefreshManifest(m, new Date("2026-09-05T22:29:00.001Z"))).toThrow(/stale/);
+  });
+  it("does not derive a new paid identity from recapture time or cutoff", () => {
+    const m = refreshManifest();
+    expect(refreshOperation({ ...m, preparedAt: "2026-09-05T22:12:00.000Z", observedThrough: "2026-09-05T22:11:00.000Z" })).toBe(m.operation);
+    expect(refreshOperation({ ...m, authority: { ...m.authority, engagementSha256: "b".repeat(64) } })).not.toBe(m.operation);
+    expect(refreshOperation({ ...m, prior: { ...m.prior, proofSha256: "b".repeat(64) } })).not.toBe(m.operation);
+  });
+  it.each([["--date", "2026-09-03"], ["--prepare", "--date", "2026-09-06"], ["--output", "/tmp/new"],
+    ["--apply", "file"], ["--prepare", "--dates", "2026-08-30..2026-09-10"]])("rejects broad flags %j", (...args) => {
+    expect(() => parseRefreshCommand(args)).toThrow();
+  });
+  it("reconciles published operation before looking at the new active slot as a prior", () => {
+    const m = refreshManifest();
+    expect(reconcileRefresh(m, [{ operation: m.operation, jobId: "job-new", artifactId: "new", status: "COMPLETED" }],
+      { jobId: "job-new", artifactId: "new", publicationId: "new" })).toBe("published");
+  });
+  it.each(["REQUESTED", "RUNNING", "FAILED", "QUALITY_REJECTED"])("never retries consumed %s even with a new digest", (status) => {
+    const m = refreshManifest();
+    expect(() => reconcileRefresh(m, [{ operation: m.operation, jobId: "new", artifactId: null, status }], m.prior)).toThrow(/consumed/);
+    expect(() => reconcileRefresh({ ...m, operation: "changed" }, [{ operation: m.operation, jobId: "new", artifactId: null, status }], m.prior)).toThrow(/consumed/);
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-manifest.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-manifest.ts
@@ -1,0 +1,106 @@
+import { createHash } from "node:crypto";
+import { readerSummaryNewInputRefreshPrefix } from
+  "@social-monitor/summary/application/contracts/reader-summary-new-input-refresh-authority";
+
+export const refreshScope = Object.freeze({
+  tenantId: "00000000-0000-7000-8000-000000006101",
+  workspaceId: "00000000-0000-7000-8000-000000006102",
+});
+export const refreshDates = Object.freeze([
+  "2026-08-30", "2026-08-31", "2026-09-01", "2026-09-02",
+  "2026-09-03", "2026-09-04", "2026-09-05",
+]);
+export type RefreshPrior = Readonly<{
+  artifactId: string; jobId: string; publicationId: string;
+  artifactSha256: string; jobSha256: string; publicationSha256: string;
+  reportSha256: string; proofSha256: string; observedThrough: string;
+  status: "COMPLETED" | "NO_SIGNAL";
+  topCount: number; additionalCount: number; citationCount: number;
+}>;
+export type RefreshAuthority = Readonly<{
+  datasetSha256: string; canonicalRowsSha256: string; engagementSha256: string; sourceScopeSha256: string;
+  policySha256: string; canonicalInputSha256: string;
+  feedCount: number; eligibleCount: number; metricRowCount: number;
+}>;
+export type RefreshManifest = Readonly<{
+  format: "reader-summary-seven-day-new-input-v1";
+  tenantId: string; workspaceId: string; date: string;
+  startedAt: string; endedAt: string; timezone: "UTC";
+  observedThrough: string; preparedAt: string;
+  prior: RefreshPrior; authority: RefreshAuthority;
+  sourceSha256: string; deployedSourceSha256: string; generationSha256: string;
+  runtime: Readonly<{ engine: string; packageVersion: string; launcherSha256: string }>;
+  fenceAuthority: Readonly<{ global: string; dates: string; fences: string }>;
+  model: "gpt-5.6-sol"; reasoningEffort: "high";
+  operation: string;
+}>;
+export const refreshHash = (value: unknown): string => createHash("sha256")
+  .update(canonical(value)).digest("hex");
+export const refreshBytesHash = (value: Uint8Array): string => createHash("sha256")
+  .update(value).digest("hex");
+export const refreshKeyPrefix = (date: string): string =>
+  `${readerSummaryNewInputRefreshPrefix}${date}:`;
+// Cutoff, capture time and path are intentionally absent: recapture cannot buy
+// another generation. Authority includes all metric rows, including observedAt.
+export const refreshOperation = (m: Omit<RefreshManifest, "operation">): string =>
+  refreshKeyPrefix(m.date) + refreshHash({
+    scope: [m.tenantId, m.workspaceId, m.startedAt, m.endedAt, m.timezone],
+    prior: m.prior, input: m.authority,
+    source: m.sourceSha256, deployed: m.deployedSourceSha256, generation: m.generationSha256,
+    runtime: m.runtime, model: m.model, effort: m.reasoningEffort,
+  });
+
+export function assertRefreshManifest(m: RefreshManifest, now: Date, fresh = true): void {
+  if (m.format !== "reader-summary-seven-day-new-input-v1" ||
+      m.tenantId !== refreshScope.tenantId || m.workspaceId !== refreshScope.workspaceId ||
+      !refreshDates.includes(m.date) || m.timezone !== "UTC" ||
+      m.startedAt !== `${m.date}T00:00:00.000Z` ||
+      m.endedAt !== new Date(Date.parse(m.startedAt) + 86_400_000).toISOString() ||
+      m.model !== "gpt-5.6-sol" || m.reasoningEffort !== "high" ||
+      m.sourceSha256 !== m.deployedSourceSha256 ||
+      m.runtime.engine !== "subscription-runtime-cli" ||
+      m.runtime.packageVersion.trim().length === 0 ||
+      !["COMPLETED", "NO_SIGNAL"].includes(m.prior.status) ||
+      m.operation !== refreshOperation(m)) {
+    throw new Error("Refresh manifest scope, period, policy or identity is invalid");
+  }
+  if (!m.fenceAuthority || ![m.fenceAuthority.global, m.fenceAuthority.dates, m.fenceAuthority.fences]
+    .every((v) => /^\d+:\d+$/u.test(v))) throw new Error("Refresh canonical fence authority is invalid");
+  for (const id of [m.prior.artifactId, m.prior.jobId, m.prior.publicationId]) {
+    if (!/^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/u.test(id)) {
+      throw new Error("Refresh prior identity is invalid");
+    }
+  }
+  for (const hash of [m.sourceSha256, m.generationSha256, m.runtime.launcherSha256,
+    m.prior.artifactSha256, m.prior.jobSha256, m.prior.publicationSha256, m.prior.reportSha256, m.prior.proofSha256,
+    m.authority.datasetSha256, m.authority.canonicalRowsSha256, m.authority.engagementSha256, m.authority.sourceScopeSha256,
+    m.authority.policySha256, m.authority.canonicalInputSha256]) {
+    if (typeof hash !== "string" || !/^[0-9a-f]{64}$/u.test(hash)) {
+      throw new Error("Refresh authority digest is invalid");
+    }
+  }
+  const [cutoff, prepared, prior] = [m.observedThrough, m.preparedAt, m.prior.observedThrough]
+    .map((s) => {
+      const d = new Date(s);
+      if (!Number.isFinite(d.getTime()) || d.toISOString() !== s) {
+        throw new Error("Refresh cutoff must be an exact real timestamp");
+      }
+      return d.getTime();
+    }) as [number, number, number];
+  if (cutoff <= prior || cutoff < Date.parse(m.startedAt) || cutoff > prepared ||
+      prepared > now.getTime() || (fresh && (now.getTime() - prepared > 30 * 60_000 || now.getTime() - cutoff > 30 * 60_000))) {
+    throw new Error("Refresh observation/review cutoff is invalid or stale");
+  }
+  for (const count of [m.authority.feedCount, m.authority.eligibleCount,
+    m.authority.metricRowCount, m.prior.topCount, m.prior.additionalCount, m.prior.citationCount]) {
+    if (!Number.isSafeInteger(count) || count < 0) throw new Error("Refresh count is invalid");
+  }
+}
+function canonical(value: unknown): string {
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (value === undefined) return "null";
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  return `{${Object.entries(value).sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, v]) => `${JSON.stringify(key)}:${canonical(v)}`).join(",")}}`;
+}

--- a/scripts/lib/reader-summary-new-input-refresh-model-attempts.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model-attempts.spec.ts
@@ -1,11 +1,8 @@
-import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
 import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
 import type { AgentRuntimeTaskCommand, AgentRuntimeTaskResult } from "@social-monitor/summary/ports";
-import type { BuildReaderSummaryTopicMapCommand } from "@social-monitor/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.command";
 import { evaluateReaderSummaryTopicMapStructure } from "@social-monitor/summary/domain";
-import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
 import { completedRefreshModelRequest, refreshModelCommand } from "./reader-summary-new-input-refresh-model.spec-support";
-import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import { wiring, topicOutput, topicCommand } from "./reader-summary-new-input-refresh-model-composition.spec-support";
 
 describe("refresh composed model attempt contract", () => {
   it("preserves the reviewer's two known low-coverage attempts, rejects the map and never invokes a third", async () => {
@@ -76,17 +73,6 @@ describe("refresh composed model attempt contract", () => {
   });
 });
 
-function wiring(respond: (command: AgentRuntimeTaskCommand) => Promise<AgentRuntimeTaskResult>) {
-  const commands: AgentRuntimeTaskCommand[] = [];
-  const events: { status: string }[] = [];
-  const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), delegate: {
-    runTask: async (command) => { commands.push(command); return respond(command); }, checkHealth: jest.fn(),
-  }, assertLocal: () => undefined, assertCurrent: async () => undefined,
-  record: (event) => events.push(event as { status: string }) });
-  const sink = { record: jest.fn(() => runtime.assertUsable()) };
-  return { runtime, commands, events, sink, model: buildRefreshModelWiring({}, runtime, sink) };
-}
-
 async function uncertain(command: AgentRuntimeTaskCommand, kind: string): Promise<AgentRuntimeTaskResult> {
   if (kind === "throw") throw new Error("Synthetic uncertain transport");
   const result = await completedRefreshModelRequest(kind === "wrong-request"
@@ -98,43 +84,4 @@ async function uncertain(command: AgentRuntimeTaskCommand, kind: string): Promis
     case "missing-usage": return { ...result, usage: undefined };
     default: return result;
   }
-}
-
-function topicOutput(command: AgentRuntimeTaskCommand, good: boolean): Record<string, unknown> {
-  if (command.purpose === purposes.generate) return { synthetic: true };
-  if (command.purpose === purposes.topicRelations) {
-    const payload = JSON.parse(command.prompt) as { pairs: { sourceNodeId: string; targetNodeId: string }[] };
-    return { decisions: payload.pairs.map((pair) => ({ sourceNodeId: pair.sourceNodeId, targetNodeId: pair.targetNodeId,
-      sameTopic: false, confidenceScore: 0.95, rationale: "Distinct synthetic announcements" })) };
-  }
-  const payload = JSON.parse(command.prompt) as { nodes: { nodeId: string; fallbackLabel: string }[] };
-  return { nodeLabels: payload.nodes.map((node, index) => ({ nodeId: node.nodeId, topicId: index < 2 && node.fallbackLabel.toLowerCase().includes("runtime") ? "topic:shared-proposal" : `topic:synthetic-${index}`,
-    subject: node.fallbackLabel, parentSubject: good ? "Runtime" : undefined, claimType: "other",
-    confidenceScore: good ? 0.95 : 0.4, keywords: good ? ["Runtime"] : [],
-    groupId: good ? "group:runtime" : "group:ungrouped",
-  })), groups: good ? [{ id: "group:runtime", label: "Runtime", semanticAnchors: ["Runtime"],
-    nodeIds: payload.nodes.map((node) => node.nodeId), confidenceScore: 0.95 }] : [], warnings: [] };
-}
-
-function topicCommand(related: boolean): BuildReaderSummaryTopicMapCommand {
-  const m = refreshManifest();
-  const names = ["Quartz", "Orchid", "Nimbus", "Cobalt"];
-  const selectedEvidence = names.map((name, index) => ({
-    feedItemId: `feed-${index}`, sourceItemId: `source-${index}`, sourceBindingId: `binding-${index}`,
-    interestId: `interest-${index}`, providerKey: "rss", canonicalUrl: `https://example.test/${index}`,
-    title: `${name}${related ? " runtime" : ""}`, bodyPreview: `${name}${related ? " runtime" : ""}`,
-    publishedAt: refreshNow, observedAt: refreshNow, score: 0.9, whyImportant: ["Synthetic evidence"],
-    contentQuality: { qualityScore: 0.9, interestRelevanceScore: 0.9, engagementIntegrityScore: 0.9,
-      eligibleForSummary: true, eligibleForTopRead: true, needsLlmReview: false, decision: "keep",
-      flags: [], reason: "Synthetic eligible evidence" },
-  }));
-  return { tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId), scope: { type: "workspace" },
-    period: { cadence: "daily", startedAt: new Date(m.startedAt), endedAt: new Date(m.endedAt), timezone: "UTC", periodKey: m.date },
-    requestedAt: refreshNow, selectedEvidence, topStories: [],
-    clusters: selectedEvidence.map((item, index) => ({ id: `story:${index}`, storyKey: `synthetic-${index}`,
-      representativeFeedItemId: item.feedItemId, duplicateFeedItemIds: [], interestIds: [item.interestId], providerKeys: [item.providerKey],
-      score: item.score, observedAtRange: { startedAt: refreshNow, endedAt: refreshNow }, whyImportant: item.whyImportant })),
-    citationMap: selectedEvidence.map((item, index) => ({ citationId: `c${index}`, feedItemId: item.feedItemId,
-      sourceItemId: item.sourceItemId, providerKey: item.providerKey, field: "title", canonicalUrl: item.canonicalUrl })),
-  };
 }

--- a/scripts/lib/reader-summary-new-input-refresh-model-attempts.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model-attempts.spec.ts
@@ -1,0 +1,140 @@
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import type { AgentRuntimeTaskCommand, AgentRuntimeTaskResult } from "@social-monitor/summary/ports";
+import type { BuildReaderSummaryTopicMapCommand } from "@social-monitor/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.command";
+import { evaluateReaderSummaryTopicMapStructure } from "@social-monitor/summary/domain";
+import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { completedRefreshModelRequest, refreshModelCommand } from "./reader-summary-new-input-refresh-model.spec-support";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+
+describe("refresh composed model attempt contract", () => {
+  it("preserves the reviewer's two known low-coverage attempts, rejects the map and never invokes a third", async () => {
+    const test = wiring(async (command) => completedRefreshModelRequest(command, topicOutput(command, false)));
+    await test.runtime.runTask(refreshModelCommand());
+    const result = await test.model.topicMap.execute(topicCommand(false));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Low coverage must remain unpublishable");
+    expect(result.error.message).toContain("grouped coverage is below 0.5");
+    const labels = test.commands.filter((command) => command.purpose === purposes.topicLabel);
+    expect(labels.map((command) => command.metadata?.attemptNumber)).toEqual(["1", "2"]);
+    expect(labels.map((command) => command.metadata?.totalAttempts)).toEqual(["2", "2"]);
+    expect(labels[0]!.requestId).not.toBe(labels[1]!.requestId);
+    expect(JSON.parse(labels[0]!.prompt).retryFeedback).toBeNull();
+    expect(JSON.parse(labels[1]!.prompt).retryFeedback).toMatchObject({
+      reason: "grouped_coverage_below_minimum", previousGroupedCoverage: 0, minimumGroupedCoverage: 0.5,
+    });
+    expect(test.commands).toHaveLength(3); // One primary plus two topic labels.
+    expect(test.events.filter((event) => event.status === "completed")).toHaveLength(3);
+    expect(() => test.runtime.assertUsable()).not.toThrow();
+    await expect(test.runtime.runTask({ ...refreshModelCommand(), requestId: "second-primary" })).rejects.toThrow(/budget/);
+    expect(test.commands).toHaveLength(3);
+  });
+
+  it.each([false, true])("keeps a grounded quality repair available (first attempt good: %s)", async (firstGood) => {
+    const test = wiring(async (command) => completedRefreshModelRequest(command,
+      topicOutput(command, firstGood || command.metadata?.attemptNumber === "2")));
+    const result = await test.model.topicMap.execute(topicCommand(true));
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw result.error;
+    const quality = evaluateReaderSummaryTopicMapStructure(result.value);
+    expect(quality.passed).toBe(true);
+    expect(quality.metrics.groupedCoverage).toBeGreaterThanOrEqual(0.5);
+    const attempts = firstGood ? ["1"] : ["1", "2"];
+    for (const purpose of [purposes.topicLabel, purposes.topicRelations]) {
+      expect(test.commands.filter((command) => command.purpose === purpose)
+        .map((command) => command.metadata?.attemptNumber)).toEqual(attempts);
+    }
+    expect(test.commands).toHaveLength(attempts.length * 2);
+    expect(test.sink.record).toHaveBeenCalledTimes(attempts.length * 2);
+    expect(() => test.runtime.assertUsable()).not.toThrow();
+  });
+
+  const uncertainties = ["throw", "failed", "waiting_for_input", "missing-attestation", "missing-usage", "wrong-request"] as const;
+  it.each(uncertainties)("permits no follow-up after uncertain topic labeling: %s", async (kind) => {
+    const test = wiring((command) => uncertain(command, kind));
+    const result = await test.model.topicMap.execute(topicCommand(false));
+    expect(result.ok).toBe(false);
+    expect(test.commands.map((command) => command.metadata?.attemptNumber)).toEqual(["1"]);
+    await expect(test.runtime.runTask(refreshModelCommand())).rejects.toThrow(/budget/);
+    expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/);
+    expect(test.sink.record).not.toHaveBeenCalled();
+    expect(test.events.filter((event) => event.status === "completed")).toHaveLength(0);
+  });
+
+  it.each(uncertainties)("a caught relation-verifier uncertainty cannot start the quality repair: %s", async (kind) => {
+    const test = wiring((command) => command.purpose === purposes.topicRelations
+      ? uncertain(command, kind) : completedRefreshModelRequest(command, topicOutput(command, false)));
+    const result = await test.model.topicMap.execute(topicCommand(true));
+    expect(result.ok).toBe(false);
+    expect(test.commands.map((command) => [command.purpose, command.metadata?.attemptNumber])).toEqual([
+      [purposes.topicLabel, "1"], [purposes.topicRelations, "1"],
+    ]);
+    await expect(test.runtime.runTask(refreshModelCommand())).rejects.toThrow(/budget/);
+    expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/);
+    expect(test.sink.record).toHaveBeenCalledTimes(1);
+    expect(test.events.filter((event) => event.status === "completed")).toHaveLength(1);
+  });
+});
+
+function wiring(respond: (command: AgentRuntimeTaskCommand) => Promise<AgentRuntimeTaskResult>) {
+  const commands: AgentRuntimeTaskCommand[] = [];
+  const events: { status: string }[] = [];
+  const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), delegate: {
+    runTask: async (command) => { commands.push(command); return respond(command); }, checkHealth: jest.fn(),
+  }, assertLocal: () => undefined, assertCurrent: async () => undefined,
+  record: (event) => events.push(event as { status: string }) });
+  const sink = { record: jest.fn(() => runtime.assertUsable()) };
+  return { runtime, commands, events, sink, model: buildRefreshModelWiring({}, runtime, sink) };
+}
+
+async function uncertain(command: AgentRuntimeTaskCommand, kind: string): Promise<AgentRuntimeTaskResult> {
+  if (kind === "throw") throw new Error("Synthetic uncertain transport");
+  const result = await completedRefreshModelRequest(kind === "wrong-request"
+    ? { ...command, prompt: command.prompt + " alternate" } : command, topicOutput(command, false));
+  switch (kind) {
+    case "failed": return { status: "failed", warnings: [] };
+    case "waiting_for_input": return { status: "waiting_for_input", warnings: [] };
+    case "missing-attestation": return { ...result, executionAttestation: undefined };
+    case "missing-usage": return { ...result, usage: undefined };
+    default: return result;
+  }
+}
+
+function topicOutput(command: AgentRuntimeTaskCommand, good: boolean): Record<string, unknown> {
+  if (command.purpose === purposes.generate) return { synthetic: true };
+  if (command.purpose === purposes.topicRelations) {
+    const payload = JSON.parse(command.prompt) as { pairs: { sourceNodeId: string; targetNodeId: string }[] };
+    return { decisions: payload.pairs.map((pair) => ({ sourceNodeId: pair.sourceNodeId, targetNodeId: pair.targetNodeId,
+      sameTopic: false, confidenceScore: 0.95, rationale: "Distinct synthetic announcements" })) };
+  }
+  const payload = JSON.parse(command.prompt) as { nodes: { nodeId: string; fallbackLabel: string }[] };
+  return { nodeLabels: payload.nodes.map((node, index) => ({ nodeId: node.nodeId, topicId: index < 2 && node.fallbackLabel.toLowerCase().includes("runtime") ? "topic:shared-proposal" : `topic:synthetic-${index}`,
+    subject: node.fallbackLabel, parentSubject: good ? "Runtime" : undefined, claimType: "other",
+    confidenceScore: good ? 0.95 : 0.4, keywords: good ? ["Runtime"] : [],
+    groupId: good ? "group:runtime" : "group:ungrouped",
+  })), groups: good ? [{ id: "group:runtime", label: "Runtime", semanticAnchors: ["Runtime"],
+    nodeIds: payload.nodes.map((node) => node.nodeId), confidenceScore: 0.95 }] : [], warnings: [] };
+}
+
+function topicCommand(related: boolean): BuildReaderSummaryTopicMapCommand {
+  const m = refreshManifest();
+  const names = ["Quartz", "Orchid", "Nimbus", "Cobalt"];
+  const selectedEvidence = names.map((name, index) => ({
+    feedItemId: `feed-${index}`, sourceItemId: `source-${index}`, sourceBindingId: `binding-${index}`,
+    interestId: `interest-${index}`, providerKey: "rss", canonicalUrl: `https://example.test/${index}`,
+    title: `${name}${related ? " runtime" : ""}`, bodyPreview: `${name}${related ? " runtime" : ""}`,
+    publishedAt: refreshNow, observedAt: refreshNow, score: 0.9, whyImportant: ["Synthetic evidence"],
+    contentQuality: { qualityScore: 0.9, interestRelevanceScore: 0.9, engagementIntegrityScore: 0.9,
+      eligibleForSummary: true, eligibleForTopRead: true, needsLlmReview: false, decision: "keep",
+      flags: [], reason: "Synthetic eligible evidence" },
+  }));
+  return { tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId), scope: { type: "workspace" },
+    period: { cadence: "daily", startedAt: new Date(m.startedAt), endedAt: new Date(m.endedAt), timezone: "UTC", periodKey: m.date },
+    requestedAt: refreshNow, selectedEvidence, topStories: [],
+    clusters: selectedEvidence.map((item, index) => ({ id: `story:${index}`, storyKey: `synthetic-${index}`,
+      representativeFeedItemId: item.feedItemId, duplicateFeedItemIds: [], interestIds: [item.interestId], providerKeys: [item.providerKey],
+      score: item.score, observedAtRange: { startedAt: refreshNow, endedAt: refreshNow }, whyImportant: item.whyImportant })),
+    citationMap: selectedEvidence.map((item, index) => ({ citationId: `c${index}`, feedItemId: item.feedItemId,
+      sourceItemId: item.sourceItemId, providerKey: item.providerKey, field: "title", canonicalUrl: item.canonicalUrl })),
+  };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-model-composition.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model-composition.spec-support.ts
@@ -1,0 +1,109 @@
+import { buildReaderSummaryCoveragePlan } from "@social-monitor/summary/domain";
+import { redditPromotionFacts } from "@social-monitor/summary/adapters/model/reader-summary-model-promotion.spec-support";
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import type { AgentRuntimeTaskCommand, AgentRuntimeTaskResult, ReaderSummaryModelInput, ReaderSummaryModelPort, ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
+import type { BuildReaderSummaryTopicMapCommand } from "@social-monitor/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.command";
+import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+
+export function wiring(respond: (command: AgentRuntimeTaskCommand) => Promise<AgentRuntimeTaskResult>) {
+  const commands: AgentRuntimeTaskCommand[] = [];
+  const events: { status: string; phase?: string; taskRole?: string }[] = [];
+  const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), delegate: {
+    runTask: async (command) => { commands.push(command); return respond(command); }, checkHealth: jest.fn(),
+  }, assertLocal: () => undefined, assertCurrent: async () => undefined,
+  record: (event) => events.push(event as { status: string }) });
+  const sink = { record: jest.fn(() => runtime.assertUsable()) };
+  return { runtime, commands, events, sink, model: buildRefreshModelWiring({}, runtime, sink) };
+}
+
+export function topicOutput(command: AgentRuntimeTaskCommand, good: boolean): Record<string, unknown> {
+  if (command.purpose === purposes.generate) return { synthetic: true };
+  if (command.purpose === purposes.topicRelations) {
+    const payload = JSON.parse(command.prompt) as { pairs: { sourceNodeId: string; targetNodeId: string }[] };
+    return { decisions: payload.pairs.map((pair) => ({ sourceNodeId: pair.sourceNodeId, targetNodeId: pair.targetNodeId,
+      sameTopic: false, confidenceScore: 0.95, rationale: "Distinct synthetic announcements" })) };
+  }
+  const payload = JSON.parse(command.prompt) as { nodes: { nodeId: string; fallbackLabel: string }[] };
+  return { nodeLabels: payload.nodes.map((node, index) => ({ nodeId: node.nodeId, topicId: index < 2 && node.fallbackLabel.toLowerCase().includes("runtime") ? "topic:shared-proposal" : `topic:synthetic-${index}`,
+    subject: node.fallbackLabel, parentSubject: good ? "Runtime" : undefined, claimType: "other",
+    confidenceScore: good ? 0.95 : 0.4, keywords: good ? ["Runtime"] : [],
+    groupId: good ? "group:runtime" : "group:ungrouped",
+  })), groups: good ? [{ id: "group:runtime", label: "Runtime", semanticAnchors: ["Runtime"],
+    nodeIds: payload.nodes.map((node) => node.nodeId), confidenceScore: 0.95 }] : [], warnings: [] };
+}
+
+export function topicCommand(related: boolean): BuildReaderSummaryTopicMapCommand {
+  const m = refreshManifest();
+  const names = ["Quartz", "Orchid", "Nimbus", "Cobalt"];
+  const selectedEvidence = names.map((name, index) => ({
+    feedItemId: `feed-${index}`, sourceItemId: `source-${index}`, sourceBindingId: `binding-${index}`,
+    interestId: `interest-${index}`, providerKey: "rss", canonicalUrl: `https://example.test/${index}`,
+    title: `${name}${related ? " runtime" : ""}`, bodyPreview: `${name}${related ? " runtime" : ""}`,
+    publishedAt: refreshNow, observedAt: refreshNow, score: 0.9, whyImportant: ["Synthetic evidence"],
+    contentQuality: { qualityScore: 0.9, interestRelevanceScore: 0.9, engagementIntegrityScore: 0.9,
+      eligibleForSummary: true, eligibleForTopRead: true, needsLlmReview: false, decision: "keep",
+      flags: [], reason: "Synthetic eligible evidence" },
+  }));
+  return { tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId), scope: { type: "workspace" },
+    period: { cadence: "daily", startedAt: new Date(m.startedAt), endedAt: new Date(m.endedAt), timezone: "UTC", periodKey: m.date },
+    requestedAt: refreshNow, selectedEvidence, topStories: [],
+    clusters: selectedEvidence.map((item, index) => ({ id: `story:${index}`, storyKey: `synthetic-${index}`,
+      representativeFeedItemId: item.feedItemId, duplicateFeedItemIds: [], interestIds: [item.interestId], providerKeys: [item.providerKey],
+      score: item.score, observedAtRange: { startedAt: refreshNow, endedAt: refreshNow }, whyImportant: item.whyImportant })),
+    citationMap: selectedEvidence.map((item, index) => ({ citationId: `c${index}`, feedItemId: item.feedItemId,
+      sourceItemId: item.sourceItemId, providerKey: item.providerKey, field: "title", canonicalUrl: item.canonicalUrl })),
+  };
+}
+
+export function primaryInput(): ReaderSummaryModelInput {
+  const command = topicCommand(true);
+  const selectedEvidence = [{ ...command.selectedEvidence[0]!, providerKey: "reddit",
+    promotionFacts: redditPromotionFacts(command.selectedEvidence[0]!.canonicalUrl!, refreshNow) }];
+  const clusters = [{ ...command.clusters[0]!, providerKeys: ["reddit"] }];
+  const evidence = { selectedEvidence, clusters, rankingPolicyVersion: "story_ranking_v1", sourceWindow: {
+    windowId: "synthetic-refresh", startedAt: command.period.startedAt, endedAt: command.period.endedAt,
+    periodStartedAt: command.period.startedAt, periodEndedAt: command.period.endedAt,
+    ingestionCutoff: new Date(refreshManifest().observedThrough),
+    selectedFeedItemIds: selectedEvidence.map((item) => item.feedItemId), storyClusterIds: clusters.map((item) => item.id),
+  } };
+  return { tenantId: command.tenantId, workspaceId: command.workspaceId, scope: command.scope,
+    period: command.period, requestedAt: command.requestedAt, evidence,
+    coveragePlan: buildReaderSummaryCoveragePlan(evidence), contextArtifacts: [],
+    policy: { language: "auto", format: "executive_brief", tone: "analytical", maxStories: 10,
+      includeRisks: true, includeInterestHighlights: true, includeRepeatedSignals: true,
+      dedupeStrategy: "canonical_url_then_title", rulesVersion: "reader_summary.rules.test.v1" },
+  };
+}
+
+export function primaryOutput(): Record<string, unknown> {
+  return { headline: "Quartz runtime", executiveSummary: "Quartz runtime introduces an isolated synthetic change.",
+    narrativeSections: [{ kind: "lead", title: "Quartz runtime", text: "Quartz runtime introduces an isolated synthetic change.",
+      citationIds: ["c1"], storyClusterId: "story:0" }],
+    topStories: [{ storyClusterId: "story:0", title: "Quartz runtime", summary: "Quartz runtime introduces an isolated synthetic change.",
+      interestIds: ["interest-0"], providerKeys: ["reddit"], citationIds: ["c1"] }],
+    interestHighlights: [], repeatedSignals: [], risksAndUnknowns: [], qualityFlags: ["limited_sources"],
+    confidence: { level: "medium", score: 0.7, rationale: "One synthetic item" }, noSignalReason: null };
+}
+
+export function primaryRoute(model: ReaderSummaryModelPort) {
+  return model.route(primaryInput(), { preferredProvider: "agent-runtime", maxInputTokens: 24_000,
+    maxOutputTokens: 16_000, maxEstimatedCostUsd: 1 }, { remainingTokens: 40_000, remainingCostUsd: 1 });
+}
+
+export function publicationProbe(runtime: { assertUsable(): void }) {
+  const assertProtected = jest.fn(async () => undefined), assertCurrent = jest.fn(async () => undefined);
+  const guard = refreshPublicationGuard({ manifest: refreshManifest(), jobId: "synthetic-job",
+    assertLocal: () => runtime.assertUsable(), assertProtected, assertCurrent });
+  const command = { finalJob: { toSnapshot: () => ({ id: "synthetic-job" }) },
+    artifact: { toSnapshot: () => ({ sourceWindow: { ingestionCutoff: new Date(refreshManifest().observedThrough) } }) },
+  } as unknown as ReaderSummaryPublicationCommand;
+  const publish = jest.fn();
+  return { assertProtected, assertCurrent, publish, attempt: async () => {
+    await guard({} as PrismaReaderSummaryClient, command);
+    publish();
+  } };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-model-normalization.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model-normalization.spec.ts
@@ -1,0 +1,149 @@
+import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import type { AgentRuntimeTaskCommand } from "@social-monitor/summary/ports";
+import { evaluateReaderSummaryTopicMapStructure } from "@social-monitor/summary/domain";
+import { completedRefreshModelRequest, refreshModelCommand } from "./reader-summary-new-input-refresh-model.spec-support";
+import { wiring, topicOutput, topicCommand, primaryInput, primaryOutput, primaryRoute,
+  publicationProbe } from "./reader-summary-new-input-refresh-model-composition.spec-support";
+
+type Decision = { sourceNodeId: string; targetNodeId: string; sameTopic: boolean; confidenceScore: number; rationale?: string };
+const decisions = (command: AgentRuntimeTaskCommand): Decision[] =>
+  (topicOutput(command, true) as { decisions: Decision[] }).decisions;
+const invalidRelations = [
+  { name: "missing", change: () => [] },
+  { name: "duplicate", change: (values: Decision[]) => [...values, values[0]] },
+  { name: "reversed duplicate", change: (values: Decision[]) => [...values,
+    { ...values[0], sourceNodeId: values[0]!.targetNodeId, targetNodeId: values[0]!.sourceNodeId }] },
+  { name: "malformed boolean", change: (values: Decision[]) => [{ ...values[0], sameTopic: "false" }] },
+  { name: "malformed confidence", change: (values: Decision[]) => [{ ...values[0], confidenceScore: 1.1 }] },
+  { name: "non-object", change: () => [null] },
+  { name: "unknown pair", change: (values: Decision[]) => [{ ...values[0], targetNodeId: "unknown:synthetic" }] },
+  { name: "extra unknown pair", change: (values: Decision[]) => [...values,
+    { ...values[0], targetNodeId: "unknown:synthetic" }] },
+];
+
+describe("refresh actual adapter normalization failures", () => {
+  describe.each([false, true])("initial label map has valid coverage: %s", (firstGood) => {
+    it.each(invalidRelations)("poisons $name relation decisions before workflow fallback", async ({ change }) => {
+      const test = wiring((command) => {
+        if (command.purpose !== purposes.topicRelations) {
+          return completedRefreshModelRequest(command, topicOutput(command, firstGood || command.metadata?.attemptNumber === "2"));
+        }
+        const values = decisions(command);
+        expect(values).toHaveLength(1); // Reproduce the reviewer's exact one-pair trigger.
+        return completedRefreshModelRequest(command, { decisions: change(values) });
+      });
+      await test.model.topicMap.execute(topicCommand(true));
+      // The real use case may catch the verifier error and return a fallback map.
+      // Its outcome cannot restore runtime/publication authority.
+      expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/);
+      expect(test.commands.map((command) => [command.purpose, command.metadata?.attemptNumber])).toEqual([
+        [purposes.topicLabel, "1"], [purposes.topicRelations, "1"],
+      ]);
+      expect(test.events.filter((event) => event.status === "completed")).toHaveLength(2);
+      expect(test.events).toContainEqual(expect.objectContaining({ status: "requires_reconciliation", taskRole: "topic_relation" }));
+      expect(test.sink.record).toHaveBeenCalledTimes(1); // Only the label adapter accepted normalization.
+      await expectPermanentlyPoisoned(test);
+    });
+  });
+
+  it.each(["missing", "duplicate", "unknown"])("poisons %s labels rejected by the real label adapter", async (kind) => {
+    const test = wiring((command) => {
+      const output = topicOutput(command, true) as { nodeLabels: Record<string, unknown>[] };
+      return completedRefreshModelRequest(command, { ...output, nodeLabels: kind === "missing" ? []
+        : kind === "duplicate" ? [...output.nodeLabels, output.nodeLabels[0]]
+        : output.nodeLabels.map((value, index) => index === 0 ? { ...value, nodeId: "unknown:synthetic" } : value) });
+    });
+    const result = await test.model.topicMap.execute(topicCommand(true));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected label normalization failure");
+    expect(result.error.message).toContain("label every requested node exactly once");
+    expect(test.commands).toHaveLength(1);
+    expect(test.events.filter((event) => event.status === "completed")).toHaveLength(1);
+    expect(test.sink.record).not.toHaveBeenCalled();
+    await expectPermanentlyPoisoned(test);
+  });
+
+  it.each(["headline", "executiveSummary"])("poisons primary %s normalization failure", async (field) => {
+    const test = wiring((command) => completedRefreshModelRequest(command, { ...primaryOutput(), [field]: null }));
+    await expect(test.model.model.generate(primaryInput(), primaryRoute(test.model.model))).rejects.toThrow(/must be a non-empty string/u);
+    expect(test.commands.map((command) => command.purpose)).toEqual([purposes.generate]);
+    expect(test.events.filter((event) => event.status === "completed")).toHaveLength(1);
+    expect(test.sink.record).not.toHaveBeenCalled();
+    await expectPermanentlyPoisoned(test);
+  });
+
+  it("does not admit the primary adapter's internal narrative repair", async () => {
+    const test = wiring((command) => completedRefreshModelRequest(command, { ...primaryOutput(), narrativeSections: [{ kind: "watch", title: "Watch",
+      text: "Quartz runtime still needs monitoring.", citationIds: ["c1"], storyClusterId: null }] }));
+    await expect(test.model.model.generate(primaryInput(), primaryRoute(test.model.model))).rejects.toThrow(/budget/u);
+    expect(test.commands.map((command) => command.purpose)).toEqual([purposes.generate]);
+    await expectPermanentlyPoisoned(test);
+  });
+
+  it("poisons a typed primary response validation failure", async () => {
+    const test = wiring((command) => completedRefreshModelRequest(command, primaryOutput()));
+    const primary = await test.model.model.generate(primaryInput(), primaryRoute(test.model.model));
+    const result = test.model.model.validateRawProviderResponse({ ...primary, draft: { ...primary.draft, headline: "" } });
+    expect(result).toMatchObject({ ok: false, failure: { kind: "invalid_schema" } });
+    await expectPermanentlyPoisoned(test);
+  });
+});
+
+describe("refresh accepted adapter normalization", () => {
+  it.each(["distinct", "same topic", "reversed and padded", "zero confidence"])("accepts %s relation decisions", async (kind) => {
+    const test = wiring((command) => completedRefreshModelRequest(command, command.purpose === purposes.topicRelations
+      ? { decisions: decisions(command).map((value) => ({ ...value,
+        sameTopic: kind === "same topic", confidenceScore: kind === "zero confidence" ? 0 : value.confidenceScore,
+        ...(kind === "reversed and padded" ? { sourceNodeId: ` ${value.targetNodeId} `,
+          targetNodeId: ` ${value.sourceNodeId} `, rationale: undefined } : {}),
+      })) } : topicOutput(command, true)));
+    const result = await test.model.topicMap.execute(topicCommand(true));
+    expect(result.ok).toBe(true);
+    expect(test.commands.map((command) => command.purpose)).toEqual([purposes.topicLabel, purposes.topicRelations]);
+    expect(test.sink.record).toHaveBeenCalledTimes(2);
+    expect(() => test.runtime.assertUsable()).not.toThrow();
+    const publication = publicationProbe(test.runtime);
+    await publication.attempt();
+    expect(publication.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps two valid coverage attempts and exactly one actual primary generation", async () => {
+    const test = wiring((command) => completedRefreshModelRequest(command, command.purpose === purposes.generate
+      ? primaryOutput() : topicOutput(command, command.metadata?.attemptNumber === "2")));
+    const route = primaryRoute(test.model.model);
+    const primary = await test.model.model.generate(primaryInput(), route);
+    expect(test.model.model.validateRawProviderResponse(primary)).toEqual({ ok: true });
+    const result = await test.model.topicMap.execute(topicCommand(true));
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw result.error;
+    expect(evaluateReaderSummaryTopicMapStructure(result.value).passed).toBe(true);
+    expect(test.commands.map((command) => [command.purpose, command.metadata?.attemptNumber])).toEqual([
+      [purposes.generate, undefined], [purposes.topicLabel, "1"], [purposes.topicRelations, "1"],
+      [purposes.topicLabel, "2"], [purposes.topicRelations, "2"],
+    ]);
+    expect(JSON.parse(test.commands[3]!.prompt).retryFeedback).toMatchObject({ reason: "grouped_coverage_below_minimum" });
+    expect(test.events.filter((event) => event.status === "requires_reconciliation")).toHaveLength(0);
+    expect(test.sink.record).toHaveBeenCalledTimes(5);
+    const publication = publicationProbe(test.runtime);
+    await publication.attempt();
+    expect(publication.publish).toHaveBeenCalledTimes(1);
+    await expect(test.model.model.generate(primaryInput(), route)).rejects.toThrow(/budget/u);
+    expect(test.commands).toHaveLength(5);
+  });
+});
+
+async function expectPermanentlyPoisoned(test: ReturnType<typeof wiring>) {
+  expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/);
+  const before = test.commands.length;
+  for (const purpose of [purposes.generate, purposes.topicLabel, purposes.topicRelations, purposes.storyRelations, purposes.relatedTopicRelations]) {
+    await expect(test.runtime.runTask({ ...refreshModelCommand(purpose), requestId: `after-normalization:${purpose}` })).rejects.toThrow(/budget/u);
+  }
+  await test.model.topicMap.execute(topicCommand(true));
+  await expect(test.model.model.generate(primaryInput(), primaryRoute(test.model.model))).rejects.toThrow(/budget/u);
+  expect(test.commands).toHaveLength(before);
+  const publication = publicationProbe(test.runtime);
+  await expect(publication.attempt()).rejects.toThrow(/reconciliation/u);
+  expect(publication.assertProtected).not.toHaveBeenCalled();
+  expect(publication.assertCurrent).not.toHaveBeenCalled();
+  expect(publication.publish).not.toHaveBeenCalled();
+}

--- a/scripts/lib/reader-summary-new-input-refresh-model.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.spec-support.ts
@@ -1,0 +1,68 @@
+import type { CallOptions, ClientUnaryCall, Metadata, ServerUnaryCall, ServiceError } from "@grpc/grpc-js";
+import {
+  AgentRuntimeTaskRequest, AgentRuntimeTaskResponse, type AgentRuntimeServiceClient,
+} from "@social-monitor/contracts/generated/grpc/agent_runtime/v1/agent_runtime";
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import { GrpcAgentRuntimeClient } from "@social-monitor/summary/adapters/model/grpc-agent-runtime-client";
+import type { AgentRuntimeTaskCommand } from "@social-monitor/summary/ports";
+import { createAgentRuntimeGrpcService } from "../../apps/agent-runtime/src/agent-runtime-grpc-service";
+import type { AgentRuntimeExecutionRequest, AgentRuntimeExecutorPort } from "../../apps/agent-runtime/src/agent-runtime-executor.port";
+import { attachExecutorOwnedExecutionAttestation } from "../../apps/agent-runtime/src/subscription-runtime-execution-attestation";
+import { admitSubscriptionRuntimeRequest } from "../../apps/agent-runtime/src/subscription-runtime-purpose-model-policy";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+
+export const refreshModelCommand = (purpose: string = purposes.generate): AgentRuntimeTaskCommand => ({
+  requestId: purpose, purpose, correlationId: "synthetic-request-binding",
+  tenantId: tenantId(refreshManifest().tenantId), workspaceId: workspaceId(refreshManifest().workspaceId),
+  provider: "codex", prompt: "Synthetic prompt", systemPrompt: "Synthetic instruction",
+  outputSchema: {}, timeoutMs: 1000, controls: {
+    model: "gpt-5.6-sol", reasoningEffort: "high",
+    ...(purpose === purposes.relatedTopicRelations ? {
+      outputSchemaName: "social_monitor_reader_summary_related_topic_relations",
+      schemaVersion: "reader_summary.related_topic_relation.v1",
+    } : {}),
+  },
+  metadata: { attempt: "primary", ...(purpose === purposes.relatedTopicRelations
+    ? { taskRole: "related_topic_relation", verificationLane: "related_topic" } : {}) },
+});
+
+// Exercise the real client serialization, protobuf defaults, service translation,
+// admission and executor-owned attestation without a socket, process or provider.
+export function refreshTestRuntimeClient(execute: AgentRuntimeExecutorPort["execute"]) {
+  const service = createAgentRuntimeGrpcService({ execute,
+    checkHealth: async () => { throw new Error("Synthetic transport has no health endpoint"); },
+  }, {});
+  const transport = {
+    runAgentTask(request: AgentRuntimeTaskRequest, metadata: Metadata, _options: CallOptions,
+      callback: (error: ServiceError | null, response: AgentRuntimeTaskResponse) => void): ClientUnaryCall {
+      service.runAgentTask({
+        request: AgentRuntimeTaskRequest.decode(AgentRuntimeTaskRequest.encode(request).finish()), metadata,
+      } as ServerUnaryCall<AgentRuntimeTaskRequest, AgentRuntimeTaskResponse>, (error, response) => {
+        callback(error as ServiceError | null, response == null ? response as never
+          : AgentRuntimeTaskResponse.decode(AgentRuntimeTaskResponse.encode(response).finish()));
+      });
+      return { cancel: () => undefined } as ClientUnaryCall;
+    },
+  } as unknown as AgentRuntimeServiceClient;
+  return new GrpcAgentRuntimeClient(transport, { now: () => refreshNow }, { timeoutMs: 1000 });
+}
+
+export async function attestRefreshExecution(request: AgentRuntimeExecutionRequest,
+  structuredOutput: Record<string, unknown> = { groups: [] }) {
+  const admission = admitSubscriptionRuntimeRequest(request);
+  const runtime = refreshManifest().runtime;
+  const installation = { executablePath: "/synthetic/runtime", packageRootRealpath: "/synthetic",
+    runtimePackageVersion: runtime.packageVersion, launcherSha256: runtime.launcherSha256 };
+  return attachExecutorOwnedExecutionAttestation({ command: installation.executablePath, request,
+    ...admission, admittedInstallation: installation,
+    installationInspector: { inspect: async () => installation },
+    result: { status: "completed", warnings: [], structuredOutput,
+      usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5, estimatedCostUsd: 0 } },
+  });
+}
+
+export function completedRefreshModelRequest(command: AgentRuntimeTaskCommand,
+  structuredOutput?: Record<string, unknown>) {
+  return refreshTestRuntimeClient((request) => attestRefreshExecution(request, structuredOutput)).runTask(command);
+}

--- a/scripts/lib/reader-summary-new-input-refresh-model.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.spec.ts
@@ -1,0 +1,85 @@
+import { canonicalJsonSha256 } from "@social-monitor/contracts/grpc/agent_runtime/v1/execution-attestation";
+import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import type { AgentRuntimeTaskCommand, ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { admitSubscriptionRuntimeRequest } from "../../apps/agent-runtime/src/subscription-runtime-purpose-model-policy";
+import { refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
+import { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { attestRefreshExecution, completedRefreshModelRequest, refreshModelCommand, refreshTestRuntimeClient } from "./reader-summary-new-input-refresh-model.spec-support";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+
+const admittedPurposes = [purposes.generate, purposes.storyRelations, purposes.topicLabel,
+  purposes.topicRelations, purposes.relatedTopicRelations];
+
+describe("refresh exact canonical request binding", () => {
+  it.each(admittedPurposes)("rejects a well-formed digest for alternate prompt bytes: %s", async (purpose) => {
+    const command = refreshModelCommand(purpose);
+    const correct = await completedRefreshModelRequest(command);
+    const alternate = await completedRefreshModelRequest({ ...command, prompt: command.prompt + " alternate" });
+    expect(alternate.executionAttestation).toMatchObject({ requestId: command.requestId, purpose,
+      model: "gpt-5.6-sol", reasoningEffort: "high", canonicalRequestSha256: expect.stringMatching(/^[0-9a-f]{64}$/u) });
+    expect(alternate.executionAttestation!.canonicalRequestSha256).not.toBe(correct.executionAttestation!.canonicalRequestSha256);
+    const events: unknown[] = [];
+    const runTask = jest.fn(async () => alternate);
+    const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), delegate: { runTask, checkHealth: jest.fn() },
+      assertLocal: () => undefined, assertCurrent: async () => undefined, record: (event) => events.push(event) });
+
+    await expect(runtime.runTask(command)).rejects.toThrow(/ambiguous/);
+    expect(events).toContainEqual(expect.objectContaining({ status: "requires_reconciliation" }));
+    expect(events).not.toContainEqual(expect.objectContaining({ status: "completed" }));
+    for (const followup of admittedPurposes) {
+      await expect(runtime.runTask({ ...refreshModelCommand(followup), requestId: `followup:${followup}` })).rejects.toThrow(/budget/);
+    }
+    expect(runTask).toHaveBeenCalledTimes(1);
+    expect(() => runtime.assertUsable()).toThrow(/reconciliation/);
+    const assertProtected = jest.fn(), assertCurrent = jest.fn();
+    const publication = refreshPublicationGuard({ manifest: refreshManifest(), jobId: "synthetic",
+      assertLocal: () => runtime.assertUsable(), assertProtected, assertCurrent });
+    await expect(publication({} as PrismaReaderSummaryClient, {} as ReaderSummaryPublicationCommand)).rejects.toThrow(/reconciliation/);
+    expect(assertProtected).not.toHaveBeenCalled();
+    expect(assertCurrent).not.toHaveBeenCalled();
+  });
+
+  it.each(admittedPurposes)("accepts actual transport/admission defaults and normalization: %s", async (purpose) => {
+    for (const optional of [undefined, "", " \t ", "  synthetic-value  "]) {
+      const base = refreshModelCommand(purpose);
+      const schema = { type: "object", properties: { z: { type: "string" }, a: { type: "number" } } };
+      const command = { ...base, providerInstanceId: optional, cwd: optional, outputSchema: schema,
+        ...(optional === undefined && purpose !== purposes.relatedTopicRelations ? { metadata: undefined } : {}),
+        controls: { ...base.controls, ...(optional === undefined ? {} : {
+          outputKind: " structured_output ", runtimeOutput: "structured_output", selectedOutputKind: "structured_output",
+          outputSchemaJson: JSON.stringify(schema), responseFormat: " json ",
+        }) },
+      };
+      const execute = jest.fn(async (request) => {
+        const canonical = admitSubscriptionRuntimeRequest(request).canonicalRequest;
+        expect(canonical).toMatchObject({ protocolVersion: 1, runId: command.requestId,
+          providerInstanceId: optional?.trim() || undefined, cwd: optional?.trim() || undefined,
+          task: { prompt: command.prompt, controls: { model: "gpt-5.6-sol", reasoningEffort: "high",
+            responseFormat: "json", outputSchema: schema }, metadata: { runtimeOutput: "structured_output" } },
+        });
+        const result = await attestRefreshExecution(request);
+        expect(result.executionAttestation!.canonicalRequestSha256).toBe(canonicalJsonSha256(canonical));
+        expect(result.executionAttestation!.canonicalRequestSha256).not.toBe(canonicalJsonSha256(command));
+        return result;
+      });
+      const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), delegate: refreshTestRuntimeClient(execute),
+        assertLocal: () => undefined, assertCurrent: async () => undefined, record: jest.fn() });
+      await expect(runtime.runTask(command)).resolves.toMatchObject({ status: "completed" });
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(() => runtime.assertUsable()).not.toThrow();
+    }
+  });
+
+  it("binds the invocation before an awaited delegate can change the command", async () => {
+    const command = { ...refreshModelCommand() };
+    const runTask = jest.fn(async (request: AgentRuntimeTaskCommand) => {
+      command.prompt = "Changed during delegate invocation";
+      return completedRefreshModelRequest(request);
+    });
+    const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), delegate: { runTask, checkHealth: jest.fn() },
+      assertLocal: () => undefined, assertCurrent: async () => undefined, record: jest.fn() });
+    await expect(runtime.runTask(command)).rejects.toThrow(/ambiguous/);
+    expect(() => runtime.assertUsable()).toThrow(/reconciliation/);
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -1,4 +1,6 @@
 import { activeReaderSummaryPurposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import { canonicalJsonSha256 } from "@social-monitor/contracts/grpc/agent_runtime/v1/execution-attestation";
+import { admitSubscriptionRuntimeRequest } from "../../apps/agent-runtime/src/subscription-runtime-purpose-model-policy";
 import { AgentRuntimeReaderSummaryModelAdapter, resolveAgentRuntimeReaderSummaryModelOptions } from
   "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-model.adapter";
 import { AgentRuntimeReaderSummaryTopicLabeler, resolveAgentRuntimeReaderSummaryTopicLabelerOptions } from
@@ -34,6 +36,8 @@ export function buildRefreshModelWiring(env: NodeJS.ProcessEnv, client: AgentRun
       ...resolveAgentRuntimeReaderSummaryModelOptions(env, client), verifiedAttestationSink: sink,
     }),
     topicMap: new BuildReaderSummaryTopicMapUseCase({
+      // The normal workflow owns at most two complete topic-map attempts after
+      // a known coverage-only rejection. This is separate from primary generation.
       mode: "agent-runtime",
       labeler: new AgentRuntimeReaderSummaryTopicLabeler({
         ...resolveAgentRuntimeReaderSummaryTopicLabelerOptions(env, client), verifiedAttestationSink: sink,
@@ -85,6 +89,18 @@ export function guardedRefreshRuntime(input: {
         observedThrough: input.manifest.observedThrough, model: "gpt-5.6-sol", reasoningEffort: "high" };
       try {
         assertUsable();
+        // Match GrpcAgentRuntimeClient JSON serialization and the service's
+        // optional-string normalization, then use the executor's real admission
+        // contract for profile defaults/controls. Hash before any awaited work;
+        // the journal's refreshHash(command) is not the canonical runtime request.
+        const canonicalRequestSha256 = canonicalJsonSha256(admitSubscriptionRuntimeRequest({
+          ...command,
+          providerInstanceId: command.providerInstanceId?.trim() || undefined,
+          cwd: command.cwd?.trim() || undefined,
+          outputSchemaJson: JSON.stringify(command.outputSchema),
+          controlsJson: JSON.stringify(command.controls),
+          metadata: command.metadata ?? {},
+        }).canonicalRequest);
         await input.assertCurrent();
         assertUsable();
         input.record({ ...identity, status: "invocation_consumed" });
@@ -108,6 +124,9 @@ export function guardedRefreshRuntime(input: {
         await verifyAndRecordReaderSummaryExecution({ command, result, taskRole,
           attempt: "primary", normalizedOutput: result.structuredOutput });
         const attestation = result.executionAttestation;
+        if (attestation.canonicalRequestSha256 !== canonicalRequestSha256) {
+          throw new Error("Refresh execution attestation does not bind the invoked request");
+        }
         assertRefreshEqual({ engine: attestation.runtimeEngine, packageVersion: attestation.runtimePackageVersion,
           launcherSha256: attestation.launcherSha256 }, input.manifest.runtime, "runtime attestation");
         assertUsable();

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -11,7 +11,7 @@ import { resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions } from
   "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter";
 import { BuildReaderSummaryTopicMapUseCase } from
   "@social-monitor/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.use-case";
-import type { AgentRuntimeClientPort } from "@social-monitor/summary/ports";
+import type { AgentRuntimeClientPort, ReaderSummaryModelPort } from "@social-monitor/summary/ports";
 import { verifyAndRecordReaderSummaryExecution, type ReaderSummaryAttestedTaskRole, type VerifiedReaderSummaryExecutionAttestationSink } from
   "@social-monitor/summary/adapters/model/reader-summary-execution-attestation";
 import { refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
@@ -29,29 +29,61 @@ export function refreshGenerationSha256(env: NodeJS.ProcessEnv): string {
     resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions(env, noInvocation),
   ].map(({ client, ...options }) => { void client; return options; }));
 }
-export function buildRefreshModelWiring(env: NodeJS.ProcessEnv, client: AgentRuntimeClientPort,
+type GuardedRefreshRuntime = AgentRuntimeClientPort & {
+  assertUsable(): void;
+  invalidateAdapter(taskRole: ReaderSummaryAttestedTaskRole): void;
+};
+
+export function buildRefreshModelWiring(env: NodeJS.ProcessEnv, client: GuardedRefreshRuntime,
   sink: VerifiedReaderSummaryExecutionAttestationSink) {
+  const model = new AgentRuntimeReaderSummaryModelAdapter({
+    ...resolveAgentRuntimeReaderSummaryModelOptions(env, client), verifiedAttestationSink: sink,
+  });
+  const labeler = new AgentRuntimeReaderSummaryTopicLabeler({
+    ...resolveAgentRuntimeReaderSummaryTopicLabelerOptions(env, client), verifiedAttestationSink: sink,
+  });
+  const relationVerifier = new AgentRuntimeReaderSummaryTopicRelationVerifier({
+    ...resolveAgentRuntimeReaderSummaryTopicRelationVerifierOptions(env, client), verifiedAttestationSink: sink,
+  });
+  // The real adapters own parsing and completeness/normalization. Poison their
+  // failures before a workflow can catch them and accept a fallback candidate.
+  // A valid plan's later coverage-only rejection never passes through this catch.
+  const validated = async <T>(taskRole: ReaderSummaryAttestedTaskRole, action: () => Promise<T>): Promise<T> => {
+    try {
+      client.assertUsable();
+      const result = await action();
+      client.assertUsable();
+      return result;
+    } catch (error) {
+      client.invalidateAdapter(taskRole);
+      throw error;
+    }
+  };
   return {
-    model: new AgentRuntimeReaderSummaryModelAdapter({
-      ...resolveAgentRuntimeReaderSummaryModelOptions(env, client), verifiedAttestationSink: sink,
-    }),
+    model: {
+      route: (...args) => model.route(...args),
+      estimate: (...args) => model.estimate(...args),
+      generate: (...args) => validated("summary", () => model.generate(...args)),
+      validateRawProviderResponse: (attempt) => {
+        const result = model.validateRawProviderResponse(attempt);
+        if (!result.ok) client.invalidateAdapter("summary");
+        return result;
+      },
+      classifyError: (error) => model.classifyError(error),
+    } satisfies ReaderSummaryModelPort,
     topicMap: new BuildReaderSummaryTopicMapUseCase({
       // The normal workflow owns at most two complete topic-map attempts after
       // a known coverage-only rejection. This is separate from primary generation.
       mode: "agent-runtime",
-      labeler: new AgentRuntimeReaderSummaryTopicLabeler({
-        ...resolveAgentRuntimeReaderSummaryTopicLabelerOptions(env, client), verifiedAttestationSink: sink,
-      }),
-      relationVerifier: new AgentRuntimeReaderSummaryTopicRelationVerifier({
-        ...resolveAgentRuntimeReaderSummaryTopicRelationVerifierOptions(env, client), verifiedAttestationSink: sink,
-      }),
+      labeler: { label: (...args) => validated("topic_label", () => labeler.label(...args)) },
+      relationVerifier: { verify: (...args) => validated("topic_relation", () => relationVerifier.verify(...args)) },
     }),
   };
 }
 export function guardedRefreshRuntime(input: {
   delegate: AgentRuntimeClientPort; manifest: RefreshManifest;
   assertLocal(): void; assertCurrent(): Promise<void>; record(event: unknown): void;
-}): AgentRuntimeClientPort & { assertUsable(): void } {
+}): GuardedRefreshRuntime {
   const seen = new Set<string>();
   let ambiguous = false;
   let generated = false;
@@ -65,6 +97,12 @@ export function guardedRefreshRuntime(input: {
     activeReaderSummaryPurposes.relatedTopicRelations];
   return {
     assertUsable,
+    invalidateAdapter: (taskRole) => {
+      if (ambiguous) return;
+      ambiguous = true; // Recording failure must not restore authority either.
+      input.record({ status: "requires_reconciliation", phase: "adapter_validation", taskRole,
+        operation: input.manifest.operation, observedThrough: input.manifest.observedThrough });
+    },
     checkHealth: async (service) => {
       try { assertUsable(); return await input.delegate.checkHealth(service); }
       catch (error) { ambiguous = true; throw error; }
@@ -119,8 +157,8 @@ export function guardedRefreshRuntime(input: {
           [activeReaderSummaryPurposes.storyRelations]: "story_relation",
           [activeReaderSummaryPurposes.relatedTopicRelations]: "related_topic_relation",
         } as Record<string, ReaderSummaryAttestedTaskRole>)[command.purpose]!;
-        // Validate the complete ordinary model contract HERE: callers may catch
-        // adapter errors and continue with another purpose after this returns.
+        // Verify the attested response envelope here. The composed adapter guard
+        // above also covers failures in the real parsers and normalizers.
         await verifyAndRecordReaderSummaryExecution({ command, result, taskRole,
           attempt: "primary", normalizedOutput: result.structuredOutput });
         const attestation = result.executionAttestation;

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -10,7 +10,7 @@ import { resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions } from
 import { BuildReaderSummaryTopicMapUseCase } from
   "@social-monitor/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.use-case";
 import type { AgentRuntimeClientPort } from "@social-monitor/summary/ports";
-import type { VerifiedReaderSummaryExecutionAttestationSink } from
+import { verifyAndRecordReaderSummaryExecution, type ReaderSummaryAttestedTaskRole, type VerifiedReaderSummaryExecutionAttestationSink } from
   "@social-monitor/summary/adapters/model/reader-summary-execution-attestation";
 import { refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
 import { assertRefreshEqual } from "./reader-summary-new-input-refresh-guard";
@@ -46,49 +46,80 @@ export function buildRefreshModelWiring(env: NodeJS.ProcessEnv, client: AgentRun
 }
 export function guardedRefreshRuntime(input: {
   delegate: AgentRuntimeClientPort; manifest: RefreshManifest;
-  assertCurrent(): Promise<void>; record(event: unknown): void;
-}): AgentRuntimeClientPort {
+  assertLocal(): void; assertCurrent(): Promise<void>; record(event: unknown): void;
+}): AgentRuntimeClientPort & { assertUsable(): void } {
   const seen = new Set<string>();
   let ambiguous = false;
   let generated = false;
+  let inFlight = false;
+  const assertUsable = () => {
+    if (ambiguous) throw new Error("Refresh invocation budget requires reconciliation");
+    try { input.assertLocal(); } catch (error) { ambiguous = true; throw error; }
+  };
   const purposes: readonly string[] = [activeReaderSummaryPurposes.generate, activeReaderSummaryPurposes.topicLabel,
     activeReaderSummaryPurposes.topicRelations, activeReaderSummaryPurposes.storyRelations,
     activeReaderSummaryPurposes.relatedTopicRelations];
   return {
-    checkHealth: (service) => input.delegate.checkHealth(service),
+    assertUsable,
+    checkHealth: async (service) => {
+      try { assertUsable(); return await input.delegate.checkHealth(service); }
+      catch (error) { ambiguous = true; throw error; }
+    },
     runTask: async (command, options) => {
-      if (!purposes.includes(command.purpose) ||
-          (generated && command.purpose === activeReaderSummaryPurposes.generate) || ambiguous || seen.has(command.requestId) || command.metadata?.attempt === "repair" ||
+      if (ambiguous || inFlight || seen.has(command.requestId) ||
+          (generated && command.purpose === activeReaderSummaryPurposes.generate)) {
+        throw new Error("Refresh invocation budget or model authority rejected");
+      }
+      if (!purposes.includes(command.purpose) || command.metadata?.attempt === "repair" ||
           command.tenantId !== input.manifest.tenantId || command.workspaceId !== input.manifest.workspaceId ||
           command.provider !== "codex" || command.controls.model !== "gpt-5.6-sol" ||
           command.controls.reasoningEffort !== "high") {
+        ambiguous = true;
         throw new Error("Refresh invocation budget or model authority rejected");
       }
       seen.add(command.requestId);
       if (command.purpose === activeReaderSummaryPurposes.generate) generated = true;
-      await input.assertCurrent();
+      inFlight = true;
       const identity = { requestId: command.requestId, purpose: command.purpose,
         requestSha256: refreshHash(command), operation: input.manifest.operation,
         observedThrough: input.manifest.observedThrough, model: "gpt-5.6-sol", reasoningEffort: "high" };
-      input.record({ ...identity, status: "invocation_consumed" });
       try {
+        assertUsable();
+        await input.assertCurrent();
+        assertUsable();
+        input.record({ ...identity, status: "invocation_consumed" });
+        assertUsable(); // fsync/recording can itself cross the cutoff.
+
         const result = await input.delegate.runTask(command, options);
         input.record({ ...identity, status: "invocation_returned", outcome: result.status,
           ...(result.usage === undefined ? {} : { tokens: result.usage }) });
         if (result.status !== "completed" || result.executionAttestation === undefined || result.usage === undefined) {
           throw new Error("Refresh invocation outcome requires reconciliation");
         }
+        const taskRole = ({
+          [activeReaderSummaryPurposes.generate]: "summary",
+          [activeReaderSummaryPurposes.topicLabel]: "topic_label",
+          [activeReaderSummaryPurposes.topicRelations]: "topic_relation",
+          [activeReaderSummaryPurposes.storyRelations]: "story_relation",
+          [activeReaderSummaryPurposes.relatedTopicRelations]: "related_topic_relation",
+        } as Record<string, ReaderSummaryAttestedTaskRole>)[command.purpose]!;
+        // Validate the complete ordinary model contract HERE: callers may catch
+        // adapter errors and continue with another purpose after this returns.
+        await verifyAndRecordReaderSummaryExecution({ command, result, taskRole,
+          attempt: "primary", normalizedOutput: result.structuredOutput });
         const attestation = result.executionAttestation;
         assertRefreshEqual({ engine: attestation.runtimeEngine, packageVersion: attestation.runtimePackageVersion,
           launcherSha256: attestation.launcherSha256 }, input.manifest.runtime, "runtime attestation");
+        assertUsable();
         input.record({ ...identity, status: result.status, tokens: result.usage,
           outputSha256: attestation.selectedOutputSha256 });
+        assertUsable();
         return result;
       } catch {
         ambiguous = true;
         input.record({ ...identity, status: "requires_reconciliation" });
         throw new Error("Refresh invocation failed or is ambiguous; original operation remains consumed");
-      }
+      } finally { inFlight = false; }
     },
   };
 }

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -1,0 +1,94 @@
+import { activeReaderSummaryPurposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import { AgentRuntimeReaderSummaryModelAdapter, resolveAgentRuntimeReaderSummaryModelOptions } from
+  "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-model.adapter";
+import { AgentRuntimeReaderSummaryTopicLabeler, resolveAgentRuntimeReaderSummaryTopicLabelerOptions } from
+  "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-topic-labeler.adapter";
+import { AgentRuntimeReaderSummaryTopicRelationVerifier, resolveAgentRuntimeReaderSummaryTopicRelationVerifierOptions } from
+  "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-topic-relation-verifier.adapter";
+import { resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions } from
+  "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter";
+import { BuildReaderSummaryTopicMapUseCase } from
+  "@social-monitor/summary/features/build-reader-summary-topic-map/build-reader-summary-topic-map.use-case";
+import type { AgentRuntimeClientPort } from "@social-monitor/summary/ports";
+import type { VerifiedReaderSummaryExecutionAttestationSink } from
+  "@social-monitor/summary/adapters/model/reader-summary-execution-attestation";
+import { refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
+import { assertRefreshEqual } from "./reader-summary-new-input-refresh-guard";
+
+const noInvocation: AgentRuntimeClientPort = {
+  runTask: async () => { throw new Error("Preparation cannot invoke a model"); },
+  checkHealth: async () => { throw new Error("Preparation cannot invoke runtime"); },
+};
+export function refreshGenerationSha256(env: NodeJS.ProcessEnv): string {
+  return refreshHash([
+    resolveAgentRuntimeReaderSummaryModelOptions(env, noInvocation),
+    resolveAgentRuntimeReaderSummaryTopicLabelerOptions(env, noInvocation),
+    resolveAgentRuntimeReaderSummaryTopicRelationVerifierOptions(env, noInvocation),
+    resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions(env, noInvocation),
+  ].map(({ client, ...options }) => { void client; return options; }));
+}
+export function buildRefreshModelWiring(env: NodeJS.ProcessEnv, client: AgentRuntimeClientPort,
+  sink: VerifiedReaderSummaryExecutionAttestationSink) {
+  return {
+    model: new AgentRuntimeReaderSummaryModelAdapter({
+      ...resolveAgentRuntimeReaderSummaryModelOptions(env, client), verifiedAttestationSink: sink,
+    }),
+    topicMap: new BuildReaderSummaryTopicMapUseCase({
+      mode: "agent-runtime",
+      labeler: new AgentRuntimeReaderSummaryTopicLabeler({
+        ...resolveAgentRuntimeReaderSummaryTopicLabelerOptions(env, client), verifiedAttestationSink: sink,
+      }),
+      relationVerifier: new AgentRuntimeReaderSummaryTopicRelationVerifier({
+        ...resolveAgentRuntimeReaderSummaryTopicRelationVerifierOptions(env, client), verifiedAttestationSink: sink,
+      }),
+    }),
+  };
+}
+export function guardedRefreshRuntime(input: {
+  delegate: AgentRuntimeClientPort; manifest: RefreshManifest;
+  assertCurrent(): Promise<void>; record(event: unknown): void;
+}): AgentRuntimeClientPort {
+  const seen = new Set<string>();
+  let ambiguous = false;
+  let generated = false;
+  const purposes: readonly string[] = [activeReaderSummaryPurposes.generate, activeReaderSummaryPurposes.topicLabel,
+    activeReaderSummaryPurposes.topicRelations, activeReaderSummaryPurposes.storyRelations,
+    activeReaderSummaryPurposes.relatedTopicRelations];
+  return {
+    checkHealth: (service) => input.delegate.checkHealth(service),
+    runTask: async (command, options) => {
+      if (!purposes.includes(command.purpose) ||
+          (generated && command.purpose === activeReaderSummaryPurposes.generate) || ambiguous || seen.has(command.requestId) || command.metadata?.attempt === "repair" ||
+          command.tenantId !== input.manifest.tenantId || command.workspaceId !== input.manifest.workspaceId ||
+          command.provider !== "codex" || command.controls.model !== "gpt-5.6-sol" ||
+          command.controls.reasoningEffort !== "high") {
+        throw new Error("Refresh invocation budget or model authority rejected");
+      }
+      seen.add(command.requestId);
+      if (command.purpose === activeReaderSummaryPurposes.generate) generated = true;
+      await input.assertCurrent();
+      const identity = { requestId: command.requestId, purpose: command.purpose,
+        requestSha256: refreshHash(command), operation: input.manifest.operation,
+        observedThrough: input.manifest.observedThrough, model: "gpt-5.6-sol", reasoningEffort: "high" };
+      input.record({ ...identity, status: "invocation_consumed" });
+      try {
+        const result = await input.delegate.runTask(command, options);
+        input.record({ ...identity, status: "invocation_returned", outcome: result.status,
+          ...(result.usage === undefined ? {} : { tokens: result.usage }) });
+        if (result.status !== "completed" || result.executionAttestation === undefined || result.usage === undefined) {
+          throw new Error("Refresh invocation outcome requires reconciliation");
+        }
+        const attestation = result.executionAttestation;
+        assertRefreshEqual({ engine: attestation.runtimeEngine, packageVersion: attestation.runtimePackageVersion,
+          launcherSha256: attestation.launcherSha256 }, input.manifest.runtime, "runtime attestation");
+        input.record({ ...identity, status: result.status, tokens: result.usage,
+          outputSha256: attestation.selectedOutputSha256 });
+        return result;
+      } catch {
+        ambiguous = true;
+        input.record({ ...identity, status: "requires_reconciliation" });
+        throw new Error("Refresh invocation failed or is ambiguous; original operation remains consumed");
+      }
+    },
+  };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-native-concurrency.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-native-concurrency.ts
@@ -21,7 +21,7 @@ const lockUnavailable = (error: unknown): boolean => {
 export async function runRefreshNativeConcurrency(input: {
   url: string; summary: PrismaSummaryConnection; manifest: RefreshManifest;
   command: ReaderSummaryPublicationCommand; clock: Clock;
-}): Promise<{ publicationMs: number; writerConflicts: number; acquisitionMs: number[] }> {
+}): Promise<{ publicationMs: number; writerConflicts: number; acquisitionMs: number[]; holderLossRejected: boolean }> {
   assert.match(decodeURIComponent(new URL(input.url).pathname.slice(1)), /^reader_summary_refresh_test_[a-z0-9]+$/u);
   const { summary, manifest: m, command, clock } = input;
   const writer = new Client({ connectionString: input.url });
@@ -105,10 +105,45 @@ export async function runRefreshNativeConcurrency(input: {
         writerConflicts++;
       } finally { await writer.query("rollback"); }
     }
+    // Establish a real publisher snapshot, lose the separate holder backend,
+    // then commit drift through the independent writer. The live PID/VXID
+    // overlap guard must reject despite the publisher still seeing old rows.
+    let holderTerminated = false, staleSnapshotProved = false, protectionRejected = false;
+    try {
+      await assert.rejects(withRefreshPublicationLocks(summary, async (assertProtected) => {
+        const holders = await writer.query<{ pid: number }>(`select distinct pid from pg_catalog.pg_locks
+          where relation='reader_summary_policies'::regclass and mode='ShareLock'
+            and granted and pid <> pg_backend_pid()`);
+        assert.equal(holders.rowCount, 1, "exactly one fixture lock holder");
+        await summary.$transaction(async (tx) => {
+          const before = await tx.$queryRaw<readonly { tone: string }[]>`select tone
+            from reader_summary_policies where tenant_id=${scope[0]}::uuid
+              and workspace_id=${scope[1]}::uuid and scope_key='workspace'`;
+          assert.equal(before.length, 1);
+          const stopped = await writer.query<{ stopped: boolean }>(
+            "select pg_terminate_backend($1::int, 1000) as stopped", [holders.rows[0]!.pid]);
+          assert.equal(stopped.rows[0]?.stopped, true); holderTerminated = true;
+          const changed = await writer.query(`update reader_summary_policies set tone=$3
+            where ${where} and scope_key='workspace'`, [...scope, tone === "analytical" ? "neutral" : "analytical"]);
+          assert.equal(changed.rowCount, 1);
+          const after = await tx.$queryRaw<readonly { tone: string }[]>`select tone
+            from reader_summary_policies where tenant_id=${scope[0]}::uuid
+              and workspace_id=${scope[1]}::uuid and scope_key='workspace'`;
+          assert.deepEqual(after, before); staleSnapshotProved = true;
+          await assert.rejects(assertProtected(tx), /snapshot protection was lost/);
+          protectionRejected = true;
+        }, { isolationLevel: "Serializable" });
+      }));
+      assert(holderTerminated && staleSnapshotProved && protectionRejected,
+        "actual holder loss must reject an otherwise stale publication snapshot");
+    } finally {
+      await writer.query(`update reader_summary_policies set tone=$3
+        where ${where} and scope_key='workspace'`, [...scope, tone]);
+    }
     const started = Date.now();
     assert.equal(await publish(summary, true), "published");
     const publicationMs = Date.now() - started;
     assert(publicationMs < 30_000, "shared max2 publication must complete without nested/root reads");
-    return { publicationMs, writerConflicts, acquisitionMs };
+    return { publicationMs, writerConflicts, acquisitionMs, holderLossRejected: protectionRejected };
   } finally { await writer.end(); }
 }

--- a/scripts/lib/reader-summary-new-input-refresh-native-concurrency.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-native-concurrency.ts
@@ -48,6 +48,12 @@ export async function runRefreshNativeConcurrency(input: {
     });
   await writer.connect();
   try {
+    // This dedicated fixture client bypasses the Prisma scope wrapper, so set
+    // the same tenant claims explicitly. Session scope spans its autocommits and
+    // rollback probes; the connection is closed below and is never pooled.
+    await writer.query(`select set_config('social_monitor.tenant_id', $1, false),
+      set_config('social_monitor.workspace_id', $2, false),
+      set_config('social_monitor.system_access', 'false', false)`, scope);
     // A commit AFTER the holder's snapshot but BEFORE locks must be visible in
     // the separate normal publisher's first validation snapshot.
     const original = await writer.query<{ tone: string }>(`select tone from reader_summary_policies where ${where} and scope_key='workspace'`, scope);

--- a/scripts/lib/reader-summary-new-input-refresh-native-concurrency.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-native-concurrency.ts
@@ -1,0 +1,108 @@
+/** Native fixture ONLY. This independent writer is not part of the runtime pool. */
+import assert from "node:assert/strict";
+import { Client } from "pg";
+import type { Clock } from "@social-monitor/shared-kernel";
+import type { ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
+import type { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
+import { PrismaReaderSummaryPublication } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-publication";
+import { withRefreshPublicationLocks } from "./reader-summary-new-input-refresh-publication-lock";
+import { assertRefreshTransactionAuthority, refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
+import { assertRefreshManifest, refreshScope, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
+
+const tables = ["source_item_engagement_snapshots", "source_items", "feed_items",
+  "source_item_engagement_observations", "source_item_engagement_daily_rollups", "source_bindings",
+  "interests", "source_catalog_entries", "reader_summary_policies"] as const;
+const lockUnavailable = (error: unknown): boolean => {
+  const value = error as { code?: string; meta?: { code?: string; driverAdapterError?: { cause?: { originalCode?: string } } } };
+  return value.code === "55P03" || value.meta?.code === "55P03" ||
+    value.meta?.driverAdapterError?.cause?.originalCode === "55P03";
+};
+
+export async function runRefreshNativeConcurrency(input: {
+  url: string; summary: PrismaSummaryConnection; manifest: RefreshManifest;
+  command: ReaderSummaryPublicationCommand; clock: Clock;
+}): Promise<{ publicationMs: number; writerConflicts: number; acquisitionMs: number[] }> {
+  assert.match(decodeURIComponent(new URL(input.url).pathname.slice(1)), /^reader_summary_refresh_test_[a-z0-9]+$/u);
+  const { summary, manifest: m, command, clock } = input;
+  const writer = new Client({ connectionString: input.url });
+  const scope = [refreshScope.tenantId, refreshScope.workspaceId];
+  const where = "tenant_id=$1::uuid and workspace_id=$2::uuid";
+  const local = () => assertRefreshManifest(m, clock.now());
+  const publish = (connection: Pick<PrismaSummaryConnection, "$transaction">, blockedWriter = false) =>
+    withRefreshPublicationLocks(connection, (assertProtected) => {
+      const guard = refreshPublicationGuard({ manifest: m, jobId: command.finalJob.toSnapshot().id,
+        assertLocal: local, assertProtected,
+        assertCurrent: (tx) => assertRefreshTransactionAuthority(tx, m, command.finalJob.toSnapshot().id, clock) });
+      return new PrismaReaderSummaryPublication(summary, async (tx, value) => {
+        if (blockedWriter) {
+          // Publisher deadline/tenant SELECTs have established its real snapshot.
+          // An independent writer must NOT commit policy drift at this seam.
+          await writer.query("begin");
+          try {
+            await writer.query("set local lock_timeout = '200ms'");
+            await assert.rejects(writer.query(`update reader_summary_policies set tone=tone where ${where}`, scope), lockUnavailable);
+          } finally { await writer.query("rollback"); }
+        }
+        await guard(tx, value);
+      }).publish(command);
+    });
+  await writer.connect();
+  try {
+    // A commit AFTER the holder's snapshot but BEFORE locks must be visible in
+    // the separate normal publisher's first validation snapshot.
+    const original = await writer.query<{ tone: string }>(`select tone from reader_summary_policies where ${where} and scope_key='workspace'`, scope);
+    assert.equal(original.rowCount, 1);
+    const tone = original.rows[0]!.tone;
+    try {
+      await assert.rejects(publish({ $transaction: (work, options) => summary.$transaction(async (tx) => {
+        await tx.$queryRaw`select 1 as holder_snapshot`;
+        const changed = await writer.query(`update reader_summary_policies set tone=$3 where ${where} and scope_key='workspace'`,
+          [...scope, tone === "analytical" ? "neutral" : "analytical"]);
+        assert.equal(changed.rowCount, 1); // Autocommit completed on independent client.
+        return work(tx);
+      }, options) }), /drifted/);
+    } finally {
+      await writer.query(`update reader_summary_policies set tone=$3 where ${where} and scope_key='workspace'`, [...scope, tone]);
+    }
+
+    // Every protected relation can be first in another writer's transaction.
+    // NOWAIT must unwind all partial locks without a publisher or a deadlock.
+    let writerConflicts = 0;
+    const acquisitionMs: number[] = [];
+    for (const table of tables) {
+      await writer.query("begin");
+      try {
+        await writer.query(`lock table ${table} in row exclusive mode`);
+        if (table === "source_item_engagement_snapshots") {
+          for (const name of ["source_item_engagement_snapshots", "source_items"] as const) {
+            const updated = await writer.query(`update ${name} set last_observed_at=last_observed_at where ${where}`, scope);
+            assert((updated.rowCount ?? 0) > 0);
+          }
+        }
+        let publisherStarted = false;
+        const attemptedAt = Date.now();
+        await assert.rejects(withRefreshPublicationLocks({ $transaction: (work, options) => summary.$transaction(async (tx) => {
+          // A regression must fail quickly instead of hanging the entire gate.
+          await tx.$queryRaw`select set_config('lock_timeout', '1000ms', true)`;
+          return work(tx);
+        }, options) }, async () => { publisherStarted = true; }), lockUnavailable);
+        const elapsed = Date.now() - attemptedAt;
+        assert(elapsed < 750, "NOWAIT must reject before the 1000ms lock timeout");
+        acquisitionMs.push(elapsed);
+        assert.equal(publisherStarted, false);
+        // Proves failed acquisition released EVERY conflicting partial lock.
+        await writer.query(`lock table ${tables.join(", ")} in row exclusive mode nowait`);
+        if (table === "source_item_engagement_snapshots") {
+          const updated = await writer.query(`update feed_items set title=title where ${where}`, scope);
+          assert((updated.rowCount ?? 0) > 0); // snapshot -> source -> feed writer progresses.
+        }
+        writerConflicts++;
+      } finally { await writer.query("rollback"); }
+    }
+    const started = Date.now();
+    assert.equal(await publish(summary, true), "published");
+    const publicationMs = Date.now() - started;
+    assert(publicationMs < 30_000, "shared max2 publication must complete without nested/root reads");
+    return { publicationMs, writerConflicts, acquisitionMs };
+  } finally { await writer.end(); }
+}

--- a/scripts/lib/reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-postgres.ts
@@ -163,11 +163,13 @@ export async function lockRefreshAuthority(client: Pick<PrismaReaderSummaryClien
   const locking = client as PrismaReaderSummaryClient & {
     $executeRaw(query: TemplateStringsArray): Promise<number>;
   };
-  await locking.$executeRaw`lock table feed_items, source_items, source_bindings,
-    interests, source_catalog_entries, source_item_engagement_snapshots,
-    source_item_engagement_observations, source_item_engagement_daily_rollups,
-    reader_summary_policies in share mode`;
-  // Slot changes and every field of the prior are compared after these locks.
+  // Match engagement projection's snapshot -> source -> feed direction. Other
+  // writers use other orders: NOWAIT on EVERY relation prevents a lock cycle
+  // while partially acquired locks are held. Failure aborts; never retry a model.
+  await locking.$executeRaw`lock table source_item_engagement_snapshots,
+    source_items, feed_items, source_item_engagement_observations,
+    source_item_engagement_daily_rollups, source_bindings, interests,
+    source_catalog_entries, reader_summary_policies in share mode nowait`;
 }
 export const sameRefreshAuthority = (a: unknown, b: unknown): boolean => refreshHash(a) === refreshHash(b);
 

--- a/scripts/lib/reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-postgres.ts
@@ -1,0 +1,193 @@
+import { stablePublicationJson } from "@social-monitor/summary/adapters/persistence/reader-summary-publication-proof";
+import { refreshBytesHash } from "./reader-summary-new-input-refresh-manifest";
+import { verifyHistoricalPromotionArtifact, type HistoricalPromotionArtifactRecord } from "./reader-summary-promotion-v2-historical-artifact";
+import type { PrismaSummaryClient } from
+  "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-client";
+import type { PrismaReaderSummaryClient } from
+  "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { refreshHash, refreshScope, refreshKeyPrefix, type RefreshPrior } from
+  "./reader-summary-new-input-refresh-manifest";
+import { assertHistoricalPromotionSystemRole } from "./reader-summary-promotion-v2-system-database";
+
+type Client = Pick<PrismaSummaryClient, "$queryRaw">;
+export async function readRefreshPrior(client: Client, date: string,
+  publicationId?: string): Promise<RefreshPrior> {
+  const rows = await client.$queryRaw<readonly (RefreshPrior & { valid: boolean; record: HistoricalPromotionArtifactRecord; report: unknown; proof: unknown })[]>`
+    select p.id::text as "publicationId", a.id::text as "artifactId",
+      j.id::text as "jobId", p.semantic_status::text as status,
+      btrim(p.report_sha256) as "reportSha256", btrim(p.proof_sha256) as "proofSha256",
+      encode(sha256(convert_to((to_jsonb(a) - 'status' - 'updated_at')::text, 'UTF8')), 'hex') as "artifactSha256",
+      encode(sha256(convert_to(to_jsonb(j)::text, 'UTF8')), 'hex') as "jobSha256",
+      encode(sha256(convert_to(to_jsonb(p)::text, 'UTF8')), 'hex') as "publicationSha256",
+      a.artifact_payload->'sourceWindow'->>'ingestionCutoff' as "observedThrough",
+      jsonb_array_length(coalesce(a.artifact_payload->'content'->'topReads', '[]')) as "topCount",
+      jsonb_array_length(coalesce(a.artifact_payload->'content'->'selectedPosts', '[]')) as "additionalCount",
+      jsonb_array_length(a.citations) as "citationCount",
+      jsonb_build_object('artifactId', a.id, 'status', p.semantic_status,
+        'tenantId', a.tenant_id, 'workspaceId', a.workspace_id, 'scopeType', a.scope_type,
+        'interestId', a.interest_id, 'cadence', a.cadence, 'periodStartedAt', a.period_started_at,
+        'periodEndedAt', a.period_ended_at, 'periodTimezone', a.period_timezone,
+        'userId', a.user_id, 'subscriptionId', a.subscription_id, 'headline', a.headline,
+        'summaryText', a.summary_text, 'createdAt', a.created_at, 'artifactPayload', a.artifact_payload) as record,
+      jsonb_build_object('schemaVersion', 'reader_summary.publication_report.v1',
+        'semanticStatus', p.semantic_status, 'modelVersion', a.model_version,
+        'promptVersion', a.prompt_version, 'headline', a.headline, 'summaryText', a.summary_text,
+        'artifactPayload', a.artifact_payload, 'citations', a.citations, 'qualitySignals', a.quality_signals) as report,
+      p.exact_proof as proof,
+      (j.status = p.semantic_status and j.reader_summary_artifact_id = a.id
+        and a.tenant_id = p.tenant_id and a.workspace_id = p.workspace_id
+        and j.tenant_id = p.tenant_id and j.workspace_id = p.workspace_id
+        and a.scope_type = 'workspace' and a.scope_key = 'workspace'
+        and j.scope_type = 'workspace' and j.scope_key = 'workspace'
+        and a.interest_id is null and j.interest_id is null
+        and a.user_id is null and j.user_id is null
+        and a.subscription_id is null and j.subscription_id is null
+        and a.cadence = 'daily' and j.cadence = 'daily'
+        and a.period_started_at = p.period_started_at and j.period_started_at = p.period_started_at
+        and a.period_ended_at = p.period_ended_at and j.period_ended_at = p.period_ended_at
+        and a.period_timezone = 'UTC' and j.period_timezone = 'UTC'
+        and p.publication_kind = 'EXACT'
+        and p.exact_proof->>'readerSummaryArtifactId' = a.id::text
+        and p.exact_proof->>'readerSummaryJobId' = j.id::text
+        and p.exact_proof->>'tenantId' = p.tenant_id::text
+        and p.exact_proof->>'workspaceId' = p.workspace_id::text
+        and p.exact_proof->>'reportSha256' = btrim(p.report_sha256)
+        and (case when ${publicationId ?? null}::uuid is null
+          then a.status = p.semantic_status else a.status in (p.semantic_status, 'SUPERSEDED') end)
+      ) as valid
+    from reader_summary_publications p
+    join reader_summary_artifacts a on a.id = p.reader_summary_artifact_id
+    join reader_summary_jobs j on j.id = p.reader_summary_job_id
+    where p.tenant_id = ${refreshScope.tenantId}::uuid
+      and p.workspace_id = ${refreshScope.workspaceId}::uuid
+      and p.scope_type = 'workspace' and p.scope_key = 'workspace'
+      and p.cadence = 'daily' and p.period_timezone = 'UTC'
+      and p.period_started_at = ${date}::date::timestamp at time zone 'UTC'
+      and p.period_ended_at = (${date}::date + 1)::timestamp at time zone 'UTC'
+      and (case when ${publicationId ?? null}::uuid is null then p.id = (
+        select current_publication_id from reader_summary_publication_slots s
+        where s.tenant_id = p.tenant_id and s.workspace_id = p.workspace_id
+          and s.scope_type = p.scope_type and s.scope_key = p.scope_key
+          and s.cadence = p.cadence and s.period_timezone = p.period_timezone
+          and s.period_started_at = p.period_started_at and s.period_ended_at = p.period_ended_at
+      ) else p.id = ${publicationId ?? null}::uuid end)
+  `;
+  if (rows.length !== 1 || rows[0]?.valid !== true) {
+    throw new Error("Refresh requires an exact terminal canonical prior publication and job");
+  }
+  const { valid: _valid, record, report, proof, ...prior } = rows[0];
+  void _valid;
+  verifyHistoricalPromotionArtifact(record);
+  for (const [value, hash] of [[report, prior.reportSha256], [proof, prior.proofSha256]]) {
+    if (refreshBytesHash(Buffer.from(stablePublicationJson(value))) !== hash) {
+      throw new Error("Refresh prior immutable report/proof digest is invalid");
+    }
+  }
+  return { ...prior, observedThrough: new Date(prior.observedThrough).toISOString() };
+}
+
+/** Hash whole engagement rows, not feed metadata projections or admitted IDs. */
+export async function readRefreshMutableAuthority(client: Client, date: string) {
+  await assertHistoricalPromotionSystemRole(client);
+  const rows = await client.$queryRaw<readonly {
+    canonicalRowsSha256: string; engagementSha256: string; sourceScopeSha256: string; policySha256: string;
+    metricRowCount: number;
+  }[]>`
+    with relevant as (
+      select distinct source_item_id from feed_items
+      where tenant_id = ${refreshScope.tenantId}::uuid
+        and workspace_id = ${refreshScope.workspaceId}::uuid and status = 'VISIBLE'
+        and published_at >= ${date}::date::timestamp at time zone 'UTC'
+        and published_at < (${date}::date + 1)::timestamp at time zone 'UTC'
+    ), canonical_rows as (
+      select jsonb_build_array(to_jsonb(f), to_jsonb(s)) as row
+      from feed_items f join source_items s on s.id = f.source_item_id
+        and s.tenant_id = f.tenant_id and s.workspace_id = f.workspace_id
+      where f.tenant_id = ${refreshScope.tenantId}::uuid
+        and f.workspace_id = ${refreshScope.workspaceId}::uuid and f.status = 'VISIBLE'
+        and f.published_at >= ${date}::date::timestamp at time zone 'UTC'
+        and f.published_at < (${date}::date + 1)::timestamp at time zone 'UTC'
+    ), metrics as (
+      select 'snapshot' as kind, to_jsonb(s) as row from source_item_engagement_snapshots s
+      where s.tenant_id = ${refreshScope.tenantId}::uuid
+        and s.workspace_id = ${refreshScope.workspaceId}::uuid and source_item_id in (select * from relevant)
+      union all
+      select 'observation', to_jsonb(o) from source_item_engagement_observations o
+      where o.tenant_id = ${refreshScope.tenantId}::uuid
+        and o.workspace_id = ${refreshScope.workspaceId}::uuid and source_item_id in (select * from relevant)
+      union all
+      select 'rollup', to_jsonb(r) from source_item_engagement_daily_rollups r
+      where r.tenant_id = ${refreshScope.tenantId}::uuid
+        and r.workspace_id = ${refreshScope.workspaceId}::uuid and source_item_id in (select * from relevant)
+    ), bindings as (
+      select jsonb_build_array(to_jsonb(b), to_jsonb(i), to_jsonb(c)) as row
+      from source_bindings b join interests i on i.id = b.interest_id
+      join source_catalog_entries c on c.id = b.source_catalog_entry_id
+      where b.tenant_id = ${refreshScope.tenantId}::uuid and b.workspace_id = ${refreshScope.workspaceId}::uuid
+        and i.tenant_id = b.tenant_id and i.workspace_id = b.workspace_id
+    ), policy as (
+      select to_jsonb(p) as row from reader_summary_policies p
+      where tenant_id = ${refreshScope.tenantId}::uuid and workspace_id = ${refreshScope.workspaceId}::uuid
+        and scope_type = 'workspace' and scope_key = 'workspace' and interest_id is null
+    )
+    select encode(sha256(convert_to(coalesce((select jsonb_agg(row order by row::text)::text
+      from canonical_rows), '[]'), 'UTF8')), 'hex') as "canonicalRowsSha256",
+      encode(sha256(convert_to(coalesce((select jsonb_agg(jsonb_build_array(kind, row)
+      order by kind, row::text)::text from metrics), '[]'), 'UTF8')), 'hex') as "engagementSha256",
+      encode(sha256(convert_to(coalesce((select jsonb_agg(row order by row::text)::text
+        from bindings), '[]'), 'UTF8')), 'hex') as "sourceScopeSha256",
+      (select encode(sha256(convert_to(row::text, 'UTF8')), 'hex') from policy) as "policySha256",
+      (select count(*)::int from metrics) as "metricRowCount"
+  `;
+  if (rows.length !== 1 || !rows[0]?.policySha256) throw new Error("Refresh policy is missing");
+  return rows[0];
+}
+
+export type RefreshJobState = Readonly<{
+  jobId: string; operation: string; status: string; artifactId: string | null;
+}>;
+export const readRefreshJobs = async (client: Client, date: string): Promise<readonly RefreshJobState[]> =>
+  client.$queryRaw<readonly RefreshJobState[]>`
+    select id::text as "jobId", idempotency_key as operation, status::text as status,
+      reader_summary_artifact_id::text as "artifactId"
+    from reader_summary_jobs where tenant_id = ${refreshScope.tenantId}::uuid
+      and workspace_id = ${refreshScope.workspaceId}::uuid
+      and starts_with(idempotency_key, ${refreshKeyPrefix(date)})
+    order by id
+  `;
+
+export async function lockRefreshAuthority(client: Pick<PrismaReaderSummaryClient, "$queryRaw">): Promise<void> {
+  if (!("$executeRaw" in client) || typeof client.$executeRaw !== "function") {
+    throw new Error("Refresh requires a lock-capable publisher transaction");
+  }
+  const locking = client as PrismaReaderSummaryClient & {
+    $executeRaw(query: TemplateStringsArray): Promise<number>;
+  };
+  await locking.$executeRaw`lock table feed_items, source_items, source_bindings,
+    interests, source_catalog_entries, source_item_engagement_snapshots,
+    source_item_engagement_observations, source_item_engagement_daily_rollups,
+    reader_summary_policies in share mode`;
+  // Slot changes and every field of the prior are compared after these locks.
+}
+export const sameRefreshAuthority = (a: unknown, b: unknown): boolean => refreshHash(a) === refreshHash(b);
+
+export async function readRefreshCounts(client: Client, date: string) {
+  const rows = await client.$queryRaw<readonly { publications: number; outbox: number; jobs: number; artifacts: number }[]>`
+    select (select count(*)::int from reader_summary_publications p where p.tenant_id = ${refreshScope.tenantId}::uuid
+      and p.workspace_id = ${refreshScope.workspaceId}::uuid and p.scope_key = 'workspace' and p.cadence = 'daily'
+      and p.period_started_at = ${date}::date::timestamp at time zone 'UTC') as publications,
+    (select count(*)::int from reader_summary_publications p join outbox_events e on e.id = p.outbox_event_id
+      and e.tenant_id = p.tenant_id and e.workspace_id = p.workspace_id
+      where p.tenant_id = ${refreshScope.tenantId}::uuid and p.workspace_id = ${refreshScope.workspaceId}::uuid
+      and p.scope_key = 'workspace' and p.cadence = 'daily'
+      and p.period_started_at = ${date}::date::timestamp at time zone 'UTC') as outbox,
+    (select count(*)::int from reader_summary_jobs where tenant_id = ${refreshScope.tenantId}::uuid
+      and workspace_id = ${refreshScope.workspaceId}::uuid and scope_key = 'workspace' and cadence = 'daily'
+      and period_started_at = ${date}::date::timestamp at time zone 'UTC') as jobs,
+    (select count(*)::int from reader_summary_artifacts where tenant_id = ${refreshScope.tenantId}::uuid
+      and workspace_id = ${refreshScope.workspaceId}::uuid and scope_key = 'workspace' and cadence = 'daily'
+      and period_started_at = ${date}::date::timestamp at time zone 'UTC') as artifacts
+  `;
+  if (rows.length !== 1) throw new Error("Refresh before/after inventory unavailable");
+  return rows[0]!;
+}

--- a/scripts/lib/reader-summary-new-input-refresh-publication-lock.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-publication-lock.spec.ts
@@ -1,0 +1,78 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { withRefreshPublicationLocks } from "./reader-summary-new-input-refresh-publication-lock";
+
+const holderRows = [{ pid: 7, vxid: "7/11" }];
+describe("refresh snapshot protection", () => {
+  it("sees a writer commit before validation, with two slots and no nested ALS transaction", async () => {
+    const context = new AsyncLocalStorage<string>();
+    const order: string[] = [];
+    let committedPolicy = "reviewed", locked = false, active = 0, peak = 0;
+    const summary = { $transaction: async <T>(work: (tx: PrismaReaderSummaryClient) => Promise<T>) => {
+      expect(context.getStore()).toBeUndefined();
+      const name = active === 0 ? "holder" : "publisher";
+      active++; peak = Math.max(peak, active);
+      // Both connections may establish snapshots via tenant/deadline SELECTs.
+      const snapshot = committedPolicy;
+      if (name === "holder") committedPolicy = "writer committed";
+      else { expect(locked).toBe(true); order.push("publisher snapshot"); }
+      try {
+        return await context.run(name, () => work({
+          $executeRaw: async () => { locked = true; order.push(`${name} locks`); return 0; },
+          $queryRaw: async (sql: TemplateStringsArray) => {
+            if (sql.join("").includes("select exists")) return [{ held: true }];
+            return name === "holder" ? holderRows : [{ policy: snapshot }];
+          },
+        } as unknown as PrismaReaderSummaryClient));
+      } finally { order.push(`${name} end`); active--; }
+    } };
+    await withRefreshPublicationLocks(summary, async (assertProtected) => summary.$transaction(async (tx) => {
+      await assertProtected(tx);
+      expect(await tx.$queryRaw`policy`).toEqual([{ policy: "writer committed" }]);
+    }));
+    expect(peak).toBe(2); expect(active).toBe(0);
+    expect(order).toEqual(["holder locks", "publisher snapshot", "publisher locks", "publisher end", "holder end"]);
+  });
+
+  it.each(["source_item_engagement_snapshots", "source_items", "feed_items", "reader_summary_policies"])(
+    "a %s writer rejects acquisition without waiting, publishing or retaining partial locks", async (busy) => {
+      const held: string[] = [];
+      const publish = jest.fn();
+      const summary = { $transaction: async <T>(work: (tx: PrismaReaderSummaryClient) => Promise<T>) => {
+        try {
+          return await work({ $executeRaw: async (sql: TemplateStringsArray) => {
+            const text = sql.join("");
+            expect(text).toMatch(/share mode nowait/iu);
+            for (const table of text.replace(/^lock table\s+/u, "").split(/,| in share/iu)) {
+              if (table.trim() === busy) throw new Error("55P03 lock unavailable");
+              held.push(table.trim());
+            }
+            return 0;
+          } } as unknown as PrismaReaderSummaryClient);
+        } finally { held.length = 0; }
+      } };
+      await expect(withRefreshPublicationLocks(summary, publish)).rejects.toThrow(/55P03/);
+      expect(publish).not.toHaveBeenCalled(); expect(held).toEqual([]);
+    });
+
+  it("rejects lost server locks even before the holder failure notification arrives", async () => {
+    let ended = false;
+    const summary = { $transaction: async <T>(work: (tx: PrismaReaderSummaryClient) => Promise<T>) => {
+      try { return await work({ $executeRaw: async () => 0, $queryRaw: async () => holderRows } as unknown as PrismaReaderSummaryClient); }
+      finally { ended = true; }
+    } };
+    const candidate = { $executeRaw: async () => 0, $queryRaw: async () => [{ held: false }] } as unknown as PrismaReaderSummaryClient;
+    await expect(withRefreshPublicationLocks(summary, (protect) => protect(candidate))).rejects.toThrow(/protection was lost/);
+    expect(ended).toBe(true);
+  });
+
+  it("releases its transaction on publisher failure", async () => {
+    let ended = false;
+    const summary = { $transaction: async <T>(work: (tx: PrismaReaderSummaryClient) => Promise<T>) => {
+      try { return await work({ $executeRaw: async () => 0, $queryRaw: async () => holderRows } as unknown as PrismaReaderSummaryClient); }
+      finally { ended = true; }
+    } };
+    await expect(withRefreshPublicationLocks(summary, async () => { throw new Error("publication rejected"); })).rejects.toThrow(/publication rejected/);
+    expect(ended).toBe(true);
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-publication-lock.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-publication-lock.ts
@@ -1,0 +1,52 @@
+import type { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { readerSummaryPublicationTimeoutMs } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-publication-deadline";
+import { lockRefreshAuthority } from "./reader-summary-new-input-refresh-postgres";
+
+export type RefreshSnapshotProtection = (tx: PrismaReaderSummaryClient) => Promise<void>;
+
+/** One holder plus the ordinary publisher, using the existing shared max2 pool.
+ * Start publish in the CALLER's async context: invoking it inside $transaction
+ * leaks the runtime's transaction AsyncLocalStorage and forbids root access. */
+export async function withRefreshPublicationLocks<T>(
+  summary: Pick<PrismaSummaryConnection, "$transaction">,
+  publish: (assertProtected: RefreshSnapshotProtection) => Promise<T>,
+): Promise<T> {
+  let acquired!: () => void, failed!: (error: unknown) => void, release!: () => void;
+  let identity: { pid: number; vxid: string } | undefined;
+  let held = false;
+  const ready = new Promise<void>((resolve, reject) => { acquired = resolve; failed = reject; });
+  const finished = new Promise<void>((resolve) => { release = resolve; });
+  const holder = summary.$transaction(async (tx) => {
+    await lockRefreshAuthority(tx);
+    const rows = await tx.$queryRaw<readonly { pid: number; vxid: string }[]>`
+      select pid, virtualxid as vxid from pg_catalog.pg_locks
+      where pid = pg_backend_pid() and locktype = 'virtualxid' and granted
+    `;
+    if (rows.length !== 1 || !rows[0]) throw new Error("Refresh lock holder identity unavailable");
+    identity = rows[0]; held = true; acquired();
+    await finished;
+  }, { isolationLevel: "Serializable", maxWait: 30_000, timeout: readerSummaryPublicationTimeoutMs + 60_000 });
+  void holder.catch((error: unknown) => { held = false; failed(error); });
+  try {
+    await ready;
+    return await publish(async (tx) => {
+      if (!held || !identity) throw new Error("Refresh snapshot protection was lost");
+      // Transfer protection to the publisher itself. pg_locks is live, not an
+      // MVCC read: prove overlap even if holder timeout/disconnect notification
+      // has not reached JS yet. A lost holder can never validate an old snapshot.
+      await lockRefreshAuthority(tx);
+      const rows = await tx.$queryRaw<readonly { held: boolean }[]>`
+        select exists(select 1 from pg_catalog.pg_locks
+          where pid = ${identity.pid} and virtualxid = ${identity.vxid}
+            and locktype = 'virtualxid' and granted) as held
+      `;
+      if (!held || rows.length !== 1 || rows[0]?.held !== true) {
+        throw new Error("Refresh snapshot protection was lost");
+      }
+    });
+  } finally {
+    held = false; release();
+    await holder;
+  }
+}

--- a/scripts/lib/reader-summary-new-input-refresh-publication.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-publication.spec.ts
@@ -1,0 +1,30 @@
+import { refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import type { ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
+
+describe("historical refresh canonical publisher transaction guard", () => {
+  const command = (cutoff = refreshManifest().observedThrough) => ({
+    finalJob: { toSnapshot: () => ({ id: "new-job" }) },
+    artifact: { toSnapshot: () => ({ sourceWindow: { ingestionCutoff: new Date(cutoff) } }) },
+  }) as unknown as ReaderSummaryPublicationCommand;
+  it.each(["old-slot", "engagement", "policy-config", "expired-review", "fence"])(
+    "fails publication on %s drift after generation", async (reason) => {
+      const tx = { $executeRaw: jest.fn(async () => 0) } as unknown as PrismaReaderSummaryClient;
+      const current = jest.fn(async (client) => { expect(client).toBe(tx); throw new Error(reason); });
+      const guard = refreshPublicationGuard({ assertLocal: () => {
+        if (["expired-review", "fence"].includes(reason)) throw new Error(reason);
+      }, assertCurrent: current, manifest: refreshManifest(), jobId: "new-job" });
+      await expect(guard(tx, command())).rejects.toThrow(reason);
+      // The guard receives the publisher's own transaction, including engagement
+      // locks, so a changed projection cannot switch the publication slot.
+      expect((tx as unknown as { $executeRaw: jest.Mock }).$executeRaw.mock.calls[0]![0].join("")).toContain("source_item_engagement_observations");
+    });
+  it("requires real transaction locking and the frozen candidate cutoff", async () => {
+    const guard = refreshPublicationGuard({ assertLocal: () => undefined,
+      assertCurrent: async () => undefined, manifest: refreshManifest(), jobId: "new-job" });
+    await expect(guard({} as PrismaReaderSummaryClient, command())).rejects.toThrow(/lock-capable/);
+    await expect(guard({ $executeRaw: async () => 0 } as unknown as PrismaReaderSummaryClient,
+      command("2026-09-05T22:10:00.000Z"))).rejects.toThrow(/cutoff/);
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-publication.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-publication.spec.ts
@@ -1,3 +1,4 @@
+import { lockRefreshAuthority } from "./reader-summary-new-input-refresh-postgres";
 import { refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
 import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
 import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
@@ -12,16 +13,16 @@ describe("historical refresh canonical publisher transaction guard", () => {
     "fails publication on %s drift after generation", async (reason) => {
       const tx = { $executeRaw: jest.fn(async () => 0) } as unknown as PrismaReaderSummaryClient;
       const current = jest.fn(async (client) => { expect(client).toBe(tx); throw new Error(reason); });
-      const guard = refreshPublicationGuard({ assertLocal: () => {
+      const guard = refreshPublicationGuard({ assertProtected: lockRefreshAuthority, assertLocal: () => {
         if (["expired-review", "fence"].includes(reason)) throw new Error(reason);
       }, assertCurrent: current, manifest: refreshManifest(), jobId: "new-job" });
       await expect(guard(tx, command())).rejects.toThrow(reason);
-      // The guard receives the publisher's own transaction, including engagement
-      // locks, so a changed projection cannot switch the publication slot.
-      expect((tx as unknown as { $executeRaw: jest.Mock }).$executeRaw.mock.calls[0]![0].join("")).toContain("source_item_engagement_observations");
+      if (!["expired-review", "fence"].includes(reason)) {
+        expect((tx as unknown as { $executeRaw: jest.Mock }).$executeRaw.mock.calls[0]![0].join("")).toContain("source_item_engagement_observations");
+      }
     });
   it("requires real transaction locking and the frozen candidate cutoff", async () => {
-    const guard = refreshPublicationGuard({ assertLocal: () => undefined,
+    const guard = refreshPublicationGuard({ assertProtected: lockRefreshAuthority, assertLocal: () => undefined,
       assertCurrent: async () => undefined, manifest: refreshManifest(), jobId: "new-job" });
     await expect(guard({} as PrismaReaderSummaryClient, command())).rejects.toThrow(/lock-capable/);
     await expect(guard({ $executeRaw: async () => 0 } as unknown as PrismaReaderSummaryClient,

--- a/scripts/lib/reader-summary-new-input-refresh-review.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-review.spec.ts
@@ -1,0 +1,130 @@
+import { canonicalJsonSha256 } from "@social-monitor/contracts/grpc/agent_runtime/v1/execution-attestation";
+import type { AgentRuntimeTaskCommand, AgentRuntimeTaskResult, ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { NewInputRefreshGuard } from "./reader-summary-new-input-refresh-guard";
+import { refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
+import { lockRefreshAuthority } from "./reader-summary-new-input-refresh-postgres";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+
+const m = refreshManifest();
+const command = (purpose: string = purposes.generate): AgentRuntimeTaskCommand => ({
+  requestId: purpose, purpose, correlationId: "synthetic-review", tenantId: tenantId(m.tenantId),
+  workspaceId: workspaceId(m.workspaceId), provider: "codex", prompt: "Synthetic", systemPrompt: "Synthetic",
+  outputSchema: {}, timeoutMs: 1000, controls: { model: "gpt-5.6-sol", reasoningEffort: "high" }, metadata: { attempt: "primary" },
+});
+const completed = (request: AgentRuntimeTaskCommand): AgentRuntimeTaskResult => ({
+  status: "completed", warnings: [], structuredOutput: { groups: [] },
+  usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5, estimatedCostUsd: 0 },
+  executionAttestation: { schemaVersion: 1, requestId: request.requestId, purpose: request.purpose,
+    provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "high", canonicalRequestSha256: "a".repeat(64),
+    runtimeEngine: "subscription-runtime-cli", runtimePackageVersion: m.runtime.packageVersion,
+    launcherSha256: m.runtime.launcherSha256, selectedOutputKind: "structured_output",
+    selectedOutputSha256: canonicalJsonSha256({ groups: [] }) },
+});
+
+describe("confirmed review defects", () => {
+  it.each(["model", "reasoningEffort", "requestId", "purpose", "provider", "schemaVersion", "selectedOutputSha256", "canonicalRequestSha256"])(
+    "a selector catching bad %s cannot proceed to primary generation", async (field) => {
+      const events: unknown[] = [];
+      const runTask = jest.fn(async (request: AgentRuntimeTaskCommand) => {
+        const result = completed(request);
+        return { ...result, executionAttestation: { ...result.executionAttestation!, [field]: "invalid" } } as AgentRuntimeTaskResult;
+      });
+      const input = { manifest: m, delegate: { runTask, checkHealth: jest.fn() },
+        assertLocal: () => undefined, assertCurrent: async () => undefined, record: (event: unknown) => events.push(event) };
+      const runtime = guardedRefreshRuntime(input);
+      // Mirrors the story selector's catch-and-continue behavior.
+      await runtime.runTask(command(purposes.storyRelations)).catch(() => undefined);
+      await expect(runtime.runTask(command())).rejects.toThrow(/budget|ambiguous/);
+      expect(runTask).toHaveBeenCalledTimes(1);
+      expect(events).not.toContainEqual(expect.objectContaining({ status: "completed" }));
+    });
+
+  it("an authority read failure permanently revokes all purposes even if the dependency recovers", async () => {
+    let unavailable = true;
+    const runTask = jest.fn(async (request: AgentRuntimeTaskCommand) => completed(request));
+    const input = { manifest: m, delegate: { runTask, checkHealth: jest.fn() }, assertLocal: () => undefined,
+      assertCurrent: async () => { if (unavailable) throw new Error("dependency unavailable"); }, record: jest.fn() };
+    const runtime = guardedRefreshRuntime(input);
+    await runtime.runTask(command(purposes.storyRelations)).catch(() => undefined);
+    unavailable = false;
+    await expect(runtime.runTask(command())).rejects.toThrow(/budget|ambiguous/);
+    expect(runTask).not.toHaveBeenCalled();
+  });
+
+  it.each([purposes.generate, purposes.storyRelations, purposes.topicLabel, purposes.topicRelations, purposes.relatedTopicRelations])(
+    "rechecks cutoff and fences after the last authority await for %s", async (purpose) => {
+      for (const drift of ["cutoff", "fence"] as const) {
+        let now = refreshNow, fence = true;
+        const guard = new NewInputRefreshGuard(m, "new", { now: () => now,
+          assertFences: () => { if (!fence) throw new Error("fence expired"); },
+          assertCurrent: async () => {
+            if (drift === "cutoff") now = new Date(Date.parse(m.observedThrough) + 1_800_001);
+            else fence = false;
+          } });
+        const runTask = jest.fn(async (request: AgentRuntimeTaskCommand) => completed(request));
+        const input = { manifest: m, delegate: { runTask, checkHealth: jest.fn() }, assertLocal: () => guard.assertLocal(),
+          assertCurrent: () => guard.assertCurrent(), record: jest.fn() };
+        await expect(guardedRefreshRuntime(input).runTask(command(purpose))).rejects.toThrow();
+        expect(runTask).not.toHaveBeenCalled();
+      }
+    });
+
+  it("checks the local fence after synchronous journaling immediately before invocation", async () => {
+    let fence = true;
+    const runTask = jest.fn(async (request: AgentRuntimeTaskCommand) => completed(request));
+    const input = { manifest: m, delegate: { runTask, checkHealth: jest.fn() }, assertCurrent: async () => undefined,
+      assertLocal: () => { if (!fence) throw new Error("fence expired"); }, record: () => { fence = false; } };
+    await expect(guardedRefreshRuntime(input).runTask(command())).rejects.toThrow();
+    expect(runTask).not.toHaveBeenCalled();
+  });
+
+  it("permits valid attested story, primary and auxiliary tasks with the unchanged model", async () => {
+    const events: unknown[] = [];
+    const runTask = jest.fn(async (request: AgentRuntimeTaskCommand) => completed(request));
+    const runtime = guardedRefreshRuntime({ manifest: m, delegate: { runTask, checkHealth: jest.fn() },
+      assertLocal: () => undefined, assertCurrent: async () => undefined, record: (event) => events.push(event) });
+    for (const purpose of [purposes.storyRelations, purposes.generate, purposes.topicLabel, purposes.topicRelations, purposes.relatedTopicRelations]) {
+      await expect(runtime.runTask(command(purpose))).resolves.toMatchObject({ status: "completed" });
+    }
+    expect(runTask).toHaveBeenCalledTimes(5);
+    expect(events.filter((event) => (event as { status: string }).status === "completed")).toHaveLength(5);
+  });
+
+  it.each(["protection", "validation"])("rechecks freshness after awaited publication %s", async (phase) => {
+    let now = refreshNow;
+    const local = new NewInputRefreshGuard(m, "new", { now: () => now,
+      assertFences: () => undefined, assertCurrent: async () => undefined });
+    const expire = () => { now = new Date(Date.parse(m.observedThrough) + 1_800_001); };
+    const candidate = { finalJob: { toSnapshot: () => ({ id: "new" }) },
+      artifact: { toSnapshot: () => ({ sourceWindow: { ingestionCutoff: new Date(m.observedThrough) } }) } } as unknown as ReaderSummaryPublicationCommand;
+    const guard = refreshPublicationGuard({ manifest: m, jobId: "new", assertLocal: () => local.assertLocal(),
+      assertProtected: async () => { if (phase === "protection") expire(); },
+      assertCurrent: async () => { if (phase === "validation") expire(); } });
+    await expect(guard({} as PrismaReaderSummaryClient, candidate)).rejects.toThrow(/stale/);
+  });
+
+  it("rejects a publisher snapshot without protection predating its first SELECT", async () => {
+    const tx = { $executeRaw: jest.fn(async () => 0) } as unknown as PrismaReaderSummaryClient;
+    // Serializable validation still sees old policy after a writer committed.
+    const current = jest.fn(async () => undefined);
+    const input = { manifest: m, jobId: "new", assertLocal: () => undefined, assertCurrent: current,
+      assertProtected: async () => { throw new Error("snapshot protection missing"); } };
+    const candidate = { finalJob: { toSnapshot: () => ({ id: "new" }) },
+      artifact: { toSnapshot: () => ({ sourceWindow: { ingestionCutoff: new Date(m.observedThrough) } }) } } as unknown as ReaderSummaryPublicationCommand;
+    await expect(refreshPublicationGuard(input)(tx, candidate)).rejects.toThrow(/protection/);
+    expect(current).not.toHaveBeenCalled();
+  });
+
+  it("never waits holding partial SHARE locks against any writer order", async () => {
+    const execute = jest.fn(async () => 0);
+    await lockRefreshAuthority({ $executeRaw: execute } as unknown as PrismaReaderSummaryClient);
+    const sql = (execute.mock.calls as unknown as [TemplateStringsArray][])[0]![0].join("");
+    expect(sql).toMatch(/in share mode nowait/iu);
+    expect(sql.indexOf("source_item_engagement_snapshots")).toBeLessThan(sql.indexOf("source_items,"));
+    expect(sql.indexOf("source_items,")).toBeLessThan(sql.indexOf("feed_items,"));
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-review.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-review.spec.ts
@@ -1,36 +1,20 @@
-import { canonicalJsonSha256 } from "@social-monitor/contracts/grpc/agent_runtime/v1/execution-attestation";
 import type { AgentRuntimeTaskCommand, AgentRuntimeTaskResult, ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
 import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
-import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
 import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
 import { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { completedRefreshModelRequest as completed, refreshModelCommand as command } from "./reader-summary-new-input-refresh-model.spec-support";
 import { NewInputRefreshGuard } from "./reader-summary-new-input-refresh-guard";
 import { refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
 import { lockRefreshAuthority } from "./reader-summary-new-input-refresh-postgres";
 import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
 
 const m = refreshManifest();
-const command = (purpose: string = purposes.generate): AgentRuntimeTaskCommand => ({
-  requestId: purpose, purpose, correlationId: "synthetic-review", tenantId: tenantId(m.tenantId),
-  workspaceId: workspaceId(m.workspaceId), provider: "codex", prompt: "Synthetic", systemPrompt: "Synthetic",
-  outputSchema: {}, timeoutMs: 1000, controls: { model: "gpt-5.6-sol", reasoningEffort: "high" }, metadata: { attempt: "primary" },
-});
-const completed = (request: AgentRuntimeTaskCommand): AgentRuntimeTaskResult => ({
-  status: "completed", warnings: [], structuredOutput: { groups: [] },
-  usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5, estimatedCostUsd: 0 },
-  executionAttestation: { schemaVersion: 1, requestId: request.requestId, purpose: request.purpose,
-    provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "high", canonicalRequestSha256: "a".repeat(64),
-    runtimeEngine: "subscription-runtime-cli", runtimePackageVersion: m.runtime.packageVersion,
-    launcherSha256: m.runtime.launcherSha256, selectedOutputKind: "structured_output",
-    selectedOutputSha256: canonicalJsonSha256({ groups: [] }) },
-});
-
 describe("confirmed review defects", () => {
   it.each(["model", "reasoningEffort", "requestId", "purpose", "provider", "schemaVersion", "selectedOutputSha256", "canonicalRequestSha256"])(
     "a selector catching bad %s cannot proceed to primary generation", async (field) => {
       const events: unknown[] = [];
       const runTask = jest.fn(async (request: AgentRuntimeTaskCommand) => {
-        const result = completed(request);
+        const result = await completed(request);
         return { ...result, executionAttestation: { ...result.executionAttestation!, [field]: "invalid" } } as AgentRuntimeTaskResult;
       });
       const input = { manifest: m, delegate: { runTask, checkHealth: jest.fn() },

--- a/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec-support.ts
@@ -1,0 +1,103 @@
+import { InMemoryFeedItemReadRepository } from "@social-monitor/feed/adapters/persistence/in-memory-feed-item-read.repository";
+import { FeedItem } from "@social-monitor/feed/domain";
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { ReaderSummaryJob } from "@social-monitor/summary/domain";
+import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import type { VerifiedReaderSummaryExecutionAttestation } from "@social-monitor/summary/adapters/model/reader-summary-execution-attestation";
+import type { AgentRuntimeTaskCommand } from "@social-monitor/summary/ports";
+import { createReaderSummaryDailyCapturePublicationWiring } from "./reader-summary-daily-story-relation-verifier";
+import { refreshPeriod } from "./reader-summary-new-input-refresh-capture";
+import { NewInputRefreshGuard } from "./reader-summary-new-input-refresh-guard";
+import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { completedRefreshModelRequest } from "./reader-summary-new-input-refresh-model.spec-support";
+import { primaryOutput, topicOutput } from "./reader-summary-new-input-refresh-model-composition.spec-support";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+
+export type SelectorEvent = { status: string; phase?: string; taskRole?: string };
+export async function selectorWiring(input: {
+  output?: (command: AgentRuntimeTaskCommand) => Record<string, unknown>;
+  guardAdapter?: boolean;
+  sameStory?: boolean;
+  assertSource?: () => void;
+  onAttestation?: (value: VerifiedReaderSummaryExecutionAttestation) => void | Promise<void>;
+  onEvent?: (value: SelectorEvent) => void;
+} = {}) {
+  const manifest = refreshManifest();
+  const period = refreshPeriod(manifest.date);
+  const guard = new NewInputRefreshGuard(manifest, "synthetic-job", {
+    now: () => refreshNow, assertFences: () => undefined, assertCurrent: async () => undefined,
+  });
+  await guard.claim(ReaderSummaryJob.request({ id: "synthetic-job", tenantId: tenantId(manifest.tenantId),
+    workspaceId: workspaceId(manifest.workspaceId), scope: { type: "workspace" }, period,
+    idempotencyKey: manifest.operation, requestedAt: refreshNow }).toSnapshot());
+  const commands: AgentRuntimeTaskCommand[] = [];
+  const events: SelectorEvent[] = [];
+  const runtime = guardedRefreshRuntime({ manifest,
+    assertLocal: () => { input.assertSource?.(); guard.assertLocal(); },
+    assertCurrent: () => guard.assertCurrent(),
+    record: (value) => { events.push(value as SelectorEvent); input.onEvent?.(value as SelectorEvent); },
+    delegate: { checkHealth: jest.fn(), runTask: async (command) => {
+      commands.push(command);
+      return completedRefreshModelRequest(command, input.output?.(command) ?? selectorOutput(command, input.sameStory));
+    } },
+  });
+  const sink = { record: jest.fn(async (value: VerifiedReaderSummaryExecutionAttestation) => {
+    runtime.assertUsable();
+    await input.onAttestation?.(value);
+  }) };
+  const canonical = createReaderSummaryDailyCapturePublicationWiring({
+    replay: null, feedItems: selectorFeed(input.sameStory), summaryClient: {} as never,
+    clock: new FixedClock(refreshNow), attestationSink: sink,
+    summaryModelMode: "agent-runtime", env: {}, agentRuntimeClient: runtime,
+    ...(input.guardAdapter === false ? {} : { storyRelationVerifierGuard: runtime }),
+  });
+  const selector = guard.selector(canonical.evidenceSelector);
+  const query = { tenantId: tenantId(manifest.tenantId), workspaceId: workspaceId(manifest.workspaceId),
+    scope: { type: "workspace" as const }, period, maxItems: 2, observedThrough: new Date(manifest.observedThrough) };
+  return { runtime, guard, commands, events, sink, model: buildRefreshModelWiring({}, runtime, sink),
+    select: () => selector.select(query) };
+}
+
+export function selectorOutput(command: AgentRuntimeTaskCommand, sameStory = false): Record<string, unknown> {
+  if (command.purpose === purposes.generate) return primaryOutput();
+  if (command.purpose !== purposes.storyRelations && command.purpose !== purposes.relatedTopicRelations) {
+    return topicOutput(command, command.metadata?.attemptNumber === "2");
+  }
+  const { pairs } = JSON.parse(command.prompt) as { pairs: { leftFeedItemId: string; rightFeedItemId: string }[] };
+  return { decisions: pairs.map(({ leftFeedItemId, rightFeedItemId }) => ({ leftFeedItemId, rightFeedItemId,
+    ...(command.purpose === purposes.relatedTopicRelations ? { relation: "unrelated" } : { sameStory }),
+    confidenceScore: 0.99, rationale: "Synthetic independent evidence" })) };
+}
+
+function selectorFeed(sameStory = false) {
+  const m = refreshManifest();
+  const feed = new InMemoryFeedItemReadRepository();
+  for (const [id, providerKey, title, bodyPreview, providerMetadata] of [
+    ["synthetic-x", "x-twitter", sameStory ? "TypeScript compiler rewrite moves to Go"
+      : "Microsoft is rewriting the TypeScript compiler in Go",
+      "Microsoft details a TypeScript compiler release for AI coding agents and developer tools.",
+      { kind: "x_post", contentKind: "original_post", likes: 500, reposts: 50,
+        promotionAuthority: { official: true, trusted: true, attestedBy: "source_catalog" } }],
+    ["synthetic-reddit", "reddit", sameStory ? "Go rewrite of the TypeScript compiler reaches developers"
+      : "Developers discuss rewriting TypeScript tooling into isolated sandboxes",
+      sameStory ? "The engineering team explains the TypeScript compiler release for AI coding agents."
+        : "A forum question compares TypeScript compiler choices for AI coding agents and developer tools.",
+      { kind: "reddit_post", score: 190, comments: 30, upvoteRatio: 0.95 }],
+  ] as const) {
+    feed.upsert(FeedItem.publish({ id, tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId),
+      interestId: "interest-ai", sourceItemId: `source-${id}`, sourceBindingId: `binding-${id}`, providerKey,
+      canonicalUrl: `https://${providerKey}.example.test/${id}`, title, bodyPreview,
+      authorHandle: providerKey === "x-twitter" ? "OpenAI" : "synthetic-forum",
+      publishedAt: new Date("2026-09-03T08:00:00Z"), observedAt: new Date("2026-09-03T08:01:00Z"),
+      providerMetadata: { ...providerMetadata, interestQuerySnapshot: { query: "TypeScript, developer tools" } },
+    }));
+  }
+  const snapshot = feed.readPromotionSnapshot.bind(feed);
+  jest.spyOn(feed, "readPromotionSnapshot").mockImplementation(async (query) => {
+    const result = await snapshot(query);
+    return result.ok ? { ...result, candidates: result.candidates.map((candidate) => ({ ...candidate,
+      metricAuthority: { observedAt: new Date("2026-09-05T21:55:00Z"), regressionState: "stable" as const },
+    })) } : result;
+  });
+  return feed;
+}

--- a/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec.ts
@@ -1,0 +1,174 @@
+import { canonicalJsonSha256 } from "@social-monitor/contracts/grpc/agent_runtime/v1/execution-attestation";
+import { AgentRuntimeReaderSummaryStoryRelationVerifier } from "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter";
+import { activeReaderSummaryPurposes as purposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
+import { evaluateReaderSummaryTopicMapStructure } from "@social-monitor/summary/domain";
+import { refreshModelCommand } from "./reader-summary-new-input-refresh-model.spec-support";
+import { primaryInput, primaryRoute, publicationProbe, topicCommand } from "./reader-summary-new-input-refresh-model-composition.spec-support";
+import { selectorOutput, selectorWiring } from "./reader-summary-new-input-refresh-selector-composition.spec-support";
+
+const malformed = [
+  { name: "missing decisions", output: {}, reason: "envelope_missing_decisions" },
+  { name: "unknown envelope property", output: { decisions: [], unexpected: true }, reason: "envelope_unknown_property" },
+];
+
+afterEach(() => jest.restoreAllMocks());
+
+describe("refresh canonical selector adapter exceptions", () => {
+  it.each(malformed)("permanently poisons $name before selector fallback", async ({ output, reason }) => {
+    const verify = jest.spyOn(AgentRuntimeReaderSummaryStoryRelationVerifier.prototype, "verify");
+    const test = await selectorWiring({ output: (command) => command.purpose === purposes.relatedTopicRelations
+      ? output : selectorOutput(command) });
+    const selection = await test.select();
+    expect(selection.selectedEvidence).toHaveLength(2);
+    expect(selection.relatedTopicRelations).toEqual([]);
+    expect(verify.mock.calls.map(([query]) => [query.verificationLane, query.candidates.length]))
+      .toEqual([[undefined, 1], ["related_topic", 1]]);
+    await expect(verify.mock.results[1]!.value).rejects.toThrow(reason);
+    expect(test.commands.map((command) => command.purpose)).toEqual([purposes.storyRelations, purposes.relatedTopicRelations]);
+    expect(test.events.filter((event) => event.status === "completed")).toHaveLength(2);
+    expect(test.sink.record.mock.calls.map(([value]) => value.taskRole)).toEqual(["story_relation"]);
+    expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/u);
+    expect(test.events).toContainEqual(expect.objectContaining({ status: "requires_reconciliation",
+      phase: "adapter_validation", taskRole: "related_topic_relation" }));
+    await expectPermanentlyPoisoned(test);
+  });
+
+  it.each(["story_relation", "related_topic_relation"] as const)("poisons residual %s sink exceptions", async (taskRole) => {
+    const verify = jest.spyOn(AgentRuntimeReaderSummaryStoryRelationVerifier.prototype, "verify");
+    const failure = new Error(`synthetic ${taskRole} sink failure`);
+    const test = await selectorWiring({ onAttestation: async (value) => {
+      if (value.taskRole === taskRole) throw failure;
+    } });
+    await test.select();
+    await expect(verify.mock.results[taskRole === "story_relation" ? 0 : 1]!.value).rejects.toBe(failure);
+    expect(test.commands.map((command) => command.purpose)).toEqual(taskRole === "story_relation"
+      ? [purposes.storyRelations] : [purposes.storyRelations, purposes.relatedTopicRelations]);
+    expect(test.events).toContainEqual(expect.objectContaining({ status: "requires_reconciliation", taskRole }));
+    await expectPermanentlyPoisoned(test);
+  });
+
+  it.each(["story_relation", "related_topic_relation"] as const)("keeps %s poison if reconciliation recording throws", async (taskRole) => {
+    const test = await selectorWiring({ onAttestation: async (value) => {
+      if (value.taskRole === taskRole) throw new Error("synthetic sink failure");
+    }, onEvent: (event) => {
+      if (event.status === "requires_reconciliation") throw new Error("synthetic journal failure");
+    } });
+    await test.select();
+    expect(test.commands).toHaveLength(taskRole === "story_relation" ? 1 : 2);
+    await expectPermanentlyPoisoned(test);
+  });
+
+  it.each(["story_relation", "related_topic_relation"] as const)("poisons source drift during %s normalization", async (taskRole) => {
+    let sourceChanged = false;
+    const test = await selectorWiring({ assertSource: () => {
+      if (sourceChanged) throw new Error("synthetic source drift");
+    }, onAttestation: (value) => { if (value.taskRole === taskRole) sourceChanged = true; } });
+    await test.select();
+    // Restoring a source check cannot restore consumed refresh authority.
+    sourceChanged = false;
+    expect(test.commands).toHaveLength(taskRole === "story_relation" ? 1 : 2);
+    await expectPermanentlyPoisoned(test);
+  });
+});
+
+describe("canonical selector accepted deterministic decisions", () => {
+  it.each(["unrelated", "same_story", "empty related decisions", "empty story decisions", "missing story decisions"])(
+    "preserves %s and normalized attestations", async (kind) => {
+      const test = await selectorWiring({ output: (command) => {
+        if (command.purpose === purposes.storyRelations && kind === "missing story decisions") return {};
+        if ((command.purpose === purposes.relatedTopicRelations && kind === "empty related decisions") ||
+            (command.purpose === purposes.storyRelations && kind === "empty story decisions")) return { decisions: [] };
+        const output = selectorOutput(command);
+        return command.purpose === purposes.relatedTopicRelations && kind === "same_story"
+          ? { decisions: (output.decisions as Record<string, unknown>[]).map((decision) => ({ ...decision, relation: "same_story" })) }
+          : output;
+      } });
+      const selection = await test.select();
+      expect(selection.selectedEvidence).toHaveLength(2);
+      expect(selection.clusters).toHaveLength(2);
+      expect(selection.relatedTopicRelations).toEqual([]);
+      expect(test.commands.map((command) => command.purpose)).toEqual([purposes.storyRelations, purposes.relatedTopicRelations]);
+      expect(test.sink.record.mock.calls.map(([value]) => [value.taskRole, value.attempt]))
+        .toEqual([["story_relation", "primary"], ["related_topic_relation", "related-topic"]]);
+      if (kind.startsWith("empty") || kind === "missing story decisions") {
+        const role = kind === "empty related decisions" ? "related_topic_relation" : "story_relation";
+        expect(test.sink.record.mock.calls.find(([value]) => value.taskRole === role)?.[0].normalizedOutputSha256)
+          .toBe(canonicalJsonSha256([]));
+      }
+      await expectAcceptedPrimaryAndPublication(test);
+    },
+  );
+
+  it("retains approved same-story reclustering", async () => {
+    const test = await selectorWiring({ sameStory: true });
+    const selection = await test.select();
+    expect(selection.clusters).toHaveLength(1);
+    expect(selection.approvedSameStoryRelations).toHaveLength(1);
+    expect(test.commands.map((command) => command.purpose)).toEqual([purposes.storyRelations]);
+    await expectAcceptedPrimaryAndPublication(test);
+  });
+
+  it("retains coverage-only topic attempt 2 after selection and exactly one primary", async () => {
+    const test = await selectorWiring();
+    await test.select();
+    const primary = await test.model.model.generate(primaryInput(), primaryRoute(test.model.model));
+    expect(test.model.model.validateRawProviderResponse(primary)).toEqual({ ok: true });
+    const topicMap = await test.model.topicMap.execute(topicCommand(true));
+    expect(topicMap.ok).toBe(true);
+    if (!topicMap.ok) throw topicMap.error;
+    expect(evaluateReaderSummaryTopicMapStructure(topicMap.value).passed).toBe(true);
+    expect(test.commands.map((command) => [command.purpose, command.metadata?.attemptNumber])).toEqual([
+      [purposes.storyRelations, undefined], [purposes.relatedTopicRelations, undefined], [purposes.generate, undefined],
+      [purposes.topicLabel, "1"], [purposes.topicRelations, "1"], [purposes.topicLabel, "2"], [purposes.topicRelations, "2"],
+    ]);
+    expect(JSON.parse(test.commands[5]!.prompt).retryFeedback).toMatchObject({ reason: "grouped_coverage_below_minimum" });
+    expect(test.sink.record).toHaveBeenCalledTimes(7);
+    expect(test.events.filter((event) => event.status === "requires_reconciliation")).toEqual([]);
+    const publication = publicationProbe(test.runtime);
+    await publication.attempt();
+    expect(publication.publish).toHaveBeenCalledTimes(1);
+    await expect(test.model.model.generate(primaryInput(), primaryRoute(test.model.model))).rejects.toThrow(/budget/u);
+    expect(test.commands).toHaveLength(7);
+  });
+
+  it.each(malformed)("leaves ordinary daily fallback unchanged for $name without the optional guard", async ({ output, reason }) => {
+    const verify = jest.spyOn(AgentRuntimeReaderSummaryStoryRelationVerifier.prototype, "verify");
+    const test = await selectorWiring({ guardAdapter: false, output: (command) => command.purpose === purposes.relatedTopicRelations
+      ? output : selectorOutput(command) });
+    expect((await test.select()).selectedEvidence).toHaveLength(2);
+    await expect(verify.mock.results[1]!.value).rejects.toThrow(reason);
+    expect(test.sink.record.mock.calls.map(([value]) => value.taskRole)).toEqual(["story_relation"]);
+    await expectAcceptedPrimaryAndPublication(test);
+    expect(test.commands.map((command) => command.purpose)).toEqual([purposes.storyRelations, purposes.relatedTopicRelations, purposes.generate]);
+  });
+});
+
+async function expectPermanentlyPoisoned(test: Awaited<ReturnType<typeof selectorWiring>>) {
+  expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/u);
+  const before = test.commands.length;
+  for (const purpose of [purposes.generate, purposes.storyRelations, purposes.relatedTopicRelations, purposes.topicLabel, purposes.topicRelations]) {
+    await expect(test.runtime.runTask({ ...refreshModelCommand(purpose), requestId: `after-selector:${purpose}` })).rejects.toThrow(/budget/u);
+  }
+  await expect(test.model.model.generate(primaryInput(), primaryRoute(test.model.model))).rejects.toThrow(/budget/u);
+  await test.model.topicMap.execute(topicCommand(true));
+  await test.select();
+  expect(test.commands).toHaveLength(before);
+  const publication = publicationProbe(test.runtime);
+  await expect(publication.attempt()).rejects.toThrow(/reconciliation/u);
+  expect(publication.assertProtected).not.toHaveBeenCalled();
+  expect(publication.assertCurrent).not.toHaveBeenCalled();
+  expect(publication.publish).not.toHaveBeenCalled();
+}
+
+async function expectAcceptedPrimaryAndPublication(test: Awaited<ReturnType<typeof selectorWiring>>) {
+  expect(() => test.runtime.assertUsable()).not.toThrow();
+  const primary = await test.model.model.generate(primaryInput(), primaryRoute(test.model.model));
+  expect(test.model.model.validateRawProviderResponse(primary)).toEqual({ ok: true });
+  expect(test.events.filter((event) => event.status === "requires_reconciliation")).toEqual([]);
+  const publication = publicationProbe(test.runtime);
+  await publication.attempt();
+  expect(publication.publish).toHaveBeenCalledTimes(1);
+  const before = test.commands.length;
+  await expect(test.model.model.generate(primaryInput(), primaryRoute(test.model.model))).rejects.toThrow(/budget/u);
+  expect(test.commands).toHaveLength(before);
+}

--- a/scripts/lib/reader-summary-new-input-refresh-selector.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selector.spec.ts
@@ -1,0 +1,34 @@
+import { FeedItem } from "@social-monitor/feed/domain";
+import { InMemoryFeedItemReadRepository } from "@social-monitor/feed/adapters/persistence/in-memory-feed-item-read.repository";
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { preflightRefreshSelection } from "./reader-summary-new-input-refresh-capture";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+
+describe("complete canonical current selector for historical inputs", () => {
+  it("reads beyond a top slice and rejects metric authority after the true cutoff", async () => {
+    const m = refreshManifest();
+    const feed = new InMemoryFeedItemReadRepository();
+    for (let i = 0; i < 651; i++) feed.upsert(FeedItem.publish({
+      id: `feed-${i}`, tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId),
+      interestId: "interest", sourceItemId: `source-${i}`, sourceBindingId: "binding",
+      providerKey: "hacker-news", canonicalUrl: `https://example.test/${i}`,
+      title: i === 650 ? "OpenAI releases an AI coding agent SDK with tool calling improvements" : `Synthetic below-threshold item ${i}`,
+      bodyPreview: "OpenAI released a developer SDK for AI coding agents with improved tool calling, model context management and reproducible inference benchmarks.",
+      publishedAt: new Date("2026-09-03T12:00:00Z"), observedAt: new Date("2026-09-03T12:01:00Z"),
+      providerMetadata: { kind: "hacker_news_story", points: i === 650 ? 500 : 1, comments: 10 },
+    }));
+    const original = feed.readPromotionSnapshot.bind(feed);
+    const snapshot = jest.spyOn(feed, "readPromotionSnapshot").mockImplementation(async (query) => {
+      const result = await original(query);
+      return !result.ok ? result : { ...result, candidates: result.candidates.map((c) => ({ ...c,
+        metricAuthority: { observedAt: new Date("2026-09-05T21:55:00Z"), regressionState: "stable" as const },
+      })) };
+    });
+    const common = { feed, date: m.date, clock: new FixedClock(refreshNow) };
+    expect(await preflightRefreshSelection({ ...common, observedThrough: new Date(m.prior.observedThrough) })).toBe(0);
+    expect(await preflightRefreshSelection({ ...common, observedThrough: new Date(m.observedThrough) })).toBeGreaterThan(0);
+    expect(snapshot).toHaveBeenLastCalledWith(expect.objectContaining({ observedThrough: new Date(m.observedThrough) }));
+    const captured = await snapshot.mock.results.at(-1)!.value;
+    expect(captured).toMatchObject({ exhausted: true, physicalRowsRead: 651 });
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-source.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-source.spec.ts
@@ -1,0 +1,179 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { refreshSourceSha256 } from "./reader-summary-new-input-refresh-files";
+import { assertRefreshEqual, NewInputRefreshGuard } from "./reader-summary-new-input-refresh-guard";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import { refreshOperation } from "./reader-summary-new-input-refresh-manifest";
+
+const requiredFiles = [
+  "package.json", "package-lock.json", "tsconfig.json", "tsconfig.build.json", "prisma.config.ts",
+  "libs/shared-kernel/src/index.ts",
+  "libs/summary/application/contracts/reader-summary-new-input-refresh-authority.ts",
+  "libs/contracts/generated/grpc/agent_runtime/v1/agent_runtime.ts",
+  "scripts/run-reader-summary-new-input-refresh.ts",
+  "scripts/lib/reader-summary-new-input-refresh-files.ts",
+  "scripts/lib/reader-summary-new-input-refresh-model.ts",
+  "apps/agent-runtime/src/subscription-runtime-purpose-model-policy.ts",
+  "apps/agent-runtime/bin/reader-promotion-v2-canary-contract.cjs",
+  "prisma/schema.prisma",
+];
+
+describe("packaged refresh source identity", () => {
+  const roots: string[] = [];
+  function disposable(): string {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "refresh-source-inventory-")));
+    roots.push(root);
+    return root;
+  }
+  function put(root: string, path: string, bytes = `source:${path}\n`): void {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    writeFileSync(join(root, path), bytes);
+  }
+  function fixture(files = requiredFiles): string {
+    const root = disposable();
+    for (const path of files) put(root, path);
+    return root;
+  }
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("hashes the same relative paths and bytes regardless of creation order, location or file mode", () => {
+    const a = fixture(), b = fixture([...requiredFiles].reverse());
+    for (const path of requiredFiles) chmodSync(join(b, path), 0o444);
+    expect(refreshSourceSha256(a)).toMatch(/^[0-9a-f]{64}$/u);
+    expect(refreshSourceSha256(a)).toBe(refreshSourceSha256(b));
+  });
+
+  it.each(requiredFiles)("binds required source/config bytes: %s", (path) => {
+    const root = fixture(), before = refreshSourceSha256(root);
+    put(root, path, "changed bytes\n");
+    expect(refreshSourceSha256(root)).not.toBe(before);
+  });
+
+  it.each(requiredFiles)("rejects missing required file: %s", (path) => {
+    const root = fixture();
+    rmSync(join(root, path));
+    expect(() => refreshSourceSha256(root)).toThrow();
+  });
+
+  it.each(["libs", "scripts", "prisma", "apps/agent-runtime"])("rejects missing or empty source root: %s", (path) => {
+    const root = fixture();
+    rmSync(join(root, path), { recursive: true });
+    expect(() => refreshSourceSha256(root)).toThrow();
+    mkdirSync(join(root, path), { recursive: true });
+    expect(() => refreshSourceSha256(root)).toThrow(/required source missing/);
+  });
+
+  it("rejects an empty tree", () => {
+    expect(() => refreshSourceSha256(disposable())).toThrow();
+  });
+
+  it("binds additions, renames and deletions, including files ignored by Git", () => {
+    const root = fixture(), original = refreshSourceSha256(root);
+    put(root, ".gitignore", "*.js\n");
+    const path = "scripts/lib/untracked-runtime.js";
+    put(root, path, "module.exports = 1;\n");
+    const added = refreshSourceSha256(root);
+    expect(added).not.toBe(original);
+    renameSync(join(root, path), join(root, "scripts/lib/renamed-runtime.js"));
+    expect(refreshSourceSha256(root)).not.toBe(added);
+    rmSync(join(root, "scripts/lib/renamed-runtime.js"));
+    expect(refreshSourceSha256(root)).toBe(original);
+  });
+
+  it.each([
+    "scripts/lib/reader-summary-new-input-refresh-model.js",
+    "scripts/lib/package.json",
+    "scripts/lib/node_modules/shadow/index.js",
+    "libs/summary/application/contracts/reader-summary-new-input-refresh-authority.js",
+    "apps/agent-runtime/src/subscription-runtime-purpose-model-policy.js",
+    "apps/agent-runtime/src/extra.cjs",
+    "apps/agent-runtime/package.json",
+    "libs/contracts/generated/runtime.mjs",
+    "libs/summary/.cache/executable.js",
+    "libs/summary/dist/executable.js",
+    "libs/summary/build/package.json",
+  ])("does not hide executable or resolution shadows: %s", (path) => {
+    const root = fixture(), before = refreshSourceSha256(root);
+    put(root, path, "shadow bytes\n");
+    expect(refreshSourceSha256(root)).not.toBe(before);
+  });
+
+  it("ignores only out-of-scope outputs and the established test/Prisma dependency exclusions", () => {
+    const root = fixture(), before = refreshSourceSha256(root);
+    for (const path of [
+      ".git/HEAD", ".git/index", ".cache/source-inventory-evidence.json", "coverage/coverage.json",
+      "dist/scripts/run-reader-summary-new-input-refresh.js", "build/runtime.js",
+      "node_modules/dependency/index.js", "prisma/generated/client/client.ts",
+      "scripts/lib/new.spec.ts", "libs/summary/test-fixtures/example.json", "libs/delivery/test-support/helper.ts",
+    ]) put(root, path, "generated/test metadata\n");
+    expect(refreshSourceSha256(root)).toBe(before);
+    rmSync(join(root, ".git"), { recursive: true });
+    put(root, ".git", "gitdir: /unavailable/worktree/metadata\n");
+    expect(refreshSourceSha256(root)).toBe(before);
+  });
+
+  it.each([
+    "libs", "apps", "apps/agent-runtime/src", "tsconfig.json",
+    "scripts/run-reader-summary-new-input-refresh.ts", "libs/new-runtime.ts", "prisma/generated",
+  ])("rejects symlink escapes without following them: %s", (path) => {
+    const root = fixture(), outside = disposable();
+    rmSync(join(root, path), { recursive: true, force: true });
+    symlinkSync(outside, join(root, path));
+    expect(() => refreshSourceSha256(root)).toThrow();
+  });
+
+  it("rejects internal, dangling and root symlinks too", () => {
+    const root = fixture(), alias = join(disposable(), "alias");
+    symlinkSync(root, alias);
+    expect(() => refreshSourceSha256(alias)).toThrow(/symlinks/);
+    symlinkSync(join(root, "scripts/run-reader-summary-new-input-refresh.ts"), join(root, "scripts/alias.ts"));
+    expect(() => refreshSourceSha256(root)).toThrow(/symlinks/);
+    rmSync(join(root, "scripts/alias.ts"));
+    symlinkSync(join(root, "absent"), join(root, "scripts/dangling.ts"));
+    expect(() => refreshSourceSha256(root)).toThrow(/symlinks/);
+  });
+
+  it("invalidates reviewed source authority before a guarded effect and keeps it invalid", async () => {
+    const root = fixture(), sourceSha256 = refreshSourceSha256(root);
+    const manifest = { ...refreshManifest(), sourceSha256, deployedSourceSha256: sourceSha256 };
+    manifest.operation = refreshOperation(manifest);
+    const path = "apps/agent-runtime/src/subscription-runtime-purpose-model-policy.ts";
+    const original = readFileSync(join(root, path));
+    const effect = jest.fn();
+    const guard = new NewInputRefreshGuard(manifest, "job", {
+      now: () => refreshNow, assertFences: () => undefined,
+      assertCurrent: async () => assertRefreshEqual(refreshSourceSha256(root), manifest.sourceSha256, "source"),
+    });
+    await expect(guard.assertCurrent()).resolves.toBeUndefined();
+    put(root, path, "changed admission\n");
+    await expect(guard.assertCurrent().then(effect)).rejects.toThrow(/source drifted/);
+    writeFileSync(join(root, path), original);
+    await expect(guard.assertCurrent().then(effect)).rejects.toThrow(/reconciliation/);
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it("runs the actual CLI with tsconfig.build.json without Git metadata or a Git binary", () => {
+    const root = disposable(), emptyPath = disposable(), repository = resolve(__dirname, "../..");
+    for (const path of ["libs", "scripts", "prisma", "apps/agent-runtime", ...requiredFiles.slice(0, 5)]) {
+      cpSync(join(repository, path), join(root, path), { recursive: true });
+    }
+    symlinkSync(realpathSync(join(repository, "node_modules")), join(root, "node_modules"));
+    const noGitEnv = { PATH: emptyPath, NODE_ENV: "test" };
+    expect(spawnSync("git", ["--version"], { env: noGitEnv }).error).toHaveProperty("code", "ENOENT");
+    const args = [join(root, "node_modules/ts-node/dist/bin.js"), "-P", "tsconfig.build.json",
+      "-r", "tsconfig-paths/register", "scripts/run-reader-summary-new-input-refresh.ts", "--source-sha256"];
+    const run = (env: NodeJS.ProcessEnv) => execFileSync(process.execPath, args, {
+      cwd: root, env, encoding: "utf8", timeout: 60_000,
+    }).trim();
+    const withoutGit = run(noGitEnv);
+    expect(withoutGit).toBe(refreshSourceSha256(root));
+    // Git's private metadata is immaterial, whether a directory or worktree file.
+    put(root, ".git/HEAD", "ref: refs/heads/main\n");
+    put(root, ".git/config", "[core]\nrepositoryformatversion = 0\n");
+    expect(run({ PATH: process.env.PATH, NODE_ENV: "test" })).toBe(withoutGit);
+  }, 150_000);
+});

--- a/scripts/lib/reader-summary-new-input-refresh-transaction.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-transaction.spec.ts
@@ -1,0 +1,40 @@
+import { FixedClock } from "@social-monitor/shared-kernel";
+import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
+import { assertRefreshTransactionAuthority, refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
+import { captureRefreshDatabaseAuthority } from "./reader-summary-new-input-refresh-capture";
+import { readRefreshPrior, readRefreshJobs } from "./reader-summary-new-input-refresh-postgres";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import type { ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
+
+jest.mock("./reader-summary-new-input-refresh-capture", () => ({
+  ...jest.requireActual("./reader-summary-new-input-refresh-capture"), captureRefreshDatabaseAuthority: jest.fn(),
+}));
+jest.mock("./reader-summary-new-input-refresh-postgres", () => ({
+  ...jest.requireActual("./reader-summary-new-input-refresh-postgres"), readRefreshPrior: jest.fn(), readRefreshJobs: jest.fn(),
+}));
+describe("publisher authority uses only its transaction for every database read", () => {
+  it.each(["unchanged", "canonicalRowsSha256", "engagementSha256", "sourceScopeSha256", "policySha256", "datasetSha256", "job", "prior"])(
+    "checks complete backing authority: %s", async (change) => {
+      const m = refreshManifest(), clock = new FixedClock(refreshNow);
+      const tx = { $executeRaw: jest.fn(async () => 0) } as unknown as PrismaReaderSummaryClient;
+      const { canonicalInputSha256, eligibleCount, ...database } = m.authority;
+      void canonicalInputSha256; void eligibleCount;
+      jest.mocked(captureRefreshDatabaseAuthority).mockImplementation(async (input) => {
+        expect(input.client).toBe(tx);
+        return change in database ? { ...database, [change]: "b".repeat(64) } : database;
+      });
+      jest.mocked(readRefreshPrior).mockImplementation(async (client) => {
+        expect(client).toBe(tx); return change === "prior" ? { ...m.prior, proofSha256: "b".repeat(64) } : m.prior;
+      });
+      jest.mocked(readRefreshJobs).mockImplementation(async (client) => {
+        expect(client).toBe(tx); return [{ jobId: "new", operation: m.operation,
+          status: change === "job" ? "FAILED" : "RUNNING", artifactId: null }];
+      });
+      const command = { artifact: { toSnapshot: () => ({ sourceWindow: { ingestionCutoff: new Date(m.observedThrough) } }) },
+        finalJob: { toSnapshot: () => ({ id: "new" }) } } as unknown as ReaderSummaryPublicationCommand;
+      const guard = refreshPublicationGuard({ manifest: m, jobId: "new", assertLocal: () => undefined,
+        assertCurrent: (client) => assertRefreshTransactionAuthority(client, m, "new", clock) });
+      if (change === "unchanged") await expect(guard(tx, command)).resolves.toBeUndefined();
+      else await expect(guard(tx, command)).rejects.toThrow(/drifted|job authority/);
+    });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-transaction.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-transaction.spec.ts
@@ -2,7 +2,7 @@ import { FixedClock } from "@social-monitor/shared-kernel";
 import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
 import { assertRefreshTransactionAuthority, refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
 import { captureRefreshDatabaseAuthority } from "./reader-summary-new-input-refresh-capture";
-import { readRefreshPrior, readRefreshJobs } from "./reader-summary-new-input-refresh-postgres";
+import { readRefreshPrior, readRefreshJobs, lockRefreshAuthority } from "./reader-summary-new-input-refresh-postgres";
 import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
 import type { ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
 
@@ -32,7 +32,7 @@ describe("publisher authority uses only its transaction for every database read"
       });
       const command = { artifact: { toSnapshot: () => ({ sourceWindow: { ingestionCutoff: new Date(m.observedThrough) } }) },
         finalJob: { toSnapshot: () => ({ id: "new" }) } } as unknown as ReaderSummaryPublicationCommand;
-      const guard = refreshPublicationGuard({ manifest: m, jobId: "new", assertLocal: () => undefined,
+      const guard = refreshPublicationGuard({ assertProtected: lockRefreshAuthority, manifest: m, jobId: "new", assertLocal: () => undefined,
         assertCurrent: (client) => assertRefreshTransactionAuthority(client, m, "new", clock) });
       if (change === "unchanged") await expect(guard(tx, command)).resolves.toBeUndefined();
       else await expect(guard(tx, command)).rejects.toThrow(/drifted|job authority/);

--- a/scripts/lib/reader-summary-new-input-refresh.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh.spec-support.ts
@@ -1,0 +1,21 @@
+import { refreshScope, refreshOperation, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
+export const refreshNow = new Date("2026-09-05T22:10:00.000Z");
+export function refreshManifest(): RefreshManifest {
+  const hash = "a".repeat(64);
+  const m: Omit<RefreshManifest, "operation"> = {
+    format: "reader-summary-seven-day-new-input-v1", ...refreshScope, date: "2026-09-03",
+    startedAt: "2026-09-03T00:00:00.000Z", endedAt: "2026-09-04T00:00:00.000Z", timezone: "UTC",
+    preparedAt: "2026-09-05T22:00:00.000Z", observedThrough: "2026-09-05T21:59:00.000Z",
+    prior: { artifactId: "00000000-0000-4000-8000-000000000001", jobId: "00000000-0000-4000-8000-000000000002",
+      publicationId: "00000000-0000-4000-8000-000000000001", status: "NO_SIGNAL",
+      artifactSha256: hash, jobSha256: hash, publicationSha256: hash, reportSha256: hash, proofSha256: hash,
+      observedThrough: "2026-09-04T00:00:00.000Z", topCount: 0, additionalCount: 0, citationCount: 0 },
+    authority: { datasetSha256: hash, canonicalRowsSha256: hash, engagementSha256: hash, sourceScopeSha256: hash, policySha256: hash,
+      canonicalInputSha256: hash, feedCount: 501, eligibleCount: 12, metricRowCount: 800 },
+    sourceSha256: hash, deployedSourceSha256: hash, generationSha256: hash,
+    runtime: { engine: "subscription-runtime-cli", packageVersion: "0.1.0-main.30", launcherSha256: hash },
+    fenceAuthority: { global: "1:2", dates: "1:3", fences: "1:4" },
+    model: "gpt-5.6-sol", reasoningEffort: "high",
+  };
+  return { ...m, operation: refreshOperation(m) };
+}

--- a/scripts/run-reader-summary-new-input-refresh.ts
+++ b/scripts/run-reader-summary-new-input-refresh.ts
@@ -1,0 +1,143 @@
+import { credentials } from "@grpc/grpc-js";
+import { AgentRuntimeServiceClient } from "@social-monitor/contracts/generated/grpc/agent_runtime/v1/agent_runtime";
+import { mkdirSync, constants, realpathSync, openSync, writeSync, fsyncSync, closeSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { runWithTenantDatabaseAccess, resolvePostgresRuntimePoolConfig } from "@social-monitor/platform-persistence";
+import { SystemClock } from "@social-monitor/shared-kernel";
+import { PrismaFeedConnection } from "@social-monitor/feed/adapters/persistence/prisma/prisma-feed-connection";
+import { PrismaFeedItemReadRepository } from "@social-monitor/feed/adapters/persistence/prisma/prisma-feed-item-read.repository";
+import { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
+import { GrpcAgentRuntimeClient } from "@social-monitor/summary/adapters/model/grpc-agent-runtime-client";
+import { requiredHistoricalPromotionSystemDatabaseUrl, assertHistoricalPromotionSystemRole } from "./lib/reader-summary-promotion-v2-system-database";
+import { refreshScope, refreshDates, refreshOperation, refreshBytesHash,
+  assertRefreshManifest, type RefreshManifest } from "./lib/reader-summary-new-input-refresh-manifest";
+import { refreshSourceSha256, readReviewedRefresh, assertRefreshFences, readRefreshFenceAuthority } from "./lib/reader-summary-new-input-refresh-files";
+import { captureRefreshAuthority, preflightRefreshSelection, assertRefreshHasNewInput, refreshPeriod } from "./lib/reader-summary-new-input-refresh-capture";
+import { readRefreshJobs, readRefreshPrior } from "./lib/reader-summary-new-input-refresh-postgres";
+import { refreshGenerationSha256 } from "./lib/reader-summary-new-input-refresh-model";
+import { assertRefreshEqual } from "./lib/reader-summary-new-input-refresh-guard";
+import { executeNewInputRefresh } from "./lib/reader-summary-new-input-refresh-execution";
+import { resolveReaderSummaryServingAuthority } from "./lib/reader-summary-serving-authority";
+
+export function parseRefreshCommand(argv: readonly string[]) {
+  if (argv.length === 1 && argv[0] === "--source-sha256") return { mode: "source" } as const;
+  if (argv.length === 4 && argv[0] === "--apply" && argv[2] === "--sha256" && /^[0-9a-f]{64}$/u.test(argv[3]!)) {
+    return { mode: "apply", path: argv[1]!, sha256: argv[3]! } as const;
+  }
+  if (argv.length === 0 || (argv.length === 1 && argv[0] === "--prepare")) {
+    return { mode: "prepare", dates: refreshDates } as const;
+  }
+  if (argv.length === 3 && argv[0] === "--prepare" && argv[1] === "--date" && refreshDates.includes(argv[2]!)) {
+    return { mode: "prepare", dates: [argv[2]!] } as const;
+  }
+  throw new Error("Use --prepare [--date ACCEPTED_DATE], --apply MANIFEST --sha256 HASH, or --source-sha256");
+}
+async function main(): Promise<void> {
+  const command = parseRefreshCommand(process.argv.slice(2));
+  if (command.mode === "source") { console.log(refreshSourceSha256()); return; }
+  const clock = new SystemClock();
+  const sourceSha256 = refreshSourceSha256();
+  const deployedSourceSha256 = required("READER_SUMMARY_REFRESH_DEPLOYED_SOURCE_SHA256");
+  if (sourceSha256 !== deployedSourceSha256) throw new Error("Refresh source differs from reviewed deployed source");
+  const runtimeAuthority = JSON.parse(required("READER_SUMMARY_REFRESH_RUNTIME_AUTHORITY_JSON")) as RefreshManifest["runtime"];
+  const generationSha256 = refreshGenerationSha256(process.env);
+  const fencePaths = {
+    globalLock: required("READER_SUMMARY_REFRESH_GLOBAL_LOCK"),
+    dateDirectory: required("READER_SUMMARY_REFRESH_DATE_LOCK_DIR"),
+    fenceDirectory: required("READER_SUMMARY_REFRESH_FENCE_DIR"),
+  };
+  const fenceAuthority = readRefreshFenceAuthority(fencePaths);
+  const config = resolvePostgresRuntimePoolConfig({ ...process.env,
+    DATABASE_URL: requiredHistoricalPromotionSystemDatabaseUrl(process.env),
+    POSTGRES_RUNTIME_PROCESS: "daily-runner", POSTGRES_RUNTIME_POOL_MIN: "0", POSTGRES_RUNTIME_POOL_MAX: "2" });
+  const summary = await PrismaSummaryConnection.create(config);
+  const feedConnection = await PrismaFeedConnection.create(config);
+  const feed = new PrismaFeedItemReadRepository(feedConnection);
+  const output = resolve(".cache/reader-summary-new-input-refresh");
+  mkdirSync(output, { recursive: true, mode: 0o700 });
+  if (realpathSync(output) !== output) throw new Error("Refresh evidence directory must not contain symlinks");
+  try {
+    await runWithTenantDatabaseAccess(refreshScope, async () => {
+      await assertHistoricalPromotionSystemRole(summary);
+      if (command.mode === "prepare") {
+        for (const date of command.dates) {
+          if ((await readRefreshJobs(summary, date)).length > 0) {
+            console.log(JSON.stringify({ date, status: "consumed_use_original_manifest_to_reconcile" }));
+            continue;
+          }
+          const observedThrough = clock.now();
+          const prior = await readRefreshPrior(summary, date);
+          const authority = await captureRefreshAuthority({ client: summary, feed, date, observedThrough, clock });
+          await assertRefreshHasNewInput(summary, date, prior.observedThrough, observedThrough.toISOString());
+          const eligible = await preflightRefreshSelection({ feed, date, observedThrough, clock });
+          assertRefreshEqual(await captureRefreshAuthority({ client: summary, feed, date, observedThrough, clock }), authority, "preparation input");
+          assertRefreshEqual(await readRefreshPrior(summary, date), prior, "preparation prior");
+          const period = refreshPeriod(date);
+          const value: Omit<RefreshManifest, "operation"> = {
+            format: "reader-summary-seven-day-new-input-v1", ...refreshScope, date,
+            startedAt: period.startedAt.toISOString(), endedAt: period.endedAt.toISOString(), timezone: "UTC",
+            observedThrough: observedThrough.toISOString(), preparedAt: clock.now().toISOString(),
+            prior, authority, sourceSha256, deployedSourceSha256, generationSha256,
+            runtime: runtimeAuthority, fenceAuthority, model: "gpt-5.6-sol", reasoningEffort: "high",
+          };
+          const manifest: RefreshManifest = { ...value, operation: refreshOperation(value) };
+          assertRefreshManifest(manifest, clock.now());
+          const bytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+          const sha256 = refreshBytesHash(bytes);
+          const path = join(output, `${date}.${sha256}.json`);
+          writeFileSync(path, bytes, { flag: "wx", mode: 0o400 });
+          console.log(JSON.stringify({ date, status: eligible ? "prepared" : "no_eligible_input",
+            path, sha256, operation: manifest.operation, observedThrough: manifest.observedThrough,
+            counts: { feed: authority.feedCount, candidates: authority.eligibleCount, selected: eligible } }));
+        }
+        return;
+      }
+      const manifest = readReviewedRefresh(command.path, command.sha256);
+      // Expired successful operations can reconcile, but cannot start again.
+      assertRefreshManifest(manifest, clock.now(), false);
+      const assertSource = () => {
+        assertRefreshEqual(refreshSourceSha256(), manifest.sourceSha256, "source");
+        assertRefreshEqual(deployedSourceSha256, manifest.deployedSourceSha256, "deployment");
+        assertRefreshEqual(refreshGenerationSha256(process.env), manifest.generationSha256, "model configuration");
+      };
+      const assertFences = () => assertRefreshFences(manifest.date, fencePaths,
+        process.env.READER_SUMMARY_DATE_FENCE_TOKEN, manifest.fenceAuthority);
+      assertFences(); assertSource();
+      const channel = new AgentRuntimeServiceClient(required("AGENT_RUNTIME_GRPC_ADDRESS"), credentials.createInsecure());
+      const runtime = new GrpcAgentRuntimeClient(channel, clock, {
+        timeoutMs: 5_000, serviceToken: process.env.AGENT_RUNTIME_SERVICE_TOKEN });
+      const record = (event: unknown) => {
+        const fd = openSync(join(output, `${manifest.date}.journal.jsonl`), constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW, 0o600);
+        try { writeSync(fd, JSON.stringify({ at: clock.now().toISOString(), event }) + "\n"); fsyncSync(fd); }
+        finally { closeSync(fd); }
+      };
+      try {
+        const receipt = await executeNewInputRefresh({ manifest, summary, feed, clock, env: process.env,
+          runtime, assertFences, assertSource, record,
+          assertRuntime: async () => {
+            const serving = await resolveReaderSummaryServingAuthority({ summaryModelMode: "agent-runtime",
+              topicLabelerMode: "agent-runtime", env: process.env, agentRuntimeClient: runtime,
+              checkedAt: clock.now().toISOString() });
+            assertRefreshEqual(serving.runtime, manifest.runtime, "deployed runtime");
+          },
+        });
+        record({ ...receipt, operation: manifest.operation, manifestSha256: command.sha256,
+          observedThrough: manifest.observedThrough });
+        console.log(JSON.stringify(receipt));
+      } catch {
+        record({ status: "stopped_requires_reconciliation", operation: manifest.operation, manifestSha256: command.sha256 });
+        throw new Error("Refresh stopped; reconcile original operation");
+      } finally { channel.close(); }
+    });
+  } finally { await feedConnection.close(); await summary.close(); }
+}
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+if (require.main === module) void main().catch(() => {
+  // SQL and provider exceptions can contain payloads or credentials.
+  console.error("Reader summary refresh stopped. Reconcile the original manifest/job; do not reset its budget.");
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Adds an explicit refresh path for a historical UTC day when retained posts have newer authoritative inputs. A previous NO_SIGNAL or completed summary can produce a new version while the original publication, artifact and proof stay immutable. The command freezes input/configuration authority and consumes one operation and one primary generation.

Publication revalidates authority through the existing shared max2 PostgreSQL pool, bounded NOWAIT locks and live holder identity checks. Attestations bind the exact admitted request. Actual adapter normalization failures invalidate the refresh before workflow fallback can continue; the two accepted topic-map coverage attempts remain supported. Model, effort, thresholds and publication quality gates are unchanged.

Source identity is computed from required source trees, imported admission contracts and configuration without invoking Git. The packaged-container check confirms identical source hashes with no Git binary or .git directory.

Validation on final head b876f7632ba1e6f6fe1a967ebf7ae3da6ca656f3: independent delta review APPROVE and all 10 exact-head CI checks passed. Verified 311 focused tests across 22 suites; independent reviewer also executed all 17 composed selector cases and checked all 419 loaded modules against source inventory. Final native PostgreSQL 18.4 fixtures passed for prior COMPLETED and NO_SIGNAL in 107.6 seconds, including actual holder loss, nine writer orders, max2 shared connections, immutable originals, one publication/artifact/outbox increment and zero-delta replay. Test database roles were cleaned up.

Final source-only CLI passes without Git; the earlier packaged-container check belongs to commit 0a83a786, not the final image. Native model output is synthetic. Historical delivery recovery is now separately confirmed in production for all 18 events with committed inbox/projections. Metric refresh and seven new historical summaries remain subsequent operator acceptance steps.

The command, authority guards and regression/native contracts form one coherent publication invariant. The change exceeds the approximate 2000-line review target to keep that invariant together; no schema or dependency change.