### PR TITLE
fix(deploy): load quorum health from reviewed target

### DIFF
--- a/ops/deploy/backend-runtime-health-lib.sh
+++ b/ops/deploy/backend-runtime-health-lib.sh
@@ -15,6 +15,20 @@ BACKEND_HEALTH_STARTUP_GRACE_SECONDS=${BACKEND_HEALTH_STARTUP_GRACE_SECONDS:-240
 OTEL_COLLECTOR_HEALTH_STARTUP_GRACE_SECONDS=${OTEL_COLLECTOR_HEALTH_STARTUP_GRACE_SECONDS:-600}
 BACKEND_HEALTH_RETRY_SLEEP_SECONDS=${BACKEND_HEALTH_RETRY_SLEEP_SECONDS:-3}
 
+# The target loader has verified all three assets before sourcing this inode.
+# Bash exposes the reviewed source helper's local sha/relative_path here; use
+# that explicit target only during this call, never HEAD or the prelude pin.
+# Reload both dependencies even when predecessor versions are already present.
+if [[ ${FUNCNAME[1]:-} == source_reviewed_deploy_library &&
+      ${FUNCNAME[2]:-} == load_target_rabbitmq_quorum_backend_health &&
+      ${relative_path:-} == ops/deploy/backend-runtime-health-lib.sh ]]; then
+  source_reviewed_deploy_library "$sha" \
+    ops/deploy/rabbitmq-quorum-health.sh 'target RabbitMQ quorum health library' || return 1
+  # Recovery must see the reviewed health definitions before its FD is sourced.
+  source_reviewed_deploy_library "$sha" \
+    ops/deploy/rabbitmq-quorum-recovery.sh 'target RabbitMQ quorum recovery library' || return 1
+fi
+
 backend_health_load_rabbitmq_quorum_recovery() {
   local script
 

--- a/ops/deploy/backend-runtime-health-lib.test.sh
+++ b/ops/deploy/backend-runtime-health-lib.test.sh
@@ -334,3 +334,6 @@ fi
 [[ $(wc -l < "$ATTEMPTS_FILE") == 5 ]]
 
 echo 'Backend runtime health contract tests passed'
+
+# Exercise the same mutable health library across an authorized HEAD transition.
+bash "$SCRIPT_DIR/backend-runtime-health-target-transition.test.sh"

--- a/ops/deploy/backend-runtime-health-target-transition.test.sh
+++ b/ops/deploy/backend-runtime-health-target-transition.test.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FIXTURE=$(mktemp -d /tmp/rabbitmq-authorized-prelude-test.XXXXXX)
+cleanup() {
+  if [[ ${RABBITMQ_PRELUDE_TEST_KEEP_FIXTURE:-0} == 1 ]]; then
+    printf 'fixture=%s\n' "$FIXTURE"
+  else
+    rm -rf "$FIXTURE"
+  fi
+}
+trap cleanup EXIT
+HEALTH=ops/deploy/rabbitmq-quorum-health.sh
+RECOVERY=ops/deploy/rabbitmq-quorum-recovery.sh
+ASSETS=(deploy-control-lib.sh deploy-control-bridge-lib.sh
+  backend-runtime-health-lib.sh backend-image-rescue-lib.sh
+  backend-image-rescue-pin-cleanup-lib.sh rabbitmq-quorum-health.sh
+  rabbitmq-quorum-recovery.sh)
+
+fail() { printf 'prelude-test-error: %s\n' "$*" >&2; exit 1; }
+
+prepare_case() {
+  local name=$1 asset
+  REPO=$FIXTURE/$name/repo
+  STATE=$FIXTURE/$name/state
+  CONTROL=$FIXTURE/$name/control
+  EVENTS=$FIXTURE/$name/events
+  SENTINEL=$FIXTURE/$name/unauthorized-executed
+  TRACE=$FIXTURE/$name/trace
+  # Consumed by the real libraries sourced through authorized Git blobs.
+  # shellcheck disable=SC2034
+  PROJECT=rabbitmq-prelude-test
+  install -d "$REPO/ops/deploy" "$STATE" "$CONTROL"
+  : > "$EVENTS"
+  git init -q -b main "$REPO"
+  git -C "$REPO" config user.name 'RabbitMQ Prelude Test'
+  git -C "$REPO" config user.email prelude@example.invalid
+  for asset in "${ASSETS[@]}"; do cp "$SCRIPT_DIR/$asset" "$REPO/ops/deploy/$asset"; done
+  chmod 0644 "$REPO/ops/deploy/"*-lib.sh
+  chmod 0755 "$REPO/$HEALTH" "$REPO/$RECOVERY"
+  git -C "$REPO" add .
+  git -C "$REPO" commit -qm 'test: authorized predecessor'
+  BASE=$(git -C "$REPO" rev-parse HEAD)
+  printf '\nprelude_fixture_health_version() { printf target-health; }\n' >> "$REPO/$HEALTH"
+  printf '\nprelude_fixture_recovery_version() { printf target-recovery; }\n' >> "$REPO/$RECOVERY"
+  git -C "$REPO" add .
+  git -C "$REPO" commit -qm 'test: next backend target'
+  TARGET=$(git -C "$REPO" rev-parse HEAD)
+  git -C "$REPO" checkout -q "$BASE"
+}
+
+load_authorized_predecessor() {
+  local asset
+  # Use the real authority, never the entrypoint's source-only TEST shortcut.
+  # shellcheck source=ops/deploy/production-transition-b0-host-control.sh
+  source "$SCRIPT_DIR/production-transition-b0-host-control.sh"
+  production_transition_host_seal_prelude_commit "$BASE"
+  readonly PRODUCTION_TRANSITION_PRELUDE_COMMIT
+  for asset in deploy-control-lib.sh deploy-control-bridge-lib.sh \
+    backend-runtime-health-lib.sh backend-image-rescue-lib.sh; do
+    production_transition_host_source_authorized_prelude "ops/deploy/$asset" "$asset"
+  done
+  ! declare -F rabbitmq_quorum_health_verify_worker_container >/dev/null
+  ! declare -F rabbitmq_quorum_recovery_ensure_steady >/dev/null
+  # shellcheck disable=SC2034
+  DEPLOY_CONTROL_BRIDGE_INITIALIZED_HEAD=$BASE
+  # This synthetic two-commit history is an ordinary fast-forward, not B0/R/H/W.
+  production_forward_derive_graph() { return 1; }
+}
+
+install_runtime_fakes() {
+  CONTAINER=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  IMAGE=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  # Only transport/image effects are faked. Rescue preparation, pin_service,
+  # verify_backend_with_retry, verify_backend and the lazy loader remain real.
+  fake_compose() {
+    [[ " $* " == *' ps '* && ${*: -1} == api ]] || fail "unexpected Compose call: $*"
+    printf '%s\n' "$CONTAINER"
+  }
+  # shellcheck disable=SC2034
+  COMPOSE=(fake_compose)
+  docker() {
+    [[ $1 == inspect && $2 == "$CONTAINER" ]] || fail "unexpected Docker call: $*"
+    case ${3:-} in
+      --format)
+        case $4 in
+          '{{.State.Status}}') printf 'running\n' ;;
+          '{{.State.OOMKilled}}') printf 'false\n' ;;
+          *) fail "unexpected Docker format: $4" ;;
+        esac ;;
+      '') printf '[{"Id":"%s","State":{"Status":"running","OOMKilled":false},"RestartCount":0}]\n' "$CONTAINER" ;;
+      *) fail "unexpected Docker inspect: $*" ;;
+    esac
+  }
+  curl() { printf 'http-health\n' >> "$EVENTS"; }
+  sleep() { fail 'healthy fixture must not retry'; }
+  marker_value() { printf '%s\n' "$BASE"; }
+  backend_image_rescue_remove_tag() { :; }
+  backend_image_rescue_image_id() { printf '%s\n' "$IMAGE"; }
+  backend_image_rescue_pin_running_container() {
+    printf -v "$4" '%s' running-image
+    printf -v "$5" '%s' "$IMAGE"
+    printf 'image-pinned\n' >> "$EVENTS"
+  }
+  # The real steady-recovery entrypoint runs with an isolated state root;
+  # broker identification and probing are deterministic transport substitutes.
+  # shellcheck disable=SC2034
+  RABBITMQ_QUORUM_RECOVERY_STATE_ROOT=$CONTROL/quorum-test
+  rabbitmq_quorum_health_identify_target() { :; }
+  rabbitmq_quorum_health_probe_target() { printf 'quorum-probe\n' >> "$EVENTS"; }
+}
+
+run_transition() (
+  local variant=$1 asset
+  prepare_case "$variant"
+  load_authorized_predecessor
+  if [[ $variant == preloaded ]]; then
+    for asset in "$HEALTH" "$RECOVERY"; do
+      production_transition_host_source_authorized_prelude "$asset" predecessor-quorum
+    done
+    # Obsolete definitions must be replaced, not merely satisfy lazy guards.
+    rabbitmq_quorum_health_verify_worker_container() { fail old-worker-health; }
+    rabbitmq_quorum_recovery_ensure_steady() { fail old-recovery; }
+  fi
+  deploy_control_after_reviewed_library_stage() {
+    printf 'reviewed:%s\n' "$1" >> "$EVENTS"
+    if [[ $variant == changed-head-after-stage && $1 != ops/deploy/backend-runtime-health-lib.sh ]]; then
+      [[ $(git -C "$REPO" rev-parse HEAD) == "$BASE" ]]
+    else
+      [[ $(git -C "$REPO" rev-parse HEAD) == "$TARGET" ]]
+    fi
+    [[ $PRODUCTION_TRANSITION_PRELUDE_COMMIT == "$BASE" ]]
+    if [[ $variant == staged-mutation ]]; then
+      printf '\nprintf unsafe > "%s"\n' "$SENTINEL" >> "$REPO/$1"
+    fi
+    if [[ $1 == ops/deploy/backend-runtime-health-lib.sh ]]; then
+      case $variant in
+        changed-head-after-stage) git -C "$REPO" checkout -q "$BASE" ;;
+        staged-missing) rm "$REPO/$HEALTH" "$REPO/$RECOVERY" ;;
+        staged-symlink)
+          for asset in "$HEALTH" "$RECOVERY"; do
+            mv "$REPO/$asset" "$REPO/$asset.real"
+            printf 'printf unsafe > "%s"\n' "$SENTINEL" > "$REPO/$asset.real"
+            ln -s "${asset##*/}.real" "$REPO/$asset"
+          done ;;
+      esac
+    fi
+  }
+  # Record the real function stack, including rescue -> pin -> retry -> health
+  # -> lazy loader. The original target health library fails here before any health or image effect.
+  exec 6>"$TRACE"
+  BASH_XTRACEFD=6
+  PS4='+${FUNCNAME[*]}: '
+  set -x
+  advance_integration "$TARGET"
+  load_target_rabbitmq_quorum_backend_health "$TARGET"
+  [[ $(declare -f rabbitmq_quorum_health_verify_worker_container) == "$(
+    source "$SCRIPT_DIR/rabbitmq-quorum-health.sh"
+    declare -f rabbitmq_quorum_health_verify_worker_container
+  )" ]]
+  [[ $(declare -f rabbitmq_quorum_recovery_ensure_steady) == "$(
+    source "$SCRIPT_DIR/rabbitmq-quorum-recovery.sh"
+    declare -f rabbitmq_quorum_recovery_ensure_steady
+  )" ]]
+  install_runtime_fakes
+  backend_image_rescue_prepare "$TARGET" "$(backend_image_rescue_state_file "$TARGET")" api
+  set +x
+  unset BASH_XTRACEFD
+  [[ $PRODUCTION_TRANSITION_PRELUDE_COMMIT == "$BASE" && $BASE != "$TARGET" ]]
+  if [[ $variant == changed-head-after-stage ]]; then
+    [[ $(git -C "$REPO" rev-parse HEAD) == "$BASE" ]]
+  else
+    [[ $(git -C "$REPO" rev-parse HEAD) == "$TARGET" ]]
+  fi
+  [[ $(prelude_fixture_health_version) == target-health ]]
+  [[ $(prelude_fixture_recovery_version) == target-recovery ]]
+  [[ ! -e $SENTINEL ]]
+  [[ $(backend_image_rescue_read_phase "$(backend_image_rescue_state_file "$TARGET")") == prepared ]]
+  [[ $(cat "$EVENTS") == \
+    $'reviewed:ops/deploy/backend-runtime-health-lib.sh\nreviewed:'"$HEALTH"$'\nreviewed:'"$RECOVERY"$'\nquorum-probe\nhttp-health\nhttp-health\nimage-pinned' ]]
+  grep -F 'backend_health_load_rabbitmq_quorum_recovery verify_backend verify_backend_with_retry backend_image_rescue_pin_service backend_image_rescue_prepare' "$TRACE" >/dev/null
+  printf 'PASS %s: predecessor authority -> target advance -> reviewed target libraries -> real rescue health; pin unchanged\n' "$variant"
+)
+
+assert_rejected() {
+  local expected=$1 status output
+  shift
+  set +e
+  output=$("$@" 2>&1)
+  status=$?
+  set -e
+  ((status != 0)) || fail "unexpected acceptance: $*"
+  grep -F "$expected" <<< "$output" >/dev/null || fail "unexpected rejection: $output"
+  printf 'PASS rejection: %s\n' "$expected"
+}
+
+reject_authorized_source() (
+  local variant=$1 asset=$2
+  prepare_case "authorized-$variant-${asset##*/}"
+  load_authorized_predecessor
+  case $variant in
+    changed-head) advance_integration "$TARGET" ;;
+    missing-blob) asset=ops/deploy/unauthorized.sh
+      printf 'printf unsafe > "%s"\n' "$SENTINEL" > "$REPO/$asset" ;;
+  esac
+  production_transition_host_source_authorized_prelude "$asset" quorum
+)
+
+reject_target_asset() (
+  local variant=$1 asset=$2
+  prepare_case "target-$variant-${asset##*/}"
+  load_authorized_predecessor
+  advance_integration "$TARGET"
+  case $variant in
+    missing) rm "$REPO/$asset" ;;
+    changed-mode) chmod 0600 "$REPO/$asset" ;;
+    missing-blob)
+      git -C "$REPO" update-index --force-remove "$asset"
+      git -C "$REPO" commit -qm 'test: absent reviewed asset'
+      TARGET=$(git -C "$REPO" rev-parse HEAD) ;;
+    changed-blob) printf '\nprintf unsafe > "%s"\n' "$SENTINEL" >> "$REPO/$asset" ;;
+    symlink) mv "$REPO/$asset" "$REPO/$asset.real"; ln -s "${asset##*/}.real" "$REPO/$asset" ;;
+    committed-symlink)
+      mv "$REPO/$asset" "$REPO/$asset.real"
+      ln -s "${asset##*/}.real" "$REPO/$asset"
+      git -C "$REPO" add .
+      git -C "$REPO" commit -qm 'test: unauthorized symlink blob'
+      TARGET=$(git -C "$REPO" rev-parse HEAD)
+      # A regular working file cannot disguise a symlink in the reviewed tree.
+      rm "$REPO/$asset"
+      mv "$REPO/$asset.real" "$REPO/$asset" ;;
+  esac
+  load_target_rabbitmq_quorum_backend_health "$TARGET"
+)
+
+reject_unsealed_or_symlink_prelude() (
+  local variant=$1 asset=$2
+  prepare_case "prelude-$variant-${asset##*/}"
+  # shellcheck source=ops/deploy/production-transition-b0-host-control.sh
+  source "$SCRIPT_DIR/production-transition-b0-host-control.sh"
+  unset PRODUCTION_TRANSITION_PRELUDE_COMMIT
+  if [[ $variant == symlink ]]; then
+    mv "$REPO/$asset" "$REPO/$asset.real"
+    ln -s "${asset##*/}.real" "$REPO/$asset"
+    git -C "$REPO" add .
+    git -C "$REPO" commit -qm 'test: symlink prelude blob'
+    production_transition_host_seal_prelude_commit "$(git -C "$REPO" rev-parse HEAD)"
+  fi
+  production_transition_host_source_authorized_prelude "$asset" quorum
+)
+
+# Pin the fixture sequence to the production call sites as well as exercising
+# the real loading/rescue functions. No deploy entrypoint is executed here.
+python3 - "$SCRIPT_DIR" <<'PY'
+from pathlib import Path
+import sys
+root = Path(sys.argv[1])
+entry = (root / 'social-monitor-production-deploy.sh').read_text()
+control = (root / 'deploy-control-lib.sh').read_text().split('deploy_release() {', 1)[1]
+assert entry.index('production_transition_host_preflight_prelude "') < entry.index("ops/deploy/backend-runtime-health-lib.sh 'backend runtime health library'")
+assert control.index('advance_integration "$sha"') < control.index('load_target_rabbitmq_quorum_backend_health "$sha"') < control.index('deploy_release_runtime_transaction "$sha"')
+backend = entry.split('deploy_backend() (', 1)[1]
+assert backend.index('backend_image_rescue_prepare "$sha"') < backend.index('build "$service"')
+PY
+
+run_transition cold
+[[ ${1:-} != --transition-only ]] || exit 0
+run_transition preloaded
+run_transition staged-mutation
+run_transition staged-missing
+run_transition staged-symlink
+run_transition changed-head-after-stage
+for asset in "$HEALTH" "$RECOVERY" ops/deploy/backend-runtime-health-lib.sh; do
+  assert_rejected 'has no stable authorized prelude commit' reject_authorized_source changed-head "$asset"
+  assert_rejected 'is not an authorized regular blob' reject_authorized_source missing-blob "$asset"
+  assert_rejected 'has no stable authorized prelude commit' reject_unsealed_or_symlink_prelude unsealed "$asset"
+  assert_rejected 'is not an authorized regular blob' reject_unsealed_or_symlink_prelude symlink "$asset"
+  assert_rejected 'is not a regular non-symlink file' reject_target_asset missing "$asset"
+  assert_rejected 'mode does not match its target Git mode' reject_target_asset changed-mode "$asset"
+  assert_rejected 'is not a regular blob at reviewed target' reject_target_asset missing-blob "$asset"
+  assert_rejected 'differs from reviewed target' reject_target_asset changed-blob "$asset"
+  assert_rejected 'is not a regular non-symlink file' reject_target_asset symlink "$asset"
+  assert_rejected 'is not a regular blob at reviewed target' reject_target_asset committed-symlink "$asset"
+done
+[[ -z $(find "$FIXTURE" -name unauthorized-executed -print -quit) ]]
+printf '%s\n' 'Backend target health authorized prelude transition tests passed'


### PR DESCRIPTION
Production deployment fails before image build when image-rescue health lazily loads RabbitMQ dependencies after integration advances beyond the sealed prelude commit. Load both dependencies from the already reviewed target while sourcing the mutable backend health library. Historical authority libraries, manifests and pins stay byte-identical.

Independent review of `48c1654606e4d6b63d297e51f7da2045b2fedd73` found no introduced P1/P2 defect. The actual historical H client with its default seal accepts this target. A separate real-history rescue reproduction fails before the fix and passes after it for cold and preloaded libraries. Six positive transitions and 30 rejection assertions pass; shellcheck, review-CI, architecture, quality and line-cap pass.

Hosted aggregate lifecycle verification is incomplete: existing fixture cleanup is blocked and ssh-keygen cannot map the sandbox UID. The unchanged base reproduces those limitations. A pre-existing disk-report test also lacks a Docker fake; the reviewer used no-live transport guards and observed no successful Docker connection. Full exact-head CI remains required before merge.

Replaces the rejected sealed-library approach in #305. Related to #294: https://github.com/777genius/social-monitor/pull/294. This PR does not claim seven-day publication or live grouping completion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Deployment health checks now consistently use the reviewed target versions of RabbitMQ health and recovery scripts during authorized backend transitions.
  - Invalid or altered transition assets are rejected, helping prevent deployments from proceeding with mismatched health-check components.

- **Tests**
  - Added comprehensive transition coverage for cold starts, preloaded states, staged changes, missing or modified assets, symlinks, and changed deployment targets.
  - Verification now includes execution order and loaded script content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->