### PR TITLE
fix(ops): extend reviewed recovery window to 2026-08-30..2026-09-05

### DIFF
--- a/ops/deploy/production-runtime/daily-run.sh
+++ b/ops/deploy/production-runtime/daily-run.sh
@@ -50,7 +50,7 @@ MAINTENANCE_DATE=${2:-}
 case "$DATE_FLAG" in
   --check-readiness|--today|--yesterday) ;;
   --maintenance-date)
-    [[ $# -eq 2 && $MAINTENANCE_DATE =~ ^2026-(07-(2[3-9]|3[01])|08-(0[1-9]|1[0-9]|2[0-6]))$ ]] || {
+    [[ $# -eq 2 && $MAINTENANCE_DATE =~ ^2026-(07-(2[3-9]|3[01])|08-(0[1-9]|1[0-9]|2[0-9]|3[01])|09-0[1-5])$ ]] || {
       echo "historical daily production-day date is outside the reviewed recovery bound" >&2
       exit 64
     }

--- a/ops/deploy/production-runtime/daily-run.test.sh
+++ b/ops/deploy/production-runtime/daily-run.test.sh
@@ -121,7 +121,7 @@ grep -Fx -- '-n 9' "$fake_flock.calls" >/dev/null
 [[ $(wc -l <"$fake_flock.calls") -eq 1 ]]
 [[ ! -e "$work_marker" ]]
 
-for invalid in 2026-07-22 2026-08-27 not-a-date; do
+for invalid in 2026-07-22 2026-09-06 not-a-date; do
   set +e
   SOCIAL_MONITOR_DAILY_RUN_TEST_MODE=1 \
   SOCIAL_MONITOR_DAILY_RUN_TEST_ROOT="$test_root" \
@@ -140,7 +140,7 @@ SOCIAL_MONITOR_DAILY_RUN_TEST_MODE=1 \
 SOCIAL_MONITOR_DAILY_RUN_TEST_ROOT="$test_root" \
 SOCIAL_MONITOR_DAILY_RUN_TEST_FLOCK="$fake_flock" \
 SOCIAL_MONITOR_DAILY_RUN_TEST_DOCKER="$fake_docker" \
-  bash "$DAILY_RUN" --maintenance-date 2026-08-26 \
+  bash "$DAILY_RUN" --maintenance-date 2026-09-05 \
     >"$test_root/valid-bound-stdout" 2>"$test_root/valid-bound-stderr"
 status=$?
 set -e


### PR DESCRIPTION
Extends the `daily-run.sh --maintenance-date` allowlist from 2026-07-23..2026-08-26 to 2026-07-23..2026-09-05, so the historical restoration of Aug30-Sep5 (blocked on subscription-runtime usage-contract fix, PR #309 / upstream #165) can actually run through the reviewed recovery path instead of bypassing it.

No other behavior changes. `daily-run.test.sh` updated: invalid-date case moved from 2026-08-27 (now valid) to 2026-09-06 (first date past new bound); valid-boundary assertion moved from 2026-08-26 to 2026-09-05. `shellcheck -S warning` clean; test passes.

Refs #294