### PR TITLE
fix(frontend): stop top-read titles collapsing behind Source text toggle

### DIFF
--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_evidence_read_card.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_evidence_read_card.dart
@@ -66,6 +66,7 @@ class _ReadCard extends StatelessWidget {
           key: ObjectKey(read),
           maxLines: compact ? 1 : (featured ? 3 : 2),
           overflow: TextOverflow.ellipsis,
+          disclosureEnabled: false,
           style:
               (featured
                       ? Theme.of(context).textTheme.titleMedium

--- a/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_source_text.dart
+++ b/apps/frontend/features/summaries/lib/src/presentation/components/reader_summary_source_text.dart
@@ -27,12 +27,19 @@ class ReaderSummarySourceText extends StatefulWidget {
     this.style,
     this.maxLines = 2,
     this.overflow = TextOverflow.ellipsis,
+    this.disclosureEnabled = true,
   });
 
   final String text;
   final TextStyle? style;
   final int maxLines;
   final TextOverflow overflow;
+
+  /// When false, always renders truncated text directly instead of
+  /// collapsing long text behind a "Source text" toggle button. Headlines
+  /// must always be visible; the toggle is only appropriate for
+  /// supplementary source quotes.
+  final bool disclosureEnabled;
 
   @override
   State<ReaderSummarySourceText> createState() => _SourceTextState();
@@ -49,7 +56,8 @@ class _SourceTextState extends State<ReaderSummarySourceText> {
 
   @override
   Widget build(BuildContext context) {
-    if (!readerSummaryNeedsSourceDisclosure(widget.text)) {
+    if (!widget.disclosureEnabled ||
+        !readerSummaryNeedsSourceDisclosure(widget.text)) {
       return Tooltip(
         message: widget.text,
         // Hover still reveals the complete short heading; touch long-press

--- a/apps/frontend/features/summaries/test/presentation/components/reader_summary_brief_surface_test.dart
+++ b/apps/frontend/features/summaries/test/presentation/components/reader_summary_brief_surface_test.dart
@@ -470,5 +470,93 @@ void main() {
     expect(openedUrls, ['https://news.ycombinator.com/item?id=2']);
   });
 
+  testWidgets(
+    'shows a long sentence-style top read title in full, never behind a Source text toggle',
+    (tester) async {
+      const mapper = SummaryMapper();
+      const longTitle =
+          'A Reddit post quotes OpenAI as saying its research organization '
+          'used 3.1 agent-workdays for every human workday as of mid-August '
+          'and had reached an automated research intern milestone.';
+      final summary = mapper.readerSummaryToDomain(
+        readerSummaryApiDto(
+          content: ReaderSummaryContentApiDto(
+            headline: 'Research acceleration',
+            oneLineTakeaway: 'OpenAI research organization scales with agents.',
+            bullets: const [],
+            interestSections: const [
+              ReaderInterestSectionApiDto(
+                title: 'Developer tooling',
+                insight: 'Agent-driven research acceleration is the main signal.',
+                items: [],
+                citationIds: ['bc-1'],
+              ),
+            ],
+            sourceMix: const [
+              SourceMixEntryApiDto(
+                providerKey: 'reddit',
+                itemCount: 1,
+                citationCount: 1,
+              ),
+            ],
+            topReads: [
+              TopReadApiDto(
+                storyClusterId: 'story:research-acceleration',
+                cardKind: 'curated_top_read',
+                title: longTitle,
+                providerKey: 'reddit',
+                reason: 'Reddit discussion backs the claim.',
+                citationIds: const ['bc-1'],
+                canonicalUrl: 'https://reddit.com/r/programming/comments/b',
+              ),
+            ],
+            trendDelta: const ReaderTrendDeltaApiDto(
+              newSignals: [],
+              growingSignals: [],
+              repeatedSignals: [],
+              fadingSignals: [],
+            ),
+            openQuestions: const [],
+            risks: const [],
+            nextActions: const [],
+          ),
+          citations: [
+            summaryCitationApiDto(
+              id: 'bc-1',
+              sourceLabel: 'Reddit thread [1]',
+              providerKey: 'reddit',
+              rawSnippet: 'Reddit source context.',
+              canonicalUrl: 'https://reddit.com/r/programming/comments/b',
+            ),
+          ],
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.dark(),
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: ReaderSummaryBriefSurface(
+                summary: summary,
+                citationsById: {
+                  for (final citation in summary.citations)
+                    citation.id: citation,
+                },
+                isRefreshing: false,
+                onOpenUrl: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(longTitle), findsWidgets);
+      expect(find.widgetWithText(AppButton, 'Source text'), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   _registerInlineCitationSourceTest();
 }


### PR DESCRIPTION
Long/sentence-style AI-generated titles were being rendered via `ReaderSummarySourceText`, which was built for optional long-quote disclosure (collapsible citation snippets) — not headlines. When a title exceeded 118 chars or had a sentence boundary, it silently turned into a generic "Source text" toggle button instead of showing the (truncated) headline.

Adds `ReaderSummarySourceText.disclosureEnabled` (default true — interest-section badges and citation snippets unaffected) and sets it false specifically for the top-read title in `_ReadCard`. Headlines now always render as truncated text, never behind a click-to-reveal button.

New widget test added covering a long sentence-style title. Could not run `flutter test` locally (no Flutter toolchain on this host) — relying on CI's "Flutter architecture and tests" job.

Refs #294