### PR TITLE
fix(ingestion): reconcile reviewed pre-budget metric content drift

### DIFF
--- a/docs/operations/retained-source-metric-refresh.md
+++ b/docs/operations/retained-source-metric-refresh.md
@@ -8,15 +8,22 @@ The fixed admission is tenant `00000000-0000-7000-8000-000000006101`, workspace 
 
 Supply `METRIC_REFRESH_DATABASE_URL` through the authorized environment. No dotenv loading or DSN argument is supported. Run as uid 1000 with the existing secure evidence root `/var/lib/social-monitor/artifacts` owned by uid 1000, mode 0700. The existing descriptor-anchored evidence contract rejects symlinks, path aliases, owner changes, unsafe modes, and unequal overwrites. It requires Linux. No new database tables are required.
 
+The revised entrypoint requires the existing maintenance locks even for dry run. First establish the release prerequisites below. Inside the parent's pinned, read-only Linux daily image, obtain `--implementation` using the direct Node command; this mode reads source/executable bytes only. Supply its exact hashes on every subsequent invocation. The Node executable SHA and source inventory SHA complement the parent's immutable image ID (which also pins dependencies and generated Prisma).
+
 ```sh
-# Default: read the complete inventory, write immutable review evidence, no providers or database writes.
-npm run run:retained-metric-refresh -- --operation-id 00000000-0000-7000-8000-000000006103
+TS_NODE_PROJECT=tsconfig.build.json node -r ts-node/register -r tsconfig-paths/register scripts/run-retained-metric-refresh.ts --implementation
 
-# Only after the parent has reviewed the exact manifest and authorized execution:
-npm run run:retained-metric-refresh -- --operation-id 00000000-0000-7000-8000-000000006103 --apply --manifest-sha REVIEWED_MANIFEST_SHA
+# Arguments below are reviewed values, not literal placeholders. The wrapper runs INSIDE the image.
+bash scripts/run-retained-metric-maintenance.sh BACKEND_RELEASE_SHA CONTROL_RELEASE_SHA \
+  --source-sha REVIEWED_SOURCE_SHA --executable-sha REVIEWED_NODE_SHA \
+  --legacy-retirement-ref PARENT_EVIDENCE_REFERENCE \
+  --operation-id 409f3cde-6073-451c-9285-eaa6802ca081
 
-# Resume with the identical operation ID and SHA; never change evidence roots or delete receipts.
+# Add --apply --manifest-sha EXACT_CURRENT_EFFECTIVE_SHA only for separately authorized execution.
+# Resume uses the same operation, current effective SHA, directory and permanent budget.
 ```
+
+Do not invoke this through `npm run` or the Node `run-with-timeout` wrapper: child spawning drops non-stdio lock descriptors. The supplied shell wrapper uses a direct `exec` chain through GNU timeout, preserving descriptors 7/9/8.
 
 The default dry run emits every retained HN/Reddit source ID in the admitted window, including sources with zero visible feed projections or below promotion floors. It also emits rejected entries for review. Any rejected target blocks apply. There is no top-16 selection, source-ID override, force switch, fresh output directory, provider retry switch, or bypass for an existing operation.
 
@@ -26,7 +33,10 @@ The manifest binds operation ID, immutable canonical evidence location, source b
 
 Canonical files live under `seven-day-6101-6102/retained-metrics-v1/` within the fixed secure root. They contain an envelope SHA and canonical JSON, installed exclusively, fsynced, and never overwritten:
 
-- `operation.json`: the complete admitted manifest (dry run may install it).
+- `operation.json`: the complete original admitted manifest; its exact bytes never change.
+- `operation.lock`: permanent empty 0400 inode; kernel flock ownership, not existence, is the fence.
+- `proposal-SHA.json`: immutable captured inventory/diff with no execution authority.
+- `amendment-000001.json` through `amendment-000008.json`: contiguous reviewed head changes, before any reservation.
 - `batch-N.reserved.json`: exact operation/manifest/batch identity before OAuth or provider fetch.
 - `batch-N.observed.json`: actual post-fetch clock time, normalized metric payload, preserved exact source/sample identity and canonical metrics/hash/patch, or a fetch failure.
 - `result-SOURCE_UUID.json`: stable terminal outcome with before/after authority evidence.
@@ -41,7 +51,7 @@ Canonical `buildSourceEngagementMetrics` rejects unknown kinds, malformed metric
 - Maximum inventory: 10,000 sources; over-limit inventories fail instead of returning a truncated manifest. Each source's feed inventory probes 1,001 rows; `fanout_over_1000` blocks apply. In that rejected case, the reported feed count is a lower bound, not a claim of full fanout coverage. Admitted fanouts are complete and at most 1,000.
 - HN: existing Firebase `getStory(id)`, one ID/request, rejects wrong IDs/kinds/timestamps and missing/malformed counters; null/dead/deleted are unavailable. No Algolia or listing calls.
 - Reddit: existing OAuth client/token provider plus one `getPostsByIds` capability, `GET /api/info?id=t3_...`. At most 100 IDs per batch is **our bound**, not a provider guarantee. Bare and `reddit:t3_...` stored identities remain unchanged. Canonical URLs and returned permalinks must identify the same post; short `/comments/ID` and `/r/SUBREDDIT/comments/ID/SLUG/` forms may differ in slug or trailing slash. Both URLs require HTTPS, an allowlisted Reddit host (`www.reddit.com`, `reddit.com`, `old.reddit.com`), no credentials, nondefault port or fragment, and a matching post ID. Returned fullnames and publication times must also match. Duplicate/unexpected fullnames, malformed counters and inconsistent omission sets fail closed. Official endpoint reference (verified by parent): https://www.reddit.com/dev/api/#GET_api_info.
-- One fetch per batch per permanent operation; batches are sequential and an uncertain reservation stops successors. Each HTTP call has a 10-second timeout, including OAuth separately. There are no provider retries, including 429. OAuth tokens are cached within an invocation using the existing provider. The package command has a four-hour process limit; a timeout may leave a reserved batch requiring reconciliation.
+- One fetch per batch per permanent operation; batches are sequential and an uncertain reservation stops successors. Each HTTP call has a 10-second timeout, including OAuth separately. There are no provider retries, including 429. OAuth tokens are cached within an invocation using the existing provider. The maintenance wrapper has a four-hour process limit; a timeout may leave a reserved batch requiring reconciliation.
 - Database composition uses one shared `admin-tool` runtime pool (min 0, max 1), no auxiliary pools. The inventory is bounded but performs per-source reads; it is intentionally an operational repair, not a scheduler.
 - Fresh metric payloads are reduced to identity-checked normalized counters; content and raw provider responses/credentials are not written into receipts. Returned counts include confirmed deleted/removed identities; omitted/null counts do not. Invalid or failed batch payloads provide no confirmed per-ID return evidence. Every provider/date cell includes target/returned/refreshed/superseded/unavailable/failed/uncertain counts and authority times/counts.
 - No live DB/provider calls were made for implementation. Missing-post collection, X search/lookup, OLD/current quality comparison and paid generation remain separate parent work.
@@ -57,3 +67,54 @@ NODE_ENV=test METRIC_REFRESH_DISPOSABLE=1 npm run check:retained-metric-refresh-
 ```
 
 The gate rejects absent, non-loopback, non-test-named, or parameter-overridden DSNs before opening a socket. No native PostgreSQL success claim is made until that command passes on the parent's disposable instance.
+
+## Reviewed content amendment for the occupied operation
+
+For incident `409f3cde-6073-451c-9285-eaa6802ca081`, the original manifest payload SHA is `0f9fa678de1921b4847ab8f0224f96e4c367308bd56604d999cd670c16b8949a`. This is distinct from SHA-256 of the envelope file bytes. Parent must independently verify the actual original and the entire canonical directory before release; no production receipt was read by the implementation worker.
+
+The supplied eligible diff is exactly HN source `ab5fc68e-c891-4641-8e67-a6568e4b7d4e` / `hn:49580353`: identity digest `bb32223966faefc45a54b863fab39b62e33c3e12e5733d8ab3678a0f31cd4828` to `f999a8b7f9ce49d0fe090e8869e3654871e63a555a62b73feb3dd27608cfc9e3`. Natural `contentUpdatedAt` changed after original planning. An opaque digest does not reconstruct old content. The amendment replaces only explicitly reviewed identity digests; scope, all 3,329 IDs, original ordering/batches, config/feed identities, cutoff, source base, limits, plannedAt and original authority baselines stay fixed. Fresh authority counters/times are captured separately, and may change again without becoming identity drift.
+
+Use these additional arguments with the wrapper and common identity/release arguments above:
+
+```sh
+# 1. Capture the complete current inventory and explicit digest diff. No provider/projection work.
+--prepare-amendment --prior-manifest-sha ORIGINAL_OR_CURRENT_EFFECTIVE_SHA \
+  --reason 'Parent review reference and reason for the natural content version'
+
+# 2. After external review of the exact proposal SHA, full inventory and effective SHA:
+--commit-amendment REVIEWED_AMENDMENT_SHA \
+  --prior-manifest-sha REVIEWED_PARENT_SHA --effective-manifest-sha REVIEWED_EFFECTIVE_SHA
+
+# 3. Separate authorized invocation; old or wrong SHA refuses before database acquisition/effects:
+--apply --manifest-sha REVIEWED_EFFECTIVE_SHA
+```
+
+Preparation prints `result.value` and `amendmentSha`; commit prints the verified original/effective head. Capture and commit each acquire a full fresh inventory. Both make zero OAuth/provider/projection calls. Apply checks the full inventory once inside the fenced use case; the duplicate CLI apply scan was removed. Dry run still scans the complete inventory, and per-batch, post-fetch and Serializable projection guards remain.
+
+Hash meanings (all lowercase SHA-256): `originalManifestSha` hashes canonical original payload; `originalOperationBytesSha` hashes exact original envelope bytes; `inventorySha` hashes the captured complete targets sorted by source UUID, including captured authority; `identityInventorySha` hashes those sorted targets with only authority omitted; `effectiveManifestSha` hashes the original with accepted digest replacements; externally supplied `amendmentSha` hashes the amendment payload without a self-reference. The proposal carries capture start/end, reason/review reference, implementation/holder proof, exact before/after diff and the full zero-budget entry inventory plus its SHA.
+
+Only 8 proposals, 8 committed amendments and 16 changed identity digests per proposal are admitted; each record is at most 16 MiB and JSON depth 32. These are ceilings, not authorization to accept extra incident changes. Review exactly the supplied one-row incident diff; additional drift requires a fresh separate review. No automatic amendment loop exists. Uncommitted proposals remain immutable and count against the bound. A newer proposal captures all earlier proposals; installing another proposal invalidates an earlier proposal's directory proof. Exact latest committed replay is idempotent before budget; stale parent/fork/gap/unequal bytes or exhausted limits require reconciliation without resets.
+
+## Existing maintenance exclusion and legacy retirement
+
+The parent owns activation. Before enabling this feature, positively establish that every old retained-metric invocation is terminal (including ones still reading inventory), that old-image/manual/queued launch routes cannot restart it, and that no evidence was removed. Record executable/image IDs, exact source and dependency release, process/container/service terminal evidence and the future writer admission route under `--legacy-retirement-ref`. That reference is an explicit parent attestation; the worker cannot prove its contents by checking a string. Missing reference/hashes or missing kernel holders refuse activation.
+
+Use the real existing host lock inodes, in order: `/var/data/social-monitor/control/production-deploy.lock` (fd 7), `daily-run-singleton.lock` (fd 9), then `daily-run.lock` (fd 8). These names/order come from `ops/deploy/social-monitor-production-deploy.sh` and `ops/deploy/reader-summary-recovery-maintenance-lib.sh`. Parent must mount the exact root-owned 0644 host files and release markers at those paths in the reviewed immutable image, with the fixed artifact root writable as uid 1000. The inner wrapper opens existing locks read-only without creating/truncating them; it takes nonblocking flocks, checks backend/control/READY markers, then directly execs Node. Do not retain conflicting outer holders while asking the inner wrapper to acquire independent descriptors. Arrange container launch under the parent's release procedure; this patch does not change the production launcher.
+
+The CLI verifies canonical path/regular file/owner/mode/link count and named/held device+inode, plus `/proc/self/fdinfo` exclusive FLOCK evidence on every operation assertion. Output includes pid, process start ticks and lock identities; the proposal binds their hash. Missing locks, busy holders, path substitution or mismatching source/executable fail closed. This proves participating maintenance exclusion, **not** retirement of arbitrary bypassing old code. A focused test executes the actual base use case and receipt adapter while holding the new operation lock and demonstrates that legacy code can still fetch. Neither `operation.lock` nor a new marker can retroactively stop it. Do not fabricate a reservation. Daily maintenance locks do not stop natural ingestion.
+
+## Crash and concurrent writer rules
+
+One verified kernel operation flock is held from head resolution through every receipt/effect in the updated invocation, including the final report. Contenders fail busy and may be explicitly re-invoked with the reviewed current head. Amendment wins: old-SHA apply refuses before reservation. First real reservation wins: amendments are permanently closed for the whole operation, including orphan/later-index reservations, crashes and failed/unused fetches. Even exact amendment replay is then refused. Batch names and fetch entitlement do not change.
+
+Zero budget requires descriptor-anchored enumeration of the entire canonical directory, canonical typed original/proposal/chain validation, and no effect files anywhere. Unknown/malformed/unsafe/unreadable entries, duplicate keys, noncanonical JSON, missing known leaves, parent/inode swaps, hard links, symlinks and nonregular files are refusals, never absence. Evidence files and the lock are 0400; directories stay 0700. A failed/partial exclusive append is left in place. Complete crash leftovers require verified leaf and parent fsync before authority can be consumed; equal-byte replay repeats that barrier. Partial/malformed/conflicting authoritative names block; do not delete, replace, skip or create a new sequence/root to recover.
+
+File fencing is not an atomic database snapshot or ingestion lock. Further drift before budget needs a new explicit review. After reservation this narrow facility is closed. A change between the last check and reservation can consume budget; the preserved post-fetch and transaction checks prevent projection against changed targets. Continuous ingestion may prevent full completion. A post-budget or coordinated-ingestion recovery requires separate design and parent authorization.
+
+## Seven-day completion handoff
+
+The parent must account for every original ID exactly once with no missing/extra IDs or new fetch entitlement, distinguish refreshed from superseded/unavailable/failed/uncertain, and verify confirmed before/after metric authority. `final.json` or a zero exit status is terminal accounting, not proof all 3,329 rows refreshed.
+
+After verifying metric authority, use the existing `scripts/run-reader-summary-new-input-refresh.ts` prepare/review/apply path separately for each date Aug 30–Sep 5. Preserve its unconsumed per-date generation budget, canonical new-input requirement, 30-minute manifest freshness, promotion freshness/eligibility, original publications, source/runtime/fence/policy checks and exact reviewed SHA. Seven `no_eligible_input` outcomes do not satisfy completion. Require seven verified new publications, previous artifacts retained, and each successful date's expected +1 job/artifact/publication/outbox. No summary algorithm, thresholds, model, date policy or provider behavior is changed here.
+
+Worker evidence is focused deterministic tests, real Linux process/flock/SIGKILL/I/O-failure tests and compiler/lint/architecture gates. SIGKILL tests are process-death evidence; they do not simulate storage hardware power loss. The narrowly extended native PostgreSQL gate checks real content-version drift, amendment, effective transactional sample guard rollback, lost acknowledgement and no-refetch/no-duplicate resume. The parent executes that gate on its disposable database before release; worker unit tests are not a native PostgreSQL or production success claim.

--- a/libs/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case.spec.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case.spec.ts
@@ -1,0 +1,140 @@
+import { chmodSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ok } from "@social-monitor/shared-kernel";
+import { incidentFixture, independentMetricSha, incidentSource, afterDigest, beforeDigest, implementation } from "../../../../scripts/lib/retained-metric-amendment.spec-support";
+import { canonicalMetricRefreshJson, metricRefreshDigest } from "../../../../scripts/lib/retained-metric-refresh-receipts";
+import { refreshBatches, sameTarget } from "./metric-refresh-admission";
+import { metricEvidencePath, metricProposalName, resolveMetricOperation } from "./metric-refresh-amendment";
+import { AmendRetainedMetricManifestUseCase } from "./amend-retained-metric-manifest.use-case";
+import { RefreshRetainedMetricsUseCase } from "./refresh-retained-metrics.use-case";
+import type { MetricManifestAmendment } from "./metric-refresh-operation.contracts";
+
+jest.setTimeout(60_000);
+describe("explicit pre-reservation retained metric content amendment", () => {
+  let root: string, f: ReturnType<typeof incidentFixture>;
+  beforeEach(async () => { root = mkdtempSync(join(tmpdir(), "metric-amendment-")); f = incidentFixture(root, 3); await f.receipts.install(metricEvidencePath("operation.json"), f.original); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  const amend = () => new AmendRetainedMetricManifestUseCase(f.inventory, f.receipts, f.clock, metricRefreshDigest, implementation);
+  const prepare = async (): Promise<MetricManifestAmendment> => {
+    const result = await amend().prepare(metricRefreshDigest(f.original), "Reviewed natural content version");
+    if (!result.ok) throw new Error(result.error);
+    return result.value;
+  };
+  const commit = (p: MetricManifestAmendment) => amend().commit(metricRefreshDigest(p), p.priorEffectiveSha, p.effectiveManifestSha);
+  it("reproduces the 3329-ID incident, preserves original bytes/baselines, and spends no effects during review/commit", async () => {
+    rmSync(root, { recursive: true }); root = mkdtempSync(join(tmpdir(), "metric-3329-")); f = incidentFixture(root);
+    await f.receipts.install(metricEvidencePath("operation.json"), f.original);
+    const bytes = readFileSync(join(root, metricEvidencePath("operation.json")));
+    const fetcher = { fetch: jest.fn(async () => ok([])) }, projection = { project: jest.fn(async () => {}) };
+    const apply = () => new RefreshRetainedMetricsUseCase(f.inventory, fetcher, projection, f.receipts, f.clock, metricRefreshDigest);
+    expect(await apply().execute(f.original)).toEqual({ ok: false, error: "inventory_drift" });
+    const proposal = await prepare();
+    expect(proposal.changes).toEqual([{ sourceItemId: incidentSource, before: beforeDigest, after: afterDigest }]);
+    expect(proposal.inventorySha).toBe(independentMetricSha(proposal.inventory));
+    expect(metricRefreshDigest(proposal)).toBe(independentMetricSha(proposal));
+    const committed = await commit(proposal); expect(committed.ok).toBe(true);
+    if (!committed.ok) return;
+    const effective = committed.value.effective;
+    expect(effective).toEqual({ ...f.original, targets: f.original.targets.map((t) => ({ ...t, identityDigest: t.sourceItemId === incidentSource ? afterDigest : t.identityDigest })) });
+    expect(proposal.effectiveManifestSha).toBe(independentMetricSha(effective));
+    expect(refreshBatches(effective.targets).flat().map((t) => t.sourceItemId).sort()).toEqual(f.original.targets.map((t) => t.sourceItemId).sort());
+    expect(effective.targets).toHaveLength(3329);
+    expect(readFileSync(join(root, metricEvidencePath("operation.json")))).toEqual(bytes);
+    expect(await apply().execute(f.original)).toEqual({ ok: false, error: "reviewed_manifest_sha_mismatch" });
+    expect(await apply().execute(effective, "0".repeat(64))).toEqual({ ok: false, error: "reviewed_manifest_sha_mismatch" });
+    expect(fetcher.fetch).not.toHaveBeenCalled(); expect(projection.project).not.toHaveBeenCalled();
+    expect(await f.receipts.read(metricEvidencePath("batch-0.reserved.json"))).toBeNull();
+    expect(await commit(proposal)).toEqual(committed);
+  });
+  it("records fresh authority separately while original before authority and effective identity stay fixed", async () => {
+    f.change(f.current().map((t) => ({ ...t, authority: { ...t.authority, observationCount: 5 } })));
+    const proposal = await prepare();
+    f.change(f.current().map((t) => ({ ...t, authority: { ...t.authority, observationCount: 6 } })));
+    const result = await commit(proposal); expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.effective.targets[0]!.authority.observationCount).toBe(0);
+      expect(proposal.inventory[0]!.authority.observationCount).toBe(5);
+      expect(sameTarget(result.value.effective.targets[0]!, f.current()[0]!, metricRefreshDigest)).toBe(true);
+    }
+  });
+  it.each(["added", "removed", "duplicate", "configDigest", "feedDigest", "sourceBindingId", "canonicalUrl", "publishedAt", "providerKey", "rejection", "visibleFeedCount", "tenantId"])("rejects full-inventory %s drift", async (field) => {
+    const rows = structuredClone(f.current());
+    if (field === "added") rows.push({ ...rows[1]!, sourceItemId: "00000000-0000-7000-8000-000000009999" });
+    else if (field === "removed") rows.pop();
+    else if (field === "duplicate") rows.push(rows[0]!);
+    else Object.assign(rows[0]!, { [field]: field.endsWith("Digest") ? "e".repeat(64) : field === "visibleFeedCount" ? 2 : "changed" });
+    f.change(rows);
+    await expect(prepare()).rejects.toThrow();
+    expect((await f.receipts.withOperation((o) => o.entries())).map((e) => e.name)).toEqual(["operation.json", "operation.lock"]);
+  });
+  it("rejects source drift after review and wrong review/effective/parent hashes without committing", async () => {
+    const p = await prepare();
+    expect(await amend().commit("0".repeat(64), p.priorEffectiveSha, p.effectiveManifestSha)).toEqual({ ok: false, error: "missing_amendment_review" });
+    expect(await amend().commit(metricRefreshDigest(p), "0".repeat(64), p.effectiveManifestSha)).toEqual({ ok: false, error: "reviewed_sha_mismatch" });
+    expect(await amend().commit(metricRefreshDigest(p), p.priorEffectiveSha, "0".repeat(64))).toEqual({ ok: false, error: "reviewed_sha_mismatch" });
+    f.change(f.current().map((t, i) => i === 1 ? { ...t, identityDigest: "e".repeat(64) } : t));
+    expect(await commit(p)).toEqual({ ok: false, error: "inventory_drift" });
+    expect(await f.receipts.read(metricEvidencePath("amendment-000001.json"))).toBeNull();
+  });
+  it.each(["batch-9999.reserved.json", "batch-2.observed.json", `result-${incidentSource}.json`, "final.json", "unknown.json"])("never interprets orphan/unknown %s as zero budget", async (name) => {
+    const p = await prepare();
+    writeFileSync(join(root, metricEvidencePath(name)), "{}", { mode: 0o400 });
+    await expect(commit(p)).rejects.toThrow();
+  });
+  it("allows a second individually reviewed head only before any reservation, then freezes all heads permanently", async () => {
+    const p = await prepare(); const first = await commit(p); expect(first.ok).toBe(true);
+    f.change(f.current().map((t, i) => i === 0 ? { ...t, identityDigest: "e".repeat(64) } : t));
+    const next = await amend().prepare(p.effectiveManifestSha, "Second separately reviewed content version");
+    expect(next.ok).toBe(true); if (!next.ok) return;
+    const accepted = await commit(next.value); expect(accepted.ok).toBe(true); if (!accepted.ok) return;
+    expect(await commit(p)).toEqual({ ok: false, error: "stale_amendment_head" });
+    const effective = accepted.value.effective;
+    const fetcher = { fetch: jest.fn(async () => { throw new Error("crash before fetch"); }) };
+    const usecase = new RefreshRetainedMetricsUseCase(f.inventory, fetcher, { project: jest.fn() }, f.receipts, f.clock, metricRefreshDigest);
+    await expect(usecase.execute(effective)).rejects.toThrow("crash before fetch");
+    await expect(commit(next.value)).rejects.toThrow("metric_budget_already_started");
+    const resumed = await usecase.execute(effective);
+    expect(resumed.ok && resumed.value.map((row) => row.status)).toEqual(["uncertain", "uncertain", "uncertain"]);
+    expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+  });
+  it("binds apply/reservation/results to effective SHA and rechecks the full inventory once plus every new batch", async () => {
+    const p = await prepare(), result = await commit(p); if (!result.ok) throw new Error(result.error);
+    f.inventory.list.mockClear();
+    const fetcher = { fetch: jest.fn(async () => ok([])) };
+    const usecase = new RefreshRetainedMetricsUseCase(f.inventory, fetcher, { project: jest.fn() }, f.receipts, f.clock, metricRefreshDigest);
+    expect(await usecase.execute(result.value.effective)).toMatchObject({ ok: true, value: expect.arrayContaining([expect.objectContaining({ manifestSha: p.effectiveManifestSha, status: "unavailable" })]) });
+    expect(f.inventory.list).toHaveBeenCalledTimes(1);
+    expect(await f.receipts.read(metricEvidencePath("batch-0.reserved.json"))).toMatchObject({ manifestDigest: p.effectiveManifestSha });
+    await expect(amend().prepare(p.effectiveManifestSha, "Never after budget")).rejects.toThrow("metric_budget_already_started");
+  });
+  it("rejects corrupted amendment chain and modified proposal inventory/diff despite a valid envelope hash", async () => {
+    const p = await prepare();
+    const wrong = { ...p, changes: [{ ...p.changes[0]!, after: "0".repeat(64) }] };
+    await f.receipts.install(metricEvidencePath(metricProposalName(metricRefreshDigest(wrong))), wrong);
+    await expect(f.receipts.withOperation((o) => resolveMetricOperation(o, metricRefreshDigest, f.clock.now(), true))).rejects.toThrow("unreviewed_content_diff");
+  });
+  it.each(["gap", "original_baseline", "missing_proposal"])("refuses %s after commit without fallback to the original head", async (kind) => {
+    const p = await prepare(); expect((await commit(p)).ok).toBe(true);
+    if (kind === "gap") renameSync(join(root, metricEvidencePath("amendment-000001.json")), join(root, metricEvidencePath("amendment-000002.json")));
+    else if (kind === "missing_proposal") unlinkSync(join(root, metricEvidencePath(metricProposalName(metricRefreshDigest(p)))));
+    else {
+      const original = { ...f.original, targets: f.original.targets.map((t) => ({ ...t, authority: { ...t.authority, observationCount: 1 } })) };
+      const path = join(root, metricEvidencePath("operation.json"));
+      chmodSync(path, 0o600); writeFileSync(path, canonicalMetricRefreshJson({ digest: metricRefreshDigest(original), value: original })); chmodSync(path, 0o400);
+    }
+    await expect(f.receipts.withOperation((o) => resolveMetricOperation(o, metricRefreshDigest, f.clock.now()))).rejects.toThrow();
+  });
+  it("bounds reviewed head/proposal history without manufacturing a reset or further budget", async () => {
+    let prior = metricRefreshDigest(f.original);
+    for (let i = 1; i <= 8; i++) {
+      f.change(f.current().map((t, index) => index === 0 ? { ...t, identityDigest: String(i).repeat(64) } : t));
+      const prepared = await amend().prepare(prior, `Review ${i}`); expect(prepared.ok).toBe(true);
+      if (!prepared.ok) throw new Error(prepared.error);
+      const accepted = await commit(prepared.value); expect(accepted.ok).toBe(true);
+      prior = prepared.value.effectiveManifestSha;
+    }
+    expect(await amend().prepare(prior, "One beyond the bound")).toEqual({ ok: false, error: "amendment_limit" });
+    expect(await f.receipts.read(metricEvidencePath("batch-0.reserved.json"))).toBeNull();
+  });
+});

--- a/libs/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case.spec.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case.spec.ts
@@ -26,7 +26,7 @@ describe("explicit pre-reservation retained metric content amendment", () => {
     rmSync(root, { recursive: true }); root = mkdtempSync(join(tmpdir(), "metric-3329-")); f = incidentFixture(root);
     await f.receipts.install(metricEvidencePath("operation.json"), f.original);
     const bytes = readFileSync(join(root, metricEvidencePath("operation.json")));
-    const fetcher = { fetch: jest.fn(async () => ok([])) }, projection = { project: jest.fn(async () => {}) };
+    const fetcher = { fetch: jest.fn(async () => ok([])) }, projection = { project: jest.fn(async () => { throw new Error("No projection expected"); }) };
     const apply = () => new RefreshRetainedMetricsUseCase(f.inventory, fetcher, projection, f.receipts, f.clock, metricRefreshDigest);
     expect(await apply().execute(f.original)).toEqual({ ok: false, error: "inventory_drift" });
     const proposal = await prepare();

--- a/libs/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case.ts
@@ -1,0 +1,67 @@
+import { err, ok, type Clock, type Result } from "@social-monitor/shared-kernel";
+import type { RefreshDigest, RetainedMetricInventory } from "./refresh-retained-metrics.contracts";
+import type { MetricImplementation, MetricManifestAmendment, MetricOperationHead, MetricRefreshOperationAuthority } from "./metric-refresh-operation.contracts";
+import { applyMetricAmendment, metricEvidencePath, metricIdentityInventory, metricAmendmentName, metricProposalName, orderedMetricTargets, resolveMetricOperation, reviewedContentChanges } from "./metric-refresh-amendment";
+import { assertMetricAmendment, assertMetricManifest, evidenceAssert, metricAmendmentLimit, metricProposalLimit, metricSha } from "./metric-refresh-evidence-validation";
+
+export class AmendRetainedMetricManifestUseCase {
+  constructor(private readonly inventory: RetainedMetricInventory, private readonly authority: MetricRefreshOperationAuthority,
+    private readonly clock: Clock, private readonly hash: RefreshDigest, private readonly implementation: MetricImplementation) {}
+
+  async prepare(expectedPriorSha: string, reason: string): Promise<Result<MetricManifestAmendment, string>> {
+    if (!metricSha(expectedPriorSha) || !reason.trim() || reason.length > 1000) return err("invalid_amendment_review");
+    return this.authority.withOperation(async (operation) => {
+      const head = await resolveMetricOperation(operation, this.hash, this.clock.now(), true);
+      if (!head || this.hash(head.effective) !== expectedPriorSha) return err("stale_amendment_head");
+      const entries = await operation.entries();
+      if (head.sequence >= metricAmendmentLimit || entries.filter((e) => e.name.startsWith("proposal-")).length >= metricProposalLimit) return err("amendment_limit");
+      const captureStartedAt = this.clock.now().toISOString();
+      const inventory = orderedMetricTargets(await this.inventory.list(head.effective.scope));
+      const captureCompletedAt = this.clock.now().toISOString();
+      let changes;
+      try {
+        assertMetricManifest({ ...head.effective, targets: inventory }, this.clock.now());
+        changes = reviewedContentChanges(head.effective, inventory, this.hash);
+      } catch { return err("inventory_drift"); }
+      if (changes.length === 0 || changes.length > 16) return err("content_change_limit");
+      const effective = { ...head.effective, targets: head.effective.targets.map((target) => ({ ...target,
+        identityDigest: changes.find((change) => change.sourceItemId === target.sourceItemId)?.after ?? target.identityDigest })) };
+      const proposal: MetricManifestAmendment = { version: "retained-metrics-amendment.v1", operationId: head.original.operationId, evidencePath: head.original.evidencePath,
+        originalManifestSha: this.hash(head.original), originalOperationBytesSha: head.originalOperationBytesSha,
+        sequence: head.sequence + 1, previousAmendmentSha: head.amendmentSha, priorEffectiveSha: expectedPriorSha,
+        captureStartedAt, captureCompletedAt, reason, implementation: this.implementation, inventory,
+        inventorySha: this.hash(inventory), identityInventorySha: this.hash(metricIdentityInventory(inventory)), changes,
+        effectiveManifestSha: this.hash(effective), zeroBudgetEvidence: entries, zeroBudgetEvidenceSha: this.hash(entries) };
+      applyMetricAmendment(head, proposal, this.hash, this.clock.now());
+      evidenceAssert(this.hash(await operation.entries()) === this.hash(entries), "directory_changed_during_capture");
+      await operation.install(metricEvidencePath(metricProposalName(this.hash(proposal))), proposal);
+      return ok(proposal);
+    });
+  }
+
+  async commit(reviewedSha: string, expectedPriorSha: string, expectedEffectiveSha: string): Promise<Result<MetricOperationHead, string>> {
+    if (![reviewedSha, expectedPriorSha, expectedEffectiveSha].every(metricSha)) return err("invalid_amendment_review");
+    return this.authority.withOperation(async (operation) => {
+      const head = await resolveMetricOperation(operation, this.hash, this.clock.now(), true);
+      const proposal = await operation.read<MetricManifestAmendment>(metricEvidencePath(metricProposalName(reviewedSha)));
+      if (!head || !proposal) return err("missing_amendment_review");
+      assertMetricAmendment(proposal);
+      if (this.hash(proposal) !== reviewedSha || proposal.priorEffectiveSha !== expectedPriorSha || proposal.effectiveManifestSha !== expectedEffectiveSha) return err("reviewed_sha_mismatch");
+      if (proposal.implementation.sourceSha !== this.implementation.sourceSha || proposal.implementation.executableSha !== this.implementation.executableSha ||
+          proposal.implementation.legacyRetirementRef !== this.implementation.legacyRetirementRef) return err("reviewed_implementation_mismatch");
+      if (head.amendmentSha === reviewedSha) return ok(head); // Exact durable replay; never another record or budget.
+      if (this.hash(head.effective) !== expectedPriorSha) return err("stale_amendment_head");
+      const effective = applyMetricAmendment(head, proposal, this.hash, this.clock.now());
+      const current = await this.inventory.list(effective.scope);
+      try { assertMetricManifest({ ...effective, targets: current }, this.clock.now()); }
+      catch { return err("inventory_drift"); }
+      if (this.hash(metricIdentityInventory(current)) !== proposal.identityInventorySha) return err("inventory_drift");
+      // Only this proposal may have appeared since its captured zero-budget proof.
+      const entries = await operation.entries();
+      const before = entries.filter((entry) => entry.name !== metricProposalName(reviewedSha));
+      evidenceAssert(this.hash(before) === this.hash(proposal.zeroBudgetEvidence), "zero_budget_evidence_changed");
+      await operation.install(metricEvidencePath(metricAmendmentName(proposal.sequence)), proposal);
+      return ok({ ...head, effective, sequence: proposal.sequence, amendmentSha: reviewedSha });
+    });
+  }
+}

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-amendment.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-amendment.ts
@@ -1,0 +1,83 @@
+import type { MetricRefreshManifest, RefreshDigest, RetainedMetricTarget } from "./refresh-retained-metrics.contracts";
+import type { MetricContentChange, MetricManifestAmendment, MetricOperationHead, MetricRefreshOperation } from "./metric-refresh-operation.contracts";
+import { metricRefreshEvidencePath, targetIdentity } from "./metric-refresh-admission";
+import { assertMetricAmendment, assertMetricManifest, evidenceAssert, metricAmendmentLimit, metricProposalLimit } from "./metric-refresh-evidence-validation";
+import { validateMetricEffectReceipts } from "./metric-refresh-effect-evidence";
+
+export const orderedMetricTargets = (targets: readonly RetainedMetricTarget[]) => [...targets].sort((a, b) => a.sourceItemId.localeCompare(b.sourceItemId));
+export const metricIdentityInventory = (targets: readonly RetainedMetricTarget[]) => orderedMetricTargets(targets).map(targetIdentity);
+export const metricAmendmentName = (sequence: number) => `amendment-${String(sequence).padStart(6, "0")}.json`;
+export const metricProposalName = (sha: string) => `proposal-${sha}.json`;
+export const metricEvidencePath = (name: string) => `${metricRefreshEvidencePath}/${name}`;
+
+export function reviewedContentChanges(prior: MetricRefreshManifest, current: readonly RetainedMetricTarget[], hash: RefreshDigest): MetricContentChange[] {
+  const ordered = orderedMetricTargets(current);
+  const previous = orderedMetricTargets(prior.targets);
+  evidenceAssert(ordered.length === previous.length, "inventory_membership_drift");
+  const changes: MetricContentChange[] = [];
+  for (const [i, row] of ordered.entries()) {
+    const before = previous[i]!;
+    evidenceAssert(hash({ ...targetIdentity(row), identityDigest: before.identityDigest }) === hash(targetIdentity(before)), "non_content_inventory_drift");
+    if (row.identityDigest !== before.identityDigest) changes.push({ sourceItemId: row.sourceItemId, before: before.identityDigest, after: row.identityDigest });
+  }
+  return changes;
+}
+export function applyMetricAmendment(head: MetricOperationHead, amendment: MetricManifestAmendment, hash: RefreshDigest, now: Date): MetricRefreshManifest {
+  assertMetricAmendment(amendment);
+  evidenceAssert(amendment.operationId === head.original.operationId && amendment.evidencePath === head.original.evidencePath &&
+    amendment.originalManifestSha === hash(head.original) && amendment.originalOperationBytesSha === head.originalOperationBytesSha &&
+    amendment.sequence === head.sequence + 1 && amendment.previousAmendmentSha === head.amendmentSha && amendment.priorEffectiveSha === hash(head.effective), "stale_amendment_head");
+  evidenceAssert(amendment.captureStartedAt >= head.original.plannedAt && amendment.captureCompletedAt <= now.toISOString(), "invalid_capture_time");
+  assertMetricManifest({ ...head.effective, targets: amendment.inventory }, now);
+  const changes = reviewedContentChanges(head.effective, amendment.inventory, hash);
+  evidenceAssert(hash(changes) === hash(amendment.changes) && changes.length > 0 && changes.length <= 16, "unreviewed_content_diff");
+  evidenceAssert(hash(orderedMetricTargets(amendment.inventory)) === amendment.inventorySha &&
+    hash(metricIdentityInventory(amendment.inventory)) === amendment.identityInventorySha, "invalid_inventory_sha");
+  const evidence = amendment.zeroBudgetEvidence;
+  evidenceAssert(hash(evidence) === amendment.zeroBudgetEvidenceSha, "invalid_zero_budget_sha");
+  evidenceAssert(hash([...evidence].sort((a, b) => a.name.localeCompare(b.name))) === hash(evidence) && new Set(evidence.map((e) => e.name)).size === evidence.length &&
+    evidence.some((e) => e.name === "operation.json" && e.bytesSha === head.originalOperationBytesSha) && evidence.some((e) => e.name === "operation.lock"), "invalid_zero_budget_evidence");
+  const replacements = new Map(changes.map((change) => [change.sourceItemId, change.after]));
+  const effective = { ...head.effective, targets: head.effective.targets.map((target) => ({ ...target, identityDigest: replacements.get(target.sourceItemId) ?? target.identityDigest })) };
+  assertMetricManifest(effective, now);
+  evidenceAssert(hash(effective) === amendment.effectiveManifestSha, "effective_sha_mismatch");
+  return effective;
+}
+
+export async function resolveMetricOperation(operation: MetricRefreshOperation, hash: RefreshDigest, now: Date, zeroBudget = false): Promise<MetricOperationHead | null> {
+  operation.assertHeld();
+  const entries = await operation.entries();
+  const proposals = entries.filter((entry) => entry.name.startsWith("proposal-"));
+  const amendments = entries.filter((entry) => entry.name.startsWith("amendment-"));
+  evidenceAssert(proposals.length <= metricProposalLimit && amendments.length <= metricAmendmentLimit, "amendment_limit");
+  const original = await operation.read<MetricRefreshManifest>(metricEvidencePath("operation.json"));
+  if (original === null) { evidenceAssert(entries.every((e) => e.name === "operation.lock"), "missing_original"); return null; }
+  assertMetricManifest(original, now);
+  let head: MetricOperationHead = { original, effective: original, originalOperationBytesSha: entries.find((entry) => entry.name === "operation.json")!.bytesSha, sequence: 0, amendmentSha: null };
+  const heads = [head];
+  for (const entry of amendments) {
+    evidenceAssert(entry.name === metricAmendmentName(head.sequence + 1), "amendment_gap_or_fork");
+    const amendment = await operation.read<MetricManifestAmendment>(metricEvidencePath(entry.name));
+    assertMetricAmendment(amendment);
+    const effective = applyMetricAmendment(head, amendment, hash, now);
+    evidenceAssert(proposals.some((p) => p.name === metricProposalName(hash(amendment))), "missing_reviewed_proposal");
+    head = { ...head, effective, sequence: amendment.sequence, amendmentSha: hash(amendment) };
+    heads.push(head);
+  }
+  for (const entry of proposals) {
+    const proposal = await operation.read<MetricManifestAmendment>(metricEvidencePath(entry.name));
+    assertMetricAmendment(proposal);
+    evidenceAssert(entry.name === metricProposalName(hash(proposal)) && proposal.originalManifestSha === hash(original) &&
+      proposal.originalOperationBytesSha === head.originalOperationBytesSha && proposal.operationId === original.operationId && proposal.evidencePath === original.evidencePath, "invalid_proposal");
+    const parent = heads[proposal.sequence - 1];
+    evidenceAssert(parent, "missing_proposal_parent");
+    applyMetricAmendment(parent, proposal, hash, now);
+    for (const recorded of proposal.zeroBudgetEvidence) {
+      evidenceAssert(entries.some((current) => current.name === recorded.name && current.bytesSha === recorded.bytesSha), "changed_zero_budget_evidence");
+    }
+  }
+  const effects = entries.filter((entry) => !["operation.json", "operation.lock"].includes(entry.name) && !proposals.includes(entry) && !amendments.includes(entry));
+  evidenceAssert(!zeroBudget || effects.length === 0, "metric_budget_already_started");
+  await validateMetricEffectReceipts(operation, head, effects, hash);
+  return head;
+}

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-effect-evidence.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-effect-evidence.ts
@@ -1,0 +1,68 @@
+import type { MetricRefreshOutcome, PreservedMetricObservation, RefreshDigest } from "./refresh-retained-metrics.contracts";
+import type { MetricEvidenceEntry, MetricOperationHead, MetricRefreshOperation } from "./metric-refresh-operation.contracts";
+import { refreshBatches } from "./metric-refresh-admission";
+import { assertMetricAuthority, evidenceAssert } from "./metric-refresh-evidence-validation";
+import { buildSourceEngagementMetrics } from "../../domain";
+import { metricRefreshCells } from "./metric-refresh-report";
+
+// Historical effect names are unchanged. Orphan effects never create allowance.
+export async function validateMetricEffectReceipts(operation: MetricRefreshOperation, head: MetricOperationHead, entries: readonly MetricEvidenceEntry[], hash: RefreshDigest) {
+  const manifest = head.effective, sha = hash(manifest), batches = refreshBatches(manifest.targets);
+  const names = new Set(entries.map((entry) => entry.name));
+  for (const entry of entries) {
+    const value = await operation.read<Record<string, unknown>>(`${manifest.evidencePath}/${entry.name}`);
+    evidenceAssert(value !== null && typeof value === "object" && !Array.isArray(value), "malformed_effect_receipt");
+    const batch = /^batch-(0|[1-9]\d*)\.(reserved|observed)\.json$/u.exec(entry.name);
+    if (batch) {
+      const targets = batches[Number(batch[1])];
+      evidenceAssert(targets, "orphan_batch_receipt");
+      if (batch[2] === "reserved") {
+        evidenceAssert(hash(value) === hash({ operationId: manifest.operationId, manifestDigest: sha, targets: targets.map((target) => target.sourceItemId) }), "reservation_head_mismatch");
+      } else {
+        evidenceAssert(names.has(`batch-${batch[1]}.reserved.json`) && Object.keys(value).sort().join() === "failure,observations" &&
+          Array.isArray(value.observations) && value.observations.length <= targets.length && (value.failure === null || typeof value.failure === "string"), "malformed_observation");
+        const observations = value.observations as PreservedMetricObservation[];
+        evidenceAssert(new Set(observations.map((o) => o?.externalId)).size === observations.length);
+        evidenceAssert(value.failure === null ? observations.length === targets.length : observations.length === 0);
+        for (const row of observations) {
+          evidenceAssert(row && Object.keys(row).sort().join() === "externalId,metadata,observedAt,reason,returned,sample" &&
+            targets.some((t) => t.externalId === row.externalId) && typeof row.returned === "boolean" &&
+            typeof row.observedAt === "string" && Number.isFinite(Date.parse(row.observedAt)) && new Date(row.observedAt).toISOString() === row.observedAt &&
+            (row.reason === null || typeof row.reason === "string") &&
+            (row.metadata === null || (typeof row.metadata === "object" && !Array.isArray(row.metadata))) &&
+            (row.sample === null || (typeof row.sample === "object" && !Array.isArray(row.sample))), "malformed_observation");
+          if (row.sample !== null) {
+            const target = targets.find((t) => t.externalId === row.externalId)!;
+            const rebuilt = buildSourceEngagementMetrics({ providerKey: target.providerKey, metadata: row.metadata ?? {} });
+            evidenceAssert(rebuilt.metrics && rebuilt.qualityFlags.providerKnown && rebuilt.qualityFlags.metadataKindKnown &&
+              !rebuilt.qualityFlags.invalidMetricValue && !rebuilt.qualityFlags.conflictingAliases && hash(row.sample) === hash({
+                sourceItemId: target.sourceItemId, externalId: target.externalId, publishedAt: target.publishedAt,
+                metrics: rebuilt.metrics, metricsFingerprint: rebuilt.metricsFingerprint,
+                providerMetadataPatch: rebuilt.providerMetadataPatch, refreshReadModels: true }), "receipt_sample_mismatch");
+          }
+        }
+      }
+    } else if (entry.name.startsWith("result-")) {
+      const row = value as unknown as MetricRefreshOutcome;
+      evidenceAssert(Object.keys(value).sort().join() === ["sourceItemId", "externalId", "providerKey", "date", "status", "returned", "reason", "observedAt", "before", "after",
+        ...(value.manifestSha === undefined ? [] : ["manifestSha"])].sort().join(), "invalid_result_schema");
+      const target = manifest.targets.find((t) => entry.name === `result-${t.sourceItemId}.json`);
+      const index = batches.findIndex((targets) => targets.some((t) => t.sourceItemId === target?.sourceItemId));
+      evidenceAssert(target && names.has(`batch-${index}.observed.json`) && row.sourceItemId === target.sourceItemId &&
+        row.externalId === target.externalId && row.providerKey === target.providerKey && row.date === target.publishedAt.slice(0, 10) &&
+        ["refreshed", "superseded", "unavailable", "failed"].includes(row.status) && typeof row.returned === "boolean" &&
+        (row.reason === null || typeof row.reason === "string") &&
+        (row.observedAt === null || (typeof row.observedAt === "string" && Number.isFinite(Date.parse(row.observedAt)) && new Date(row.observedAt).toISOString() === row.observedAt)) &&
+        hash(row.before) === hash(target.authority) && (row.manifestSha === sha || (head.sequence === 0 && row.manifestSha === undefined)), "invalid_result_receipt");
+      assertMetricAuthority(row.after);
+    } else if (entry.name === "final.json") {
+      evidenceAssert(value.manifestSha === sha && Array.isArray(value.results) && value.results.length === manifest.targets.length && Array.isArray(value.cells), "invalid_final_receipt");
+      for (const target of manifest.targets) {
+        const row = await operation.read(`${manifest.evidencePath}/result-${target.sourceItemId}.json`);
+        evidenceAssert(row !== null && value.results.some((r) => hash(r) === hash(row)), "incomplete_final_receipt");
+      }
+      evidenceAssert(hash(value) === hash({ manifestSha: sha, results: value.results,
+        cells: metricRefreshCells(value.results as MetricRefreshOutcome[], manifest.scope.dates) }), "invalid_final_cells");
+    } else evidenceAssert(false, "unknown_metric_evidence");
+  }
+}

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-effect-evidence.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-effect-evidence.ts
@@ -5,10 +5,14 @@ import { assertMetricAuthority, evidenceAssert } from "./metric-refresh-evidence
 import { buildSourceEngagementMetrics } from "../../domain";
 import { metricRefreshCells } from "./metric-refresh-report";
 
+type BatchEvidence = { observations: readonly PreservedMetricObservation[]; failure: string | null };
+
 // Historical effect names are unchanged. Orphan effects never create allowance.
 export async function validateMetricEffectReceipts(operation: MetricRefreshOperation, head: MetricOperationHead, entries: readonly MetricEvidenceEntry[], hash: RefreshDigest) {
   const manifest = head.effective, sha = hash(manifest), batches = refreshBatches(manifest.targets);
   const names = new Set(entries.map((entry) => entry.name));
+  const observedBatches = new Map<number, BatchEvidence>();
+  const results: { row: MetricRefreshOutcome; batchIndex: number }[] = [];
   for (const entry of entries) {
     const value = await operation.read<Record<string, unknown>>(`${manifest.evidencePath}/${entry.name}`);
     evidenceAssert(value !== null && typeof value === "object" && !Array.isArray(value), "malformed_effect_receipt");
@@ -31,16 +35,23 @@ export async function validateMetricEffectReceipts(operation: MetricRefreshOpera
             (row.reason === null || typeof row.reason === "string") &&
             (row.metadata === null || (typeof row.metadata === "object" && !Array.isArray(row.metadata))) &&
             (row.sample === null || (typeof row.sample === "object" && !Array.isArray(row.sample))), "malformed_observation");
+          const target = targets.find((t) => t.externalId === row.externalId)!;
+          const rebuilt = buildSourceEngagementMetrics({ providerKey: target.providerKey, metadata: row.metadata ?? {} });
+          const valid = Boolean(rebuilt.metrics && rebuilt.metricsFingerprint && rebuilt.qualityFlags.providerKnown &&
+            rebuilt.qualityFlags.metadataKindKnown && !rebuilt.qualityFlags.invalidMetricValue && !rebuilt.qualityFlags.conflictingAliases);
+          evidenceAssert((row.sample !== null) === valid, "receipt_sample_mismatch");
+          // The writer preserves explicit provider reasons/returned flags, even with a
+          // valid sample. Only a missing reason is defaulted for omitted/invalid data.
+          evidenceAssert(row.sample !== null || row.reason !== null, "receipt_observation_mismatch");
           if (row.sample !== null) {
-            const target = targets.find((t) => t.externalId === row.externalId)!;
-            const rebuilt = buildSourceEngagementMetrics({ providerKey: target.providerKey, metadata: row.metadata ?? {} });
-            evidenceAssert(rebuilt.metrics && rebuilt.qualityFlags.providerKnown && rebuilt.qualityFlags.metadataKindKnown &&
-              !rebuilt.qualityFlags.invalidMetricValue && !rebuilt.qualityFlags.conflictingAliases && hash(row.sample) === hash({
+            evidenceAssert(row.observedAt >= manifest.plannedAt, "receipt_observation_time_invalid");
+            evidenceAssert(hash(row.sample) === hash({
                 sourceItemId: target.sourceItemId, externalId: target.externalId, publishedAt: target.publishedAt,
                 metrics: rebuilt.metrics, metricsFingerprint: rebuilt.metricsFingerprint,
                 providerMetadataPatch: rebuilt.providerMetadataPatch, refreshReadModels: true }), "receipt_sample_mismatch");
           }
         }
+        observedBatches.set(Number(batch[1]), { observations, failure: value.failure as string | null });
       }
     } else if (entry.name.startsWith("result-")) {
       const row = value as unknown as MetricRefreshOutcome;
@@ -55,6 +66,7 @@ export async function validateMetricEffectReceipts(operation: MetricRefreshOpera
         (row.observedAt === null || (typeof row.observedAt === "string" && Number.isFinite(Date.parse(row.observedAt)) && new Date(row.observedAt).toISOString() === row.observedAt)) &&
         hash(row.before) === hash(target.authority) && (row.manifestSha === sha || (head.sequence === 0 && row.manifestSha === undefined)), "invalid_result_receipt");
       assertMetricAuthority(row.after);
+      results.push({ row, batchIndex: index });
     } else if (entry.name === "final.json") {
       evidenceAssert(value.manifestSha === sha && Array.isArray(value.results) && value.results.length === manifest.targets.length && Array.isArray(value.cells), "invalid_final_receipt");
       for (const target of manifest.targets) {
@@ -64,5 +76,30 @@ export async function validateMetricEffectReceipts(operation: MetricRefreshOpera
       evidenceAssert(hash(value) === hash({ manifestSha: sha, results: value.results,
         cells: metricRefreshCells(value.results as MetricRefreshOutcome[], manifest.scope.dates) }), "invalid_final_cells");
     } else evidenceAssert(false, "unknown_metric_evidence");
+  }
+  // Bind only after all batches validate; directory enumeration need not put
+  // observations before results (or final.json before/after either of them).
+  for (const { row, batchIndex } of results) {
+    const evidence = observedBatches.get(batchIndex);
+    evidenceAssert(evidence, "result_observation_mismatch");
+    const observation = evidence.observations.find((value) => value.externalId === row.externalId);
+    evidenceAssert(row.returned === (observation?.returned ?? false) &&
+      row.observedAt === (observation?.observedAt ?? null) &&
+      row.reason === (evidence.failure ?? observation?.reason ?? null), "result_observation_mismatch");
+    if (evidence.failure !== null) {
+      evidenceAssert(row.status === "failed", "result_observation_mismatch");
+    } else {
+      evidenceAssert(observation, "result_observation_mismatch");
+      if (observation.sample === null) {
+        evidenceAssert(row.status === (observation.reason === "invalid_metrics" ? "failed" : "unavailable"), "result_observation_mismatch");
+      } else {
+        // Projection exceptions never install a terminal receipt. Successful
+        // projection must confirm this sample or a strictly newer snapshot.
+        evidenceAssert(row.after.metricsHash !== null && row.after.observedAt !== null &&
+          row.after.observationAt !== null && row.after.observationAt <= row.after.observedAt &&
+          ((row.status === "refreshed" && row.after.observedAt === observation.observedAt && row.after.metricsHash === observation.sample.metricsFingerprint) ||
+           (row.status === "superseded" && row.after.observedAt > observation.observedAt)), "result_observation_mismatch");
+      }
+    }
   }
 }

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-evidence-validation.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-evidence-validation.ts
@@ -1,0 +1,66 @@
+import type { MetricRefreshManifest, MetricAuthority, RetainedMetricTarget } from "./refresh-retained-metrics.contracts";
+import type { MetricManifestAmendment } from "./metric-refresh-operation.contracts";
+import { manifestProblem, metricRefreshTargetLimit } from "./metric-refresh-admission";
+
+export const metricAmendmentLimit = 8;
+export const metricProposalLimit = 8;
+export const metricSha = (v: unknown): v is string => typeof v === "string" && /^[a-f0-9]{64}$/u.test(v);
+export const metricUuid = (v: unknown): v is string => typeof v === "string" && /^[a-f0-9]{8}-[a-f0-9]{4}-[1-8][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/u.test(v);
+const time = (v: unknown): boolean => typeof v === "string" && Number.isFinite(Date.parse(v)) && new Date(v).toISOString() === v;
+const count = (v: unknown): boolean => typeof v === "number" && Number.isSafeInteger(v) && v >= 0;
+export function evidenceAssert(valid: unknown, reason = "invalid_metric_evidence"): asserts valid {
+  if (!valid) throw new Error(reason);
+}
+function object(value: unknown, keys: string): asserts value is Record<string, unknown> {
+  evidenceAssert(value !== null && typeof value === "object" && !Array.isArray(value));
+  evidenceAssert(Object.keys(value).sort().join() === keys.split(" ").sort().join());
+}
+export function assertMetricAuthority(value: unknown): asserts value is MetricAuthority {
+  object(value, "metricsHash observedAt observationAt observationCount regressionCount");
+  evidenceAssert((value.metricsHash === null || metricSha(value.metricsHash)) &&
+    (value.observedAt === null || time(value.observedAt)) && (value.observationAt === null || time(value.observationAt)) &&
+    count(value.observationCount) && count(value.regressionCount) && Number(value.regressionCount) <= Number(value.observationCount));
+}
+export function assertMetricTargets(value: unknown): asserts value is readonly RetainedMetricTarget[] {
+  evidenceAssert(Array.isArray(value) && value.length <= metricRefreshTargetLimit);
+  for (const row of value) {
+    object(row, "sourceItemId externalId sourceBindingId providerKey canonicalUrl publishedAt tenantId workspaceId configDigest identityDigest feedDigest visibleFeedCount rejection authority");
+    evidenceAssert([row.sourceItemId, row.sourceBindingId, row.tenantId, row.workspaceId].every(metricUuid) &&
+      [row.configDigest, row.identityDigest, row.feedDigest].every(metricSha) &&
+      ["hacker-news", "reddit"].includes(String(row.providerKey)) && typeof row.externalId === "string" &&
+      typeof row.canonicalUrl === "string" && time(row.publishedAt) && count(row.visibleFeedCount) &&
+      (row.rejection === null || typeof row.rejection === "string"));
+    assertMetricAuthority(row.authority);
+  }
+}
+export function assertMetricManifest(value: unknown, now: Date): asserts value is MetricRefreshManifest {
+  object(value, "version sourceBase bounds operationId evidencePath scope plannedAt targets");
+  object(value.bounds, "targets redditBatch hnBatch attempts concurrency timeoutMs");
+  object(value.scope, "tenantId workspaceId dates endAt");
+  evidenceAssert(Array.isArray(value.scope.dates) && value.scope.dates.every((date) => typeof date === "string") && time(value.scope.endAt) && time(value.plannedAt));
+  assertMetricTargets(value.targets);
+  evidenceAssert(manifestProblem(value as MetricRefreshManifest, now) === null, "invalid_original_manifest");
+}
+export function assertMetricAmendment(value: unknown): asserts value is MetricManifestAmendment {
+  object(value, "version operationId evidencePath originalManifestSha originalOperationBytesSha sequence previousAmendmentSha priorEffectiveSha captureStartedAt captureCompletedAt reason implementation inventory inventorySha identityInventorySha changes effectiveManifestSha zeroBudgetEvidence zeroBudgetEvidenceSha");
+  evidenceAssert(value.version === "retained-metrics-amendment.v1" && metricUuid(value.operationId) &&
+    typeof value.evidencePath === "string" && count(value.sequence) && Number(value.sequence) >= 1 && Number(value.sequence) <= metricAmendmentLimit &&
+    [value.originalManifestSha, value.originalOperationBytesSha, value.priorEffectiveSha, value.inventorySha, value.identityInventorySha, value.effectiveManifestSha, value.zeroBudgetEvidenceSha].every(metricSha) &&
+    (value.previousAmendmentSha === null || metricSha(value.previousAmendmentSha)) && time(value.captureStartedAt) && time(value.captureCompletedAt) &&
+    String(value.captureStartedAt) <= String(value.captureCompletedAt) && typeof value.reason === "string" && value.reason.trim().length > 0 && value.reason.length <= 1000);
+  object(value.implementation, "sourceSha executableSha legacyRetirementRef holderProof");
+  evidenceAssert(metricSha(value.implementation.sourceSha) && metricSha(value.implementation.executableSha) && metricSha(value.implementation.holderProof) &&
+    typeof value.implementation.legacyRetirementRef === "string" && /^[A-Za-z0-9][A-Za-z0-9:/_.-]{0,255}$/u.test(value.implementation.legacyRetirementRef));
+  assertMetricTargets(value.inventory);
+  evidenceAssert(Array.isArray(value.changes) && value.changes.length > 0 && value.changes.length <= 16);
+  for (const row of value.changes) {
+    object(row, "sourceItemId before after");
+    evidenceAssert(metricUuid(row.sourceItemId) && metricSha(row.before) && metricSha(row.after) && row.before !== row.after);
+  }
+  evidenceAssert(Array.isArray(value.zeroBudgetEvidence) && value.zeroBudgetEvidence.length <= 2 + metricAmendmentLimit + metricProposalLimit);
+  for (const entry of value.zeroBudgetEvidence) {
+    object(entry, "name bytesSha");
+    evidenceAssert(typeof entry.name === "string" && metricSha(entry.bytesSha) &&
+      /^(?:operation\.json|operation\.lock|proposal-[a-f0-9]{64}\.json|amendment-00000[1-8]\.json)$/u.test(entry.name));
+  }
+}

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-operation.contracts.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-operation.contracts.ts
@@ -1,0 +1,28 @@
+import type { MetricRefreshManifest, MetricRefreshReceipts, RetainedMetricTarget } from "./refresh-retained-metrics.contracts";
+
+export type MetricEvidenceEntry = { name: string; bytesSha: string };
+export type MetricImplementation = {
+  sourceSha: string; executableSha: string; legacyRetirementRef: string; holderProof: string;
+};
+export interface MetricRefreshOperation extends MetricRefreshReceipts {
+  // A live lease, never a persisted marker. All I/O and effects require it.
+  assertHeld(): void;
+  entries(): Promise<readonly MetricEvidenceEntry[]>;
+}
+export interface MetricRefreshOperationAuthority extends MetricRefreshReceipts {
+  withOperation<T>(work: (operation: MetricRefreshOperation) => Promise<T>): Promise<T>;
+}
+export type MetricContentChange = { sourceItemId: string; before: string; after: string };
+export type MetricManifestAmendment = {
+  version: "retained-metrics-amendment.v1"; operationId: string; evidencePath: string;
+  originalManifestSha: string; originalOperationBytesSha: string;
+  sequence: number; previousAmendmentSha: string | null; priorEffectiveSha: string;
+  captureStartedAt: string; captureCompletedAt: string; reason: string;
+  implementation: MetricImplementation; inventory: readonly RetainedMetricTarget[];
+  inventorySha: string; identityInventorySha: string; changes: readonly MetricContentChange[];
+  effectiveManifestSha: string; zeroBudgetEvidence: readonly MetricEvidenceEntry[]; zeroBudgetEvidenceSha: string;
+};
+export type MetricOperationHead = {
+  original: MetricRefreshManifest; effective: MetricRefreshManifest;
+  originalOperationBytesSha: string; sequence: number; amendmentSha: string | null;
+};

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-report.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-report.ts
@@ -1,0 +1,13 @@
+import type { MetricRefreshOutcome } from "./refresh-retained-metrics.contracts";
+import { metricRefreshDates } from "./metric-refresh-admission";
+
+export function metricRefreshCells(results: readonly MetricRefreshOutcome[], dates: readonly string[] = metricRefreshDates) {
+  return dates.flatMap((date) => ["hacker-news", "reddit"].map((provider) => {
+    const rows = results.filter((row) => row.date === date && row.providerKey === provider);
+    return { date, provider, targets: rows.length, returned: rows.filter((row) => row.returned).length,
+      ...Object.fromEntries(["refreshed", "superseded", "unavailable", "failed", "uncertain"].map((status) => [status, rows.filter((row) => row.status === status).length])),
+      beforeObservations: rows.reduce((sum, row) => sum + row.before.observationCount, 0),
+      afterObservations: rows.reduce((sum, row) => sum + row.after.observationCount, 0),
+      authorityTimes: rows.map((row) => ({ id: row.externalId, before: row.before.observationAt, after: row.after.observationAt })) };
+  }));
+}

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-result-binding.spec-support.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-result-binding.spec-support.ts
@@ -1,0 +1,73 @@
+import { fixture, manifest, now, scope, target } from "../../../../scripts/lib/retained-metric-refresh.spec-support";
+import { metricRefreshDigest } from "../../../../scripts/lib/retained-metric-refresh-receipts";
+import { buildSourceEngagementMetrics } from "../../domain";
+import { RefreshRetainedMetricsUseCase } from "./refresh-retained-metrics.use-case";
+import type { MetricRefreshManifest, MetricRefreshOutcome, PreservedMetricObservation, RetainedMetricFetchCapability } from "./refresh-retained-metrics.contracts";
+
+export const resultPath = `${manifest().evidencePath}/result-${target().sourceItemId}.json`;
+export const observedPath = `${manifest().evidencePath}/batch-0.observed.json`;
+export const later = "2026-09-05T13:00:00.000Z";
+export const earlier = "2026-09-05T11:00:00.000Z";
+export type BatchEvidence = { observations: PreservedMetricObservation[]; failure: string | null };
+
+export function bindingFixture(root: string) {
+  const f = fixture(root);
+  // The shared success fixture infers Ok only; exercise the full capability's
+  // Result contract on the same mock used by its writer.
+  const fetcher = f.fetcher as { fetch: jest.Mock<ReturnType<RetainedMetricFetchCapability["fetch"]>, []> };
+  const project = jest.spyOn(f.projection, "project");
+  const clearEffects = () => {
+    f.inventory.list.mockClear(); f.inventory.read.mockClear(); f.fetcher.fetch.mockClear(); project.mockClear(); f.install.mockClear();
+  };
+  const expectNoEffects = () => {
+    expect(f.inventory.list).not.toHaveBeenCalled(); expect(f.inventory.read).not.toHaveBeenCalled();
+    expect(f.fetcher.fetch).not.toHaveBeenCalled(); expect(project).not.toHaveBeenCalled(); expect(f.install).not.toHaveBeenCalled();
+  };
+  const usecaseWithOrder = () => new RefreshRetainedMetricsUseCase(f.inventory, f.fetcher, f.projection, {
+    read: f.receipts.read.bind(f.receipts), install: f.receipts.install.bind(f.receipts),
+    withOperation: (work) => f.receipts.withOperation((operation) => work({ ...operation,
+      entries: async () => [...await operation.entries()].sort((a, b) => b.name.localeCompare(a.name)),
+    })),
+  }, f.clock, metricRefreshDigest);
+  const rejectBeforeEffects = async (error: string, planned = manifest(), reversed = false) => {
+    clearEffects();
+    await expect((reversed ? usecaseWithOrder() : f.usecase()).execute(planned)).rejects.toThrow(error);
+    expectNoEffects();
+  };
+  const captureTerminal = async (planned: MetricRefreshManifest = manifest()) => {
+    const install = f.install.getMockImplementation()!;
+    let terminal: MetricRefreshOutcome | undefined;
+    f.install.mockImplementation(async (operation, path, value) => {
+      if (path.includes("/result-")) { terminal = value as MetricRefreshOutcome; throw new Error("interrupted_result_install"); }
+      return install(operation, path, value);
+    });
+    await expect(f.usecase().execute(planned)).rejects.toThrow("interrupted_result_install");
+    f.install.mockImplementation(install);
+    if (!terminal) throw new Error("Writer did not reach a terminal result");
+    expect(await f.receipts.read(resultPath)).toBeNull();
+    return terminal;
+  };
+  const projectNatural = async (observedAt = later, score = 99) => {
+    const built = buildSourceEngagementMetrics({ providerKey: "reddit", metadata: { kind: "reddit_post", score, numComments: 9 } });
+    await f.projection.project({ tenantId: scope.tenantId as never, workspaceId: scope.workspaceId as never,
+      sourceBindingId: target().sourceBindingId, scanJobId: manifest().operationId, providerKey: "reddit", observedAt: new Date(observedAt),
+      samples: [{ sourceItemId: target().sourceItemId, externalId: target().externalId, publishedAt: new Date(target().publishedAt),
+        metrics: built.metrics!, metricsFingerprint: built.metricsFingerprint!, providerMetadataPatch: built.providerMetadataPatch, refreshReadModels: true }] });
+  };
+  const assertReplay = async (planned = manifest(), reversed = false) => {
+    const terminal = await f.receipts.read<MetricRefreshOutcome>(resultPath);
+    expect(terminal).not.toBeNull();
+    const fetches = f.fetcher.fetch.mock.calls.length, projections = project.mock.calls.length;
+    const resumed = await (reversed ? usecaseWithOrder() : f.usecase()).execute(planned);
+    expect(resumed).toEqual({ ok: true, value: [terminal] });
+    expect(f.fetcher.fetch).toHaveBeenCalledTimes(fetches); expect(project).toHaveBeenCalledTimes(projections);
+    expect(await f.receipts.read(resultPath)).toEqual(terminal);
+    return terminal!;
+  };
+  return { ...f, fetcher, project, clearEffects, expectNoEffects, rejectBeforeEffects, captureTerminal, projectNatural, assertReplay, usecaseWithOrder };
+}
+
+export const refreshedAuthority = () => {
+  const built = buildSourceEngagementMetrics({ providerKey: "reddit", metadata: { kind: "reddit_post", score: 42, numComments: 9 } });
+  return { metricsHash: built.metricsFingerprint!, observedAt: now, observationAt: now, observationCount: 1, regressionCount: 0 };
+};

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-result-binding.spec.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-result-binding.spec.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { err, ok } from "@social-monitor/shared-kernel";
+import { manifest, now, target } from "../../../../scripts/lib/retained-metric-refresh.spec-support";
+import { metricRefreshDigest } from "../../../../scripts/lib/retained-metric-refresh-receipts";
+import { metricRefreshCells } from "./metric-refresh-report";
+import { bindingFixture, earlier, later, observedPath, refreshedAuthority, resultPath, type BatchEvidence } from "./metric-refresh-result-binding.spec-support";
+import type { MetricRefreshOutcome, PreservedMetricObservation } from "./refresh-retained-metrics.contracts";
+
+describe("retained metric terminal result observation binding", () => {
+  let root: string;
+  let f: ReturnType<typeof bindingFixture>;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), "metric-result-binding-")); f = bindingFixture(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("rejects a forged unavailable result for a valid preserved sample before inventory or effects", async () => {
+    const project = jest.spyOn(f.projection, "project").mockRejectedValueOnce(new Error("lost projection acknowledgement"));
+    const first = await f.usecase().execute(manifest());
+    if (!first.ok) throw new Error(first.error);
+    const path = `${manifest().evidencePath}/result-${target().sourceItemId}.json`;
+    expect(await f.receipts.read(path)).toBeNull();
+    const forged: MetricRefreshOutcome = { ...first.value[0]!, status: "unavailable", reason: null };
+    await f.receipts.install(path, forged);
+    f.inventory.list.mockClear(); f.inventory.read.mockClear(); f.fetcher.fetch.mockClear(); project.mockClear();
+
+    await expect(f.usecase().execute(manifest())).rejects.toThrow("result_observation_mismatch");
+    expect(f.inventory.list).not.toHaveBeenCalled();
+    expect(f.inventory.read).not.toHaveBeenCalled();
+    expect(f.fetcher.fetch).not.toHaveBeenCalled();
+    expect(project).not.toHaveBeenCalled();
+  });
+
+  it.each<[string, (row: MetricRefreshOutcome) => MetricRefreshOutcome]>([
+    ["failed with a valid sample", (row) => ({ ...row, status: "failed" })],
+    ["projection exception persisted as terminal", (row) => ({ ...row, status: "failed", reason: "projection_unacknowledged_resume_same_operation" })],
+    ["superseded at equal time", (row) => ({ ...row, status: "superseded" })],
+    ["superseded by older authority", (row) => ({ ...row, status: "superseded", after: { ...row.after, observedAt: earlier, observationAt: earlier } })],
+    ["superseded without a metrics hash", (row) => ({ ...row, status: "superseded", after: { ...row.after, observedAt: later, metricsHash: null } })],
+    ["refreshed at an older time", (row) => ({ ...row, after: { ...row.after, observedAt: earlier, observationAt: earlier } })],
+    ["refreshed at a later time", (row) => ({ ...row, after: { ...row.after, observedAt: later } })],
+    ["refreshed with a different hash", (row) => ({ ...row, after: { ...row.after, metricsHash: "f".repeat(64) } })],
+    ["refreshed with null hash", (row) => ({ ...row, after: { ...row.after, metricsHash: null } })],
+    ["refreshed with null time", (row) => ({ ...row, after: { ...row.after, observedAt: null } })],
+    ["refreshed with no cadence time", (row) => ({ ...row, after: { ...row.after, observationAt: null } })],
+    ["cadence time after snapshot time", (row) => ({ ...row, after: { ...row.after, observationAt: later } })],
+    ["returned flag differs", (row) => ({ ...row, returned: false })],
+    ["reason differs", (row) => ({ ...row, reason: "omitted" })],
+    ["observation time differs", (row) => ({ ...row, observedAt: earlier })],
+    ["observation time missing", (row) => ({ ...row, observedAt: null })],
+  ])("rejects %s before inventory, provider or projection", async (_name, mutate) => {
+    const terminal = await f.captureTerminal();
+    await f.receipts.install(resultPath, mutate(terminal));
+    await f.rejectBeforeEffects("result_observation_mismatch");
+  });
+
+  it.each([
+    ["unavailable", "refreshed"], ["unavailable", "superseded"],
+    ["invalid_metrics", "refreshed"], ["invalid_metrics", "superseded"],
+    ["batch_failure", "refreshed"], ["batch_failure", "superseded"],
+  ] as const)("rejects %s claiming %s without a sample", async (kind, status) => {
+    if (kind === "batch_failure") f.fetcher.fetch.mockResolvedValueOnce(err("provider_429_no_retry"));
+    else f.fetcher.fetch.mockResolvedValueOnce(ok(kind === "unavailable" ? [] : [{ externalId: target().externalId,
+      returned: true, reason: null, metadata: { kind: "reddit_post", score: 42, numComments: -1 } }]));
+    const terminal = await f.captureTerminal();
+    // Each claim has individually well-formed authority; its observation has no sample.
+    const row = { ...terminal, status, after: { ...refreshedAuthority(), observedAt: status === "refreshed" ? now : later } };
+    await f.receipts.install(resultPath, row);
+    await f.rejectBeforeEffects("result_observation_mismatch");
+  });
+
+  it.each<[string, Partial<MetricRefreshOutcome>]>([
+    ["unavailable status", { status: "unavailable" }],
+    ["returned flag", { returned: true }],
+    ["invented observation time", { observedAt: now }],
+    ["different failure reason", { reason: "provider_fetch_failed_no_retry" }],
+    ["missing failure reason", { reason: null }],
+  ])("binds a failed batch to its exact %s", async (_name, change) => {
+    f.fetcher.fetch.mockResolvedValueOnce(err("provider_429_no_retry"));
+    const row = await f.captureTerminal();
+    await f.receipts.install(resultPath, { ...row, ...change });
+    await f.rejectBeforeEffects("result_observation_mismatch");
+  });
+
+  it.each(["unavailable", "failed"] as const)("rejects the wrong no-sample status for %s", async (status) => {
+    f.fetcher.fetch.mockResolvedValueOnce(ok([{ externalId: target().externalId, returned: true,
+      metadata: null, reason: status === "failed" ? "invalid_metrics" : "removed_deleted_or_hidden" }]));
+    const row = await f.captureTerminal();
+    expect(row.status).toBe(status);
+    await f.receipts.install(resultPath, { ...row, status: status === "failed" ? "unavailable" : "failed" });
+    await f.rejectBeforeEffects("result_observation_mismatch");
+  });
+
+  it("rejects uncertain as a persisted terminal status", async () => {
+    const row = await f.captureTerminal();
+    await f.receipts.install(resultPath, { ...row, status: "uncertain" });
+    await f.rejectBeforeEffects("invalid_result_receipt");
+  });
+
+  it("rejects a self-consistent final report backed by an inconsistent result, even with reversed entries", async () => {
+    const row = { ...await f.captureTerminal(), status: "unavailable" as const };
+    await f.receipts.install(resultPath, row);
+    await f.receipts.install(`${manifest().evidencePath}/final.json`, { manifestSha: metricRefreshDigest(manifest()),
+      results: [row], cells: metricRefreshCells([row], manifest().scope.dates) });
+    await f.rejectBeforeEffects("result_observation_mismatch", manifest(), true);
+  });
+
+  it.each<[string, (row: PreservedMetricObservation) => PreservedMetricObservation, string]>([
+    ["valid metrics stripped of sample", (row) => ({ ...row, sample: null, reason: "omitted" }), "receipt_sample_mismatch"],
+    ["sample metrics changed", (row) => ({ ...row, sample: { ...row.sample!, metrics: { score: 100 } } }), "receipt_sample_mismatch"],
+    ["sample hash changed", (row) => ({ ...row, sample: { ...row.sample!, metricsFingerprint: "e".repeat(64) } }), "receipt_sample_mismatch"],
+    ["sample target changed", (row) => ({ ...row, sample: { ...row.sample!, externalId: "reddit:t3_other" } }), "receipt_sample_mismatch"],
+    ["sample time before planning", (row) => ({ ...row, observedAt: earlier }), "receipt_observation_time_invalid"],
+    ["missing metadata and no normalized reason", (row) => ({ ...row, sample: null, metadata: null, reason: null }), "receipt_observation_mismatch"],
+    ["invalid metadata and no normalized reason", (row) => ({ ...row, sample: null, metadata: { kind: "unknown" }, reason: null }), "receipt_observation_mismatch"],
+  ])("rejects impossible normalized evidence: %s", async (_name, mutate, error) => {
+    const install = f.install.getMockImplementation()!;
+    f.install.mockImplementation(async (operation, path, value) => {
+      if (path === observedPath) {
+        const batch = value as BatchEvidence;
+        await install(operation, path, { ...batch, observations: batch.observations.map(mutate) });
+        throw new Error("interrupted_after_observation");
+      }
+      return install(operation, path, value);
+    });
+    await expect(f.usecase().execute(manifest())).rejects.toThrow("interrupted_after_observation");
+    f.install.mockImplementation(install);
+    await f.rejectBeforeEffects(error);
+  });
+});

--- a/libs/ingestion/features/refresh-retained-metrics/metric-refresh-result-replay.spec.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-refresh-result-replay.spec.ts
@@ -1,0 +1,197 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { err, ok } from "@social-monitor/shared-kernel";
+import { manifest, now, target } from "../../../../scripts/lib/retained-metric-refresh.spec-support";
+import { metricRefreshDigest } from "../../../../scripts/lib/retained-metric-refresh-receipts";
+import { metricRefreshCells } from "./metric-refresh-report";
+import { bindingFixture, earlier, later, observedPath, resultPath, type BatchEvidence } from "./metric-refresh-result-binding.spec-support";
+import type { MetricFetchObservation, MetricRefreshOutcome } from "./refresh-retained-metrics.contracts";
+
+describe("writer-produced retained metric terminal replay", () => {
+  let root: string, f: ReturnType<typeof bindingFixture>;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), "metric-result-replay-")); f = bindingFixture(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it.each(["provider_429_no_retry", "provider_fetch_failed_no_retry", "invalid_metrics", "provider_identity_mismatch", ""])("replays batch failure %j without refetch", async (failure) => {
+    f.fetcher.fetch.mockResolvedValueOnce(err(failure));
+    expect(await f.usecase().execute(manifest())).toMatchObject({ ok: true, value: [{ status: "failed", returned: false, reason: failure, observedAt: null }] });
+    expect(await f.receipts.read(observedPath)).toEqual({ failure, observations: [] });
+    await f.assertReplay();
+    expect(f.fetcher.fetch).toHaveBeenCalledTimes(1); expect(f.project).not.toHaveBeenCalled();
+  });
+
+  it.each<[string, Omit<MetricFetchObservation, "externalId"> | null, string, string, boolean]>([
+    ["omission", null, "unavailable", "omitted", false],
+    ["explicit null/dead reason", { returned: false, reason: "null_dead_deleted", metadata: null }, "unavailable", "null_dead_deleted", false],
+    ["removed identity", { returned: true, reason: "removed_deleted_or_hidden", metadata: null }, "unavailable", "removed_deleted_or_hidden", true],
+    ["unknown kind", { returned: true, reason: null, metadata: { kind: "unknown", score: 5 } }, "failed", "invalid_metrics", true],
+    ["missing counters", { returned: true, reason: null, metadata: { kind: "reddit_post" } }, "failed", "invalid_metrics", true],
+    ["invalid counter", { returned: true, reason: null, metadata: { kind: "reddit_post", score: 5, numComments: -1 } }, "failed", "invalid_metrics", true],
+    ["conflicting aliases", { returned: true, reason: null, metadata: { kind: "reddit_post", score: 5, providerScore: 9 } }, "failed", "invalid_metrics", true],
+    ["explicit invalid reason without metadata", { returned: false, reason: "invalid_metrics", metadata: null }, "failed", "invalid_metrics", false],
+    ["explicit reason overrides invalid data", { returned: true, reason: "provider_unavailable", metadata: { kind: "unknown" } }, "unavailable", "provider_unavailable", true],
+    ["empty explicit reason", { returned: false, reason: "", metadata: null }, "unavailable", "", false],
+    ["null reason defaults for missing metadata", { returned: true, reason: null, metadata: null }, "unavailable", "omitted", true],
+  ])("replays normalized %s using writer reason/status semantics", async (_name, observation, status, reason, returned) => {
+    f.fetcher.fetch.mockResolvedValueOnce(ok(observation ? [{ externalId: target().externalId, ...observation }] : []));
+    expect(await f.usecase().execute(manifest())).toMatchObject({ ok: true, value: [{ status, reason, returned, observedAt: now }] });
+    expect(await f.receipts.read(observedPath)).toMatchObject({ failure: null, observations: [{ sample: null, reason, returned }] });
+    await f.assertReplay();
+    expect(f.fetcher.fetch).toHaveBeenCalledTimes(1); expect(f.project).not.toHaveBeenCalled();
+  });
+
+  it.each<[boolean, string | null]>([[true, null], [false, null], [true, "invalid_metrics"], [false, "provider_annotation"], [true, ""]])(
+    "replays a valid sample with preserved returned=%s reason=%j", async (returned, reason) => {
+      f.fetcher.fetch.mockResolvedValueOnce(ok([{ externalId: target().externalId, returned, reason,
+        metadata: { kind: "reddit_post", score: -2, numComments: 9, upvoteRatio: 0.75 } }]));
+      expect(await f.usecase().execute(manifest())).toMatchObject({ ok: true, value: [{ status: "refreshed", reason, returned }] });
+      await f.assertReplay();
+      expect(f.fetcher.fetch).toHaveBeenCalledTimes(1); expect(f.project).toHaveBeenCalledTimes(1);
+      expect(f.db.rows("sourceItemEngagementSnapshot")[0]?.score).toBe(-2n);
+    });
+
+  it.each(["refreshed", "superseded", "unavailable", "failed"] as const)("preserves historical sequence-zero %s receipts without manifestSha", async (status) => {
+    if (status === "unavailable") f.fetcher.fetch.mockResolvedValueOnce(ok([]));
+    if (status === "failed") f.fetcher.fetch.mockResolvedValueOnce(err("provider_fetch_failed_no_retry"));
+    if (status === "superseded") await f.projectNatural();
+    const row = await f.captureTerminal();
+    expect(row.status).toBe(status);
+    delete row.manifestSha;
+    await f.receipts.install(resultPath, row);
+    await f.assertReplay();
+  });
+
+  it.each(["unavailable", "invalid_metrics", "batch_failure"] as const)("allows natural ingestion to change current authority for %s", async (kind) => {
+    f.fetcher.fetch.mockImplementation(async () => {
+      await f.projectNatural();
+      if (kind === "batch_failure") return err("provider_fetch_failed_no_retry");
+      if (kind === "unavailable") return ok([]);
+      return ok([{ externalId: target().externalId, returned: true,
+        reason: null, metadata: { kind: "reddit_post", numComments: -1 } }]);
+    });
+    const result = await f.usecase().execute(manifest());
+    expect(result).toMatchObject({ ok: true, value: [{ status: kind === "unavailable" ? "unavailable" : "failed",
+      before: { metricsHash: null, observedAt: null }, after: { observedAt: later, observationCount: 1 } }] });
+    const row = await f.assertReplay();
+    expect(row.after).not.toEqual(row.before); expect(row.after.metricsHash).toMatch(/^[a-f0-9]{64}$/u);
+    expect(f.project).toHaveBeenCalledTimes(1); expect(f.fetcher.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays superseded with a strictly newer canonical hash, and never overwrites that authority", async () => {
+    await f.projectNatural();
+    expect(await f.usecase().execute(manifest())).toMatchObject({ ok: true, value: [{ status: "superseded", observedAt: now, after: { observedAt: later } }] });
+    const row = await f.assertReplay();
+    const evidence = await f.receipts.read<BatchEvidence>(observedPath);
+    expect(row.after.metricsHash).not.toEqual(evidence!.observations[0]!.sample!.metricsFingerprint);
+    expect(f.db.rows("sourceItemEngagementSnapshot")[0]?.score).toBe(99n);
+    expect(f.db.rows("sourceItemEngagementObservation")).toHaveLength(1);
+    expect(f.fetcher.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays a newer equal-metric snapshot as superseded", async () => {
+    await f.projectNatural(later, 42);
+    expect(await f.usecase().execute(manifest())).toMatchObject({ ok: true, value: [{ status: "superseded" }] });
+    const row = await f.assertReplay();
+    const batch = await f.receipts.read<BatchEvidence>(observedPath);
+    expect(row.after.metricsHash).toEqual(batch!.observations[0]!.sample!.metricsFingerprint);
+  });
+
+  it("does not require a cadence append or after.observationAt to equal the sample time", async () => {
+    await f.projectNatural("2026-09-05T11:59:00.000Z", 42);
+    const before = await f.inventory.read();
+    const planned = manifest([before]);
+    expect(await f.usecase().execute(planned)).toMatchObject({ ok: true, value: [{ status: "refreshed",
+      before: { observationCount: 1 }, after: { observedAt: now, observationAt: "2026-09-05T11:59:00.000Z", observationCount: 1 } }] });
+    await f.assertReplay(planned);
+  });
+
+  it.each(["before_commit", "after_commit"])("keeps projection failure %s nonterminal and resumes the exact sample without refetch", async (point) => {
+    const project = f.project.getMockImplementation()!.bind(f.projection);
+    f.project.mockImplementationOnce(async (command) => {
+      if (point === "after_commit") await project(command);
+      throw new Error("lost acknowledgement");
+    });
+    expect(await f.usecase().execute(manifest())).toMatchObject({ ok: true, value: [{ status: "failed", reason: "projection_unacknowledged_resume_same_operation" }] });
+    expect(await f.receipts.read(resultPath)).toBeNull();
+    expect(f.db.rows("sourceItemEngagementObservation")).toHaveLength(point === "after_commit" ? 1 : 0);
+    const evidence = await f.receipts.read<BatchEvidence>(observedPath);
+    expect(await f.usecase().execute(manifest())).toMatchObject({ ok: true, value: [{ status: "refreshed" }] });
+    expect(f.project.mock.calls[1]).toEqual(f.project.mock.calls[0]);
+    expect(await f.receipts.read(observedPath)).toEqual(evidence);
+    expect(f.db.rows("sourceItemEngagementObservation")).toHaveLength(1);
+    expect(f.fetcher.fetch).toHaveBeenCalledTimes(1);
+    await f.assertReplay();
+  });
+
+  it("keeps valid final accounting replayable with results enumerated before batches", async () => {
+    const result = await f.usecase().execute(manifest());
+    if (!result.ok) throw new Error(result.error);
+    await f.receipts.install(`${manifest().evidencePath}/final.json`, { manifestSha: metricRefreshDigest(manifest()),
+      results: result.value, cells: metricRefreshCells(result.value, manifest().scope.dates) });
+    await f.assertReplay(manifest(), true);
+  });
+
+  it.each([false, true])("binds mixed results by target identity with reversed observations/entries (forged=%s)", async (forged) => {
+    const second = target({ sourceItemId: "00000000-0000-7000-8000-000000006106", externalId: "reddit:t3_def",
+      canonicalUrl: "https://www.reddit.com/comments/def" });
+    const planned = manifest([target(), second]);
+    f.inventory.list.mockResolvedValue([...planned.targets]);
+    const read = f.inventory.read.getMockImplementation()!;
+    // The base fixture has one real projected target; the second has no sample.
+    f.inventory.read.mockImplementation(async (...args: unknown[]) => args[1] === second.sourceItemId ? second : read());
+    const fetch = f.fetcher.fetch.getMockImplementation()!;
+    f.fetcher.fetch.mockImplementation(async () => {
+      const result = await fetch();
+      if (!result.ok) return result;
+      return ok([{ externalId: second.externalId, returned: false, reason: "omitted", metadata: null }, ...result.value]);
+    });
+    const install = f.install.getMockImplementation()!;
+    f.install.mockImplementation(async (operation, path, value) => {
+      if (path === observedPath) {
+        const batch = value as BatchEvidence;
+        value = { ...batch, observations: [...batch.observations].reverse() };
+      }
+      if (forged && path === resultPath) value = { ...value as MetricRefreshOutcome, returned: false, reason: "omitted" };
+      return install(operation, path, value);
+    });
+    expect(await f.usecase().execute(planned)).toMatchObject({ ok: true, value: [{ status: "refreshed" }, { status: "unavailable" }] });
+    if (forged) await f.rejectBeforeEffects("result_observation_mismatch", planned, true);
+    else {
+      expect(await f.usecaseWithOrder().execute(planned)).toMatchObject({ ok: true, value: [{ sourceItemId: target().sourceItemId,
+        status: "refreshed", returned: true, reason: null }, { sourceItemId: second.sourceItemId, status: "unavailable", returned: false, reason: "omitted" }] });
+      expect(f.fetcher.fetch).toHaveBeenCalledTimes(1); expect(f.project).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("rejects equal-time different-hash projection as unconfirmed and leaves no terminal receipt", async () => {
+    await f.projectNatural(now, 99);
+    expect(await f.usecase().execute(manifest())).toEqual({ ok: false, error: "projection_not_confirmed" });
+    expect(await f.receipts.read(resultPath)).toBeNull();
+    expect(await f.usecase().execute(manifest())).toEqual({ ok: false, error: "projection_not_confirmed" });
+    expect(f.fetcher.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows observation history counts to differ from snapshot freshness after retention", async () => {
+    await f.projectNatural(earlier, 42);
+    f.db.rows("sourceItemEngagementObservation").splice(0);
+    const planned = manifest([await f.inventory.read()]);
+    expect(await f.usecase().execute(planned)).toMatchObject({ ok: true, value: [{ status: "refreshed", after: { observationCount: 0 } }] });
+    await f.assertReplay(planned);
+  });
+
+  it("rebuilds and replays a Hacker News sample under its own target provider", async () => {
+    const hn = target({ providerKey: "hacker-news", externalId: "hn:49580353", canonicalUrl: "https://news.ycombinator.com/item?id=49580353" });
+    const metadata = { kind: "hacker_news_story", points: 42, comments: 9 };
+    Object.assign(f.db.rows("sourceItem")[0]!, { providerKey: hn.providerKey, providerItemId: hn.externalId, canonicalUrl: hn.canonicalUrl, metadata });
+    Object.assign(f.db.rows("feedItem")[0]!, { providerKey: hn.providerKey, providerItemId: hn.externalId, canonicalUrl: hn.canonicalUrl, providerMetadata: metadata });
+    f.inventory.list.mockResolvedValue([hn]);
+    const read = f.inventory.read.getMockImplementation()!;
+    f.inventory.read.mockImplementation(async () => ({ ...hn, authority: (await read()).authority }));
+    f.fetcher.fetch.mockResolvedValueOnce(ok([{ externalId: hn.externalId, returned: true, reason: null, metadata }]));
+    const planned = manifest([hn]);
+    expect(await f.usecase().execute(planned)).toMatchObject({ ok: true, value: [{ status: "refreshed", providerKey: hn.providerKey }] });
+    await f.assertReplay(planned);
+    expect(f.fetcher.fetch).toHaveBeenCalledTimes(1); expect(f.project).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts.ts
@@ -39,6 +39,7 @@ export type PreservedMetricObservation = {
   reason: string | null;
 };
 export type MetricRefreshOutcome = {
+  manifestSha?: string;
   sourceItemId: string; externalId: string; providerKey: RefreshProvider; date: string;
   status: "refreshed" | "superseded" | "unavailable" | "failed" | "uncertain";
   returned: boolean; reason: string | null; observedAt: string | null;

--- a/libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case.spec.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildSourceEngagementMetrics } from "../../domain";
@@ -20,8 +20,8 @@ describe("bounded retained metric refresh using canonical projection", () => {
     const beforeFeed = structuredClone(f.db.rows("feedItem")[0]);
     const beforeFetch = f.fetcher.fetch.getMockImplementation()!;
     f.fetcher.fetch.mockImplementation(async () => {
-      expect(await f.receipts.read(`${manifest().evidencePath}/operation.json`)).toEqual(manifest());
-      expect(await f.receipts.read(`${manifest().evidencePath}/batch-0.reserved.json`)).not.toBeNull();
+      expect(JSON.parse(readFileSync(join(root, manifest().evidencePath, "operation.json"), "utf8")).value).toEqual(manifest());
+      expect(JSON.parse(readFileSync(join(root, manifest().evidencePath, "batch-0.reserved.json"), "utf8")).value).toBeDefined();
       return beforeFetch();
     });
     const result = await f.usecase().execute(manifest());
@@ -44,8 +44,8 @@ describe("bounded retained metric refresh using canonical projection", () => {
       throw new Error("simulated interruption");
     });
     else {
-      const install = f.receipts.install.bind(f.receipts);
-      jest.spyOn(f.receipts, "install").mockImplementationOnce(install).mockImplementationOnce(install).mockImplementationOnce(install)
+      const install = f.install.getMockImplementation()!;
+      f.install.mockImplementationOnce(install).mockImplementationOnce(install).mockImplementationOnce(install)
         .mockRejectedValueOnce(new Error("lost result acknowledgement"));
     }
     const first = await f.usecase().execute(manifest()).catch(() => null);
@@ -76,7 +76,7 @@ describe("bounded retained metric refresh using canonical projection", () => {
     await expect(f.usecase().execute(manifest())).rejects.toThrow();
     expect(await f.usecase().execute(manifest())).toMatchObject({ ok: true, value: [{ status: "uncertain" }] });
     expect(f.fetcher.fetch).toHaveBeenCalledTimes(1);
-    await expect(f.usecase().execute({ ...manifest(), operationId: "00000000-0000-7000-8000-000000006199" })).rejects.toThrow("different bytes");
+    expect(await f.usecase().execute({ ...manifest(), operationId: "00000000-0000-7000-8000-000000006199" })).toEqual({ ok: false, error: "reviewed_manifest_sha_mismatch" });
   });
   it.each<{ metadata?: JsonObject }>([{}, { metadata: { kind: "unknown", score: 5 } }, { metadata: { kind: "reddit_post", score: -2, providerScore: 4 } }])("accounts omission and rejects untrusted payload %j", async (row) => {
     f.fetcher.fetch.mockResolvedValueOnce(ok("metadata" in row ? [{ externalId: target().externalId, returned: true, reason: null, metadata: row.metadata! }] : []));
@@ -165,9 +165,9 @@ describe("bounded retained metric refresh using canonical projection", () => {
     expect(await f.receipts.read(`${planned.evidencePath}/batch-1.reserved.json`)).toBeNull();
   });
   it("never lets an old preserved sample overwrite a newer observation", async () => {
-    const install = f.receipts.install.bind(f.receipts);
-    jest.spyOn(f.receipts, "install").mockImplementation(async (path, value) => {
-      const installed = await install(path, value);
+    const install = f.install.getMockImplementation()!;
+    f.install.mockImplementation(async (operation, path, value) => {
+      const installed = await install(operation, path, value);
       if (path.endsWith("observed.json")) {
         const evidence = value as { observations: { sample: Record<string, unknown> }[] };
         const sample = evidence.observations[0]!.sample;

--- a/libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case.ts
@@ -4,8 +4,11 @@ import type { SourceEngagementProjectionPort } from "../../ports/source-engageme
 import { manifestProblem, refreshBatches, sameTarget, targetIdentity, targetProblem } from "./metric-refresh-admission";
 import type {
   MetricRefreshManifest, MetricRefreshOutcome, PreservedMetricObservation, RefreshDigest,
-  RetainedMetricFetchCapability, RetainedMetricInventory, MetricRefreshReceipts, RetainedMetricTarget,
+  RetainedMetricFetchCapability, RetainedMetricInventory, RetainedMetricTarget,
 } from "./refresh-retained-metrics.contracts";
+
+import type { MetricRefreshOperation, MetricRefreshOperationAuthority } from "./metric-refresh-operation.contracts";
+import { resolveMetricOperation } from "./metric-refresh-amendment";
 
 type BatchEvidence = { observations: readonly PreservedMetricObservation[]; failure: string | null };
 export class RefreshRetainedMetricsUseCase {
@@ -13,24 +16,32 @@ export class RefreshRetainedMetricsUseCase {
     private readonly inventory: RetainedMetricInventory,
     private readonly fetcher: RetainedMetricFetchCapability,
     private readonly projection: SourceEngagementProjectionPort,
-    private readonly receipts: MetricRefreshReceipts,
+    private readonly receipts: MetricRefreshOperationAuthority,
     private readonly clock: Clock,
     private readonly digest: RefreshDigest,
   ) {}
 
-  async execute(manifest: MetricRefreshManifest): Promise<Result<readonly MetricRefreshOutcome[], string>> {
+  async execute(manifest: MetricRefreshManifest, expectedSha = this.digest(manifest)): Promise<Result<readonly MetricRefreshOutcome[], string>> {
+    return this.receipts.withOperation((operation) => this.executeLocked(operation, manifest, expectedSha));
+  }
+
+  async executeLocked(receipts: MetricRefreshOperation, manifest: MetricRefreshManifest, expectedSha: string): Promise<Result<readonly MetricRefreshOutcome[], string>> {
+    receipts.assertHeld();
+    const head = await resolveMetricOperation(receipts, this.digest, this.clock.now());
+    if (expectedSha !== this.digest(manifest) || (head && this.digest(head.effective) !== expectedSha)) return err("reviewed_manifest_sha_mismatch");
+    manifest = head?.effective ?? manifest;
     const problem = manifestProblem(manifest, this.clock.now());
     if (problem) return err(problem);
     const current = await this.inventory.list(manifest.scope);
     const identities = (targets: readonly RetainedMetricTarget[]) => targets.map(targetIdentity).sort((a, b) => a.sourceItemId.localeCompare(b.sourceItemId));
     if (this.digest(identities(current)) !== this.digest(identities(manifest.targets))) return err("inventory_drift");
     const root = manifest.evidencePath;
-    await this.receipts.install(`${root}/operation.json`, manifest);
+    if (!head) await receipts.install(`${root}/operation.json`, manifest);
     const results: MetricRefreshOutcome[] = [];
     for (const [index, targets] of refreshBatches(manifest.targets).entries()) {
       const path = `${root}/batch-${index}`;
       const reservation = { operationId: manifest.operationId, manifestDigest: this.digest(manifest), targets: targets.map((t) => t.sourceItemId) };
-      if (await this.receipts.read(`${path}.reserved.json`) === null) {
+      if (await receipts.read(`${path}.reserved.json`) === null) {
         // Recheck the entire batch before spending its permanent fetch budget.
         // Existing reservations must still reconcile or replay without a fresh fetch.
         for (const target of targets) {
@@ -38,10 +49,11 @@ export class RefreshRetainedMetricsUseCase {
           if (!sameTarget(target, latest, this.digest) || latest === null || targetProblem(latest, manifest.scope)) return err("target_drift");
         }
       }
-      const reserved = await this.receipts.install(`${path}.reserved.json`, reservation);
-      let evidence = await this.receipts.read<BatchEvidence>(`${path}.observed.json`);
+      const reserved = await receipts.install(`${path}.reserved.json`, reservation);
+      let evidence = await receipts.read<BatchEvidence>(`${path}.observed.json`);
       if (evidence === null && reserved === "installed") {
         // No provider work precedes the permanent batch reservation. No retry on resume.
+        receipts.assertHeld();
         const fetched = await this.fetcher.fetch(targets);
         const observedAt = this.clock.now().toISOString();
         if (!fetched.ok) evidence = { observations: [], failure: fetched.error };
@@ -65,12 +77,12 @@ export class RefreshRetainedMetricsUseCase {
           }
         }
         // Persist the normalized provider observation AND exact canonical sample before projection.
-        await this.receipts.install(`${path}.observed.json`, evidence);
+        await receipts.install(`${path}.observed.json`, evidence);
       }
       if (evidence === null) {
         const remaining = manifest.targets.filter((target) => !results.some((row) => row.sourceItemId === target.sourceItemId));
         return ok([...results, ...remaining.map((target): MetricRefreshOutcome => ({
-          sourceItemId: target.sourceItemId, externalId: target.externalId, providerKey: target.providerKey,
+          manifestSha: expectedSha, sourceItemId: target.sourceItemId, externalId: target.externalId, providerKey: target.providerKey,
           date: target.publishedAt.slice(0, 10), status: "uncertain", returned: false,
           reason: "reserved_without_observation_reconcile_required", observedAt: null,
           before: target.authority, after: target.authority,
@@ -78,13 +90,13 @@ export class RefreshRetainedMetricsUseCase {
       }
       for (const target of targets) {
         const resultPath = `${root}/result-${target.sourceItemId}.json`;
-        const previous = await this.receipts.read<MetricRefreshOutcome>(resultPath);
+        const previous = await receipts.read<MetricRefreshOutcome>(resultPath);
         if (previous !== null) { results.push(previous); continue; }
         const observation = evidence.observations.find((row) => row.externalId === target.externalId);
         const latest = await this.inventory.read(manifest.scope, target.sourceItemId);
         if (!sameTarget(target, latest, this.digest) || latest === null || targetProblem(latest, manifest.scope)) return err("target_drift");
         let result: MetricRefreshOutcome = {
-          sourceItemId: target.sourceItemId, externalId: target.externalId, providerKey: target.providerKey,
+          manifestSha: expectedSha, sourceItemId: target.sourceItemId, externalId: target.externalId, providerKey: target.providerKey,
           date: target.publishedAt.slice(0, 10), before: target.authority, after: latest.authority,
           returned: observation?.returned ?? false,
           observedAt: observation?.observedAt ?? null, status: observation?.reason === "invalid_metrics" ? "failed" : "unavailable", reason: observation?.reason ?? null,
@@ -102,6 +114,7 @@ export class RefreshRetainedMetricsUseCase {
           if (!Number.isFinite(Date.parse(observation.observedAt)) || new Date(observation.observedAt).toISOString() !== observation.observedAt || Date.parse(observation.observedAt) > now.getTime() || Date.parse(observation.observedAt) < Date.parse(manifest.plannedAt)) return err("receipt_observation_time_invalid");
           try {
             // Replaying these same bytes is safe, including a lost commit acknowledgement.
+            receipts.assertHeld();
             await this.projection.project({ tenantId: tenantId(manifest.scope.tenantId), workspaceId: workspaceId(manifest.scope.workspaceId),
               sourceBindingId: target.sourceBindingId, scanJobId: manifest.operationId,
               providerKey: target.providerKey, observedAt: new Date(observation.observedAt),
@@ -116,7 +129,7 @@ export class RefreshRetainedMetricsUseCase {
             continue;
           }
         }
-        if (result.status !== "uncertain") await this.receipts.install(resultPath, result);
+        if (result.status !== "uncertain") await receipts.install(resultPath, result);
         results.push(result);
       }
     }

--- a/scripts/check-retained-metric-refresh-postgres.ts
+++ b/scripts/check-retained-metric-refresh-postgres.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { acquirePrismaPgRuntimeConnection, defaultPostgresRuntimePoolConfig, runWithSystemDatabaseAccess,
   runWithTenantDatabaseAccess, withPrismaWriteRetry, type PrismaPgRuntimeClientConstructor } from "@social-monitor/platform-persistence";
@@ -12,8 +12,8 @@ import { RefreshRetainedMetricsUseCase } from "@social-monitor/ingestion/feature
 import { metricRefreshBounds, metricRefreshSourceBase, metricRefreshDates, metricRefreshEvidencePath, metricRefreshTenant,
   metricRefreshWorkspace, sameTarget } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-admission";
 import type { MetricFetchObservation, MetricRefreshManifest, RetainedMetricFetchCapability } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
-import { createRecoveryEvidenceFilesystemTestHarness } from "./lib/reader-summary-recovery-evidence-secure-file";
 import { metricRefreshDigest, SecureMetricRefreshReceipts } from "./lib/retained-metric-refresh-receipts";
+import { AmendRetainedMetricManifestUseCase } from "@social-monitor/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case";
 
 type Row = Record<string, unknown>;
 type Writer = { create(args: { data: Row }): Promise<unknown> };
@@ -61,11 +61,17 @@ async function main() {
       const inventory = new PrismaRetainedMetricInventory(lease.client, metricRefreshDigest);
       const targets = await inventory.list(scope);
       assert.equal(targets.length, 2);
-      const manifest: MetricRefreshManifest = { version: "retained-metrics.v1", sourceBase: metricRefreshSourceBase, bounds: metricRefreshBounds,
+      let manifest: MetricRefreshManifest = { version: "retained-metrics.v1", sourceBase: metricRefreshSourceBase, bounds: metricRefreshBounds,
         operationId: id(6250), evidencePath: metricRefreshEvidencePath, plannedAt: scope.endAt, scope, targets };
+      let transactionDrift = true;
       const projection = new PrismaSourceEngagementProjectionAdapter(lease.client, new CryptoIdGenerator(), { retention: "skip",
         sampleGuard: async (transaction, _command, sample) => {
-          const expected = targets.find((target) => target.sourceItemId === sample.sourceItemId)!;
+          const expected = manifest.targets.find((target) => target.sourceItemId === sample.sourceItemId)!;
+          if (transactionDrift) {
+            transactionDrift = false;
+            const source = transaction as unknown as { sourceItem: { update(args: unknown): Promise<unknown> } };
+            await source.sourceItem.update({ where: { id: expected.sourceItemId }, data: { body: "TEST transactional drift must roll back" } });
+          }
           const inside = new PrismaRetainedMetricInventory(transaction as unknown as PrismaMetricInventoryClient, metricRefreshDigest);
           assert(sameTarget(expected, await inside.read(scope, expected.sourceItemId), metricRefreshDigest));
         } });
@@ -75,24 +81,44 @@ async function main() {
         return { ok: true, value: batch.map((target): MetricFetchObservation => ({ externalId: target.externalId, returned: true, reason: null,
           metadata: target.providerKey === "reddit" ? { kind: "reddit_post", score: 42, numComments: 9 } : { kind: "hacker_news_story", points: 42, comments: 9 } })) };
       } };
-      const receipts = new SecureMetricRefreshReceipts(createRecoveryEvidenceFilesystemTestHarness(root));
+      const receipts = SecureMetricRefreshReceipts.forTest(root);
+      const clock = new FixedClock(new Date("2026-09-05T13:00:00.000Z"));
+      await receipts.install(`${metricRefreshEvidencePath}/operation.json`, manifest);
+      const originalBytes = readFileSync(resolve(root, metricRefreshEvidencePath, "operation.json"));
+      await withPrismaWriteRetry(() => lease.client.$transaction(async (transaction) => {
+        const source = transaction as unknown as { sourceItem: { update(args: unknown): Promise<unknown> } };
+        await source.sourceItem.update({ where: { id: id(6230) }, data: {
+          body: "TEST natural source content version", contentHash: "changed", contentUpdatedAt: new Date("2026-09-05T12:01:00Z"),
+        } });
+      }, { isolationLevel: "Serializable" }));
+      const oldApply = new RefreshRetainedMetricsUseCase(inventory, fetcher, projection, receipts, clock, metricRefreshDigest);
+      assert.deepEqual(await oldApply.execute(manifest), { ok: false, error: "inventory_drift" });
+      const amend = new AmendRetainedMetricManifestUseCase(inventory, receipts, clock, metricRefreshDigest,
+        { sourceSha: "1".repeat(64), executableSha: "2".repeat(64), holderProof: "3".repeat(64), legacyRetirementRef: "TEST-no-legacy" });
+      const prepared = await amend.prepare(metricRefreshDigest(manifest), "TEST single natural content version");
+      assert(prepared.ok); assert.equal(prepared.value.changes.length, 1);
+      const committed = await amend.commit(metricRefreshDigest(prepared.value), prepared.value.priorEffectiveSha, prepared.value.effectiveManifestSha);
+      assert(committed.ok); manifest = committed.value.effective;
+      assert.equal(fetches, 0);
+      assert(readFileSync(resolve(root, metricRefreshEvidencePath, "operation.json")).equals(originalBytes));
       let loseAck = true;
       const uncertainProjection = { project: async (command: Parameters<typeof projection.project>[0]) => {
         const result = await projection.project(command);
         if (loseAck) { loseAck = false; throw new Error("fixture lost commit acknowledgement"); }
         return result;
       } };
-      const usecase = new RefreshRetainedMetricsUseCase(inventory, fetcher, uncertainProjection, receipts, new FixedClock(new Date(scope.endAt)), metricRefreshDigest);
+      const usecase = new RefreshRetainedMetricsUseCase(inventory, fetcher, uncertainProjection, receipts, clock, metricRefreshDigest);
       const first = await usecase.execute(manifest);
       assert(first.ok && first.value.some((row) => row.status === "failed"));
+      assert.equal((await inventory.read(scope, id(6230)))?.authority.observationCount, 0);
       const resumed = await usecase.execute(manifest);
       assert(resumed.ok && resumed.value.every((row) => row.status === "refreshed" && row.after.observationCount === 1));
       assert.deepEqual(await usecase.execute(manifest), resumed);
       assert.equal(fetches, 2);
-      for (const target of targets) {
+      for (const target of manifest.targets) {
         const current = await inventory.read(scope, target.sourceItemId);
         assert(sameTarget(target, current, metricRefreshDigest));
-        assert.equal(current?.authority.observedAt, scope.endAt);
+        assert.equal(current?.authority.observedAt, clock.now().toISOString());
       }
       process.stdout.write(`${JSON.stringify({ evidenceKind: "disposable_postgres_fixture", lostAckResume: "passed", fetches, results: resumed.value }, null, 2)}\n`);
     });

--- a/scripts/lib/reader-summary-recovery-evidence-secure-file.ts
+++ b/scripts/lib/reader-summary-recovery-evidence-secure-file.ts
@@ -86,7 +86,19 @@ type TrustedParent = Readonly<{
   leafName: string;
   stamp: FileStamp;
   policy: RecoveryEvidenceFilesystemPolicy;
+  ancestors: readonly FileStamp[];
 }>;
+
+// A narrow descriptor lease for the metric journal. The caller owns close();
+// revalidation includes every ancestor, not just the final directory inode.
+export function openSecureRecoveryEvidenceDirectory(relativePath: string, testRoot?: string) {
+  if (testRoot !== undefined && process.env.NODE_ENV !== "test") fail("test directory unavailable outside tests");
+  const policy = testRoot === undefined ? productionPolicy : { root: testRoot, effectiveUserId: requiredEffectiveUserId() };
+  if (!isAbsolute(policy.root) || resolve(policy.root) !== policy.root) fail("directory root must be normalized");
+  const parent = openTrustedParent(`${relativePath}/operation.json`, true, policy);
+  return { descriptor: parent.descriptor, effectiveUserId: policy.effectiveUserId,
+    assertNamed: () => assertTrustedParentStillNamed(parent), close: () => closeSync(parent.descriptor) };
+}
 
 const procDescriptorRoot = "/proc/self/fd";
 
@@ -283,6 +295,7 @@ const openTrustedParent = (
       .split(sep)
       .filter(Boolean);
     let traversed = root;
+    const ancestors: FileStamp[] = [fileStamp(fstatSync(descriptor, { bigint: true }))];
     const evidenceRootComponents = policy.root
       .slice(root.length)
       .split(sep)
@@ -325,6 +338,7 @@ const openTrustedParent = (
           index >= evidenceRootComponents.length - 1,
           policy,
         );
+        ancestors.push(fileStamp(fstatSync(nextDescriptor, { bigint: true })));
         // Existing children may belong to a creator that has not fsynced yet.
         // Anchor every child below the evidence root before advancing.
         if (createMissing && index >= evidenceRootComponents.length) {
@@ -343,6 +357,7 @@ const openTrustedParent = (
       leafName,
       stamp: fileStamp(fstatSync(descriptor, { bigint: true })),
       policy,
+      ancestors,
     });
   } catch (error) {
     closeSync(descriptor);
@@ -364,7 +379,9 @@ const assertTrustedParentStillNamed = (trustedParent: TrustedParent): void => {
     trustedParent.policy,
   );
   try {
-    if (!sameFileIdentity(trustedParent.stamp, probe.stamp)) {
+    if (!sameFileIdentity(trustedParent.stamp, probe.stamp) ||
+        trustedParent.ancestors.length !== probe.ancestors.length ||
+        trustedParent.ancestors.some((stamp, i) => !sameFileIdentity(stamp, probe.ancestors[i]!))) {
       fail("parent directory changed after validation");
     }
   } finally {

--- a/scripts/lib/retained-metric-amendment.spec-support.ts
+++ b/scripts/lib/retained-metric-amendment.spec-support.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import { FixedClock } from "@social-monitor/shared-kernel";
+import { manifest, target } from "./retained-metric-refresh.spec-support";
+import { SecureMetricRefreshReceipts, metricRefreshDigest } from "./retained-metric-refresh-receipts";
+import { AmendRetainedMetricManifestUseCase } from "@social-monitor/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case";
+import type { RetainedMetricTarget } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
+export const incidentSource = "ab5fc68e-c891-4641-8e67-a6568e4b7d4e";
+export const beforeDigest = "bb32223966faefc45a54b863fab39b62e33c3e12e5733d8ab3678a0f31cd4828";
+export const afterDigest = "f999a8b7f9ce49d0fe090e8869e3654871e63a555a62b73feb3dd27608cfc9e3";
+export const implementation = { sourceSha: "1".repeat(64), executableSha: "2".repeat(64), legacyRetirementRef: "TEST-legacy-retired", holderProof: "3".repeat(64) };
+export function incidentFixture(root: string, count = 3329) {
+  const targets = Array.from({ length: count }, (_, i) => target({
+    sourceItemId: i === 0 ? incidentSource : `00000000-0000-7000-8000-${String(7000 + i).padStart(12, "0")}`,
+    providerKey: i % 2 ? "reddit" : "hacker-news", externalId: i % 2 ? `reddit:t3_fixture${i}` : `hn:${49580353 + i}`,
+    canonicalUrl: i % 2 ? `https://www.reddit.com/comments/fixture${i}` : `https://news.ycombinator.com/item?id=${49580353 + i}`,
+    publishedAt: `${["2026-08-30", "2026-08-31", "2026-09-01", "2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05"][i % 7]}T01:00:00.000Z`,
+    identityDigest: i === 0 ? beforeDigest : "b".repeat(64),
+  }));
+  const original = { ...manifest(targets), operationId: "409f3cde-6073-451c-9285-eaa6802ca081", plannedAt: "2026-09-06T02:35:17.000Z",
+    scope: { ...manifest().scope, endAt: "2026-09-06T00:00:00.000Z" } };
+  let current = targets.map((t) => ({ ...t, identityDigest: t.sourceItemId === incidentSource ? afterDigest : t.identityDigest }));
+  const inventory = { list: jest.fn(async () => current), read: jest.fn(async (_: unknown, id: string) => current.find((t) => t.sourceItemId === id) ?? null) };
+  const receipts = SecureMetricRefreshReceipts.forTest(root), clock = new FixedClock(new Date("2026-09-06T04:00:00.000Z"));
+  const amendment = () => new AmendRetainedMetricManifestUseCase(inventory, receipts, clock, metricRefreshDigest, implementation);
+  return { original, inventory, receipts, clock, amendment, current: () => current, change: (rows: RetainedMetricTarget[]) => { current = rows; } };
+}
+// Independent recursive object normalization, separate from production serializer.
+export function independentMetricSha(value: unknown): string {
+  const normalize = (v: unknown): unknown => Array.isArray(v) ? v.map(normalize) : v && typeof v === "object" ?
+    Object.fromEntries(Object.keys(v).sort().map((key) => [key, normalize((v as Record<string, unknown>)[key])])) : v;
+  return createHash("sha256").update(JSON.stringify(normalize(value))).digest("hex");
+}

--- a/scripts/lib/retained-metric-journal.spec.ts
+++ b/scripts/lib/retained-metric-journal.spec.ts
@@ -1,0 +1,109 @@
+import { chmodSync, linkSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, truncateSync, unlinkSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type * as NodeFilesystem from "node:fs";
+import { incidentFixture } from "./retained-metric-amendment.spec-support";
+import { canonicalMetricRefreshJson, metricRefreshDigest, SecureMetricRefreshReceipts } from "./retained-metric-refresh-receipts";
+import { metricEvidencePath, resolveMetricOperation } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-amendment";
+const fs = jest.requireActual<typeof NodeFilesystem>("node:fs");
+
+describe("whole-directory metric authority and durable adoption", () => {
+  let root: string, f: ReturnType<typeof incidentFixture>;
+  const path = (name: string) => join(root, metricEvidencePath(name));
+  const resolve = (receipts = f.receipts) => receipts.withOperation((o) => resolveMetricOperation(o, metricRefreshDigest, f.clock.now(), true));
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "metric-journal-")); f = incidentFixture(root, 1);
+    await f.receipts.install(metricEvidencePath("operation.json"), f.original);
+  });
+  afterEach(() => { jest.restoreAllMocks(); rmSync(root, { recursive: true, force: true }); });
+  it.each(["batch-99999.reserved.json", "batch-12.observed.json", "result-00000000-0000-7000-8000-000000009999.json", "final.json"])("never interprets orphan %s as zero budget", async (name) => {
+    await f.receipts.install(metricEvidencePath(name), {});
+    await expect(resolve()).rejects.toThrow("metric_budget_already_started");
+    await expect(f.amendment().prepare(metricRefreshDigest(f.original), "must stop")).rejects.toThrow();
+    expect(f.inventory.list).not.toHaveBeenCalled();
+  });
+  it.each(["unknown.json", "batch-01.reserved.json", "amendment-000009.json", "nested"])("refuses unknown name %s across the entire namespace", async (name) => {
+    if (name === "nested") mkdirSync(path(name), { mode: 0o700 });
+    else writeFileSync(path(name), "{}", { mode: 0o400 });
+    await expect(resolve()).rejects.toThrow();
+  });
+  it.each(["empty", "duplicate", "noncanonical", "null", "bad_schema", "depth", "oversized", "unsafe_mode", "hardlink", "symlink", "fifo"])("refuses %s evidence without absence or blocking", async (kind) => {
+    const leaf = path("batch-99999.reserved.json");
+    const envelope = canonicalMetricRefreshJson({ digest: metricRefreshDigest({}), value: {} });
+    if (kind === "fifo") expect(spawnSync("mkfifo", ["-m", "400", leaf]).status).toBe(0);
+    else if (kind === "symlink") symlinkSync(path("operation.json"), leaf);
+    else if (kind === "hardlink") linkSync(path("operation.json"), leaf);
+    else {
+      const text = kind === "empty" ? "" : kind === "duplicate" ? envelope.replace('"value":{}', '"value":{},"value":{}') :
+        kind === "noncanonical" ? `${envelope}\n` : kind === "null" ? "null" : kind === "depth" ? "[".repeat(34) + "0" + "]".repeat(34) :
+          kind === "bad_schema" ? canonicalMetricRefreshJson({ digest: metricRefreshDigest(null), value: null }) : envelope;
+      writeFileSync(leaf, text, { mode: 0o600 });
+      if (kind === "oversized") truncateSync(leaf, 16 * 1024 * 1024 + 1);
+      chmodSync(leaf, kind === "unsafe_mode" ? 0o600 : 0o400);
+    }
+    await expect(resolve()).rejects.toThrow();
+    expect(f.inventory.list).not.toHaveBeenCalled();
+  });
+  it.each(["leaf", "parent", "ancestor", "enumeration"])("detects %s replacement during a descriptor-anchored read", async (kind) => {
+    let changed = false;
+    const receipts = SecureMetricRefreshReceipts.forTest(root, (point, name) => {
+      if (changed || (kind === "enumeration" ? point !== "directory_enumerated" : point !== "file_opened" || name !== "operation.json")) return;
+      changed = true;
+      if (kind === "leaf") { const bytes = readFileSync(path(name)); unlinkSync(path(name)); writeFileSync(path(name), bytes, { mode: 0o400 }); }
+      else if (kind === "enumeration") writeFileSync(path("unknown.json"), "", { mode: 0o400 });
+      else {
+        const directory = kind === "parent" ? path("") : join(root, "seven-day-6101-6102");
+        renameSync(directory, `${directory.replace(/\/$/u, "")}-old`);
+        mkdirSync(directory, { mode: 0o700 });
+      }
+    });
+    await expect(resolve(receipts)).rejects.toThrow();
+    expect(changed).toBe(true);
+  });
+  it("does not turn a vanished known leaf or parent into a missing receipt", async () => {
+    await f.receipts.withOperation(async (o) => {
+      await o.read(metricEvidencePath("operation.json"));
+      unlinkSync(path("operation.json"));
+      await expect(o.read(metricEvidencePath("operation.json"))).rejects.toThrow();
+    });
+  });
+  it("requires the durability barrier even for complete equal-byte replay", async () => {
+    const receipts = SecureMetricRefreshReceipts.forTest(root, (point, name) => {
+      if (point === "before_adoption_sync" && name === "operation.json") throw new Error("injected fsync unavailable");
+    });
+    await expect(receipts.install(metricEvidencePath("operation.json"), f.original)).rejects.toThrow("fsync unavailable");
+    await expect(resolve(receipts)).rejects.toThrow("fsync unavailable");
+    expect(await f.receipts.install(metricEvidencePath("operation.json"), f.original)).toBe("replayed");
+  });
+  it("refuses an unheld lease and a competing real kernel flock", async () => {
+    let saved: (() => void) | undefined;
+    await f.receipts.withOperation(async (o) => {
+      saved = o.assertHeld;
+      await expect(f.receipts.withOperation(async () => {})).rejects.toThrow("fence busy");
+      o.assertHeld();
+    });
+    expect(saved).toBeDefined(); expect(() => saved!()).toThrow();
+    expect((await resolve())?.sequence).toBe(0);
+  });
+  it.each(["file", "directory"])("retains append evidence on actual %s fsync EIO and adopts only after a successful barrier", async (kind) => {
+    const name = "batch-0.reserved.json", value = { test: "untrusted receipt; never zero" };
+    await f.receipts.withOperation(async (o) => {
+      const realSync = fs.fsyncSync;
+      const sync = jest.spyOn(fs, "fsyncSync").mockImplementation((fd) => {
+        if ((kind === "directory" && fs.fstatSync(fd).isDirectory()) ||
+            (kind === "file" && fs.readlinkSync(`/proc/self/fd/${fd}`).endsWith(name))) {
+          throw Object.assign(new Error("Injected fsync EIO"), { code: "EIO" });
+        }
+        realSync(fd);
+      });
+      await expect(o.install(metricEvidencePath(name), value)).rejects.toThrow("fsync EIO");
+      const bytes = readFileSync(path(name));
+      await expect(o.read(metricEvidencePath(name))).rejects.toThrow("fsync EIO");
+      sync.mockRestore();
+      expect(await o.install(metricEvidencePath(name), value)).toBe("replayed");
+      expect(readFileSync(path(name))).toEqual(bytes);
+    });
+    await expect(resolve()).rejects.toThrow("metric_budget_already_started");
+  });
+});

--- a/scripts/lib/retained-metric-journal.ts
+++ b/scripts/lib/retained-metric-journal.ts
@@ -1,0 +1,144 @@
+import { closeSync, constants, fchmodSync, fstatSync, fsyncSync, openSync, opendirSync, readFileSync, readSync, writeFileSync, writeSync, type BigIntStats } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { openSecureRecoveryEvidenceDirectory } from "./reader-summary-recovery-evidence-secure-file";
+import { metricRefreshEvidencePath } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-admission";
+
+const maxBytes = 16 * 1024 * 1024;
+const flags = constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK;
+const bytesSha = (bytes: Buffer) => createHash("sha256").update(bytes).digest("hex");
+const same = (a: BigIntStats, b: BigIntStats) => a.dev === b.dev && a.ino === b.ino && a.uid === b.uid && a.mode === b.mode && a.nlink === b.nlink && a.size === b.size && a.mtimeNs === b.mtimeNs && a.ctimeNs === b.ctimeNs;
+const code = (e: unknown) => typeof e === "object" && e !== null && "code" in e ? e.code : undefined;
+function requireValid(ok: unknown): asserts ok { if (!ok) throw new Error("Unsafe or changed metric evidence filesystem"); }
+export type MetricJournalCheckpoint = (point: string, name: string) => void;
+
+// The only test override changes the root/uid, never safety rules or locking.
+export class RetainedMetricJournal {
+  private readonly directory;
+  private lock: number | undefined;
+  private lockStamp: BigIntStats | undefined;
+  private readonly seen = new Map<string, BigIntStats>();
+  private closed = false;
+  constructor(private readonly maintenance: () => void, testRoot?: string, private readonly checkpoint?: MetricJournalCheckpoint) {
+    maintenance();
+    this.directory = openSecureRecoveryEvidenceDirectory(metricRefreshEvidencePath, testRoot);
+    try {
+      try {
+        const fd = openSync(this.path("operation.lock"), constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o400);
+        try { fchmodSync(fd, 0o400); fsyncSync(fd); fsyncSync(this.directory.descriptor); } finally { closeSync(fd); }
+      } catch (e) { if (code(e) !== "EEXIST") throw e; }
+      this.lock = openSync(this.path("operation.lock"), flags);
+      this.lockStamp = this.stat(this.lock);
+      requireValid(this.lockStamp.size === 0n);
+      const acquired = spawnSync("/usr/bin/flock", ["--exclusive", "--nonblock", "3"], { stdio: ["ignore", "ignore", "pipe", this.lock], timeout: 5000 });
+      if (acquired.error || acquired.status !== 0) throw new Error("Metric operation fence busy or unavailable");
+      this.assertHeld();
+      fsyncSync(this.lock); fsyncSync(this.directory.descriptor);
+    } catch (e) { this.close(); throw e; }
+  }
+  private path(name: string) { return `/proc/self/fd/${this.directory.descriptor}/${name}`; }
+  private name(path: string) {
+    const prefix = `${metricRefreshEvidencePath}/`;
+    requireValid(path.startsWith(prefix));
+    const name = path.slice(prefix.length);
+    requireValid(/^(?:operation\.json|proposal-[a-f0-9]{64}\.json|amendment-00000[1-8]\.json|batch-(?:0|[1-9]\d{0,4})\.(?:reserved|observed)\.json|result-[a-f0-9-]{36}\.json|final\.json)$/u.test(name));
+    return name;
+  }
+  private stat(fd: number) {
+    const stat = fstatSync(fd, { bigint: true });
+    requireValid(stat.isFile() && stat.uid === BigInt(this.directory.effectiveUserId) && (stat.mode & 0o7777n) === 0o400n && stat.nlink === 1n && stat.size <= BigInt(maxBytes));
+    return stat;
+  }
+  assertHeld = () => {
+    requireValid(!this.closed && this.lock !== undefined && this.lockStamp !== undefined);
+    this.maintenance();
+    this.directory.assertNamed();
+    const probe = openSync(this.path("operation.lock"), flags);
+    try { requireValid(same(this.lockStamp, this.stat(probe)) && same(this.lockStamp, this.stat(this.lock))); } finally { closeSync(probe); }
+    requireValid(/lock:\s+\d+: FLOCK\s+ADVISORY\s+WRITE/u.test(readFileSync(`/proc/self/fdinfo/${this.lock}`, "utf8")));
+  };
+  read(path: string): Buffer | null {
+    const name = this.name(path);
+    this.assertHeld();
+    let fd: number;
+    try { fd = openSync(this.path(name), flags); }
+    catch (e) {
+      this.assertHeld();
+      if (code(e) === "ENOENT" && !this.seen.has(name)) return null;
+      throw e;
+    }
+    try {
+      const before = this.stat(fd), previous = this.seen.get(name);
+      requireValid(!previous || same(previous, before));
+      this.checkpoint?.("file_opened", name);
+      const buffer = Buffer.alloc(Number(before.size) + 1);
+      let length = 0, got: number;
+      do { got = readSync(fd, buffer, length, buffer.length - length, null); length += got; } while (got && length < buffer.length);
+      requireValid(length === Number(before.size) && same(before, this.stat(fd)));
+      this.checkpoint?.("before_adoption_sync", name);
+      // Complete crash leftovers become durable before returning any authority.
+      fsyncSync(fd); fsyncSync(this.directory.descriptor);
+      const probe = openSync(this.path(name), flags);
+      try { requireValid(same(before, this.stat(probe)) && same(before, this.stat(fd))); } finally { closeSync(probe); }
+      this.assertHeld(); this.seen.set(name, before);
+      return buffer.subarray(0, length);
+    } finally { closeSync(fd); }
+  }
+  install(path: string, bytes: Buffer): "installed" | "replayed" {
+    const name = this.name(path);
+    requireValid(bytes.length <= maxBytes);
+    this.assertHeld();
+    let fd: number;
+    try { fd = openSync(this.path(name), constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW | constants.O_NONBLOCK, 0o400); }
+    catch (e) {
+      if (code(e) !== "EEXIST") throw e;
+      const previous = this.read(path);
+      if (!previous?.equals(bytes)) throw new Error("Metric evidence already exists with different bytes");
+      return "replayed";
+    }
+    // Never remove a partially installed authoritative name, even on an error.
+    try {
+      fchmodSync(fd, 0o400); this.stat(fd);
+      this.checkpoint?.("file_created", name);
+      const first = writeSync(fd, bytes, 0, Math.floor(bytes.length / 2));
+      this.checkpoint?.("file_partial", name);
+      writeFileSync(fd, bytes.subarray(first));
+      this.checkpoint?.("file_written", name);
+      fsyncSync(fd); this.checkpoint?.("file_synced", name);
+      fsyncSync(this.directory.descriptor); this.checkpoint?.("directory_synced", name);
+    } finally { closeSync(fd); }
+    requireValid(this.read(path)?.equals(bytes));
+    return "installed";
+  }
+  entries() {
+    this.assertHeld();
+    const scan = () => {
+      const names: string[] = [], directory = opendirSync(`/proc/self/fd/${this.directory.descriptor}`);
+      try {
+        let entry;
+        while ((entry = directory.readSync())) {
+          requireValid(names.length < 30_030);
+          names.push(entry.name);
+        }
+      } finally { directory.closeSync(); }
+      return names.sort((a, b) => a.localeCompare(b));
+    };
+    const names = scan();
+    const entries = names.map((name) => {
+      if (name === "operation.lock") return { name, bytesSha: bytesSha(Buffer.alloc(0)) };
+      const bytes = this.read(`${metricRefreshEvidencePath}/${name}`);
+      requireValid(bytes !== null);
+      return { name, bytesSha: bytesSha(bytes) };
+    });
+    this.checkpoint?.("directory_enumerated", "");
+    requireValid(JSON.stringify(scan()) === JSON.stringify(names));
+    this.assertHeld();
+    return entries;
+  }
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.lock !== undefined) closeSync(this.lock);
+    this.directory.close();
+  }
+}

--- a/scripts/lib/retained-metric-maintenance.spec.ts
+++ b/scripts/lib/retained-metric-maintenance.spec.ts
@@ -41,17 +41,21 @@ describe("existing production maintenance contract, honestly bounded legacy excl
     const driver = join(root, "legacy.cjs");
     writeFileSync(driver, `
       require(process.cwd() + '/node_modules/ts-node').register({transpileOnly:true,project:process.cwd()+'/tsconfig.build.json'}); require(process.cwd() + '/node_modules/tsconfig-paths/register');
-      const {execFileSync} = require('node:child_process'), Module = require('node:module');
+      const {readFileSync} = require('node:fs'), {createHash} = require('node:crypto'), Module = require('node:module');
       const ts = require(process.cwd() + '/node_modules/typescript');
-      function original(path) {
-        const source = execFileSync('git', ['show', '0de33d8751bfd1e8ae722698e60ef893d324d9e5:' + path], {encoding:'utf8'});
+      // Exact source bytes from 0de33d8751bfd1e8ae722698e60ef893d324d9e5, available in shallow CI checkouts.
+      function original(path, expectedSha256) {
+        const source = readFileSync(process.cwd() + '/test-fixtures/retained-metric-legacy/' + path.split('/').at(-1) + '.txt');
+        if (createHash('sha256').update(source).digest('hex') !== expectedSha256) throw Error('Legacy source SHA256 mismatch: ' + path);
         const filename = process.cwd() + '/' + path;
         const mod = new Module(filename, module); mod.filename = filename; mod.paths = Module._nodeModulePaths(require('node:path').dirname(filename));
-        mod._compile(ts.transpileModule(source, {compilerOptions:{module:ts.ModuleKind.CommonJS,target:ts.ScriptTarget.ES2023}}).outputText, filename);
+        mod._compile(ts.transpileModule(source.toString('utf8'), {compilerOptions:{module:ts.ModuleKind.CommonJS,target:ts.ScriptTarget.ES2023}}).outputText, filename);
         return mod.exports;
       }
-      const {SecureMetricRefreshReceipts, metricRefreshDigest} = original('scripts/lib/retained-metric-refresh-receipts.ts');
-      const {RefreshRetainedMetricsUseCase} = original('libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case.ts');
+      const {SecureMetricRefreshReceipts, metricRefreshDigest} = original('scripts/lib/retained-metric-refresh-receipts.ts',
+        '2ea4f4e236e8244aaebf6cfda77b7e024a1fbc5ab915fe2a091b1294f5d3fea2');
+      const {RefreshRetainedMetricsUseCase} = original('libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case.ts',
+        '856f4d16b9d977638156728a734e2ae6c370e7766cf26627ad74c78acb7efb9d');
       const {createRecoveryEvidenceFilesystemTestHarness} = require(process.cwd() + '/scripts/lib/reader-summary-recovery-evidence-secure-file');
       const {manifest} = require(process.cwd() + '/scripts/lib/retained-metric-refresh.spec-support');
       const m = manifest(), row = m.targets[0]; let fetches = 0;

--- a/scripts/lib/retained-metric-maintenance.spec.ts
+++ b/scripts/lib/retained-metric-maintenance.spec.ts
@@ -1,0 +1,71 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assertMetricMaintenanceLocks, metricMaintenanceAdmission, metricMaintenanceLocks } from "./retained-metric-maintenance";
+
+describe("existing production maintenance contract, honestly bounded legacy exclusion", () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), "metric-maintenance-")); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+  it("requires an explicit parent retirement reference before touching source, locks or database", () => {
+    expect(() => metricMaintenanceAdmission("a".repeat(64), "b".repeat(64), undefined)).toThrow("legacy-retirement");
+    expect(() => assertMetricMaintenanceLocks([[7, join(root, "absent.lock")]])).toThrow();
+  });
+  it("verifies inherited INNER wrapper flocks, and rejects open-but-unheld, symlink and replacement inodes", () => {
+    const paths = [7, 9, 8].map((fd) => [fd, join(root, `${fd}.lock`)] as const);
+    for (const [, path] of paths) writeFileSync(path, "", { mode: 0o400 });
+    const driver = join(root, "driver.cjs");
+    writeFileSync(driver, `
+      require(process.cwd() + '/node_modules/ts-node').register({transpileOnly:true,project:process.cwd()+'/tsconfig.build.json'}); require(process.cwd() + '/node_modules/tsconfig-paths/register');
+      const fs = require('node:fs'); const {assertMetricMaintenanceLocks} = require(process.cwd() + '/scripts/lib/retained-metric-maintenance');
+      const paths = JSON.parse(process.env.METRIC_TEST_LOCK_PATHS);
+      assertMetricMaintenanceLocks(paths);
+      const contender = require('node:child_process').spawnSync('bash', ['-c', 'exec 3<"$1"; flock -xn 3', 'contender', paths[0][1]]);
+      if(contender.status !== 1) throw Error('existing maintenance lock did not exclude contender');
+      fs.renameSync(paths[0][1], paths[0][1]+'.old'); fs.writeFileSync(paths[0][1], '', {mode:0o400});
+      let refused = false; try {assertMetricMaintenanceLocks(paths)} catch {refused=true} if(!refused) throw Error('replacement admitted');
+      fs.unlinkSync(paths[0][1]); fs.symlinkSync(paths[0][1]+'.old', paths[0][1]);
+      refused = false; try {assertMetricMaintenanceLocks(paths)} catch {refused=true} if(!refused) throw Error('alias admitted');
+    `);
+    const env = { ...process.env, NODE_ENV: "test", METRIC_TEST_LOCK_PATHS: JSON.stringify(paths) };
+    const unlocked = spawnSync("bash", ["-c", 'exec 7<"$1" 9<"$2" 8<"$3"; exec "$4" "$5"',
+      "unheld-wrapper", ...paths.map(([, path]) => path), process.execPath, driver], { env, stdio: "pipe", timeout: 15_000 });
+    expect(unlocked.status).not.toBe(0);
+    execFileSync("bash", ["-c", 'exec 7<"$1" 9<"$2" 8<"$3"; flock -x 7; flock -x 9; flock -x 8; exec "$4" "$5"', "inner-wrapper", ...paths.map(([, path]) => path), process.execPath, driver], { env, stdio: "pipe", timeout: 15_000 });
+  });
+  it("demonstrates that an unmodified writer can ignore operation.lock; only the existing maintenance contract excludes it", () => {
+    const directory = join(root, "seven-day-6101-6102/retained-metrics-v1");
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const path = join(directory, "operation.lock"); writeFileSync(path, "", { mode: 0o400 });
+    const driver = join(root, "legacy.cjs");
+    writeFileSync(driver, `
+      require(process.cwd() + '/node_modules/ts-node').register({transpileOnly:true,project:process.cwd()+'/tsconfig.build.json'}); require(process.cwd() + '/node_modules/tsconfig-paths/register');
+      const {execFileSync} = require('node:child_process'), Module = require('node:module');
+      const ts = require(process.cwd() + '/node_modules/typescript');
+      function original(path) {
+        const source = execFileSync('git', ['show', '0de33d8751bfd1e8ae722698e60ef893d324d9e5:' + path], {encoding:'utf8'});
+        const filename = process.cwd() + '/' + path;
+        const mod = new Module(filename, module); mod.filename = filename; mod.paths = Module._nodeModulePaths(require('node:path').dirname(filename));
+        mod._compile(ts.transpileModule(source, {compilerOptions:{module:ts.ModuleKind.CommonJS,target:ts.ScriptTarget.ES2023}}).outputText, filename);
+        return mod.exports;
+      }
+      const {SecureMetricRefreshReceipts, metricRefreshDigest} = original('scripts/lib/retained-metric-refresh-receipts.ts');
+      const {RefreshRetainedMetricsUseCase} = original('libs/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case.ts');
+      const {createRecoveryEvidenceFilesystemTestHarness} = require(process.cwd() + '/scripts/lib/reader-summary-recovery-evidence-secure-file');
+      const {manifest} = require(process.cwd() + '/scripts/lib/retained-metric-refresh.spec-support');
+      const m = manifest(), row = m.targets[0]; let fetches = 0;
+      const receipts = new SecureMetricRefreshReceipts(createRecoveryEvidenceFilesystemTestHarness(process.argv[2]));
+      const usecase = new RefreshRetainedMetricsUseCase({list:async()=>m.targets,read:async()=>row},
+        {fetch:async()=>{fetches++;return {ok:true,value:[]}}}, {project:async()=>{throw Error('unexpected projection')}},
+        receipts, {now:()=>new Date(m.plannedAt)}, metricRefreshDigest);
+      usecase.execute(m).then(result=>{if(!result.ok || fetches!==1) throw Error('legacy execution did not cross marker');})
+        .catch(error=>{console.error(error);process.exitCode=1});
+    `);
+    execFileSync("bash", ["-c", 'exec 3<"$1"; flock -x 3; exec "$2" "$3" "$4"', "legacy-test", path, process.execPath, driver, root],
+      { env: { ...process.env, NODE_ENV: "test" }, timeout: 20_000 });
+    expect(JSON.parse(readFileSync(join(directory, "batch-0.reserved.json"), "utf8"))).toHaveProperty("value.manifestDigest");
+    expect(metricMaintenanceLocks.map(([fd, lock]) => [fd, lock.split("/").at(-1)])).toEqual([[7, "production-deploy.lock"], [9, "daily-run-singleton.lock"], [8, "daily-run.lock"]]);
+    expect(spawnSync("bash", ["-n", "scripts/run-retained-metric-maintenance.sh"]).status).toBe(0);
+  });
+});

--- a/scripts/lib/retained-metric-maintenance.ts
+++ b/scripts/lib/retained-metric-maintenance.ts
@@ -1,0 +1,46 @@
+import { createHash } from "node:crypto";
+import { closeSync, constants, fstatSync, lstatSync, openSync, readFileSync, realpathSync } from "node:fs";
+import type { MetricImplementation } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-operation.contracts";
+import { refreshSourceSha256 } from "./reader-summary-new-input-refresh-files";
+
+export const metricMaintenanceLocks = [
+  [7, "/var/data/social-monitor/control/production-deploy.lock"],
+  [9, "/var/data/social-monitor/control/daily-run-singleton.lock"],
+  [8, "/var/data/social-monitor/control/daily-run.lock"],
+] as const;
+const sha = (bytes: Buffer | string) => createHash("sha256").update(bytes).digest("hex");
+export function metricExecutableIdentity() {
+  return { sourceSha: refreshSourceSha256(), executableSha: sha(readFileSync(process.execPath)) };
+}
+// Contract already used by reader-summary-recovery-maintenance-lib.sh:
+// deployment exclusion (7), daily singleton (9), PostgreSQL admission (8).
+// A descriptor inherited from the wrapper INSIDE the container proves a live holder. It does
+// not prove old bypassing invocations were retired; that remains parent evidence.
+export function assertMetricMaintenanceLocks(testPaths?: readonly (readonly [number, string])[]) {
+  if (testPaths && process.env.NODE_ENV !== "test") throw new Error("Test maintenance paths unavailable");
+  const proof = (testPaths ?? metricMaintenanceLocks).map(([fd, path]) => {
+    if (realpathSync(path) !== path) throw new Error("Maintenance lock path is not canonical");
+    const descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    try {
+      const named = fstatSync(descriptor), held = fstatSync(fd);
+      const current = lstatSync(path);
+      if (!named.isFile() || named.nlink !== 1 || (testPaths ? named.uid !== process.geteuid?.() : named.uid !== 0 || (named.mode & 0o7777) !== 0o644) || (named.mode & 0o022) !== 0 ||
+          named.dev !== held.dev || named.ino !== held.ino || current.dev !== held.dev || current.ino !== held.ino ||
+          current.mode !== named.mode || current.uid !== named.uid || current.nlink !== 1 ||
+          !/lock:\s+\d+: FLOCK\s+ADVISORY\s+WRITE/u.test(readFileSync(`/proc/self/fdinfo/${fd}`, "utf8"))) throw new Error("Required existing maintenance lock is not held");
+      return { fd, path, device: String(held.dev), inode: String(held.ino) };
+    } finally { closeSync(descriptor); }
+  });
+  const stat = readFileSync("/proc/self/stat", "utf8");
+  return { pid: process.pid, startTicks: stat.slice(stat.lastIndexOf(")") + 2).split(" ")[19], locks: proof };
+}
+export function metricMaintenanceAdmission(sourceSha: string | undefined, executableSha: string | undefined, legacyRetirementRef: string | undefined) {
+  if (!sourceSha || !executableSha || !legacyRetirementRef || !/^[A-Za-z0-9][A-Za-z0-9:/_.-]{0,255}$/u.test(legacyRetirementRef)) throw new Error("Reviewed source/executable hashes and parent legacy-retirement evidence reference required");
+  const actual = metricExecutableIdentity();
+  if (actual.sourceSha !== sourceSha || actual.executableSha !== executableSha) throw new Error("Reviewed metric executable/source mismatch");
+  const holder = assertMetricMaintenanceLocks();
+  const implementation: MetricImplementation = { ...actual, legacyRetirementRef, holderProof: sha(JSON.stringify(holder)) };
+  return { implementation, holder, assertHeld: () => {
+    if (sha(JSON.stringify(assertMetricMaintenanceLocks())) !== implementation.holderProof) throw new Error("Maintenance holder changed");
+  } };
+}

--- a/scripts/lib/retained-metric-process.spec-support.ts
+++ b/scripts/lib/retained-metric-process.spec-support.ts
@@ -1,0 +1,54 @@
+// Subprocess driver for disposable TEST directories only; never a production entrypoint.
+import { appendFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { FixedClock, ok } from "@social-monitor/shared-kernel";
+import type { MetricManifestAmendment } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-operation.contracts";
+import type { MetricRefreshManifest, RetainedMetricTarget } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
+import { AmendRetainedMetricManifestUseCase } from "@social-monitor/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case";
+import { RefreshRetainedMetricsUseCase } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case";
+import { metricRefreshDigest, SecureMetricRefreshReceipts } from "./retained-metric-refresh-receipts";
+
+export type MetricProcessInput = {
+  action: "apply" | "commit"; manifest: MetricRefreshManifest; proposal?: MetricManifestAmendment;
+  pauseName?: string; killPoint?: string; killName?: string;
+};
+async function main() {
+  if (process.env.NODE_ENV !== "test" || !process.send) throw new Error("TEST IPC required");
+  const root = process.argv[2]!, input = JSON.parse(readFileSync(process.argv[3]!, "utf8")) as MetricProcessInput;
+  const inventory = {
+    list: async () => JSON.parse(readFileSync(join(root, "current.json"), "utf8")) as RetainedMetricTarget[],
+    read: async (_: unknown, id: string) => (await inventory.list()).find((t) => t.sourceItemId === id) ?? null,
+  };
+  const receipts = SecureMetricRefreshReceipts.forTest(root, (point, name) => {
+    if (input.killPoint === point && input.killName === name) process.kill(process.pid, "SIGKILL");
+  });
+  const authority = { read: receipts.read.bind(receipts), install: receipts.install.bind(receipts),
+    withOperation: <T>(work: Parameters<typeof receipts.withOperation<T>>[0]) => receipts.withOperation((o) => work({ ...o,
+      install: async (path, value) => {
+        if (path.endsWith(`/${input.pauseName}`)) {
+          process.send!({ paused: input.pauseName });
+          await new Promise<void>((resolve) => process.once("message", () => resolve()));
+        }
+        const result = await o.install(path, value);
+        if (input.killPoint === "install_ack" && path.endsWith(`/${input.killName}`)) process.kill(process.pid, "SIGKILL");
+        return result;
+      } })) };
+  const clock = new FixedClock(new Date("2026-09-06T04:00:00.000Z"));
+  if (input.action === "commit") {
+    const p = input.proposal!;
+    return new AmendRetainedMetricManifestUseCase(inventory, authority, clock, metricRefreshDigest, p.implementation)
+      .commit(metricRefreshDigest(p), p.priorEffectiveSha, p.effectiveManifestSha);
+  }
+  const fetcher = { fetch: async () => {
+    appendFileSync(join(root, "fetches.log"), "fetch\n");
+    if (input.killPoint === "fetch") process.kill(process.pid, "SIGKILL");
+    return ok([]);
+  } };
+  return new RefreshRetainedMetricsUseCase(inventory, fetcher, { project: async () => { throw new Error("No sample expected"); } }, authority, clock, metricRefreshDigest)
+    .execute(input.manifest);
+}
+if (require.main === module) void main().then((result) => {
+  process.send!({ result }); process.disconnect();
+}).catch((e: unknown) => {
+  process.send!({ error: e instanceof Error ? e.message : String(e) }); process.disconnect(); process.exitCode = 1;
+});

--- a/scripts/lib/retained-metric-process.spec.ts
+++ b/scripts/lib/retained-metric-process.spec.ts
@@ -1,0 +1,99 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { incidentFixture } from "./retained-metric-amendment.spec-support";
+import { metricRefreshDigest } from "./retained-metric-refresh-receipts";
+import type { MetricProcessInput } from "./retained-metric-process.spec-support";
+import { metricEvidencePath, resolveMetricOperation } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-amendment";
+
+// Each case starts multiple fresh Node runtimes; allow slow disposable filesystems.
+jest.setTimeout(180_000);
+describe("independent-process amendment/apply races and abrupt death", () => {
+  let root: string, f: ReturnType<typeof incidentFixture>, serial: number;
+  const children = new Set<ChildProcess>();
+  const current = (rows = f.current()) => writeFileSync(join(root, "current.json"), JSON.stringify(rows));
+  const start = (input: MetricProcessInput) => {
+    const path = join(root, `input-${++serial}.json`); writeFileSync(path, JSON.stringify(input));
+    const child = fork(resolve("scripts/lib/retained-metric-process.spec-support.ts"), [root, path], {
+      execArgv: ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
+      env: { ...process.env, NODE_ENV: "test", TS_NODE_PROJECT: "tsconfig.build.json" }, stdio: ["ignore", "ignore", "pipe", "ipc"],
+    });
+    children.add(child);
+    let errorText = "", response: unknown;
+    child.stderr!.on("data", (v: Buffer) => { errorText += v.toString(); });
+    const pauseMessage = new Promise<void>((done) => child.on("message", (v: { paused?: string }) => { if (v.paused) done(); }));
+    const completed = new Promise<{ response: unknown; signal: string | null; code: number | null }>((done, reject) => {
+      child.on("message", (v) => { response = v; }); child.on("error", reject);
+      child.on("exit", (code, signal) => { children.delete(child); if (!response && signal !== "SIGKILL") reject(new Error(errorText || `Child exit ${code}`)); else done({ response, code, signal }); });
+    });
+    const paused = Promise.race([pauseMessage, completed.then(() => { throw new Error(errorText || "Child exited before pause"); })]);
+    void paused.catch(() => {}); void completed.catch(() => {});
+    return { child, paused, completed };
+  };
+  const proposal = async () => {
+    const p = await f.amendment().prepare(metricRefreshDigest(f.original), "TEST reviewed content version");
+    if (!p.ok) throw new Error(p.error); return p.value;
+  };
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "metric-process-")); f = incidentFixture(root, 1); serial = 0;
+    await f.receipts.install(metricEvidencePath("operation.json"), f.original); current();
+  });
+  afterEach(async () => {
+    await Promise.all([...children].map((child) => new Promise<void>((done) => {
+      child.once("exit", () => done()); child.kill("SIGKILL");
+    })));
+    children.clear(); rmSync(root, { recursive: true, force: true });
+  });
+  it("amendment wins; old-SHA apply is excluded while held and stale before any effects afterward", async () => {
+    const p = await proposal();
+    const writer = start({ action: "commit", manifest: f.original, proposal: p, pauseName: "amendment-000001.json" });
+    await writer.paused;
+    expect((await start({ action: "apply", manifest: f.original }).completed).response).toMatchObject({ error: expect.stringContaining("fence busy") });
+    writer.child.send("continue"); expect((await writer.completed).response).toMatchObject({ result: { ok: true } });
+    expect((await start({ action: "apply", manifest: f.original }).completed).response).toEqual({ result: { ok: false, error: "reviewed_manifest_sha_mismatch" } });
+    expect(existsSync(join(root, "fetches.log"))).toBe(false);
+  });
+  it("apply paused immediately before first reservation excludes amendment; reservation permanently freezes head", async () => {
+    const p = await proposal(); current(f.original.targets);
+    const writer = start({ action: "apply", manifest: f.original, pauseName: "batch-0.reserved.json", killPoint: "install_ack", killName: "batch-0.reserved.json" });
+    await writer.paused;
+    expect((await start({ action: "commit", manifest: f.original, proposal: p }).completed).response).toMatchObject({ error: expect.stringContaining("fence busy") });
+    writer.child.send("continue"); expect((await writer.completed).signal).toBe("SIGKILL"); current();
+    expect((await start({ action: "commit", manifest: f.original, proposal: p }).completed).response).toMatchObject({ error: "metric_budget_already_started" });
+    expect(existsSync(join(root, "fetches.log"))).toBe(false);
+  });
+  it("two unequal committers cannot fork; identical committed replay is deterministic", async () => {
+    const first = await proposal();
+    const secondResult = await f.amendment().prepare(first.priorEffectiveSha, "Different explicit review");
+    if (!secondResult.ok) throw new Error(secondResult.error); const second = secondResult.value;
+    const writer = start({ action: "commit", manifest: f.original, proposal: second, pauseName: "amendment-000001.json" });
+    await writer.paused;
+    expect((await start({ action: "commit", manifest: f.original, proposal: first }).completed).response).toMatchObject({ error: expect.stringContaining("fence busy") });
+    writer.child.send("continue"); const accepted = (await writer.completed).response;
+    expect(accepted).toMatchObject({ result: { ok: true } });
+    expect((await start({ action: "commit", manifest: f.original, proposal: second }).completed).response).toEqual(accepted);
+    expect((await start({ action: "commit", manifest: f.original, proposal: first }).completed).response).toEqual({ result: { ok: false, error: "stale_amendment_head" } });
+  });
+  it.each(["file_created", "file_partial", "file_written", "file_synced", "directory_synced", "install_ack"])("survives SIGKILL at amendment %s without skipping or replacing evidence", async (point) => {
+    const p = await proposal(), input: MetricProcessInput = { action: "commit", manifest: f.original, proposal: p };
+    expect((await start({ ...input, killPoint: point, killName: "amendment-000001.json" }).completed).signal).toBe("SIGKILL");
+    const bytes = readFileSync(join(root, metricEvidencePath("amendment-000001.json")));
+    const resumed = (await start(input).completed).response;
+    if (["file_created", "file_partial"].includes(point)) expect(resumed).toHaveProperty("error");
+    else expect(resumed).toMatchObject({ result: { ok: true, value: { sequence: 1 } } });
+    expect(readFileSync(join(root, metricEvidencePath("amendment-000001.json")))).toEqual(bytes);
+    expect(existsSync(join(root, "fetches.log"))).toBe(false);
+  });
+  it.each(["reservation", "fetch", "observation_partial", "observation_written", "observation_ack"])("never refetches after SIGKILL at %s", async (point) => {
+    current(f.original.targets);
+    const killPoint = point === "fetch" ? "fetch" : point === "observation_partial" ? "file_partial" : point === "observation_written" ? "file_written" : "install_ack";
+    const input: MetricProcessInput = { action: "apply", manifest: f.original };
+    expect((await start({ ...input, killPoint, killName: point === "reservation" ? "batch-0.reserved.json" : "batch-0.observed.json" }).completed).signal).toBe("SIGKILL");
+    const resumed = (await start(input).completed).response;
+    if (point === "observation_partial") expect(resumed).toHaveProperty("error");
+    else expect(resumed).toMatchObject({ result: { ok: true, value: [{ status: point.startsWith("observation") ? "unavailable" : "uncertain" }] } });
+    expect(existsSync(join(root, "fetches.log")) ? readFileSync(join(root, "fetches.log"), "utf8") : "").toBe(point === "reservation" ? "" : "fetch\n");
+    await expect(f.receipts.withOperation((o) => resolveMetricOperation(o, metricRefreshDigest, f.clock.now(), true))).rejects.toThrow();
+  });
+});

--- a/scripts/lib/retained-metric-process.spec.ts
+++ b/scripts/lib/retained-metric-process.spec.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { incidentFixture } from "./retained-metric-amendment.spec-support";
 import { metricRefreshDigest } from "./retained-metric-refresh-receipts";
 import type { MetricProcessInput } from "./retained-metric-process.spec-support";
+import type { RetainedMetricTarget } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
 import { metricEvidencePath, resolveMetricOperation } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-amendment";
 
 // Each case starts multiple fresh Node runtimes; allow slow disposable filesystems.
@@ -12,7 +13,7 @@ jest.setTimeout(180_000);
 describe("independent-process amendment/apply races and abrupt death", () => {
   let root: string, f: ReturnType<typeof incidentFixture>, serial: number;
   const children = new Set<ChildProcess>();
-  const current = (rows = f.current()) => writeFileSync(join(root, "current.json"), JSON.stringify(rows));
+  const current = (rows: readonly RetainedMetricTarget[] = f.current()) => writeFileSync(join(root, "current.json"), JSON.stringify(rows));
   const start = (input: MetricProcessInput) => {
     const path = join(root, `input-${++serial}.json`); writeFileSync(path, JSON.stringify(input));
     const child = fork(resolve("scripts/lib/retained-metric-process.spec-support.ts"), [root, path], {

--- a/scripts/lib/retained-metric-refresh-receipts.spec.ts
+++ b/scripts/lib/retained-metric-refresh-receipts.spec.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SecureMetricRefreshReceipts } from "./retained-metric-refresh-receipts";
-import { createRecoveryEvidenceFilesystemTestHarness } from "./reader-summary-recovery-evidence-secure-file";
+import { metricRefreshEvidencePath as directory } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-admission";
 import { requireMetricRefreshTestDatabase } from "../check-retained-metric-refresh-postgres";
 
 describe("retained refresh permanent evidence boundary", () => {
@@ -10,19 +10,20 @@ describe("retained refresh permanent evidence boundary", () => {
   beforeEach(() => { root = mkdtempSync(join(tmpdir(), "metric-refresh-receipts-")); });
   afterEach(() => rmSync(root, { recursive: true, force: true }));
   it("keeps immutable operation identity across adapter/process recreation", async () => {
-    const filesystem = createRecoveryEvidenceFilesystemTestHarness(root);
-    await new SecureMetricRefreshReceipts(filesystem).install("operation.json", { id: "operation-1" });
-    const resumed = new SecureMetricRefreshReceipts(filesystem);
-    expect(await resumed.read("operation.json")).toEqual({ id: "operation-1" });
-    await expect(resumed.install("operation.json", { id: "operation-2" })).rejects.toThrow("different bytes");
+    const receipts = SecureMetricRefreshReceipts.forTest(root);
+    await receipts.install(`${directory}/operation.json`, { id: "operation-1" });
+    const resumed = SecureMetricRefreshReceipts.forTest(root);
+    expect(await resumed.read(`${directory}/operation.json`)).toEqual({ id: "operation-1" });
+    await expect(resumed.install(`${directory}/operation.json`, { id: "operation-2" })).rejects.toThrow("different bytes");
     await expect(resumed.install("../operation.json", {})).rejects.toThrow();
   });
   it("rejects symlink aliases and corrupt receipts", async () => {
-    const receipts = new SecureMetricRefreshReceipts(createRecoveryEvidenceFilesystemTestHarness(root));
-    writeFileSync(join(root, "corrupt.json"), '{"digest":"wrong","value":{}}', { mode: 0o400 });
-    symlinkSync(join(root, "corrupt.json"), join(root, "alias.json"));
-    await expect(receipts.read("corrupt.json")).rejects.toThrow("digest mismatch");
-    await expect(receipts.read("alias.json")).rejects.toThrow();
+    const receipts = SecureMetricRefreshReceipts.forTest(root);
+    await receipts.install(`${directory}/operation.json`, {});
+    writeFileSync(join(root, directory, "batch-0.reserved.json"), '{"digest":"wrong","value":{}}', { mode: 0o400 });
+    symlinkSync(join(root, directory, "batch-0.reserved.json"), join(root, directory, "batch-1.reserved.json"));
+    await expect(receipts.read(`${directory}/batch-0.reserved.json`)).rejects.toThrow("digest mismatch");
+    await expect(receipts.read(`${directory}/batch-1.reserved.json`)).rejects.toThrow();
   });
   it.each([undefined, "postgres://fixture@remote.example/metric_refresh_test_fixture", "postgres://fixture@localhost/social_monitor", "postgres://fixture@localhost/metric_refresh_test_fixture?host=remote.example"])("refuses a missing or non-disposable PostgreSQL DSN before a socket", (url) => {
     expect(() => requireMetricRefreshTestDatabase({ NODE_ENV: "test", METRIC_REFRESH_DISPOSABLE: "1", METRIC_REFRESH_TEST_DATABASE_URL: url })).toThrow();

--- a/scripts/lib/retained-metric-refresh-receipts.ts
+++ b/scripts/lib/retained-metric-refresh-receipts.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
-import type { MetricRefreshReceipts } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
-import { installSecureRecoveryEvidenceFile, readSecureRecoveryEvidenceFile,
-  type RecoveryEvidenceFilesystemTestHarness } from "./reader-summary-recovery-evidence-secure-file";
+import type { MetricRefreshOperation, MetricRefreshOperationAuthority } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-operation.contracts";
+import { metricRefreshEvidencePath } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-admission";
+import { RetainedMetricJournal, type MetricJournalCheckpoint } from "./retained-metric-journal";
 
 export function metricRefreshDigest(value: unknown): string {
   return createHash("sha256").update(canonicalMetricRefreshJson(value)).digest("hex");
@@ -14,23 +14,42 @@ export function canonicalMetricRefreshJson(value: unknown): string {
     .sort(([a], [b]) => a.localeCompare(b)).map(([key, v]) => `${JSON.stringify(key)}:${canonicalMetricRefreshJson(v)}`).join(",")}}`;
   return JSON.stringify(value);
 }
-export class SecureMetricRefreshReceipts implements MetricRefreshReceipts {
-  constructor(private readonly filesystem: RecoveryEvidenceFilesystemTestHarness = {
-    read: readSecureRecoveryEvidenceFile, install: installSecureRecoveryEvidenceFile,
-  }) {}
-  async read<T>(path: string): Promise<T | null> {
-    let bytes: Buffer;
-    try { bytes = this.filesystem.read({ relativePath: path, label: "metric refresh receipt" }); }
-    catch (error) {
-      if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") return null;
-      throw error;
-    }
-    const envelope = JSON.parse(bytes.toString()) as { digest: string; value: T };
-    if (envelope.digest !== metricRefreshDigest(envelope.value)) throw new Error("Metric refresh receipt digest mismatch");
-    return envelope.value;
+function decodeMetricEnvelope<T>(bytes: Buffer): T {
+  const text = bytes.toString("utf8");
+  if (!Buffer.from(text).equals(bytes)) throw new Error("Invalid metric UTF-8");
+  let depth = 0, quoted = false, escaped = false;
+  for (const char of text) {
+    if (quoted) { if (escaped) escaped = false; else if (char === "\\") escaped = true; else if (char === '"') quoted = false; }
+    else if (char === '"') quoted = true;
+    else if (char === "{" || char === "[") { if (++depth > 32) throw new Error("Metric evidence depth limit"); }
+    else if (char === "}" || char === "]") depth--;
   }
-  async install(path: string, value: unknown) {
-    return this.filesystem.install({ relativePath: path, label: "metric refresh receipt",
-      bytes: Buffer.from(canonicalMetricRefreshJson({ digest: metricRefreshDigest(value), value })) });
+  const envelope = JSON.parse(text) as { digest: string; value: T };
+  if (!envelope || Object.keys(envelope).sort().join() !== "digest,value" || envelope.digest !== metricRefreshDigest(envelope.value)) throw new Error("Metric refresh receipt digest mismatch");
+  if (canonicalMetricRefreshJson(envelope) !== text) throw new Error("Noncanonical metric evidence or duplicate keys");
+  return envelope.value;
+}
+export class SecureMetricRefreshReceipts implements MetricRefreshOperationAuthority {
+  constructor(private readonly maintenance: () => void, private readonly testRoot?: string, private readonly checkpoint?: MetricJournalCheckpoint) {}
+  static forTest(root: string, checkpoint?: MetricJournalCheckpoint) {
+    if (process.env.NODE_ENV !== "test") throw new Error("Metric test receipts unavailable");
+    return new SecureMetricRefreshReceipts(() => {}, root, checkpoint);
   }
+  async withOperation<T>(work: (operation: MetricRefreshOperation) => Promise<T>): Promise<T> {
+    const journal = new RetainedMetricJournal(this.maintenance, this.testRoot, this.checkpoint);
+    const operation: MetricRefreshOperation = {
+      assertHeld: journal.assertHeld,
+      read: async <V>(path: string) => { const bytes = journal.read(path); return bytes === null ? null : decodeMetricEnvelope<V>(bytes); },
+      install: async (path, value) => journal.install(path, Buffer.from(canonicalMetricRefreshJson({ digest: metricRefreshDigest(value), value }))),
+      entries: async () => {
+        const entries = journal.entries();
+        // The entire namespace must parse canonically, even an unused orphan.
+        for (const entry of entries) if (entry.name !== "operation.lock") await operation.read(`${metricRefreshEvidencePath}/${entry.name}`);
+        return entries;
+      },
+    };
+    try { return await work(operation); } finally { journal.close(); }
+  }
+  async read<T>(path: string): Promise<T | null> { return this.withOperation((operation) => operation.read<T>(path)); }
+  async install(path: string, value: unknown) { return this.withOperation((operation) => operation.install(path, value)); }
 }

--- a/scripts/lib/retained-metric-refresh.spec-support.ts
+++ b/scripts/lib/retained-metric-refresh.spec-support.ts
@@ -3,16 +3,16 @@ import { AcquisitionDatabaseFixture } from "./clean-real-day-engagement.spec-sup
 import { PrismaSourceEngagementProjectionAdapter } from "@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-projection.adapter";
 import type { PrismaSourceEngagementClient } from "@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-client";
 import { metricRefreshDigest, SecureMetricRefreshReceipts } from "./retained-metric-refresh-receipts";
-import { createRecoveryEvidenceFilesystemTestHarness } from "./reader-summary-recovery-evidence-secure-file";
 import { metricRefreshBounds, metricRefreshSourceBase, metricRefreshDates, metricRefreshEvidencePath, metricRefreshTenant, metricRefreshWorkspace } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-admission";
 import type { MetricRefreshManifest, RetainedMetricTarget, MetricFetchObservation } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
+import type { MetricRefreshOperation } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-operation.contracts";
 import { RefreshRetainedMetricsUseCase } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case";
 
 export const now = "2026-09-05T12:00:00.000Z";
 export const scope = { tenantId: metricRefreshTenant, workspaceId: metricRefreshWorkspace, dates: metricRefreshDates, endAt: now };
 export const authority = { metricsHash: null, observedAt: null, observationAt: null, observationCount: 0, regressionCount: 0 };
 export function target(extra: Partial<RetainedMetricTarget> = {}): RetainedMetricTarget {
-  return { ...scope, sourceItemId: "00000000-0000-7000-8000-000000006104", externalId: "reddit:t3_abc", providerKey: "reddit",
+  return { tenantId: scope.tenantId, workspaceId: scope.workspaceId, sourceItemId: "00000000-0000-7000-8000-000000006104", externalId: "reddit:t3_abc", providerKey: "reddit",
     sourceBindingId: "00000000-0000-7000-8000-000000006105", canonicalUrl: "https://www.reddit.com/r/sandbox/comments/abc/example/",
     publishedAt: "2026-09-04T11:00:00.000Z", configDigest: "a".repeat(64), identityDigest: "b".repeat(64), feedDigest: "c".repeat(64),
     rejection: null, visibleFeedCount: 1, authority, ...extra };
@@ -42,8 +42,12 @@ export function fixture(root: string) {
   }) };
   const fetcher = { fetch: jest.fn(async () => ok<readonly MetricFetchObservation[]>([{ externalId: original.externalId, returned: true,
     reason: null, metadata: { kind: "reddit_post", score: 42, numComments: 9 } }])) };
-  const receipts = new SecureMetricRefreshReceipts(createRecoveryEvidenceFilesystemTestHarness(root));
+  const receipts = SecureMetricRefreshReceipts.forTest(root);
   const clock = new FixedClock(new Date(now));
-  const usecase = () => new RefreshRetainedMetricsUseCase(inventory, fetcher, projection, receipts, clock, metricRefreshDigest);
-  return { db, original, projection, inventory, fetcher, receipts, clock, usecase };
+  const install = jest.fn((operation: MetricRefreshOperation, path: string, value: unknown) => operation.install(path, value));
+  const operationAuthority = { read: receipts.read.bind(receipts), install: receipts.install.bind(receipts),
+    withOperation: <T>(work: (operation: MetricRefreshOperation) => Promise<T>) => receipts.withOperation((operation) =>
+      work({ ...operation, install: (path, value) => install(operation, path, value) })) };
+  const usecase = () => new RefreshRetainedMetricsUseCase(inventory, fetcher, projection, operationAuthority, clock, metricRefreshDigest);
+  return { db, original, projection, inventory, fetcher, receipts, clock, usecase, install };
 }

--- a/scripts/run-retained-metric-maintenance.sh
+++ b/scripts/run-retained-metric-maintenance.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Run INSIDE the reviewed read-only daily image, as uid 1000. The parent mounts
+# existing host lock inodes at these exact paths and retires all legacy writers.
+set -euo pipefail
+PATH=/usr/local/bin:/usr/bin:/bin
+export TS_NODE_PROJECT=tsconfig.build.json
+[[ $# -ge 3 && $1 =~ ^[a-f0-9]{40}$ && $2 =~ ^[a-f0-9]{40}$ ]] || exit 64
+metric_backend=$1
+metric_control=$2
+shift 2
+metric_lock_root=/var/data/social-monitor/control
+# Read-only opens cannot create, truncate, or replace the canonical root:0644 locks.
+exec 7<"$metric_lock_root/production-deploy.lock"
+/usr/bin/flock --exclusive --nonblock 7
+exec 9<"$metric_lock_root/daily-run-singleton.lock"
+/usr/bin/flock --exclusive --nonblock 9
+exec 8<"$metric_lock_root/daily-run.lock"
+/usr/bin/flock --exclusive --nonblock 8
+# Parent pins the Docker image ID; deployed marker checks happen after all locks.
+[[ $(cat "$metric_lock_root/deploy-state/backend.sha") == "$metric_backend" &&
+   $(cat "$metric_lock_root/deploy-state/control.sha") == "$metric_control" &&
+   $(cat "$metric_lock_root/postgres-runtime-current/READY") == "$metric_backend" ]] || exit 65
+# Direct exec preserves descriptors 7/9/8. npm and Node spawn wrappers ordinarily
+# close non-stdio descriptors, so they are not supported for this invocation.
+exec /usr/bin/timeout --signal=TERM --kill-after=30s 4h node --max-old-space-size=1024 \
+  -r ts-node/register -r tsconfig-paths/register scripts/run-retained-metric-refresh.ts "$@"

--- a/scripts/run-retained-metric-refresh.spec.ts
+++ b/scripts/run-retained-metric-refresh.spec.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SystemClock } from "@social-monitor/shared-kernel";
+import * as persistence from "@social-monitor/platform-persistence";
+import * as prismaRuntime from "@social-monitor/platform-persistence/prisma-runtime-client";
+import { PrismaRetainedMetricInventory } from "@social-monitor/ingestion/adapters/persistence/prisma-retained-metric-inventory";
+import * as projectionModule from "@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-projection.adapter";
+import { RetainedMetricFetchAdapter } from "@social-monitor/ingestion/adapters/source/retained-metric-fetch.capability";
+import * as receiptModule from "./lib/retained-metric-refresh-receipts";
+import * as maintenanceModule from "./lib/retained-metric-maintenance";
+import { incidentFixture, implementation } from "./lib/retained-metric-amendment.spec-support";
+import { metricEvidencePath } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-amendment";
+import { runRetainedMetricRefresh } from "./run-retained-metric-refresh";
+
+jest.mock("@social-monitor/platform-persistence", () => ({
+  ...jest.requireActual<typeof persistence>("@social-monitor/platform-persistence"),
+  acquirePrismaPgRuntimeConnection: jest.fn(),
+}));
+
+jest.setTimeout(60_000);
+describe("retained metric CLI composition and effective sample guard", () => {
+  let root: string, f: ReturnType<typeof incidentFixture>, output: string;
+  const sha = receiptModule.metricRefreshDigest;
+  const run = (...args: string[]) => runRetainedMetricRefresh(["--operation-id", f.original.operationId,
+    "--source-sha", implementation.sourceSha, "--executable-sha", implementation.executableSha,
+    "--legacy-retirement-ref", implementation.legacyRetirementRef, ...args],
+    { METRIC_REFRESH_DATABASE_URL: "postgresql://fixture@127.0.0.1/metric_refresh_test_cli" });
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    root = mkdtempSync(join(tmpdir(), "metric-cli-")); f = incidentFixture(root, 3); output = "";
+    await f.receipts.install(metricEvidencePath("operation.json"), f.original);
+    jest.spyOn(SystemClock.prototype, "now").mockImplementation(() => f.clock.now());
+    jest.spyOn(process.stdout, "write").mockImplementation((bytes) => { output += String(bytes); return true; });
+    jest.spyOn(maintenanceModule, "metricMaintenanceAdmission").mockReturnValue({ implementation,
+      holder: { pid: 1, startTicks: "1", locks: [] }, assertHeld: () => {} });
+    jest.spyOn(receiptModule, "SecureMetricRefreshReceipts").mockImplementation(() => f.receipts);
+    jest.spyOn(persistence, "acquirePrismaPgRuntimeConnection").mockResolvedValue({ client: {}, close: async () => {} } as never);
+    jest.spyOn(prismaRuntime, "loadPrismaRuntimeClient").mockReturnValue(class {} as never);
+    jest.spyOn(PrismaRetainedMetricInventory.prototype, "list").mockImplementation(f.inventory.list);
+    jest.spyOn(PrismaRetainedMetricInventory.prototype, "read").mockImplementation(f.inventory.read);
+    jest.spyOn(RetainedMetricFetchAdapter.prototype, "fetch").mockResolvedValue({ ok: true, value: [] });
+    jest.spyOn(projectionModule, "PrismaSourceEngagementProjectionAdapter").mockImplementation(() => ({ project: jest.fn() }) as never);
+  });
+  afterEach(() => { jest.restoreAllMocks(); process.exitCode = 0; rmSync(root, { recursive: true, force: true }); });
+  it("keeps dry-run inventory complete, then review/commit spend no provider/projection calls", async () => {
+    await run();
+    expect(JSON.parse(output)).toMatchObject({ mode: "dry-run", problem: "inventory_drift", currentTargets: f.current() });
+    expect(f.inventory.list).toHaveBeenCalledTimes(1); output = "";
+    await run("--prepare-amendment", "--prior-manifest-sha", sha(f.original), "--reason", "TEST exact content review");
+    const prepared = JSON.parse(output); expect(prepared.result.ok).toBe(true); output = "";
+    await run("--commit-amendment", prepared.amendmentSha, "--prior-manifest-sha", sha(f.original),
+      "--effective-manifest-sha", prepared.result.value.effectiveManifestSha);
+    expect(JSON.parse(output).result.ok).toBe(true);
+    expect(RetainedMetricFetchAdapter.prototype.fetch).not.toHaveBeenCalled();
+    expect(projectionModule.PrismaSourceEngagementProjectionAdapter).not.toHaveBeenCalled();
+  });
+  it("rejects old apply SHA before database acquisition and uses effective identity inside the transaction", async () => {
+    const prepared = await f.amendment().prepare(sha(f.original), "TEST reviewed amendment");
+    if (!prepared.ok) throw new Error(prepared.error);
+    const p = prepared.value;
+    expect((await f.amendment().commit(sha(p), p.priorEffectiveSha, p.effectiveManifestSha)).ok).toBe(true);
+    await expect(run("--apply", "--manifest-sha", sha(f.original))).rejects.toThrow("SHA mismatch");
+    expect(persistence.acquirePrismaPgRuntimeConnection).not.toHaveBeenCalled();
+    f.inventory.list.mockClear();
+    await run("--apply", "--manifest-sha", p.effectiveManifestSha);
+    const report = JSON.parse(output);
+    expect(report.manifestSha).toBe(p.effectiveManifestSha);
+    expect(report.results).toHaveLength(3); expect(report.cells).toHaveLength(14);
+    expect(report.results.every((r: { status: string }) => r.status === "unavailable")).toBe(true);
+    expect(f.inventory.list).toHaveBeenCalledTimes(1);
+    const options = jest.mocked(projectionModule.PrismaSourceEngagementProjectionAdapter).mock.calls[0]![2]!;
+    const sample = { sourceItemId: f.current()[0]!.sourceItemId };
+    await expect(options.sampleGuard!({} as never, {} as never, sample as never)).resolves.toBeUndefined();
+    f.change(f.original.targets);
+    await expect(options.sampleGuard!({} as never, {} as never, sample as never)).rejects.toThrow("Transactional target drift");
+    expect(await f.receipts.read(metricEvidencePath("final.json"))).toEqual(report);
+  });
+});

--- a/scripts/run-retained-metric-refresh.spec.ts
+++ b/scripts/run-retained-metric-refresh.spec.ts
@@ -72,7 +72,7 @@ describe("retained metric CLI composition and effective sample guard", () => {
     const options = jest.mocked(projectionModule.PrismaSourceEngagementProjectionAdapter).mock.calls[0]![2]!;
     const sample = { sourceItemId: f.current()[0]!.sourceItemId };
     await expect(options.sampleGuard!({} as never, {} as never, sample as never)).resolves.toBeUndefined();
-    f.change(f.original.targets);
+    f.change([...f.original.targets]);
     await expect(options.sampleGuard!({} as never, {} as never, sample as never)).rejects.toThrow("Transactional target drift");
     expect(await f.receipts.read(metricEvidencePath("final.json"))).toEqual(report);
   });

--- a/scripts/run-retained-metric-refresh.ts
+++ b/scripts/run-retained-metric-refresh.ts
@@ -11,22 +11,40 @@ import { RedditAppOnlyTokenProvider } from "@social-monitor/ingestion/adapters/s
 import { RetainedMetricFetchAdapter } from "@social-monitor/ingestion/adapters/source/retained-metric-fetch.capability";
 import { RefreshRetainedMetricsUseCase } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.use-case";
 import { manifestProblem, metricRefreshBounds, metricRefreshSourceBase, metricRefreshDates, metricRefreshEvidencePath, metricRefreshTenant, metricRefreshWorkspace, sameTarget, scopeProblem, targetIdentity } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-admission";
-import type { MetricRefreshManifest, MetricRefreshOutcome } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
+import type { MetricRefreshManifest } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
 import { metricRefreshDigest, SecureMetricRefreshReceipts } from "./lib/retained-metric-refresh-receipts";
+
+import { AmendRetainedMetricManifestUseCase } from "@social-monitor/ingestion/features/refresh-retained-metrics/amend-retained-metric-manifest.use-case";
+import { resolveMetricOperation } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-amendment";
+import { metricExecutableIdentity, metricMaintenanceAdmission } from "./lib/retained-metric-maintenance";
+
+import { metricRefreshCells as summarizeMetricRefresh } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-report";
+export { summarizeMetricRefresh };
 
 type RuntimeClient = PrismaMetricInventoryClient & PrismaSourceEngagementClient & { $disconnect(): Promise<void> };
 export async function runRetainedMetricRefresh(args: readonly string[], env: NodeJS.ProcessEnv): Promise<void> {
+  if (args.length === 1 && args[0] === "--implementation") {
+    process.stdout.write(`${JSON.stringify(metricExecutableIdentity())}\n`); return;
+  }
   const options = new Map<string, string>();
   for (let i = 0; i < args.length; i++) {
     const key = args[i]!;
-    if (!["--apply", "--operation-id", "--dates", "--manifest-sha"].includes(key) || options.has(key)) throw new Error("Invalid or duplicate CLI flag");
-    const value = key === "--apply" ? "true" : args[++i];
+    if (!["--apply", "--operation-id", "--dates", "--manifest-sha", "--prepare-amendment", "--commit-amendment", "--prior-manifest-sha", "--effective-manifest-sha", "--reason", "--source-sha", "--executable-sha", "--legacy-retirement-ref"].includes(key) || options.has(key)) throw new Error("Invalid or duplicate CLI flag");
+    const value = ["--apply", "--prepare-amendment"].includes(key) ? "true" : args[++i];
     if (!value || value.startsWith("--")) throw new Error("Missing CLI value");
     options.set(key, value);
   }
   const operationId = options.get("--operation-id");
   if (!operationId || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u.test(operationId)) throw new Error("An explicit operation UUID is required");
   if (options.has("--apply") !== options.has("--manifest-sha")) throw new Error("Apply requires the reviewed manifest SHA");
+  const prepare = options.has("--prepare-amendment"), commit = options.has("--commit-amendment");
+  if (Number(prepare) + Number(commit) + Number(options.has("--apply")) > 1 ||
+      options.has("--prior-manifest-sha") !== (prepare || commit) || options.has("--reason") !== prepare ||
+      options.has("--effective-manifest-sha") !== commit) throw new Error("Invalid amendment mode or review fields");
+  for (const key of ["--manifest-sha", "--commit-amendment", "--prior-manifest-sha", "--effective-manifest-sha", "--source-sha", "--executable-sha"]) {
+    if (options.has(key) && !/^[a-f0-9]{64}$/u.test(options.get(key)!)) throw new Error("Invalid reviewed SHA");
+  }
+  const maintenance = metricMaintenanceAdmission(options.get("--source-sha"), options.get("--executable-sha"), options.get("--legacy-retirement-ref"));
   const clock = new SystemClock();
   const now = clock.now();
   const dates = options.get("--dates")?.split(",") ?? metricRefreshDates;
@@ -34,25 +52,40 @@ export async function runRetainedMetricRefresh(args: readonly string[], env: Nod
     endAt: new Date(Math.min(now.getTime(), Date.parse(`${dates.at(-1)}T00:00:00Z`) + 86_400_000)).toISOString() };
   const invalid = scopeProblem(scope, now);
   if (invalid) throw new Error(invalid);
-  const receipts = new SecureMetricRefreshReceipts();
+  const authority = new SecureMetricRefreshReceipts(maintenance.assertHeld);
+  await authority.withOperation(async (receipts) => {
   const path = `${metricRefreshEvidencePath}/operation.json`;
-  const existing = await receipts.read<MetricRefreshManifest>(path);
+  const head = await resolveMetricOperation(receipts, metricRefreshDigest, now);
+  const existing = head?.effective;
   if (existing && (existing.operationId !== operationId || existing.scope.dates.join() !== dates.join())) throw new Error("Canonical operation identity cannot change");
+  if ((prepare || commit || options.has("--apply")) && !existing) throw new Error("Prepare the immutable operation first");
+  // Wrong/stale apply SHA rejects before even acquiring a database connection.
+  if (options.has("--apply") && options.get("--manifest-sha") !== metricRefreshDigest(existing)) throw new Error("Reviewed manifest SHA mismatch");
   const config = defaultPostgresRuntimePoolConfig(env.METRIC_REFRESH_DATABASE_URL ?? "", "admin-tool");
   const PrismaClient = loadPrismaRuntimeClient<PrismaPgRuntimeClientConstructor<RuntimeClient>>();
   const connection = await acquirePrismaPgRuntimeConnection(config, PrismaClient);
   try {
     await runWithTenantDatabaseAccess(scope, async () => {
       const inventory = new PrismaRetainedMetricInventory(connection.client, metricRefreshDigest);
+      const scopedAuthority = { ...receipts, withOperation: async <T>(work: (operation: typeof receipts) => Promise<T>) => { receipts.assertHeld(); return work(receipts); } };
+      if (prepare || commit) {
+        const amend = new AmendRetainedMetricManifestUseCase(inventory, scopedAuthority, clock, metricRefreshDigest, maintenance.implementation);
+        const result = prepare ? await amend.prepare(options.get("--prior-manifest-sha")!, options.get("--reason")!) :
+          await amend.commit(options.get("--commit-amendment")!, options.get("--prior-manifest-sha")!, options.get("--effective-manifest-sha")!);
+        process.stdout.write(`${JSON.stringify({ mode: prepare ? "prepare-amendment" : "commit-amendment", result,
+          ...(result.ok && prepare ? { amendmentSha: metricRefreshDigest(result.value) } : {}), maintenance: maintenance.holder }, null, 2)}\n`);
+        if (!result.ok) process.exitCode = 1;
+        return;
+      }
       const manifest: MetricRefreshManifest = existing ?? { version: "retained-metrics.v1", sourceBase: metricRefreshSourceBase, bounds: metricRefreshBounds, operationId,
         evidencePath: metricRefreshEvidencePath, scope, plannedAt: now.toISOString(), targets: await inventory.list(scope) };
-      const currentTargets = existing ? await inventory.list(manifest.scope) : manifest.targets;
+      const currentTargets = existing && !options.has("--apply") ? await inventory.list(manifest.scope) : manifest.targets;
       const identities = (targets: typeof manifest.targets) => targets.map(targetIdentity).sort((a, b) => a.sourceItemId.localeCompare(b.sourceItemId));
       const problem = manifestProblem(manifest, now) ??
         (metricRefreshDigest(identities(currentTargets)) === metricRefreshDigest(identities(manifest.targets)) ? null : "inventory_drift");
       const manifestSha = metricRefreshDigest(manifest);
       if (problem || !options.has("--apply")) {
-        if (!problem) await receipts.install(path, manifest);
+        if (!problem && !existing) await receipts.install(path, manifest);
         process.stdout.write(`${JSON.stringify({ mode: "dry-run", manifestSha, problem, manifest, ...(problem === "inventory_drift" ? { currentTargets } : {}) }, null, 2)}\n`);
         if (problem) process.exitCode = 1;
         return;
@@ -76,7 +109,7 @@ export async function runRetainedMetricRefresh(args: readonly string[], env: Nod
       } };
       const fetcher = new RetainedMetricFetchAdapter(new HttpHackerNewsClient(10_000), new HttpRedditClient("https://oauth.reddit.com", 10_000), token,
         env.REDDIT_APP_USER_AGENT ?? "social-monitor-retained-metrics/1");
-      const result = await new RefreshRetainedMetricsUseCase(inventory, fetcher, projection, receipts, clock, metricRefreshDigest).execute(manifest);
+      const result = await new RefreshRetainedMetricsUseCase(inventory, fetcher, projection, authority, clock, metricRefreshDigest).executeLocked(receipts, manifest, options.get("--manifest-sha")!);
       const report = result.ok ? { manifestSha, results: result.value, cells: summarizeMetricRefresh(result.value, manifest.scope.dates) } : { manifestSha, error: result.error };
       if (result.ok) {
         let terminal = true;
@@ -89,16 +122,7 @@ export async function runRetainedMetricRefresh(args: readonly string[], env: Nod
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     });
   } finally { await connection.close(); }
-}
-export function summarizeMetricRefresh(results: readonly MetricRefreshOutcome[], dates: readonly string[] = metricRefreshDates) {
-  return dates.flatMap((date) => ["hacker-news", "reddit"].map((provider) => {
-    const rows = results.filter((row) => row.date === date && row.providerKey === provider);
-    return { date, provider, targets: rows.length, returned: rows.filter((row) => row.returned).length,
-      ...Object.fromEntries(["refreshed", "superseded", "unavailable", "failed", "uncertain"].map((status) => [status, rows.filter((row) => row.status === status).length])),
-      beforeObservations: rows.reduce((sum, row) => sum + row.before.observationCount, 0),
-      afterObservations: rows.reduce((sum, row) => sum + row.after.observationCount, 0),
-      authorityTimes: rows.map((row) => ({ id: row.externalId, before: row.before.observationAt, after: row.after.observationAt })) };
-  }));
+  });
 }
 if (require.main === module) void runRetainedMetricRefresh(process.argv.slice(2), process.env).catch(() => {
   process.stderr.write("Metric refresh failed closed; preserve canonical receipts and reconcile before resuming.\n");

--- a/test-fixtures/retained-metric-legacy/refresh-retained-metrics.use-case.ts.txt
+++ b/test-fixtures/retained-metric-legacy/refresh-retained-metrics.use-case.ts.txt
@@ -1,0 +1,125 @@
+import { err, ok, tenantId, workspaceId, type Clock, type Result } from "@social-monitor/shared-kernel";
+import { buildSourceEngagementMetrics } from "../../domain";
+import type { SourceEngagementProjectionPort } from "../../ports/source-engagement-projection.port";
+import { manifestProblem, refreshBatches, sameTarget, targetIdentity, targetProblem } from "./metric-refresh-admission";
+import type {
+  MetricRefreshManifest, MetricRefreshOutcome, PreservedMetricObservation, RefreshDigest,
+  RetainedMetricFetchCapability, RetainedMetricInventory, MetricRefreshReceipts, RetainedMetricTarget,
+} from "./refresh-retained-metrics.contracts";
+
+type BatchEvidence = { observations: readonly PreservedMetricObservation[]; failure: string | null };
+export class RefreshRetainedMetricsUseCase {
+  constructor(
+    private readonly inventory: RetainedMetricInventory,
+    private readonly fetcher: RetainedMetricFetchCapability,
+    private readonly projection: SourceEngagementProjectionPort,
+    private readonly receipts: MetricRefreshReceipts,
+    private readonly clock: Clock,
+    private readonly digest: RefreshDigest,
+  ) {}
+
+  async execute(manifest: MetricRefreshManifest): Promise<Result<readonly MetricRefreshOutcome[], string>> {
+    const problem = manifestProblem(manifest, this.clock.now());
+    if (problem) return err(problem);
+    const current = await this.inventory.list(manifest.scope);
+    const identities = (targets: readonly RetainedMetricTarget[]) => targets.map(targetIdentity).sort((a, b) => a.sourceItemId.localeCompare(b.sourceItemId));
+    if (this.digest(identities(current)) !== this.digest(identities(manifest.targets))) return err("inventory_drift");
+    const root = manifest.evidencePath;
+    await this.receipts.install(`${root}/operation.json`, manifest);
+    const results: MetricRefreshOutcome[] = [];
+    for (const [index, targets] of refreshBatches(manifest.targets).entries()) {
+      const path = `${root}/batch-${index}`;
+      const reservation = { operationId: manifest.operationId, manifestDigest: this.digest(manifest), targets: targets.map((t) => t.sourceItemId) };
+      if (await this.receipts.read(`${path}.reserved.json`) === null) {
+        // Recheck the entire batch before spending its permanent fetch budget.
+        // Existing reservations must still reconcile or replay without a fresh fetch.
+        for (const target of targets) {
+          const latest = await this.inventory.read(manifest.scope, target.sourceItemId);
+          if (!sameTarget(target, latest, this.digest) || latest === null || targetProblem(latest, manifest.scope)) return err("target_drift");
+        }
+      }
+      const reserved = await this.receipts.install(`${path}.reserved.json`, reservation);
+      let evidence = await this.receipts.read<BatchEvidence>(`${path}.observed.json`);
+      if (evidence === null && reserved === "installed") {
+        // No provider work precedes the permanent batch reservation. No retry on resume.
+        const fetched = await this.fetcher.fetch(targets);
+        const observedAt = this.clock.now().toISOString();
+        if (!fetched.ok) evidence = { observations: [], failure: fetched.error };
+        else {
+          const ids = fetched.value.map((row) => row.externalId);
+          if (new Set(ids).size !== ids.length || ids.some((id) => !targets.some((t) => t.externalId === id))) {
+            evidence = { observations: [], failure: "provider_identity_mismatch" };
+          } else {
+            evidence = { failure: null, observations: targets.map((target) => {
+              const returned = fetched.value.find((row) => row.externalId === target.externalId);
+              const metadata = returned?.metadata ?? null;
+              const built = metadata === null ? null : buildSourceEngagementMetrics({ providerKey: target.providerKey, metadata });
+              const valid = built?.metrics && built.metricsFingerprint && built.qualityFlags.providerKnown && built.qualityFlags.metadataKindKnown &&
+                !built.qualityFlags.invalidMetricValue && !built.qualityFlags.conflictingAliases;
+              return { externalId: target.externalId, returned: returned?.returned ?? false, observedAt, metadata,
+                reason: returned?.reason ?? (metadata === null ? "omitted" : valid ? null : "invalid_metrics"),
+                sample: valid ? { sourceItemId: target.sourceItemId, externalId: target.externalId,
+                  publishedAt: target.publishedAt, metrics: built.metrics!, metricsFingerprint: built.metricsFingerprint!,
+                  providerMetadataPatch: built.providerMetadataPatch, refreshReadModels: true } : null };
+            }) };
+          }
+        }
+        // Persist the normalized provider observation AND exact canonical sample before projection.
+        await this.receipts.install(`${path}.observed.json`, evidence);
+      }
+      if (evidence === null) {
+        const remaining = manifest.targets.filter((target) => !results.some((row) => row.sourceItemId === target.sourceItemId));
+        return ok([...results, ...remaining.map((target): MetricRefreshOutcome => ({
+          sourceItemId: target.sourceItemId, externalId: target.externalId, providerKey: target.providerKey,
+          date: target.publishedAt.slice(0, 10), status: "uncertain", returned: false,
+          reason: "reserved_without_observation_reconcile_required", observedAt: null,
+          before: target.authority, after: target.authority,
+        }))]);
+      }
+      for (const target of targets) {
+        const resultPath = `${root}/result-${target.sourceItemId}.json`;
+        const previous = await this.receipts.read<MetricRefreshOutcome>(resultPath);
+        if (previous !== null) { results.push(previous); continue; }
+        const observation = evidence.observations.find((row) => row.externalId === target.externalId);
+        const latest = await this.inventory.read(manifest.scope, target.sourceItemId);
+        if (!sameTarget(target, latest, this.digest) || latest === null || targetProblem(latest, manifest.scope)) return err("target_drift");
+        let result: MetricRefreshOutcome = {
+          sourceItemId: target.sourceItemId, externalId: target.externalId, providerKey: target.providerKey,
+          date: target.publishedAt.slice(0, 10), before: target.authority, after: latest.authority,
+          returned: observation?.returned ?? false,
+          observedAt: observation?.observedAt ?? null, status: observation?.reason === "invalid_metrics" ? "failed" : "unavailable", reason: observation?.reason ?? null,
+        };
+        if (evidence.failure !== null) result = { ...result, status: "failed", reason: evidence.failure };
+        else if (observation === undefined) return err("receipt_observation_missing");
+        else if (observation.sample !== null) {
+          const rebuilt = buildSourceEngagementMetrics({ providerKey: target.providerKey, metadata: observation.metadata ?? {} });
+          const expectedSample = { sourceItemId: target.sourceItemId, externalId: target.externalId,
+            publishedAt: target.publishedAt, metrics: rebuilt.metrics, metricsFingerprint: rebuilt.metricsFingerprint,
+            providerMetadataPatch: rebuilt.providerMetadataPatch, refreshReadModels: true };
+          if (!rebuilt.metrics || rebuilt.qualityFlags.invalidMetricValue || rebuilt.qualityFlags.conflictingAliases ||
+              this.digest(expectedSample) !== this.digest(observation.sample)) return err("receipt_sample_mismatch");
+          const now = this.clock.now();
+          if (!Number.isFinite(Date.parse(observation.observedAt)) || new Date(observation.observedAt).toISOString() !== observation.observedAt || Date.parse(observation.observedAt) > now.getTime() || Date.parse(observation.observedAt) < Date.parse(manifest.plannedAt)) return err("receipt_observation_time_invalid");
+          try {
+            // Replaying these same bytes is safe, including a lost commit acknowledgement.
+            await this.projection.project({ tenantId: tenantId(manifest.scope.tenantId), workspaceId: workspaceId(manifest.scope.workspaceId),
+              sourceBindingId: target.sourceBindingId, scanJobId: manifest.operationId,
+              providerKey: target.providerKey, observedAt: new Date(observation.observedAt),
+              samples: [{ ...observation.sample, publishedAt: new Date(observation.sample.publishedAt) }] });
+            const after = (await this.inventory.read(manifest.scope, target.sourceItemId))?.authority;
+            if (!after?.observedAt || after.observedAt < observation.observedAt ||
+                (after.observedAt === observation.observedAt && after.metricsHash !== observation.sample.metricsFingerprint)) return err("projection_not_confirmed");
+            result = { ...result, after, status: after.observedAt > observation.observedAt ? "superseded" : "refreshed" };
+          } catch {
+            // No terminal receipt for an uncertain projection; resume uses the preserved sample.
+            results.push({ ...result, status: "failed", reason: "projection_unacknowledged_resume_same_operation" });
+            continue;
+          }
+        }
+        if (result.status !== "uncertain") await this.receipts.install(resultPath, result);
+        results.push(result);
+      }
+    }
+    return ok(results);
+  }
+}

--- a/test-fixtures/retained-metric-legacy/retained-metric-refresh-receipts.ts.txt
+++ b/test-fixtures/retained-metric-legacy/retained-metric-refresh-receipts.ts.txt
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+import type { MetricRefreshReceipts } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
+import { installSecureRecoveryEvidenceFile, readSecureRecoveryEvidenceFile,
+  type RecoveryEvidenceFilesystemTestHarness } from "./reader-summary-recovery-evidence-secure-file";
+
+export function metricRefreshDigest(value: unknown): string {
+  return createHash("sha256").update(canonicalMetricRefreshJson(value)).digest("hex");
+}
+export function canonicalMetricRefreshJson(value: unknown): string {
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (typeof value === "bigint") return JSON.stringify(value.toString());
+  if (Array.isArray(value)) return `[${value.map(canonicalMetricRefreshJson).join(",")}]`;
+  if (value !== null && typeof value === "object") return `{${Object.entries(value).filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b)).map(([key, v]) => `${JSON.stringify(key)}:${canonicalMetricRefreshJson(v)}`).join(",")}}`;
+  return JSON.stringify(value);
+}
+export class SecureMetricRefreshReceipts implements MetricRefreshReceipts {
+  constructor(private readonly filesystem: RecoveryEvidenceFilesystemTestHarness = {
+    read: readSecureRecoveryEvidenceFile, install: installSecureRecoveryEvidenceFile,
+  }) {}
+  async read<T>(path: string): Promise<T | null> {
+    let bytes: Buffer;
+    try { bytes = this.filesystem.read({ relativePath: path, label: "metric refresh receipt" }); }
+    catch (error) {
+      if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") return null;
+      throw error;
+    }
+    const envelope = JSON.parse(bytes.toString()) as { digest: string; value: T };
+    if (envelope.digest !== metricRefreshDigest(envelope.value)) throw new Error("Metric refresh receipt digest mismatch");
+    return envelope.value;
+  }
+  async install(path: string, value: unknown) {
+    return this.filesystem.install({ relativePath: path, label: "metric refresh receipt",
+      bytes: Buffer.from(canonicalMetricRefreshJson({ digest: metricRefreshDigest(value), value })) });
+  }
+}


### PR DESCRIPTION
A retained-metric operation stopped before its first provider request because one stored HN post changed content after the 3,329-post manifest was captured. This adds separately reviewed, append-only content-identity amendments before any reservation. The original bytes, IDs, dates, authority baselines and provider allowance remain fixed; the first reservation permanently freezes the effective manifest.

Preparation, review and commit are separate zero-provider-effect steps. Full inventory, batch, post-fetch and Serializable projection guards remain. Existing maintenance locks, pinned source/executable identity and an operator legacy-retirement reference are mandatory. Old invocations must actually be retired: new locks cannot constrain old code. Natural ingestion remains a documented source of drift.

Terminal result receipts now also bind to their exact preserved target observation. A forged unavailable result for a valid sample is rejected before replay can skip projection. Valid failed/unavailable/refreshed/superseded outcomes, historical receipts, cadence lag, changing authority and lost-ack replay remain supported.

Latest head: aa609f8f0fe9bfdd25c4cef44483a43dd8be0fa3. Independent delta review APPROVE: 188 focused tests in 9 suites plus 17 independent probes passed, including the exploit against previous/current validators and archived legacy writer replay. Root TypeScript, affected lint, architecture, code quality and source line cap passed. The initial expanded run on OLD failed/incompleted under severe memory pressure and was stopped; the complete exact-SHA gate passed on NEW without timeout/guard changes. Initial implementation also had 239 tests and an independent seven-probe review.

Fresh PostgreSQL 18 schema fixture on the latest SHA passed native transactional drift rollback and lost-ack/no-refetch verification in 7.600 seconds; its database and temporary role were removed. This is not full-migration/RLS certification or production metric refresh. Earlier read-only Docker/no-Git wrapper evidence is for 702dde6; the latest source identity is 6770547072b62572f0324b2a2f6f0bcbc1331266a3d8973ae38e27fb4b35cb03. All 10 project CI checks passed on aa609f8f in run 34014423281. PR is CLEAN/MERGEABLE. The user has authorized production release and routine account-pool decisions. The 12:15 UTC rolling run terminated with a topic-map coverage rejection (0.375 below 0.5); its exact evidence was preserved before acknowledging the inactive failed service in systemd. This acknowledgement does not fix or certify topic quality. No rolling process or deployment is active. Production account capacity is being rechecked separately; all quality gates remain unchanged.

31 paths, 2,076 changed lines including tests and separately identifiable exact archived legacy fixtures. The non-archived delta stays within the 2,000-line review target. This remains one operation/replay invariant and one reversible PR. Production metric refresh and seven new publications remain pending.

Related: https://github.com/777genius/social-monitor/pull/293
Related: https://github.com/777genius/social-monitor/pull/294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reviewed amendment workflow for correcting retained metric content while preserving original records and audit history.
  - Added amendment preparation and commit options with implementation and legacy-retirement verification.
  - Added detailed refresh reporting by date, provider, and outcome status.
  - Added secure operation locking, crash recovery, concurrency protection, and durable evidence handling.

- **Bug Fixes**
  - Refreshes now detect inventory or manifest changes and reject incomplete, inconsistent, or tampered evidence.
  - Result records are validated against their corresponding observations.

- **Documentation**
  - Updated operational guidance for maintenance locks, amendment reviews, legacy retirement, recovery, and completion handoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
