### PR TITLE
fix(summary): observe concurrent coverage failures

### DIFF
--- a/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
+++ b/libs/platform/persistence/src/postgres-runtime-pool-budget.spec.ts
@@ -298,6 +298,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
     PUBLICATION_POSTGRES_TEST_ONLY_FILES;
   const sourceFiles = [...runtimeSourceFiles('apps'), ...runtimeSourceFiles('libs')];
   const completeDatabaseSourceFiles = [
+    'test/feed-reader-summary-coverage-pool.integration.spec.ts',
     ...sourceFiles,
     ...runtimeSourceFiles('scripts'),
     ...runtimeSourceFiles('prisma').filter(
@@ -428,6 +429,8 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/run-reader-summary-promotion-v2-rollback.ts:Pool
       scripts/run-reader-summary-weekly-production.ts:Pool
       scripts/run-reader-summary-weekly-review-producer.ts:Pool
+      test/feed-reader-summary-coverage-pool.integration.spec.ts:Pool
+      test/feed-reader-summary-coverage-pool.integration.spec.ts:PrismaPg
     `));
   });
 
@@ -553,6 +556,7 @@ describe('production PostgreSQL construction and entrypoint inventory', () => {
       scripts/run-reader-summary-promotion-v2-rollback.ts
       scripts/run-reader-summary-weekly-production.ts
       scripts/run-reader-summary-weekly-review-producer.ts
+      test/feed-reader-summary-coverage-pool.integration.spec.ts
     `));
     for (const path of rawDependencyFiles) {
       expect(readSource(path)).not.toMatch(

--- a/libs/summary/adapters/evidence/feed-reader-summary-coverage-ownership.spec-support.ts
+++ b/libs/summary/adapters/evidence/feed-reader-summary-coverage-ownership.spec-support.ts
@@ -1,0 +1,235 @@
+import { strict as assert } from 'node:assert';
+
+import type { FeedItem } from '@social-monitor/feed/domain';
+import type {
+  FeedItemReadRepositoryPort,
+  ListFeedItemSignalCandidatesQuery,
+} from '@social-monitor/feed/ports';
+import { tenantId, workspaceId } from '@social-monitor/shared-kernel';
+
+import type {
+  CountReaderSummaryCollectedFeedItemsQuery,
+  ReaderSummaryProviderCollectionHealth,
+} from '../../ports';
+import { FeedReaderSummaryCoverageCounter } from './feed-reader-summary-coverage.counter';
+
+const query: CountReaderSummaryCollectedFeedItemsQuery = {
+  tenantId: tenantId('11111111-1111-4111-8111-111111111111'),
+  workspaceId: workspaceId('22222222-2222-4222-8222-222222222222'),
+  scope: { type: 'interest', interestId: '33333333-3333-4333-8333-333333333333' },
+  period: {
+    cadence: 'daily',
+    periodKey: 'daily:2026-09-01T00:00:00.000Z:2026-09-02T00:00:00.000Z:UTC',
+    startedAt: new Date('2026-09-01T00:00:00Z'),
+    endedAt: new Date('2026-09-02T00:00:00Z'),
+    timezone: 'UTC',
+  },
+  observedThrough: new Date('2026-09-02T00:05:00Z'),
+};
+const emptyCoverage = {
+  collectedFeedItemCount: 0,
+  lowRelevanceFeedItemCount: 0,
+  mutedFeedItemCount: 0,
+  userRatedFeedItemCount: 0,
+  providerBreakdown: [],
+  topicBreakdown: [],
+  queryBreakdown: [],
+};
+const nextTurn = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+async function verifyOrdering(mode: string, scenario: string): Promise<void> {
+  const health = deferred<readonly ReaderSummaryProviderCollectionHealth[]>();
+  const feed = deferred<readonly FeedItem[]>();
+  const healthError = new Error('TEST health failure');
+  const feedError = new Error('TEST feed failure');
+  let healthCalls = 0;
+  let feedCalls = 0;
+  let listCalls = 0;
+  const readFeed = (feedQuery: ListFeedItemSignalCandidatesQuery) => {
+    feedCalls += 1;
+    assert.deepEqual(feedQuery, {
+      tenantId: query.tenantId,
+      workspaceId: query.workspaceId,
+      interestId: query.scope.type === 'interest' ? query.scope.interestId : undefined,
+      publishedAtOrAfter: query.period.startedAt,
+      publishedBefore: query.period.endedAt,
+      observedAtOrBefore: query.observedThrough,
+    });
+    if (scenario === 'sync-feed' || scenario === 'sync-both') throw feedError;
+    return feed.promise;
+  };
+  const repository: FeedItemReadRepositoryPort = {
+    async findById() { return null; },
+    async list({ limit, cursor, ...feedQuery }) {
+      assert.equal(this, repository);
+      listCalls += 1;
+      assert.equal(limit, 100);
+      assert.equal(cursor, undefined);
+      return { items: await readFeed(feedQuery) };
+    },
+    ...(mode === 'candidate' ? {
+      listSignalCandidates(this: FeedItemReadRepositoryPort, feedQuery: ListFeedItemSignalCandidatesQuery) {
+        assert.equal(this, repository);
+        return readFeed(feedQuery);
+      },
+    } : {}),
+  };
+  // Use a genuinely synchronous throwing list implementation in that case.
+  if (mode === 'pagination' && (scenario === 'sync-feed' || scenario === 'sync-both')) {
+    repository.list = () => { listCalls += 1; feedCalls += 1; throw feedError; };
+  }
+  const counter = new FeedReaderSummaryCoverageCounter(repository, {
+    readProviderCollectionHealth(healthQuery) {
+      healthCalls += 1;
+      assert.equal(healthQuery, query);
+      if (scenario === 'sync-health' || scenario === 'sync-both') throw healthError;
+      return health.promise;
+    },
+  });
+  const result = Promise.allSettled([counter.countCollectedFeedItemCoverage(query)]);
+  // Both requests must start before either settles, including synchronous throws.
+  assert.equal(healthCalls, 1);
+  assert.equal(feedCalls, 1);
+  let expected: Error | undefined;
+  switch (scenario) {
+    case 'health-first':
+      expected = healthError;
+      health.reject(healthError);
+      assertRejected(await result, expected);
+      await nextTurn();
+      feed.reject(feedError);
+      break;
+    case 'feed-first':
+      expected = feedError;
+      feed.reject(feedError);
+      assertRejected(await result, expected);
+      await nextTurn();
+      health.reject(healthError);
+      break;
+    case 'simultaneous':
+      health.reject(healthError);
+      feed.reject(feedError);
+      // Promise adoption can order same-turn errors differently between the
+      // candidate and pagination workflows; either original error must escape.
+      expected = ((await result)[0] as PromiseRejectedResult).reason as Error;
+      assert(expected === healthError || expected === feedError);
+      break;
+    case 'sync-health':
+    case 'sync-both':
+      expected = healthError;
+      assertRejected(await result, expected);
+      if (scenario === 'sync-health') feed.reject(feedError);
+      break;
+    case 'sync-feed':
+      expected = feedError;
+      assertRejected(await result, expected);
+      await nextTurn();
+      health.reject(healthError);
+      break;
+    case 'health-only-error':
+      expected = healthError;
+      feed.resolve([]);
+      await nextTurn();
+      health.reject(healthError);
+      break;
+    case 'feed-only-error':
+      expected = feedError;
+      health.resolve([]);
+      await nextTurn();
+      feed.reject(feedError);
+      break;
+    case 'success':
+      health.resolve([]);
+      feed.resolve([]);
+      break;
+    default:
+      throw new Error(`Unknown ordering scenario: ${scenario}`);
+  }
+  if (expected === undefined) {
+    assert.deepEqual(await result, [{ status: 'fulfilled', value: emptyCoverage }]);
+  } else {
+    assertRejected(await result, expected);
+  }
+  // A later rejection of the losing branch is fatal under strict Node if orphaned.
+  await nextTurn();
+  assert.equal(healthCalls, 1);
+  assert.equal(feedCalls, 1);
+  assert.equal(listCalls, mode === 'candidate' ? 0 : 1);
+}
+
+function assertRejected(results: readonly PromiseSettledResult<unknown>[], error: Error): void {
+  assert.equal(results.length, 1);
+  assert.equal(results[0]?.status, 'rejected');
+  assert.equal((results[0] as PromiseRejectedResult).reason, error);
+}
+
+async function verifyEarlyExit(mode: string, rejectHealth: boolean): Promise<void> {
+  const health = deferred<readonly ReaderSummaryProviderCollectionHealth[]>();
+  const healthError = new Error('TEST health failed after pagination stopped');
+  let calls = 0;
+  let healthCalls = 0;
+  let completed = false;
+  const counter = new FeedReaderSummaryCoverageCounter({
+    async findById() { return null; },
+    async list({ cursor, limit }) {
+      assert.equal(limit, 100);
+      assert.equal(cursor, calls === 0 ? undefined : mode === 'repeat' ? 'same' : String(calls));
+      calls += 1;
+      return { items: [], nextCursor: mode === 'repeat' ? 'same' : String(calls) };
+    },
+  }, {
+    readProviderCollectionHealth() { healthCalls += 1; return health.promise; },
+  });
+  const result = Promise.allSettled([counter.countCollectedFeedItems(query)]).then((value) => {
+    completed = true;
+    return value;
+  });
+  await nextTurn();
+  assert.equal(calls, mode === 'repeat' ? 2 : 1000);
+  assert.equal(completed, false, 'pagination exit still owns pending health');
+  if (rejectHealth) {
+    health.reject(healthError);
+    assertRejected(await result, healthError);
+  } else {
+    health.resolve([]);
+    assert.deepEqual(await result, [{ status: 'fulfilled', value: undefined }]);
+  }
+  await nextTurn();
+  assert.equal(healthCalls, 1);
+  assert.equal(calls, mode === 'repeat' ? 2 : 1000);
+}
+
+async function main(mode: string): Promise<void> {
+  if (mode === 'early-exits') {
+    for (const exit of ['repeat', 'ceiling']) {
+      await verifyEarlyExit(exit, true);
+      await verifyEarlyExit(exit, false);
+    }
+  } else {
+    assert(['candidate', 'pagination'].includes(mode));
+    for (const scenario of [
+      'health-first', 'feed-first', 'simultaneous', 'sync-health', 'sync-feed',
+      'sync-both', 'health-only-error', 'feed-only-error', 'success',
+    ]) {
+      await verifyOrdering(mode, scenario);
+    }
+  }
+  process.stdout.write(`verified ${mode}\n`);
+}
+
+if (require.main === module) {
+  // Keep a hung join observable by the parent's timeout even with deferred fakes.
+  const keepAlive = setInterval(() => undefined, 1000);
+  void main(process.argv[2] ?? '').then(() => clearInterval(keepAlive), (error: unknown) => {
+    clearInterval(keepAlive);
+    process.stderr.write(`${String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/libs/summary/adapters/evidence/feed-reader-summary-coverage-strict.spec.ts
+++ b/libs/summary/adapters/evidence/feed-reader-summary-coverage-strict.spec.ts
@@ -1,0 +1,25 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+describe('coverage owns health and the complete feed workflow under strict Node', () => {
+  it.each([
+    ['ownership', 'candidate'],
+    ['ownership', 'pagination'],
+    ['ownership', 'early-exits'],
+  ])('%s: %s returns failures without crashing', (support, scenario) => {
+    const output = execFileSync(process.execPath, [
+      '--unhandled-rejections=strict',
+      '--max-old-space-size=4096',
+      '-r', 'ts-node/register/transpile-only',
+      '-r', 'tsconfig-paths/register',
+      resolve(__dirname, `feed-reader-summary-coverage-${support}.spec-support.ts`),
+      scenario,
+    ], {
+      cwd: process.cwd(),
+      env: { ...process.env, TS_NODE_PROJECT: 'test/tsconfig.jest.json' },
+      encoding: 'utf8',
+      timeout: 20_000,
+    });
+    expect(output.trim()).toBe(`verified ${scenario}`);
+  }, 25_000);
+});

--- a/libs/summary/adapters/evidence/feed-reader-summary-coverage.counter.ts
+++ b/libs/summary/adapters/evidence/feed-reader-summary-coverage.counter.ts
@@ -37,17 +37,29 @@ export class FeedReaderSummaryCoverageCounter implements ReaderSummaryCoverageCo
   async countCollectedFeedItemCoverage(
     query: CountReaderSummaryCollectedFeedItemsQuery,
   ): Promise<ReaderSummaryCollectedFeedItemCoverage | undefined> {
+    // Own both branches before yielding, including synchronous port throws and
+    // pagination exits. A failure must not leave the other branch unobserved.
+    const [collectionHealth, accumulator] = await Promise.all([
+      (async () => this.collectionHealth.readProviderCollectionHealth(query))(),
+      this.collectFeedItemCoverage(query),
+    ]);
+    return accumulator === undefined
+      ? undefined
+      : coverageResult(accumulator, collectionHealth);
+  }
+
+  private async collectFeedItemCoverage(
+    query: CountReaderSummaryCollectedFeedItemsQuery,
+  ): Promise<CoverageAccumulator | undefined> {
     let cursor: string | undefined;
     const accumulator = emptyCoverageAccumulator();
-    const collectionHealthPromise =
-      this.collectionHealth.readProviderCollectionHealth(query);
     const candidateReader = this.feedItems.listSignalCandidates;
     const feedQuery = coverageFeedItemQuery(query);
 
     if (candidateReader !== undefined) {
       const items = await candidateReader.call(this.feedItems, feedQuery);
       recordCoverageItems(items, accumulator);
-      return coverageResult(accumulator, await collectionHealthPromise);
+      return accumulator;
     }
 
     for (let page = 0; page < MAX_PAGES; page += 1) {
@@ -59,7 +71,7 @@ export class FeedReaderSummaryCoverageCounter implements ReaderSummaryCoverageCo
       recordCoverageItems(result.items, accumulator);
 
       if (result.nextCursor === undefined) {
-        return coverageResult(accumulator, await collectionHealthPromise);
+        return accumulator;
       }
 
       if (result.nextCursor === cursor) {

--- a/test/feed-reader-summary-coverage-pool.integration.spec.ts
+++ b/test/feed-reader-summary-coverage-pool.integration.spec.ts
@@ -1,0 +1,237 @@
+import { strict as assert } from 'node:assert';
+import { EventEmitter } from 'node:events';
+import { execFileSync } from 'node:child_process';
+
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool, type PoolConfig } from 'pg';
+import { PrismaFeedItemReadRepository } from '@social-monitor/feed/adapters/persistence/prisma/prisma-feed-item-read.repository';
+import type { PrismaFeedClient } from '@social-monitor/feed/adapters/persistence/prisma/prisma-feed-client';
+import {
+  currentDatabaseAccess,
+  defaultPostgresRuntimePoolConfig,
+  PostgresRuntimePoolRegistry,
+  runWithTenantDatabaseAccess,
+  type PrismaPgRuntimeClientConstructor,
+} from '@social-monitor/platform-persistence';
+import { loadPrismaRuntimeClient } from '@social-monitor/platform-persistence/prisma-runtime-client';
+import { tenantId, workspaceId } from '@social-monitor/shared-kernel';
+
+import type { CountReaderSummaryCollectedFeedItemsQuery } from '@social-monitor/summary/ports';
+import { PrismaReaderSummaryProviderCollectionHealthReader } from '@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-provider-collection-health.reader';
+import { FeedReaderSummaryCoverageCounter } from '@social-monitor/summary/adapters/evidence/feed-reader-summary-coverage.counter';
+
+const scope = {
+  tenantId: tenantId('11111111-1111-4111-8111-111111111111'),
+  workspaceId: workspaceId('22222222-2222-4222-8222-222222222222'),
+};
+const query: CountReaderSummaryCollectedFeedItemsQuery = {
+  ...scope,
+  scope: { type: 'workspace' },
+  period: {
+    cadence: 'daily',
+    periodKey: 'daily:2026-09-01T00:00:00.000Z:2026-09-02T00:00:00.000Z:UTC',
+    startedAt: new Date('2026-09-01T00:00:00Z'),
+    endedAt: new Date('2026-09-02T00:00:00Z'),
+    timezone: 'UTC',
+  },
+};
+type RuntimeClient = PrismaFeedClient & {
+  $disconnect(): Promise<void>;
+  $queryRaw<T>(query: TemplateStringsArray, ...values: readonly unknown[]): Promise<T>;
+  $executeRawUnsafe(query: string): Promise<number>;
+};
+type Statement = { readonly text: string; readonly values: readonly unknown[] };
+
+// Adapted from R1's actual installed-pg/Prisma strict-process harness. Only the
+// wire client is fake: it has no socket, URL lookup, provider or database access.
+class NoNetworkClient extends EventEmitter {
+  readonly _queryable = true;
+  readonly _ending = false;
+  static statements: Statement[] = [];
+  static rejectConfiguration = false;
+
+  connect(callback: (error?: Error) => void): void {
+    queueMicrotask(() => callback());
+  }
+
+  async query(statement: Statement) {
+    NoNetworkClient.statements.push(statement);
+    if (statement.text.includes('set_config') && NoNetworkClient.rejectConfiguration) {
+      throw new Error('TEST scope configuration failed');
+    }
+    if (statement.text === 'SELECT sandbox_failure') {
+      throw new Error('TEST statement failed');
+    }
+    return { command: '', rowCount: 0, rows: [], fields: [] };
+  }
+
+  end(callback?: () => void): void {
+    this.emit('end');
+    callback?.();
+  }
+}
+
+async function verify(): Promise<void> {
+  const config = {
+    ...defaultPostgresRuntimePoolConfig(
+      'postgresql://no-network.invalid/coverage_rejection_test', 'api-gateway',
+    ),
+    connectionTimeoutMillis: 100,
+  };
+  const pool = new Pool({
+    min: 0,
+    max: 2,
+    connectionTimeoutMillis: config.connectionTimeoutMillis,
+    Client: NoNetworkClient,
+  } as unknown as PoolConfig);
+  const registry = new PostgresRuntimePoolRegistry({
+    createPool: () => pool,
+    createAdapter: (ownedPool) => new PrismaPg(ownedPool, { disposeExternalPool: false }),
+  });
+  const Client = loadPrismaRuntimeClient<PrismaPgRuntimeClientConstructor<RuntimeClient>>();
+  const lease = await registry.acquire(config, Client);
+  const counter = new FeedReaderSummaryCoverageCounter(
+    new PrismaFeedItemReadRepository(lease.client),
+    new PrismaReaderSummaryProviderCollectionHealthReader(lease.client),
+  );
+  // pg timeouts are unref'ed; this substitutes for the real sockets' liveness.
+  const keepAlive = setInterval(() => undefined, 1000);
+  let releases = 0;
+  pool.on('release', () => { releases += 1; });
+  try {
+    const held = await Promise.all([pool.connect(), pool.connect()]);
+    const acquisitionErrors: unknown[] = [];
+    const connect = pool.connect.bind(pool);
+    // Record original pg error identities, then return their rejections intact.
+    pool.connect = (() => connect().catch((error: unknown) => {
+      acquisitionErrors.push(error);
+      throw error;
+    })) as typeof pool.connect;
+    try {
+      const results = await runWithTenantDatabaseAccess(scope, () =>
+        Promise.allSettled(Array.from({ length: 7 }, () =>
+          counter.countCollectedFeedItemCoverage(query))),
+      );
+      assert.equal(results.length, 7);
+      for (const result of results) {
+        assert.equal(result.status, 'rejected');
+        if (result.status !== 'rejected') throw new Error('Expected caller failure');
+        assert(acquisitionErrors.includes(result.reason));
+        assert.match((result.reason as Error).message, /timeout exceeded when trying to connect/);
+        assert.match((result.reason as Error).stack ?? '', /pg-pool/);
+      }
+      // The rejected join may precede the other seven timeouts. Keep both slots
+      // held until every losing branch can reject under strict Node as well.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      assert.equal(acquisitionErrors.length, 14, 'exactly one health and feed request per call');
+      assert.equal(pool.waitingCount, 0);
+      assert.equal(pool.totalCount, 2);
+      assert.equal(releases, 0);
+      assert.equal(NoNetworkClient.statements.length, 0);
+    } finally {
+      held.forEach((connection) => connection.release());
+    }
+
+    // The same bounded runtime recovers and still scopes both successful reads.
+    const coverage = await runWithTenantDatabaseAccess(scope, () =>
+      counter.countCollectedFeedItemCoverage(query));
+    assert.deepEqual(coverage, {
+      collectedFeedItemCount: 0,
+      lowRelevanceFeedItemCount: 0,
+      mutedFeedItemCount: 0,
+      userRatedFeedItemCount: 0,
+      providerBreakdown: [],
+      topicBreakdown: [],
+      queryBreakdown: [],
+    });
+    assert.equal(releases, 4);
+    assert.equal(pool.idleCount, 2);
+    assertScopes(2);
+    const sql = NoNetworkClient.statements.map(({ text }) => text);
+    assert.equal(sql.filter((text) => text === 'BEGIN').length, 2);
+    assert.equal(sql.filter((text) => text === 'COMMIT').length, 2);
+    assert.equal(sql.filter((text) => text.includes('latest_binding_scans')).length, 1);
+    assert.equal(sql.filter((text) => text.includes('"public"."feed_items"')).length, 1);
+
+    // Preserve R1's scope/rollback/release invariants on this recovered pool.
+    for (const stage of ['configuration', 'statement', 'callback'] as const) {
+      NoNetworkClient.statements = [];
+      NoNetworkClient.rejectConfiguration = stage === 'configuration';
+      const before: number = releases;
+      const callbackError = new Error('TEST callback failed');
+      let callbacks = 0;
+      await assert.rejects(runWithTenantDatabaseAccess(scope, () => {
+        if (stage !== 'callback') return lease.client.$executeRawUnsafe('SELECT sandbox_failure');
+        assert(lease.client.$transaction);
+        return lease.client.$transaction(async (transaction) => {
+          callbacks += 1;
+          assert(transaction.$executeRawUnsafe);
+          await transaction.$executeRawUnsafe('SELECT sandbox_success');
+          await transaction.$executeRawUnsafe('SELECT sandbox_success');
+          throw callbackError;
+        }, { isolationLevel: 'Serializable', maxWait: 1234, timeout: 5678 });
+      }), (error: unknown) => stage === 'callback' ? error === callbackError :
+        error instanceof Error && error.message.includes(
+          stage === 'configuration' ? 'TEST scope configuration failed' : 'TEST statement failed'));
+      assert.equal(callbacks, stage === 'callback' ? 1 : 0);
+      assertScopes(1);
+      assert.deepEqual(NoNetworkClient.statements.map(({ text }) =>
+        text.includes('set_config') ? 'scope' : text),
+      stage === 'callback'
+        ? ['BEGIN', 'SET TRANSACTION ISOLATION LEVEL SERIALIZABLE', 'scope',
+          'SELECT sandbox_success', 'SELECT sandbox_success', 'ROLLBACK']
+        : stage === 'configuration' ? ['BEGIN', 'scope', 'ROLLBACK']
+          : ['BEGIN', 'scope', 'SELECT sandbox_failure', 'ROLLBACK']);
+      assert.equal(releases, before + 1);
+      assert.equal(pool.idleCount, pool.totalCount);
+      assert.equal(pool.waitingCount, 0);
+    }
+    assert.equal(currentDatabaseAccess(), undefined);
+    await lease.close();
+    await lease.close();
+    assert.deepEqual(registry.diagnostics(), {
+      poolInstances: 0, prismaClientInstances: 0, activeConnectionLeases: 0, closing: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    process.stdout.write('verified pressure\n');
+  } finally {
+    clearInterval(keepAlive);
+    await lease.close();
+  }
+}
+
+function assertScopes(count: number): void {
+  const configurations = NoNetworkClient.statements.filter(({ text }) => text.includes('set_config'));
+  assert.equal(configurations.length, count);
+  for (const statement of configurations) {
+    assert.deepEqual(statement.values, [scope.tenantId, scope.workspaceId, 'false']);
+    assert.match(statement.text, /set_config\('social_monitor.tenant_id', \$1, true\)/);
+    assert.match(statement.text, /set_config\('social_monitor.workspace_id', \$2, true\)/);
+    assert.match(statement.text, /set_config\('social_monitor.system_access', \$3, true\)/);
+  }
+}
+
+if (require.main === module) {
+  void verify().catch((error: unknown) => {
+    process.stderr.write(`${String(error)}\n`);
+    process.exitCode = 1;
+  });
+} else {
+  describe('coverage under actual installed-pg/Prisma pool pressure', () => {
+    it('returns acquisition errors, recovers and preserves scoped rollback under strict Node', () => {
+      const output = execFileSync(process.execPath, [
+        '--unhandled-rejections=strict',
+        '--max-old-space-size=4096',
+        '-r', 'ts-node/register/transpile-only',
+        '-r', 'tsconfig-paths/register',
+        __filename,
+      ], {
+        cwd: process.cwd(),
+        env: { ...process.env, TS_NODE_PROJECT: 'test/tsconfig.jest.json' },
+        encoding: 'utf8',
+        timeout: 20_000,
+      });
+      expect(output.trim()).toBe('verified pressure');
+    }, 25_000);
+  });
+}


### PR DESCRIPTION
Concurrent Reader Summary reads can leave a health-read rejection unobserved when feed accumulation fails or exits early. Join both started operations immediately so acquisition failures reach the caller without terminating Node; preserve scoped reads, original errors and pool limits.

Independent review approved exact b11d384a442be5ed92dcdbc96703638a3b8ed3c0: 170 tests and 44 additional strict-Node cases passed. The actual installed pg/Prisma exhausted-pool probe changes process exit 1 to exit 0 with all seven caller errors observed. TypeScript, changed-file lint, architecture, quality, line-cap and tenant guards pass. Production attribution remains a matching reachable mechanism; post-deploy concurrent-read canary is pending.

Related https://github.com/777genius/social-monitor/pull/294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of feed coverage calculations during concurrent database activity.
  - Improved handling of connection timeouts, transaction failures, pagination exits, and recovery after errors.
  - Ensured successful requests return expected coverage results after temporary resource pressure.

- **Tests**
  - Added comprehensive coverage for concurrent requests, failure handling, pagination behavior, transaction cleanup, and connection-pool recovery.
  - Added integration validation using a real PostgreSQL connection pool without external network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->