### PR TITLE
fix(relevance): recognize explicit ChatGPT topic context

### DIFF
--- a/libs/relevance/domain/source-content-quality-chatgpt.spec.ts
+++ b/libs/relevance/domain/source-content-quality-chatgpt.spec.ts
@@ -1,0 +1,90 @@
+import { SourceContentQualityPolicy } from "./source-content-quality";
+import { normalizeSourceContentQualityInput } from "./source-content-quality-normalizer";
+
+const policy = new SourceContentQualityPolicy();
+const titleWith = (term: string): string =>
+  `Has anyone else felt their daily life improved since using ${term}?`;
+
+describe("ChatGPT lexical topic context", () => {
+  it.each(["ChatGPT", "chatgpt", "CHATGPT", "cHaTgPt", "(ChatGPT)", "'ChatGPT'"])(
+    "recognizes the standalone core signal %s without query metadata",
+    (term) => {
+      const input = { providerKey: "reddit", title: titleWith(term) };
+      expect(normalizeSourceContentQualityInput(input)).toMatchObject({
+        legacyCoreTopicSignal: true,
+        missingTopicContext: true,
+      });
+      expect(policy.evaluate(input)).toMatchObject({
+        interestRelevanceScore: 0.78,
+        decision: "promote",
+        eligibleForTopRead: true,
+      });
+    },
+  );
+
+  it.each(["ChatGPT", "chatgpt", "CHATGPT", "cHaTgPt", "(ChatGPT)"])(
+    "matches %s against an explicit AI interest through existing aliases",
+    (term) => {
+      const verdict = policy.evaluate({
+        providerKey: "reddit",
+        title: titleWith(term),
+        providerMetadata: { interestQuerySnapshot: { query: "AI" } },
+      });
+      expect(verdict.interestRelevanceScore).toBe(0.9);
+      expect(verdict.flags).not.toContain("weak_topic_match");
+    },
+  );
+
+  it.each([
+    "prechatgpt", "chatgptish", "xchatgptx", "chatgpt2", "2chatgpt",
+    "chatgpt_helper", "helper_chatgpt", "CHATGPTISH",
+  ])("does not recognize the embedded substring %s", (term) => {
+    const input = { providerKey: "reddit", title: titleWith(term) };
+    expect(normalizeSourceContentQualityInput(input).legacyCoreTopicSignal)
+      .toBe(false);
+    expect(policy.evaluate(input)).toMatchObject({
+      interestRelevanceScore: 0.49,
+      decision: "downrank",
+      eligibleForTopRead: false,
+    });
+    expect(policy.evaluate({
+      ...input,
+      providerMetadata: { interestQuerySnapshot: { query: "AI" } },
+    })).toMatchObject({
+      interestRelevanceScore: 0.38,
+      flags: ["weak_topic_match"],
+    });
+  });
+
+  it("recognizes explicit body context without using URL text as context", () => {
+    expect(policy.evaluate({
+      providerKey: "reddit",
+      title: "A synthetic account of changes to everyday habits",
+      bodyPreview: "I have been using ChatGPT to organize daily tasks.",
+    }).interestRelevanceScore).toBe(0.78);
+    expect(policy.evaluate({
+      providerKey: "reddit",
+      title: "A synthetic account of changes to everyday habits",
+      bodyPreview: "https://example.test/ChatGPT",
+    }).interestRelevanceScore).toBe(0.49);
+  });
+
+  it.each(["GPT", "GPT-4", "OpenAI", "Anthropic", "Claude", "LLM", "LLMs"])(
+    "preserves the existing standalone core signal %s",
+    (term) => expect(policy.evaluate({
+      providerKey: "reddit", title: titleWith(term),
+    }).interestRelevanceScore).toBe(0.78),
+  );
+
+  it.each([
+    "artificial", "intelligence", "llm", "llms", "gpt", "openai",
+    "anthropic", "claude", "model", "models", "token", "tokens",
+    "inference", "neural", "stochastic", "parrot", "parrots",
+  ])("preserves the existing AI alias %s", (term) => {
+    expect(policy.evaluate({
+      providerKey: "reddit",
+      title: titleWith(term),
+      providerMetadata: { interestQuerySnapshot: { query: "AI" } },
+    }).interestRelevanceScore).toBe(0.9);
+  });
+});

--- a/libs/relevance/domain/source-content-quality-normalizer.ts
+++ b/libs/relevance/domain/source-content-quality-normalizer.ts
@@ -379,7 +379,7 @@ const aiCodingToolPattern =
 const medicalContextPattern =
   /\b(?:mri|ct\s+scan|scan|diagnos(?:is|e|ed)|doctor|medical|medicine|clinical|hospital|patient|cancer|tumou?r|symptom|therapy|treatment|prescription)\b/iu;
 const legacyCoreTopicSignalPattern =
-  /\b(?:ai|a\.i\.|artificial\s+intelligence|llm|llms|gpt|openai|anthropic|claude|codex|cursor|copilot|mcp|model|models|agentic|agent|agents|inference|token|tokens|neural|machine\s+learning|deep\s+learning|deepfake|cybersecurity|security|privacy|surveillance|geolocation|developer\s+tool|developer\s+tools|coding\s+agent|coding\s+agents|ai-generated\s+code|ai\s+code|vibe-coding)\b/iu;
+  /\b(?:ai|a\.i\.|artificial\s+intelligence|llm|llms|gpt|chatgpt|openai|anthropic|claude|codex|cursor|copilot|mcp|model|models|agentic|agent|agents|inference|token|tokens|neural|machine\s+learning|deep\s+learning|deepfake|cybersecurity|security|privacy|surveillance|geolocation|developer\s+tool|developer\s+tools|coding\s+agent|coding\s+agents|ai-generated\s+code|ai\s+code|vibe-coding)\b/iu;
 const trustedXAuthors = new Set([
   "anthropicai",
   "gdb",
@@ -397,6 +397,7 @@ const topicTermAliases = new Map<string, readonly string[]>([
       "llm",
       "llms",
       "gpt",
+      "chatgpt",
       "openai",
       "anthropic",
       "claude",

--- a/test/chatgpt-title-promotion.integration.spec.ts
+++ b/test/chatgpt-title-promotion.integration.spec.ts
@@ -1,0 +1,204 @@
+import {
+  classifyFeedPromotionEligibility,
+  evaluateReaderPromotionV2,
+  type ReaderPromotionV2Candidate,
+} from "@social-monitor/feed/domain";
+import type { JsonObject } from "@social-monitor/shared-kernel";
+import { readerSummaryPromotionV2Candidate } from
+  "@social-monitor/summary/adapters/evidence/reader-summary-editorial-candidate";
+import type {
+  SummaryEvidenceItem,
+  SummaryEvidenceSelection,
+} from "@social-monitor/summary/domain";
+
+import { SourceContentQualityPolicy } from
+  "@social-monitor/relevance/domain/source-content-quality";
+import { SourceContentSafetyPolicy } from
+  "@social-monitor/relevance/domain/source-content-safety";
+import { promotionSafeProviderMetadata } from
+  "@social-monitor/relevance/features/rank-feed-items/rank-feed-item-projection";
+
+// User-supplied public title, URL, identities and observed score only.
+// The original 839-character body is unavailable; this is not a full-post replay.
+const publicTitle = "Has anyone else felt like their life has improved significantly since using ChatGPT?";
+const publicUrl = "https://www.reddit.com/r/ChatGPT/comments/1w7nv0q/has_anyone_else_felt_like_their_life_has_improved/";
+const observedMetadata = { kind: "reddit_post", score: 444 };
+
+describe("exact Reddit title through canonical metadata, quality and V2 admission", () => {
+  it("admits the explicit title when independently supplied fixture gates pass", () => {
+    const { safeMetadata, quality, item, candidate } = titleOnlyFixture();
+    expect(safeMetadata).toEqual({
+      kind: "reddit_post", contentKind: "original_post", score: 444,
+    });
+    expect(item.title).toBe(publicTitle);
+    expect(item.bodyPreview).toBeUndefined();
+    expect(item.sourceText).toBeUndefined();
+    expect(quality).toMatchObject({
+      qualityScore: 0.95,
+      interestRelevanceScore: 0.78,
+      engagementIntegrityScore: 0.92,
+      eligibleForSummary: true,
+      eligibleForTopRead: true,
+      needsLlmReview: false,
+      decision: "promote",
+      // This flag records missing query metadata, which remains unchanged.
+      flags: ["missing_topic_context"],
+    });
+    expect(evaluateReaderPromotionV2(candidate)).toMatchObject({
+      admitted: true,
+      topQualified: true,
+      providerSignal: 444,
+      relativePopularity: 8.88,
+      admissionAttestation: {
+        relevance: { minimum: 0.5, passed: true },
+        quality: { minimum: 0.55, passed: true },
+        integrity: { minimum: 0.5, passed: true },
+        provider: { admissionFloor: 25, topFloor: 50, passed: true },
+      },
+    });
+  });
+
+  it.each(["it", "prechatgpt", "chatgptish", "chatgpt2", "chatgpt_helper"])(
+    "keeps the same URL and popularity ineligible with unrelated title text %s",
+    (term) => {
+      const { quality, candidate } = titleOnlyFixture(
+        publicTitle.replace("ChatGPT", term),
+      );
+      expect(quality).toMatchObject({
+        qualityScore: 0.95,
+        interestRelevanceScore: 0.49,
+        engagementIntegrityScore: 0.92,
+        eligibleForSummary: true,
+        eligibleForTopRead: false,
+        decision: "downrank",
+        flags: ["missing_topic_context"],
+      });
+      expect(evaluateReaderPromotionV2(candidate)).toMatchObject({
+        admitted: false,
+        reasons: ["relevance_floor_not_met", "quality_floor_not_met"],
+      });
+    },
+  );
+
+  it("does not depend on query or community fields removed by canonical metadata", () => {
+    // Synthetic metadata extras exercise canonical stripping, not real provenance.
+    const metadata = {
+      ...observedMetadata,
+      subreddit: "ChatGPT",
+      interestQuerySnapshot: { query: "AI" },
+    };
+    const { safeMetadata, quality } = titleOnlyFixture(publicTitle, metadata);
+    expect(safeMetadata).toEqual(titleOnlyFixture().safeMetadata);
+    expect(quality).toEqual(titleOnlyFixture().quality);
+    expect(metadata.interestQuerySnapshot).toEqual({ query: "AI" });
+  });
+
+  it.each([
+    ["relevanceScore", 0.49, "relevance_floor_not_met"],
+    ["evidenceQualityScore", 0.54, "quality_floor_not_met"],
+    ["integrityScore", 0.49, "integrity_floor_not_met"],
+  ] as const)("still enforces the independent %s floor", (field, score, reason) => {
+    const { candidate } = titleOnlyFixture();
+    expect(evaluateReaderPromotionV2({ ...candidate, [field]: score }))
+      .toMatchObject({ admitted: false, reasons: [reason] });
+  });
+
+  it.each([
+    ["safetyFloorMet", "safety_floor_not_met"],
+    ["freshnessFloorMet", "freshness_floor_not_met"],
+  ] as const)("still enforces %s", (field, reason) => {
+    const { candidate } = titleOnlyFixture();
+    expect(evaluateReaderPromotionV2({
+      ...candidate, admission: { ...candidate.admission, [field]: false },
+    })).toMatchObject({ admitted: false, reasons: [reason] });
+  });
+
+  it("does not turn the supplied score into verified metric authority", () => {
+    const { item, selection } = titleOnlyFixture();
+    const candidate = readerSummaryPromotionV2Candidate({
+      ...item,
+      promotionFacts: { ...item.promotionFacts!, engagementAuthority: undefined },
+    }, selection)!;
+    expect(evaluateReaderPromotionV2(candidate)).toMatchObject({
+      admitted: false, reasons: ["engagement_unauthoritative"],
+    });
+  });
+
+  it("does not bypass the provider floor when explicit topic context exists", () => {
+    const { candidate } = titleOnlyFixture(publicTitle, {
+      ...observedMetadata, score: 24,
+    });
+    expect(evaluateReaderPromotionV2(candidate)).toMatchObject({
+      admitted: false, reasons: ["provider_floor_not_met"],
+    });
+  });
+});
+
+const titleOnlyFixture = (
+  title = publicTitle,
+  metadata: JsonObject = observedMetadata,
+) => {
+  const safeMetadata = promotionSafeProviderMetadata("reddit", metadata);
+  const canonical = classifyFeedPromotionEligibility({
+    providerKey: "reddit", providerMetadata: safeMetadata,
+  });
+  if (!canonical.eligible || canonical.metrics.kind !== "reddit_post") {
+    throw new Error("Expected canonical Reddit fixture metrics");
+  }
+  const safety = new SourceContentSafetyPolicy().evaluate({
+    providerKey: "reddit", title, canonicalUrl: publicUrl,
+  });
+  const quality = new SourceContentQualityPolicy().evaluate({
+    providerKey: "reddit",
+    title: safety.sanitizedTitle,
+    canonicalUrl: safety.sanitizedCanonicalUrl,
+    providerMetadata: safeMetadata,
+  });
+  // All timing, binding and authority fields below are synthetic test controls.
+  // They prove conditional policy admission, not actual durable post eligibility.
+  const publishedAt = new Date("2026-09-05T12:00:00.000Z");
+  const observedAt = new Date("2026-09-05T13:00:00.000Z");
+  const cutoff = new Date("2026-09-05T14:00:00.000Z");
+  const item: SummaryEvidenceItem = {
+    feedItemId: "3cbf8b8d-5174-4a97-bdf8-7e0718da03d0",
+    sourceItemId: "59d38ff3-98ce-43a7-8297-4a746145899b",
+    sourceBindingId: "test-title-only-binding",
+    interestId: "test-title-only-interest",
+    providerKey: "reddit",
+    canonicalUrl: publicUrl,
+    title: safety.sanitizedTitle,
+    publishedAt,
+    observedAt,
+    score: 0,
+    whyImportant: [],
+    contentQuality: quality,
+    promotionFacts: {
+      contentKind: canonical.contentKind,
+      canonicalIdentity: publicUrl,
+      safetyValid: safety.status === "allowed",
+      freshnessValid: true,
+      freshnessProvenance: {
+        status: "observed", publishedAt, observedAt, ingestionCutoff: cutoff,
+      },
+      metricsState: canonical.metricsState,
+      metrics: { provider: "reddit", score: canonical.metrics.score },
+      engagementAuthority: { observedAt, regressionState: "stable" },
+    },
+  };
+  const selection: SummaryEvidenceSelection = {
+    rankingPolicyVersion: "title-only-test",
+    sourceWindow: {
+      windowId: "title-only-test",
+      startedAt: new Date("2026-09-05T00:00:00.000Z"),
+      endedAt: cutoff,
+      ingestionCutoff: cutoff,
+      selectedFeedItemIds: [],
+      storyClusterIds: [],
+    },
+    selectedEvidence: [],
+    clusters: [],
+  };
+  const candidate: ReaderPromotionV2Candidate =
+    readerSummaryPromotionV2Candidate(item, selection)!;
+  return { safeMetadata, quality, item, selection, candidate };
+};


### PR DESCRIPTION
A real Reddit title explicitly mentioning ChatGPT was rejected for relevance because the existing topic alias rules did not recognize ChatGPT. Add the standalone, case-insensitive alias to the existing context paths while preserving admission thresholds and metric authority checks.

The exact supplied title now has relevance 0.78 instead of 0.49. An independent title-only competition probe through production ranking and editorial slate puts score444 above an otherwise-equivalent eligible Reddit score89. Historical body, freshness and authority are not reconstructed; live seven-day acceptance remains pending.

Validation: independent exact-head APPROVE; 416 tests across 14 suites and 50 additional probe groups; root/build TypeScript, changed-file lint, architecture, quality and line-cap checks passed. Production change is two alias additions; boundary, safety, freshness and authority negatives remain enforced.

Related #294.
