### PR TITLE
fix(summary): retain private canonical selection receipts

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -20,6 +20,7 @@ import { readRefreshJobs, readRefreshPrior, readRefreshCounts } from "./reader-s
 import { createRefreshAdmission } from "./reader-summary-new-input-refresh-admission";
 import { withRefreshPublicationLocks, type RefreshSnapshotProtection } from "./reader-summary-new-input-refresh-publication-lock";
 import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { withRefreshSelectionAudit } from "./reader-summary-new-input-refresh-selection-audit";
 
 export async function executeNewInputRefresh(input: {
   manifest: RefreshManifest; summary: PrismaSummaryConnection;
@@ -131,7 +132,9 @@ export async function executeNewInputRefresh(input: {
       listScheduled: (query) => policies.listScheduled(query),
       save: async () => { throw new Error("Refresh policy mutation is prohibited"); },
     },
-    guard.selector(canonical.evidenceSelector), model.model, publication, ids, clock,
+    withRefreshSelectionAudit({ selector: guard.selector(canonical.evidenceSelector), manifest: m,
+      jobId: request.value.readerSummaryJobId, record: input.record, invalidate: () => guard.invalidate() }),
+    model.model, publication, ids, clock,
     readerSummaryPromotionControl(new ReaderSummaryPromotionMetricsRecorder(new InMemoryMetricsRecorder())),
     undefined, undefined, model.topicMap, undefined, canonical.githubProjectionReader,
     undefined, undefined, undefined, guard,

--- a/scripts/lib/reader-summary-new-input-refresh-selection-audit-execution.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selection-audit-execution.spec.ts
@@ -1,0 +1,46 @@
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { ReaderSummaryJob } from "@social-monitor/summary/domain";
+import { ExecuteReaderSummaryJobUseCase } from "@social-monitor/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case";
+import { FakeReaderSummaryJobRepository } from "@social-monitor/summary/features/execute-reader-summary-job/execute-reader-summary-job.spec-support";
+import { PromotionControlArtifactRepository, PromotionControlCapturingModel, PromotionControlIdGenerator,
+  PromotionControlPolicyRepository } from "@social-monitor/summary/features/execute-reader-summary-job/execute-reader-summary-job-promotion-control.spec-support";
+import { readerSummaryPromotionControl, NOOP_READER_SUMMARY_PROMOTION_METRICS } from
+  "@social-monitor/summary/features/execute-reader-summary-job/reader-summary-promotion-control";
+import { selection, xEvidence } from "@social-monitor/summary/adapters/evidence/reader-summary-editorial-slate.spec-support";
+import { refreshPeriod } from "./reader-summary-new-input-refresh-capture";
+import { NewInputRefreshGuard } from "./reader-summary-new-input-refresh-guard";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import { withRefreshSelectionAudit } from "./reader-summary-new-input-refresh-selection-audit";
+
+it("a failed diagnostic write consumes the job and cannot retry even with fresh guard composition", async () => {
+  const m = refreshManifest(), jobs = new FakeReaderSummaryJobRepository();
+  const scope = { tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId) };
+  const job = ReaderSummaryJob.request({ ...scope, id: "audit-job", scope: { type: "workspace" },
+    period: refreshPeriod(m.date), idempotencyKey: m.operation, requestedAt: refreshNow });
+  await jobs.save(job);
+  const artifacts = new PromotionControlArtifactRepository(), model = new PromotionControlCapturingModel();
+  const evidence = selection([xEvidence("synthetic", 500)], []);
+  const select = jest.fn(async () => ({ ...evidence,
+    sourceWindow: { ...evidence.sourceWindow, ingestionCutoff: new Date(m.observedThrough) } }));
+  const record = jest.fn(() => { throw new Error("synthetic private journal failure"); }), publish = jest.fn();
+  const execute = () => {
+    const guard = new NewInputRefreshGuard(m, "audit-job", { now: () => refreshNow,
+      assertFences: jest.fn(), assertCurrent: async () => undefined });
+    return new ExecuteReaderSummaryJobUseCase(jobs, artifacts, new PromotionControlPolicyRepository(),
+      withRefreshSelectionAudit({ selector: guard.selector({ select }), manifest: m, jobId: "audit-job",
+        record, invalidate: () => guard.invalidate() }), model, { publish }, new PromotionControlIdGenerator(),
+      new FixedClock(refreshNow), readerSummaryPromotionControl(NOOP_READER_SUMMARY_PROMOTION_METRICS),
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, guard)
+      .execute({ ...scope, readerSummaryJobId: "audit-job" });
+  };
+  expect(await execute()).toMatchObject({ ok: false });
+  const failed = (await jobs.findById({ ...scope, readerSummaryJobId: "audit-job" }))!.toSnapshot();
+  expect(failed.status).toBe("failed");
+  expect(await execute()).toMatchObject({ ok: false, error: { code: "operation.conflict" } });
+  expect((await jobs.findById({ ...scope, readerSummaryJobId: "audit-job" }))!.toSnapshot()).toEqual(failed);
+  expect(select).toHaveBeenCalledTimes(1);
+  expect(record).toHaveBeenCalledTimes(1);
+  expect(model.generatedEvidenceIds()).toEqual([]);
+  expect(artifacts.all()).toEqual([]);
+  expect(publish).not.toHaveBeenCalled();
+});

--- a/scripts/lib/reader-summary-new-input-refresh-selection-audit-execution.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selection-audit-execution.spec.ts
@@ -44,3 +44,69 @@ it("a failed diagnostic write consumes the job and cannot retry even with fresh 
   expect(artifacts.all()).toEqual([]);
   expect(publish).not.toHaveBeenCalled();
 });
+
+it.each(["resolve", "reject"])("awaits an asynchronous journal %s in the consumed-job use case", async (outcome) => {
+  let settle!: () => void;
+  const failure = new Error("synthetic private async journal failure");
+  const pending = new Promise<void>((resolve, reject) => {
+    settle = outcome === "resolve" ? resolve : () => reject(failure);
+  });
+  let started!: () => void;
+  const entered = new Promise<void>((resolve) => { started = resolve; });
+  const record = jest.fn(() => { started(); return pending; });
+  const test = await asyncAuditExecution(record);
+  const running = test.execute();
+  await entered;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const downstreamBeforeRecord = test.findByScope.mock.calls.length;
+  const before = await test.snapshot();
+  const retryWhilePending = await test.execute();
+  settle();
+  const result = await running;
+  expect(downstreamBeforeRecord).toBe(0);
+  expect(before.status).toBe("running");
+  expect(retryWhilePending).toMatchObject({ ok: false, error: { code: "operation.conflict" } });
+  // Successful journaling reaches the next policy boundary; stop there using a synthetic failure.
+  expect(result).toEqual({ ok: false, error: outcome === "resolve" ? test.policyStop : failure });
+  expect(test.findByScope).toHaveBeenCalledTimes(outcome === "resolve" ? 1 : 0);
+  expect(test.invalidate).toHaveBeenCalledTimes(outcome === "reject" ? 1 : 0);
+  const failed = await test.snapshot();
+  expect(failed.status).toBe("failed");
+  expect(await test.execute()).toMatchObject({ ok: false, error: { code: "operation.conflict" } });
+  expect(await test.snapshot()).toEqual(failed);
+  expect(test.select).toHaveBeenCalledTimes(1);
+  expect(record).toHaveBeenCalledTimes(1);
+  expect(test.claim).toHaveBeenCalledTimes(1);
+  expect(test.saveOutcome).toHaveBeenCalledTimes(1);
+  expect(test.model.generatedEvidenceIds()).toEqual([]);
+  expect(test.artifacts.all()).toEqual([]);
+  expect(test.publish).not.toHaveBeenCalled();
+});
+
+async function asyncAuditExecution(record: (event: unknown) => void | Promise<void>) {
+  const m = refreshManifest(), jobs = new FakeReaderSummaryJobRepository();
+  const scope = { tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId) };
+  const job = ReaderSummaryJob.request({ ...scope, id: "audit-job", scope: { type: "workspace" },
+    period: refreshPeriod(m.date), idempotencyKey: m.operation, requestedAt: refreshNow });
+  await jobs.save(job);
+  const claim = jest.spyOn(jobs, "claimForExecution"), saveOutcome = jest.spyOn(jobs, "saveExecutionOutcome");
+  const artifacts = new PromotionControlArtifactRepository(), model = new PromotionControlCapturingModel();
+  const evidence = selection([xEvidence("synthetic", 500)], []);
+  const select = jest.fn(async () => ({ ...evidence,
+    sourceWindow: { ...evidence.sourceWindow, ingestionCutoff: new Date(m.observedThrough) } }));
+  const publish = jest.fn(), invalidate = jest.fn();
+  const policyStop = new Error("synthetic stop after recorded selection"), policies = new PromotionControlPolicyRepository();
+  const findByScope = jest.spyOn(policies, "findByScope").mockRejectedValue(policyStop);
+  const execute = () => {
+    const guard = new NewInputRefreshGuard(m, "audit-job", { now: () => refreshNow,
+      assertFences: jest.fn(), assertCurrent: async () => undefined });
+    return new ExecuteReaderSummaryJobUseCase(jobs, artifacts, policies,
+      withRefreshSelectionAudit({ selector: guard.selector({ select }), manifest: m, jobId: "audit-job",
+        record, invalidate: () => { invalidate(); guard.invalidate(); } }), model, { publish }, new PromotionControlIdGenerator(),
+      new FixedClock(refreshNow), readerSummaryPromotionControl(NOOP_READER_SUMMARY_PROMOTION_METRICS),
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, guard)
+      .execute({ ...scope, readerSummaryJobId: "audit-job" });
+  };
+  const snapshot = async () => (await jobs.findById({ ...scope, readerSummaryJobId: "audit-job" }))!.toSnapshot();
+  return { execute, snapshot, select, findByScope, invalidate, policyStop, claim, saveOutcome, model, artifacts, publish };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-selection-audit.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selection-audit.spec.ts
@@ -1,0 +1,139 @@
+import { PROMOTION_ELIGIBLE_ITEM_CEILING } from "@social-monitor/feed/ports";
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { ReaderSummaryJob, type SummaryEvidenceSelection, type SummaryEvidenceItem } from "@social-monitor/summary/domain";
+import { composeReaderSummaryEditorialSlate, materializeReaderSummaryEditorialSlate } from
+  "@social-monitor/summary/adapters/evidence/reader-summary-editorial-slate";
+import { selection, xEvidence, redditEvidence, storyCluster } from
+  "@social-monitor/summary/adapters/evidence/reader-summary-editorial-slate.spec-support";
+import { refreshPeriod } from "./reader-summary-new-input-refresh-capture";
+import { NewInputRefreshGuard, reconcileRefresh } from "./reader-summary-new-input-refresh-guard";
+import { refreshHash, refreshOperation } from "./reader-summary-new-input-refresh-manifest";
+import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import { withRefreshSelectionAudit } from "./reader-summary-new-input-refresh-selection-audit";
+
+const m = refreshManifest();
+const query = { tenantId: tenantId(m.tenantId), workspaceId: workspaceId(m.workspaceId),
+  scope: { type: "workspace" as const }, period: refreshPeriod(m.date), maxItems: 120,
+  observedThrough: new Date(m.observedThrough) };
+const job = ReaderSummaryJob.request({ ...query, id: "audit-job", idempotencyKey: m.operation, requestedAt: refreshNow });
+
+describe("private refresh selection receipt", () => {
+  it("captures actual ranking, duplicate and capacity exclusions without changing selected/support evidence", async () => {
+    const result = canonical([
+      ...Array.from({ length: 18 }, (_, i) => xEvidence(`x-${i}`, 1_000 - i)),
+      redditEvidence("support", 80, { canonicalIdentity: "story:x-0" }),
+      xEvidence("viral-irrelevant", 9_999_999, { relevanceScore: 0.49 }),
+    ]);
+    const before = refreshHash(result);
+    const manifest = { ...m, authority: { ...m.authority, eligibleCount: 20 } };
+    manifest.operation = refreshOperation(manifest);
+    const select = jest.fn(async () => result), record = jest.fn(), invalidate = jest.fn();
+    const audited = withRefreshSelectionAudit({ selector: { select }, manifest, jobId: "audit-job", record, invalidate });
+    expect(await audited.select(query)).toBe(result);
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenCalledWith(query);
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(invalidate).not.toHaveBeenCalled();
+    expect(refreshHash(result)).toBe(before);
+    const receipt = record.mock.calls[0]![0];
+    expect(receipt).toMatchObject({ status: "selection_audit", tenantId: m.tenantId, workspaceId: m.workspaceId,
+      date: m.date, jobId: "audit-job", operation: manifest.operation, observedThrough: m.observedThrough,
+      manifestCanonicalSha256: refreshHash(manifest), sourceSha256: m.sourceSha256,
+      canonicalInputSha256: m.authority.canonicalInputSha256,
+      selectedFeedItemIds: result.selectedEvidence.map((item) => item.feedItemId),
+      editorialSlate: { topCandidateIds: result.editorialSlate!.top.map((item) => item.candidateId),
+        additionalCandidateIds: result.editorialSlate!.additional.map((item) => item.candidateId),
+        excluded: result.editorialSlate!.excluded.map(({ candidateId, reasonCodes }) => ({ candidateId, reasonCodes })) },
+    });
+    expect(receipt.editorialSlate.excluded).toEqual(expect.arrayContaining([
+      { candidateId: "viral-irrelevant", reasonCodes: ["relevance_floor_not_met"] },
+      { candidateId: "support", reasonCodes: ["semantic_story_duplicate"] },
+      { candidateId: "x-17", reasonCodes: ["editorial_capacity_exhausted"] },
+    ]));
+    expect(receipt.support).toContainEqual({ representativeFeedItemId: "x-0", supportFeedItemIds: ["support"] });
+    expect(Object.isFrozen(receipt.selectedFeedItemIds)).toBe(true);
+    expect(Object.isFrozen(receipt.support[0].supportFeedItemIds)).toBe(true);
+    expect(Object.isFrozen(receipt.editorialSlate.excluded[0].reasonCodes)).toBe(true);
+    expect(JSON.stringify(receipt)).not.toMatch(/DO_NOT_RECORD|canonicalIdentity|digestMaterial|candidateDigestInput|bodyPreview|sourceText|providerMetadata|whyImportant|tokens|secret/u);
+  });
+
+  it.each(["absent", "empty", "no_signal"])("distinguishes %s without inventing exclusions", async (kind) => {
+    const result = canonical(kind === "no_signal" ? [xEvidence("below-floor", 34)] : []);
+    const record = jest.fn();
+    await withRefreshSelectionAudit({ selector: { select: async () => kind === "absent"
+      ? { ...result, editorialSlate: undefined } : result }, manifest: m, jobId: "audit-job", record,
+    invalidate: jest.fn() }).select(query);
+    const receipt = record.mock.calls[0]![0];
+    expect(receipt.selectedFeedItemIds).toEqual([]);
+    expect(receipt.support).toEqual([]);
+    expect(receipt.editorialSlate).toEqual(kind === "absent" ? null : {
+      policyVersion: result.editorialSlate!.policyVersion, topCandidateIds: [], additionalCandidateIds: [],
+      excluded: kind === "empty" ? [] : [{ candidateId: "below-floor", reasonCodes: ["provider_floor_not_met"] }],
+    });
+  });
+
+  it.each(["success", "precheck", "selector", "cutoff", "postcheck", "journal"])("preserves %s error ordering", async (phase) => {
+    const order: string[] = [], failure = new Error("synthetic failure");
+    const guard = new NewInputRefreshGuard(m, "audit-job", { now: () => refreshNow, assertFences: jest.fn(),
+      assertCurrent: async () => { order.push("check");
+        if (phase === "precheck" || (phase === "postcheck" && order.includes("select"))) throw failure;
+      } });
+    // Claim before enabling the failing execution checks.
+    const claimCheck = jest.spyOn(guard, "assertCurrent").mockResolvedValueOnce(undefined);
+    await guard.claim(job.toSnapshot()); claimCheck.mockRestore();
+    const select = jest.fn(async () => {
+      order.push("select"); if (phase === "selector") throw failure;
+      const result = canonical([]);
+      return phase === "cutoff" ? { ...result, sourceWindow: { ...result.sourceWindow, ingestionCutoff: refreshNow } } : result;
+    });
+    const record = jest.fn(() => { order.push("record"); if (phase === "journal") throw failure; });
+    const audited = withRefreshSelectionAudit({ selector: guard.selector({ select }), manifest: m,
+      jobId: "audit-job", record, invalidate: () => guard.invalidate() });
+    if (phase === "success") await audited.select(query);
+    else await expect(audited.select(query)).rejects.toThrow();
+    expect(order).toEqual(phase === "precheck" ? ["check"] : ["success", "journal"].includes(phase)
+      ? ["check", "select", "check", "record"] : phase === "postcheck"
+        ? ["check", "select", "check"] : ["check", "select"]);
+    if (phase === "journal") {
+      await expect(audited.select(query)).rejects.toThrow(/reconciliation/u);
+      expect(select).toHaveBeenCalledTimes(1);
+      expect(record).toHaveBeenCalledTimes(1);
+      expect(() => reconcileRefresh(m, [{ jobId: "audit-job", operation: m.operation,
+        status: "FAILED", artifactId: null }], m.prior)).toThrow(/consumed/u);
+    } else expect(record).toHaveBeenCalledTimes(phase === "success" ? 1 : 0);
+  });
+
+  it.each(["at_limit", "over_limit", "unknown_reason"])("bounds canonical counts and reason codes: %s", async (kind) => {
+    const result = canonical([]), record = jest.fn(), invalidate = jest.fn();
+    const count = PROMOTION_ELIGIBLE_ITEM_CEILING + (kind === "over_limit" ? 1 : 0);
+    const excluded = Array.from({ length: count }, (_, i) => ({ candidateId: `excluded-${i}`,
+      canonicalIdentity: "DO_NOT_RECORD", reasonCodes: [kind === "unknown_reason" ? "DO_NOT_RECORD" : "quality_floor_not_met"] }));
+    const promise = withRefreshSelectionAudit({ selector: { select: async () => ({ ...result,
+      editorialSlate: { ...result.editorialSlate!, excluded } }) },
+    manifest: { ...m, authority: { ...m.authority, eligibleCount: count } }, jobId: "audit-job", record, invalidate }).select(query);
+    if (kind === "at_limit") {
+      await promise;
+      expect(record.mock.calls[0]![0].editorialSlate.excluded).toHaveLength(count);
+      expect(invalidate).not.toHaveBeenCalled();
+    } else { await expect(promise).rejects.toThrow(/bounds or reason/u);
+      expect(record).not.toHaveBeenCalled(); expect(invalidate).toHaveBeenCalledTimes(1); }
+  });
+});
+
+function canonical(items: readonly SummaryEvidenceItem[]): SummaryEvidenceSelection {
+  const publishedAt = new Date(`${m.date}T12:00:00Z`), observedAt = new Date(`${m.date}T13:00:00Z`);
+  const evidence = items.map((item) => ({ ...item, publishedAt, observedAt, promotionFacts: { ...item.promotionFacts!,
+    engagementAuthority: { observedAt: query.observedThrough, regressionState: "stable" as const },
+    freshnessProvenance: { status: "observed" as const, publishedAt, observedAt, ingestionCutoff: query.observedThrough },
+  } }));
+  const original = selection(evidence, evidence.map((item) => storyCluster(item.feedItemId, [item])));
+  const source = { ...original, sourceWindow: { ...original.sourceWindow, startedAt: query.period.startedAt,
+    endedAt: query.period.endedAt, periodStartedAt: query.period.startedAt, periodEndedAt: query.period.endedAt,
+    ingestionCutoff: query.observedThrough } };
+  const result = materializeReaderSummaryEditorialSlate({ selection: source,
+    slate: composeReaderSummaryEditorialSlate({ selection: source }) });
+  return { ...result, editorialSlate: Object.assign({}, result.editorialSlate!, { hidden: "DO_NOT_RECORD" }),
+    selectedEvidence: result.selectedEvidence.map((item) => ({ ...item,
+    title: "DO_NOT_RECORD", bodyPreview: "DO_NOT_RECORD", providerMetadata: { secret: "DO_NOT_RECORD" } })),
+  };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-selection-audit.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selection-audit.spec.ts
@@ -1,6 +1,7 @@
-import { PROMOTION_ELIGIBLE_ITEM_CEILING } from "@social-monitor/feed/ports";
+import { PROMOTION_ELIGIBLE_ITEM_CEILING, PROMOTION_PHYSICAL_ROW_CEILING } from "@social-monitor/feed/ports";
 import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
-import { ReaderSummaryJob, type SummaryEvidenceSelection, type SummaryEvidenceItem } from "@social-monitor/summary/domain";
+import { READER_SUMMARY_EDITORIAL_SLATE_VERSION, ReaderSummaryJob,
+  type SummaryEvidenceSelection, type SummaryEvidenceItem } from "@social-monitor/summary/domain";
 import { composeReaderSummaryEditorialSlate, materializeReaderSummaryEditorialSlate } from
   "@social-monitor/summary/adapters/evidence/reader-summary-editorial-slate";
 import { selection, xEvidence, redditEvidence, storyCluster } from
@@ -118,7 +119,107 @@ describe("private refresh selection receipt", () => {
     } else { await expect(promise).rejects.toThrow(/bounds or reason/u);
       expect(record).not.toHaveBeenCalled(); expect(invalidate).toHaveBeenCalledTimes(1); }
   });
+
+  describe.each(["selected", "representative", "support", "top", "additional", "excluded"])("primitive %s IDs", (field) => {
+    it.each(["object", "array", "boxed_string", "number", "boolean", "null", "undefined"])("rejects %s without coercion or recording", async (kind) => {
+      const result = canonical([xEvidence("synthetic", 500)]);
+      const coerce = jest.fn(() => "DO_NOT_RECORD");
+      const payload = { rawContent: "DO_NOT_RECORD", toString: coerce, toJSON: coerce };
+      const values: Record<string, unknown> = { object: payload, array: [payload], boxed_string: Object("synthetic"),
+        number: 1, boolean: true, null: null, undefined: undefined };
+      const value = values[kind];
+      if (field === "selected") Object.assign(result.selectedEvidence[0]!, { feedItemId: value });
+      if (field === "representative") Object.assign(result.clusters[0]!, { representativeFeedItemId: value });
+      if (field === "support") Object.assign(result.clusters[0]!, { duplicateFeedItemIds: [value] });
+      // Canonical entries are frozen; inject a malformed copy into the test slate.
+      if (field === "top") Object.assign(result.editorialSlate!, { top: [{ ...result.editorialSlate!.top[0]!, candidateId: value }] });
+      if (field === "additional") Object.assign(result.editorialSlate!, { additional: [{ candidateId: value }] });
+      if (field === "excluded") Object.assign(result.editorialSlate!, {
+        excluded: [{ candidateId: value, reasonCodes: ["provider_floor_not_met"] }],
+      });
+      await expectMalformedSelection(result);
+      expect(coerce).not.toHaveBeenCalled();
+      expect(Object.isFrozen(payload)).toBe(false);
+    });
+  });
+
+  it.each(["object", "boxed_string", "wrong_version", "null", "undefined"])("rejects %s policy version", async (kind) => {
+    const result = canonical([]), coerce = jest.fn(() => READER_SUMMARY_EDITORIAL_SLATE_VERSION);
+    const versions: Record<string, unknown> = { object: { rawContent: "DO_NOT_RECORD", toString: coerce, toJSON: coerce },
+      boxed_string: Object(READER_SUMMARY_EDITORIAL_SLATE_VERSION), wrong_version: "unknown-policy", null: null, undefined: undefined };
+    Object.assign(result.editorialSlate!, { policyVersion: versions[kind] });
+    await expectMalformedSelection(result);
+    expect(coerce).not.toHaveBeenCalled();
+  });
+
+  describe.each(["selectedEvidence", "clusters", "support", "top", "additional", "excluded", "reasons"])("required %s array", (field) => {
+    it.each(["missing", "null", "array_like", "iterable", "string", "sparse"])("rejects %s rather than inventing receipt data", async (kind) => {
+      const result = canonical([xEvidence("synthetic", 500)]), iterate = jest.fn(() => [][Symbol.iterator]());
+      const arrays: Record<string, unknown> = { missing: undefined, null: null, array_like: { length: 0 },
+        iterable: { [Symbol.iterator]: iterate }, string: "", sparse: new Array(1) };
+      const value = arrays[kind];
+      if (field === "selectedEvidence" || field === "clusters") Object.assign(result, { [field]: value });
+      if (field === "support") Object.assign(result.clusters[0]!, { duplicateFeedItemIds: value });
+      if (field === "top" || field === "additional" || field === "excluded") Object.assign(result.editorialSlate!, { [field]: value });
+      if (field === "reasons") Object.assign(result.editorialSlate!, {
+        excluded: [{ candidateId: "excluded", reasonCodes: value }],
+      });
+      await expectMalformedSelection(result);
+      expect(iterate).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects a null slate while preserving undefined as the absent slate", async () => {
+    await expectMalformedSelection(Object.assign(canonical([]), { editorialSlate: null }));
+  });
+
+  it("keeps reason order and duplicates exactly, copying and freezing all receipt containers", async () => {
+    const result = canonical([xEvidence("synthetic", 500)]), record = jest.fn();
+    const reasonCodes = ["semantic_story_duplicate", "quality_floor_not_met", "semantic_story_duplicate"];
+    Object.assign(result.editorialSlate!, { excluded: [{ candidateId: "excluded", reasonCodes }] });
+    await withRefreshSelectionAudit({ selector: { select: async () => result }, manifest: m, jobId: "audit-job",
+      record, invalidate: jest.fn() }).select(query);
+    const receipt = record.mock.calls[0]![0];
+    expect(receipt.editorialSlate.excluded[0].reasonCodes).toEqual(reasonCodes);
+    for (const container of [receipt, receipt.support, receipt.support[0], receipt.support[0].supportFeedItemIds,
+      receipt.editorialSlate, receipt.editorialSlate.topCandidateIds, receipt.editorialSlate.additionalCandidateIds,
+      receipt.editorialSlate.excluded, receipt.editorialSlate.excluded[0], receipt.editorialSlate.excluded[0].reasonCodes]) {
+      expect(Object.isFrozen(container)).toBe(true);
+    }
+    reasonCodes.push("provider_floor_not_met");
+    expect(receipt.editorialSlate.excluded[0].reasonCodes).toHaveLength(3);
+    expect(Object.isFrozen(result.editorialSlate!.excluded)).toBe(false);
+  });
+
+  it.each(["non_string_reason", "reason_ceiling", "manifest_ceiling", "selected_ceiling", "cluster_ceiling", "support_ceiling"])("retains %s rejection", async (kind) => {
+    const result = canonical([xEvidence("synthetic", 500)]);
+    if (kind === "non_string_reason" || kind === "reason_ceiling") Object.assign(result.editorialSlate!, {
+      excluded: [{ candidateId: "excluded", reasonCodes: kind === "non_string_reason"
+        ? [{ rawContent: "DO_NOT_RECORD" }] : Array(22).fill("semantic_story_duplicate") }],
+    });
+    if (kind === "manifest_ceiling") Object.assign(result.editorialSlate!, {
+      excluded: Array.from({ length: m.authority.eligibleCount }, (_, i) => ({ candidateId: `excluded-${i}`, reasonCodes: [] })),
+    });
+    if (kind === "selected_ceiling") Object.assign(result, { selectedEvidence: Array(PROMOTION_PHYSICAL_ROW_CEILING + 1).fill(result.selectedEvidence[0]) });
+    if (kind === "cluster_ceiling") Object.assign(result, { clusters: Array(PROMOTION_PHYSICAL_ROW_CEILING + 1).fill(result.clusters[0]) });
+    if (kind === "support_ceiling") Object.assign(result.clusters[0]!, { duplicateFeedItemIds: Array(PROMOTION_PHYSICAL_ROW_CEILING + 1).fill("support") });
+    await expectMalformedSelection(result);
+  });
 });
+
+async function expectMalformedSelection(result: SummaryEvidenceSelection): Promise<void> {
+  const guard = new NewInputRefreshGuard(m, "audit-job", { now: () => refreshNow,
+    assertFences: jest.fn(), assertCurrent: async () => undefined });
+  await guard.claim(job.toSnapshot());
+  const select = jest.fn(async () => result), record = jest.fn(), invalidate = jest.fn(() => guard.invalidate());
+  const audited = withRefreshSelectionAudit({ selector: guard.selector({ select }), manifest: m,
+    jobId: "audit-job", record, invalidate });
+  await expect(audited.select(query)).rejects.toThrow();
+  expect(record).not.toHaveBeenCalled();
+  expect(invalidate).toHaveBeenCalledTimes(1);
+  await expect(audited.select(query)).rejects.toThrow(/reconciliation/u);
+  expect(select).toHaveBeenCalledTimes(1);
+}
 
 function canonical(items: readonly SummaryEvidenceItem[]): SummaryEvidenceSelection {
   const publishedAt = new Date(`${m.date}T12:00:00Z`), observedAt = new Date(`${m.date}T13:00:00Z`);

--- a/scripts/lib/reader-summary-new-input-refresh-selection-audit.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selection-audit.ts
@@ -1,5 +1,5 @@
 import { PROMOTION_ELIGIBLE_ITEM_CEILING, PROMOTION_PHYSICAL_ROW_CEILING } from "@social-monitor/feed/ports";
-import type { SummaryEvidenceSelection } from "@social-monitor/summary/domain";
+import { READER_SUMMARY_EDITORIAL_SLATE_VERSION, type SummaryEvidenceSelection } from "@social-monitor/summary/domain";
 import type { ReaderSummaryEvidenceSelectorPort } from "@social-monitor/summary/ports";
 import { refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
 
@@ -17,11 +17,11 @@ const exclusionCodes = new Set([
  * This is the actual selection decision, not a later reconstruction or publication proof. */
 export function withRefreshSelectionAudit(input: {
   selector: ReaderSummaryEvidenceSelectorPort; manifest: RefreshManifest; jobId: string;
-  record(event: unknown): void; invalidate(): void;
+  record(event: unknown): void | Promise<void>; invalidate(): void;
 }): ReaderSummaryEvidenceSelectorPort {
   return { select: async (query) => {
     const selection = await input.selector.select(query);
-    try { input.record(selectionReceipt(input.manifest, input.jobId, selection)); }
+    try { await input.record(selectionReceipt(input.manifest, input.jobId, selection)); }
     catch (error) { input.invalidate(); throw error; }
     return selection;
   } };
@@ -29,14 +29,18 @@ export function withRefreshSelectionAudit(input: {
 
 function selectionReceipt(m: RefreshManifest, jobId: string, selection: SummaryEvidenceSelection) {
   const slate = selection.editorialSlate;
-  const excluded = slate?.excluded ?? [];
-  const candidateCount = (slate?.top.length ?? 0) + (slate?.additional.length ?? 0) + excluded.length;
-  const supportCount = selection.clusters.reduce((sum, cluster) => sum + cluster.duplicateFeedItemIds.length, 0);
+  const selectedEvidence = auditArray(selection.selectedEvidence), clusters = auditArray(selection.clusters);
+  const top = slate === undefined ? [] : auditArray(slate.top);
+  const additional = slate === undefined ? [] : auditArray(slate.additional);
+  const excluded = slate === undefined ? [] : auditArray(slate.excluded);
+  if (slate !== undefined && slate.policyVersion !== READER_SUMMARY_EDITORIAL_SLATE_VERSION) {
+    throw new Error("Refresh selection audit requires the canonical policy version");
+  }
+  const candidateCount = top.length + additional.length + excluded.length;
+  const supportCount = clusters.reduce((sum, cluster) => sum + auditArray(cluster.duplicateFeedItemIds).length, 0);
   if (candidateCount > PROMOTION_ELIGIBLE_ITEM_CEILING || candidateCount > m.authority.eligibleCount ||
-      selection.selectedEvidence.length > PROMOTION_PHYSICAL_ROW_CEILING ||
-      selection.clusters.length > PROMOTION_PHYSICAL_ROW_CEILING || supportCount > PROMOTION_PHYSICAL_ROW_CEILING ||
-      excluded.some((item) => item.reasonCodes.length > exclusionCodes.size ||
-        item.reasonCodes.some((code) => !exclusionCodes.has(code)))) {
+      selectedEvidence.length > PROMOTION_PHYSICAL_ROW_CEILING ||
+      clusters.length > PROMOTION_PHYSICAL_ROW_CEILING || supportCount > PROMOTION_PHYSICAL_ROW_CEILING) {
     throw new Error("Refresh selection audit exceeds canonical bounds or reason vocabulary");
   }
   return Object.freeze({
@@ -49,19 +53,42 @@ function selectionReceipt(m: RefreshManifest, jobId: string, selection: SummaryE
     manifestCanonicalSha256: refreshHash(m), sourceSha256: m.sourceSha256,
     generationSha256: m.generationSha256, canonicalInputSha256: m.authority.canonicalInputSha256,
     canonicalCandidateCount: m.authority.eligibleCount,
-    selectedFeedItemIds: Object.freeze(selection.selectedEvidence.map((item) => item.feedItemId)),
-    support: Object.freeze(selection.clusters.map((cluster) => Object.freeze({
-      representativeFeedItemId: cluster.representativeFeedItemId,
-      supportFeedItemIds: Object.freeze([...cluster.duplicateFeedItemIds]),
+    selectedFeedItemIds: Object.freeze(Array.from(selectedEvidence, (item) => auditId(item.feedItemId))),
+    support: Object.freeze(Array.from(clusters, (cluster) => Object.freeze({
+      representativeFeedItemId: auditId(cluster.representativeFeedItemId),
+      supportFeedItemIds: Object.freeze(Array.from(auditArray(cluster.duplicateFeedItemIds), auditId)),
     }))),
     // Absent is distinct from an authoritative empty/no-signal slate.
     editorialSlate: slate === undefined ? null : Object.freeze({
-      policyVersion: slate.policyVersion,
-      topCandidateIds: Object.freeze(slate.top.map((entry) => entry.candidateId)),
-      additionalCandidateIds: Object.freeze(slate.additional.map((entry) => entry.candidateId)),
-      excluded: Object.freeze(excluded.map((item) => Object.freeze({
-        candidateId: item.candidateId, reasonCodes: Object.freeze([...item.reasonCodes]),
+      policyVersion: READER_SUMMARY_EDITORIAL_SLATE_VERSION,
+      topCandidateIds: Object.freeze(Array.from(top, (entry) => auditId(entry.candidateId))),
+      additionalCandidateIds: Object.freeze(Array.from(additional, (entry) => auditId(entry.candidateId))),
+      excluded: Object.freeze(Array.from(excluded, (item) => Object.freeze({
+        candidateId: auditId(item.candidateId), reasonCodes: auditReasons(item.reasonCodes),
       }))),
     }),
   });
+}
+
+function auditArray<T>(value: readonly T[]): readonly T[] {
+  if (!Array.isArray(value)) throw new Error("Refresh selection audit requires actual arrays");
+  return value;
+}
+
+function auditId(value: unknown): string {
+  if (typeof value !== "string") throw new Error("Refresh selection audit requires primitive string IDs");
+  return value;
+}
+
+function auditReasons(value: readonly string[]): readonly string[] {
+  const codes = auditArray(value);
+  if (codes.length > exclusionCodes.size) {
+    throw new Error("Refresh selection audit exceeds canonical bounds or reason vocabulary");
+  }
+  return Object.freeze(Array.from(codes, (code) => {
+    if (typeof code !== "string" || !exclusionCodes.has(code)) {
+      throw new Error("Refresh selection audit exceeds canonical bounds or reason vocabulary");
+    }
+    return code;
+  }));
 }

--- a/scripts/lib/reader-summary-new-input-refresh-selection-audit.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selection-audit.ts
@@ -1,0 +1,67 @@
+import { PROMOTION_ELIGIBLE_ITEM_CEILING, PROMOTION_PHYSICAL_ROW_CEILING } from "@social-monitor/feed/ports";
+import type { SummaryEvidenceSelection } from "@social-monitor/summary/domain";
+import type { ReaderSummaryEvidenceSelectorPort } from "@social-monitor/summary/ports";
+import { refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
+
+// Diagnostic vocabulary only: unknown codes fail closed instead of admitting prose.
+const exclusionCodes = new Set([
+  "identity_missing", "publication_time_malformed", "score_malformed", "content_kind_not_admitted",
+  "relevance_floor_not_met", "quality_floor_not_met", "integrity_floor_not_met", "safety_floor_not_met",
+  "freshness_floor_not_met", "engagement_missing", "engagement_malformed", "engagement_conflict",
+  "engagement_unauthoritative", "engagement_authority_missing", "engagement_authority_malformed",
+  "engagement_observed_after_cutoff", "engagement_stale", "engagement_regression_unresolved",
+  "provider_floor_not_met", "semantic_story_duplicate", "editorial_capacity_exhausted",
+]);
+
+/** Wrap the already guarded selector, so both snapshot checks precede recording.
+ * This is the actual selection decision, not a later reconstruction or publication proof. */
+export function withRefreshSelectionAudit(input: {
+  selector: ReaderSummaryEvidenceSelectorPort; manifest: RefreshManifest; jobId: string;
+  record(event: unknown): void; invalidate(): void;
+}): ReaderSummaryEvidenceSelectorPort {
+  return { select: async (query) => {
+    const selection = await input.selector.select(query);
+    try { input.record(selectionReceipt(input.manifest, input.jobId, selection)); }
+    catch (error) { input.invalidate(); throw error; }
+    return selection;
+  } };
+}
+
+function selectionReceipt(m: RefreshManifest, jobId: string, selection: SummaryEvidenceSelection) {
+  const slate = selection.editorialSlate;
+  const excluded = slate?.excluded ?? [];
+  const candidateCount = (slate?.top.length ?? 0) + (slate?.additional.length ?? 0) + excluded.length;
+  const supportCount = selection.clusters.reduce((sum, cluster) => sum + cluster.duplicateFeedItemIds.length, 0);
+  if (candidateCount > PROMOTION_ELIGIBLE_ITEM_CEILING || candidateCount > m.authority.eligibleCount ||
+      selection.selectedEvidence.length > PROMOTION_PHYSICAL_ROW_CEILING ||
+      selection.clusters.length > PROMOTION_PHYSICAL_ROW_CEILING || supportCount > PROMOTION_PHYSICAL_ROW_CEILING ||
+      excluded.some((item) => item.reasonCodes.length > exclusionCodes.size ||
+        item.reasonCodes.some((code) => !exclusionCodes.has(code)))) {
+    throw new Error("Refresh selection audit exceeds canonical bounds or reason vocabulary");
+  }
+  return Object.freeze({
+    status: "selection_audit", format: "reader-summary-refresh-selection-v1",
+    tenantId: m.tenantId, workspaceId: m.workspaceId, scope: "workspace", date: m.date,
+    startedAt: m.startedAt, endedAt: m.endedAt, timezone: m.timezone,
+    jobId, operation: m.operation, observedThrough: m.observedThrough,
+    priorArtifactId: m.prior.artifactId, priorObservedThrough: m.prior.observedThrough,
+    // Canonical object hash; the CLI's terminal receipt binds the reviewed file-byte hash via operation.
+    manifestCanonicalSha256: refreshHash(m), sourceSha256: m.sourceSha256,
+    generationSha256: m.generationSha256, canonicalInputSha256: m.authority.canonicalInputSha256,
+    canonicalCandidateCount: m.authority.eligibleCount,
+    selectedFeedItemIds: Object.freeze(selection.selectedEvidence.map((item) => item.feedItemId)),
+    support: Object.freeze(selection.clusters.map((cluster) => Object.freeze({
+      representativeFeedItemId: cluster.representativeFeedItemId,
+      supportFeedItemIds: Object.freeze([...cluster.duplicateFeedItemIds]),
+    }))),
+    // Absent is distinct from an authoritative empty/no-signal slate.
+    editorialSlate: slate === undefined ? null : Object.freeze({
+      policyVersion: slate.policyVersion,
+      topCandidateIds: Object.freeze(slate.top.map((entry) => entry.candidateId)),
+      additionalCandidateIds: Object.freeze(slate.additional.map((entry) => entry.candidateId)),
+      excluded: Object.freeze(excluded.map((item) => Object.freeze({
+        candidateId: item.candidateId, reasonCodes: Object.freeze([...item.reasonCodes]),
+      }))),
+    }),
+  });
+}


### PR DESCRIPTION
Historical refresh previously preserved publication and model receipts without recording the actual editorial exclusions. Add a private journal receipt containing canonical selected/support IDs, exact exclusion reasons, and manifest/cutoff/source linkage from the actual guarded selector result.

Await journal completion before downstream work, invalidate on recording failure, and validate primitive values and required arrays before copying a frozen allowlisted receipt. Selection identity, guard order, exactly-once consumed-job behavior, thresholds and public contracts are preserved. No raw post content is journaled. This records future decisions; it cannot reconstruct historical or upstream eligibility exclusions.

Validation: final independent APPROVE at37df877d; 458 focused tests,10 retained independent probes and34 additional revision probes passed. Root/build TypeScript, changed-file lint, architecture, quality and line-cap passed. Earlier async/privacy findings R1/R2 were reproduced and fixed. Live seven-day acceptance remains pending.

Related #294.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Refresh processing now records and validates evidence-selection details, helping ensure selections comply with configured policies.
  * Invalid or malformed selection data is rejected without being recorded.
  * Selection-audit failures stop downstream processing and prevent unsafe retries.

* **Data Integrity**
  * Audit records preserve selected evidence, exclusions, relationships, and editorial slate details.
  * Recorded audit information is protected from later modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->