### PR TITLE
feat(summary): reconcile a consumed new-input refresh job and admit one fresh attempt

### DIFF
--- a/ops/security/tenant-db-guard-contract.json
+++ b/ops/security/tenant-db-guard-contract.json
@@ -16,7 +16,8 @@
     "prisma/migrations/20260803173000_reader_summary_daily_canonical_recovery_v4_tenant_rls/migration.sql",
     "prisma/migrations/20260803174000_reader_summary_daily_execution_tenant_rls/migration.sql",
     "prisma/migrations/20260804130000_reader_summary_daily_v4_ambiguity_retry_schema/migration.sql",
-    "prisma/migrations/20260831120000_reader_summary_promotion_v2_rollback/migration.sql"
+    "prisma/migrations/20260831120000_reader_summary_promotion_v2_rollback/migration.sql",
+    "prisma/migrations/20260907170000_reader_summary_new_input_refresh_reconciliation/migration.sql"
   ],
   "forwardRlsCoverage": [
     {
@@ -97,6 +98,16 @@
     {
       "table": "webhook_secrets",
       "migrationPath": "prisma/migrations/20260726120000_tenant_secret_scope_and_weekly_evidence_rls/migration.sql",
+      "ownerRole": "social_monitor_public_schema_owner"
+    },
+    {
+      "table": "reader_summary_new_input_refresh_reconciliations",
+      "migrationPath": "prisma/migrations/20260907170000_reader_summary_new_input_refresh_reconciliation/migration.sql",
+      "ownerRole": "social_monitor_public_schema_owner"
+    },
+    {
+      "table": "reader_summary_new_input_refresh_reconciliation_counters",
+      "migrationPath": "prisma/migrations/20260907170000_reader_summary_new_input_refresh_reconciliation/migration.sql",
       "ownerRole": "social_monitor_public_schema_owner"
     }
   ],
@@ -257,6 +268,20 @@
       "workspaceIdRequired": false,
       "tenantPrefixedIndexRequired": true,
       "reason": "Platform outbox can emit global events, but tenant event dispatch and support triage must remain tenant-queryable."
+    },
+    {
+      "table": "reader_summary_new_input_refresh_reconciliations",
+      "tenantIdRequired": true,
+      "workspaceIdRequired": true,
+      "tenantPrefixedIndexRequired": true,
+      "reason": "Append-only accounting that marks a consumed-but-unpublished new-input refresh job reconciled; operator recovery state, never user data."
+    },
+    {
+      "table": "reader_summary_new_input_refresh_reconciliation_counters",
+      "tenantIdRequired": true,
+      "workspaceIdRequired": true,
+      "tenantPrefixedIndexRequired": true,
+      "reason": "Immutable supplemental provider counters for an already-consumed refresh invocation; append-only operator evidence, never user data."
     }
   ],
   "indirectTenantOwnedTables": [

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "check:reader-summary-new-input-refresh:postgres": "node scripts/run-with-timeout.mjs --timeout-ms 180000 --node-options --max-old-space-size=1024 -- ts-node -P tsconfig.build.json -r tsconfig-paths/register scripts/check-reader-summary-new-input-refresh-postgres.ts",
     "run:reader-summary-new-input-refresh": "ts-node -P tsconfig.build.json -r tsconfig-paths/register scripts/run-reader-summary-new-input-refresh.ts",
+    "run:reader-summary-new-input-refresh-reconciliation": "ts-node -P tsconfig.build.json -r tsconfig-paths/register scripts/run-reader-summary-new-input-refresh-reconciliation.ts",
     "check:retained-metric-refresh-postgres": "node scripts/run-with-timeout.mjs --timeout-ms 120000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-retained-metric-refresh-postgres.ts",
     "run:retained-metric-refresh": "node scripts/run-with-timeout.mjs --timeout-ms 14400000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/run-retained-metric-refresh.ts",
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",

--- a/prisma/migrations/20260907170000_reader_summary_new_input_refresh_reconciliation/migration.sql
+++ b/prisma/migrations/20260907170000_reader_summary_new_input_refresh_reconciliation/migration.sql
@@ -1,0 +1,194 @@
+-- @social-monitor-forward-migration
+-- A FAILED new-input-refresh job that already consumed a paid provider
+-- invocation but published no summary has no representation today: the guard
+-- can only read "unconsumed" or "already published", so the date is wedged.
+--
+-- This adds append-only accounting for exactly that state. It records that the
+-- original job is ACCOUNTED FOR, never that it succeeded: the original job row
+-- is not written to, its digest is captured as an immutability witness, and the
+-- foreign key refuses to let it be deleted. Provider counters were not reported
+-- for the consumed invocation and their provenance stays UNKNOWN; independently
+-- verified counters can only ever arrive later as immutable supplemental rows
+-- that reference the original request/attempt, never as a rewrite of history.
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
+SET LOCAL ROLE "social_monitor_public_schema_owner";
+
+CREATE TABLE "reader_summary_new_input_refresh_reconciliations" (
+  "id" UUID NOT NULL,
+  "tenant_id" UUID NOT NULL,
+  "workspace_id" UUID NOT NULL,
+  "period_started_at" TIMESTAMPTZ(6) NOT NULL,
+  "period_ended_at" TIMESTAMPTZ(6) NOT NULL,
+  "reader_summary_job_id" UUID NOT NULL,
+  "operation" TEXT NOT NULL,
+  "job_status" TEXT NOT NULL,
+  "job_sha256" CHAR(64) NOT NULL,
+  "manifest_sha256" CHAR(64) NOT NULL,
+  "evidence_sha256" CHAR(64) NOT NULL,
+  "reason" TEXT NOT NULL,
+  "invocation" JSONB NOT NULL,
+  "accounting" JSONB NOT NULL,
+  "reconciled_at" TIMESTAMPTZ(6) NOT NULL,
+  CONSTRAINT "rs_nir_reconciliations_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "rs_nir_reconciliations_job_key"
+    UNIQUE ("tenant_id", "workspace_id", "reader_summary_job_id"),
+  CONSTRAINT "rs_nir_reconciliations_operation_key"
+    UNIQUE ("tenant_id", "operation"),
+  -- RESTRICT, not CASCADE: the consumed original job can never be deleted while
+  -- it is accounted for, so its failure history cannot be dropped to buy a
+  -- cheaper retry.
+  CONSTRAINT "rs_nir_reconciliations_job_fkey"
+    FOREIGN KEY ("reader_summary_job_id")
+    REFERENCES "reader_summary_jobs"("id")
+    ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT "rs_nir_reconciliations_identity_check" CHECK (
+    "job_status" = 'FAILED'
+    AND "reason" = 'consumed_provider_invocation_without_summary'
+    AND "operation" LIKE 'new-input-refresh:v1:%'
+    AND "period_ended_at" = "period_started_at" + INTERVAL '1 day'
+    AND "job_sha256" ~ '^[0-9a-f]{64}$'
+    AND "manifest_sha256" ~ '^[0-9a-f]{64}$'
+    AND "evidence_sha256" ~ '^[0-9a-f]{64}$'
+  ),
+  -- The reconciled attempt produced no summary, no artifact and no
+  -- publication. Provider usage is recorded as unknown, never as zero.
+  CONSTRAINT "rs_nir_reconciliations_accounting_check" CHECK (
+    jsonb_typeof("invocation") = 'object'
+    AND jsonb_typeof("accounting") = 'object'
+    AND "invocation" ?& ARRAY[
+      'requestId', 'purpose', 'requestSha256', 'attemptSha256',
+      'consumedAt', 'returnedAt', 'outcome', 'providerUsageReported'
+    ]
+    AND jsonb_typeof("invocation"->'requestId') = 'string'
+    AND jsonb_typeof("invocation"->'purpose') = 'string'
+    AND "invocation"->>'requestSha256' ~ '^[0-9a-f]{64}$'
+    AND "invocation"->>'attemptSha256' ~ '^[0-9a-f]{64}$'
+    AND "invocation"->'providerUsageReported' = 'false'::JSONB
+    AND "accounting" ?& ARRAY[
+      'summaryGenerations', 'publications', 'artifacts',
+      'providerInvocations', 'providerUsage'
+    ]
+    AND "accounting"->'summaryGenerations' = '0'::JSONB
+    AND "accounting"->'publications' = '0'::JSONB
+    AND "accounting"->'artifacts' = '0'::JSONB
+    AND "accounting"->'providerInvocations' = '1'::JSONB
+    AND "accounting"->>'providerUsage' = 'unknown'
+  )
+);
+
+-- Supplemental only. A counters row explains what an already-consumed provider
+-- request cost; it never changes the reconciliation's own accounting and never
+-- grants generation budget.
+CREATE TABLE "reader_summary_new_input_refresh_reconciliation_counters" (
+  "id" UUID NOT NULL,
+  "reconciliation_id" UUID NOT NULL,
+  "tenant_id" UUID NOT NULL,
+  "workspace_id" UUID NOT NULL,
+  "request_id" TEXT NOT NULL,
+  "attempt_sha256" CHAR(64) NOT NULL,
+  "counters" JSONB NOT NULL,
+  "counters_sha256" CHAR(64) NOT NULL,
+  "evidence_sha256" CHAR(64) NOT NULL,
+  "provenance" TEXT NOT NULL,
+  "recorded_at" TIMESTAMPTZ(6) NOT NULL,
+  CONSTRAINT "rs_nir_reconciliation_counters_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "rs_nir_reconciliation_counters_request_key"
+    UNIQUE ("tenant_id", "reconciliation_id", "request_id"),
+  CONSTRAINT "rs_nir_reconciliation_counters_evidence_key"
+    UNIQUE ("tenant_id", "reconciliation_id", "evidence_sha256"),
+  CONSTRAINT "rs_nir_reconciliation_counters_parent_fkey"
+    FOREIGN KEY ("reconciliation_id")
+    REFERENCES "reader_summary_new_input_refresh_reconciliations"("id")
+    ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT "rs_nir_reconciliation_counters_identity_check" CHECK (
+    "attempt_sha256" ~ '^[0-9a-f]{64}$'
+    AND "counters_sha256" ~ '^[0-9a-f]{64}$'
+    AND "evidence_sha256" ~ '^[0-9a-f]{64}$'
+    AND btrim("request_id") <> ''
+    AND "provenance" = 'independently_verified_provider_statement'
+  ),
+  CONSTRAINT "rs_nir_reconciliation_counters_shape_check" CHECK (
+    jsonb_typeof("counters") = 'object'
+    AND "counters" ?& ARRAY['inputTokens', 'outputTokens', 'totalTokens']
+    AND jsonb_typeof("counters"->'inputTokens') = 'number'
+    AND jsonb_typeof("counters"->'outputTokens') = 'number'
+    AND jsonb_typeof("counters"->'totalTokens') = 'number'
+    AND ("counters"->>'inputTokens')::NUMERIC >= 0
+    AND ("counters"->>'outputTokens')::NUMERIC >= 0
+    AND ("counters"->>'totalTokens')::NUMERIC =
+      ("counters"->>'inputTokens')::NUMERIC +
+      ("counters"->>'outputTokens')::NUMERIC
+  )
+);
+
+CREATE INDEX "rs_nir_reconciliations_period_idx"
+  ON "reader_summary_new_input_refresh_reconciliations"(
+    "tenant_id", "workspace_id", "period_started_at"
+  );
+CREATE INDEX "rs_nir_reconciliation_counters_parent_idx"
+  ON "reader_summary_new_input_refresh_reconciliation_counters"(
+    "tenant_id", "workspace_id", "reconciliation_id"
+  );
+
+ALTER TABLE "reader_summary_new_input_refresh_reconciliations"
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_new_input_refresh_reconciliations"
+  FORCE ROW LEVEL SECURITY;
+CREATE POLICY "tenant_isolation"
+  ON "reader_summary_new_input_refresh_reconciliations"
+  USING (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  )
+  WITH CHECK (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  );
+
+ALTER TABLE "reader_summary_new_input_refresh_reconciliation_counters"
+  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "reader_summary_new_input_refresh_reconciliation_counters"
+  FORCE ROW LEVEL SECURITY;
+CREATE POLICY "tenant_isolation"
+  ON "reader_summary_new_input_refresh_reconciliation_counters"
+  USING (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  )
+  WITH CHECK (
+    public.social_monitor_rls_workspace_match("tenant_id", "workspace_id")
+  );
+
+-- Append-only at the database level. Accounting that can be edited afterwards
+-- is not accounting.
+CREATE FUNCTION public."reject_rs_nir_reconciliation_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = pg_catalog AS $function$
+BEGIN
+  RAISE EXCEPTION
+    'reader summary new-input refresh reconciliation records are append-only';
+END;
+$function$;
+
+CREATE TRIGGER "rs_nir_reconciliations_append_only"
+BEFORE UPDATE OR DELETE
+ON "reader_summary_new_input_refresh_reconciliations"
+FOR EACH ROW EXECUTE FUNCTION public."reject_rs_nir_reconciliation_mutation"();
+
+CREATE TRIGGER "rs_nir_reconciliation_counters_append_only"
+BEFORE UPDATE OR DELETE
+ON "reader_summary_new_input_refresh_reconciliation_counters"
+FOR EACH ROW EXECUTE FUNCTION public."reject_rs_nir_reconciliation_mutation"();
+
+REVOKE ALL PRIVILEGES ON TABLE
+  "reader_summary_new_input_refresh_reconciliations",
+  "reader_summary_new_input_refresh_reconciliation_counters"
+FROM PUBLIC;
+REVOKE ALL ON FUNCTION public."reject_rs_nir_reconciliation_mutation"()
+FROM PUBLIC;
+GRANT SELECT, INSERT ON TABLE
+  "reader_summary_new_input_refresh_reconciliations",
+  "reader_summary_new_input_refresh_reconciliation_counters"
+TO "social_monitor_reader_summary_publication_runtime";
+
+RESET ROLE;
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -969,12 +969,63 @@ model ReaderSummaryJob {
   weeklyPublicationEvidence ReaderSummaryWeeklyPublicationEvidence?
   recoveryReceipt         ReaderSummaryRecoveryReceipt?
   dailyModelJob            ReaderSummaryDailyModelJob? @relation("ReaderSummaryDailyJob")
+  newInputRefreshReconciliations ReaderSummaryNewInputRefreshReconciliation[]
 
   @@unique([tenantId, idempotencyKey])
   @@index([tenantId, workspaceId, scopeKey, cadence, periodStartedAt], map: "reader_summary_jobs_period_lookup_idx")
   @@index([tenantId, workspaceId, scopeKey, status, createdAt])
   @@index([tenantId, workspaceId, userId, scopeKey, createdAt])
   @@map("reader_summary_jobs")
+}
+
+/// Append-only accounting for a FAILED new-input-refresh job that already
+/// consumed a paid provider invocation and published nothing. It marks the
+/// original job reconciled, never completed, and never writes to it.
+model ReaderSummaryNewInputRefreshReconciliation {
+  id                      String            @id(map: "rs_nir_reconciliations_pkey") @db.Uuid
+  tenantId                String            @map("tenant_id") @db.Uuid
+  workspaceId             String            @map("workspace_id") @db.Uuid
+  periodStartedAt         DateTime          @map("period_started_at") @db.Timestamptz(6)
+  periodEndedAt           DateTime          @map("period_ended_at") @db.Timestamptz(6)
+  readerSummaryJobId      String            @map("reader_summary_job_id") @db.Uuid
+  operation               String
+  jobStatus               String            @map("job_status")
+  jobSha256               String            @map("job_sha256") @db.Char(64)
+  manifestSha256          String            @map("manifest_sha256") @db.Char(64)
+  evidenceSha256          String            @map("evidence_sha256") @db.Char(64)
+  reason                  String
+  invocation              Json
+  accounting              Json
+  reconciledAt            DateTime          @map("reconciled_at") @db.Timestamptz(6)
+  job                     ReaderSummaryJob  @relation(fields: [readerSummaryJobId], references: [id], onDelete: Restrict, onUpdate: Restrict, map: "rs_nir_reconciliations_job_fkey")
+  counters                ReaderSummaryNewInputRefreshReconciliationCounters[]
+
+  @@unique([tenantId, workspaceId, readerSummaryJobId], map: "rs_nir_reconciliations_job_key")
+  @@unique([tenantId, operation], map: "rs_nir_reconciliations_operation_key")
+  @@index([tenantId, workspaceId, periodStartedAt], map: "rs_nir_reconciliations_period_idx")
+  @@map("reader_summary_new_input_refresh_reconciliations")
+}
+
+/// Immutable supplemental provider counters for the already-consumed request
+/// of a reconciled job. Never replaces the reconciliation's own accounting.
+model ReaderSummaryNewInputRefreshReconciliationCounters {
+  id                      String            @id(map: "rs_nir_reconciliation_counters_pkey") @db.Uuid
+  reconciliationId        String            @map("reconciliation_id") @db.Uuid
+  tenantId                String            @map("tenant_id") @db.Uuid
+  workspaceId             String            @map("workspace_id") @db.Uuid
+  requestId               String            @map("request_id")
+  attemptSha256           String            @map("attempt_sha256") @db.Char(64)
+  counters                Json
+  countersSha256          String            @map("counters_sha256") @db.Char(64)
+  evidenceSha256          String            @map("evidence_sha256") @db.Char(64)
+  provenance              String
+  recordedAt              DateTime          @map("recorded_at") @db.Timestamptz(6)
+  reconciliation          ReaderSummaryNewInputRefreshReconciliation @relation(fields: [reconciliationId], references: [id], onDelete: Restrict, onUpdate: Restrict, map: "rs_nir_reconciliation_counters_parent_fkey")
+
+  @@unique([tenantId, reconciliationId, requestId], map: "rs_nir_reconciliation_counters_request_key")
+  @@unique([tenantId, reconciliationId, evidenceSha256], map: "rs_nir_reconciliation_counters_evidence_key")
+  @@index([tenantId, workspaceId, reconciliationId], map: "rs_nir_reconciliation_counters_parent_idx")
+  @@map("reader_summary_new_input_refresh_reconciliation_counters")
 }
 
 model ReaderSummaryPublication {

--- a/scripts/check-reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/check-reader-summary-new-input-refresh-postgres.ts
@@ -22,6 +22,7 @@ import { captureRefreshAuthority, preflightRefreshSelection, assertRefreshHasNew
 import { assertRefreshTransactionAuthority } from "./lib/reader-summary-new-input-refresh-execution";
 import { runRefreshNativeConcurrency } from "./lib/reader-summary-new-input-refresh-native-concurrency";
 import { readReviewedRefresh } from "./lib/reader-summary-new-input-refresh-files";
+import { assertRefreshReconciliationContract } from "./lib/reader-summary-new-input-refresh-reconciliation-postgres-contract";
 
 const required = (name: string): string => {
   const value = process.env[name];
@@ -67,7 +68,8 @@ async function main() {
       const command = await fixtureCommand(summary, candidate);
       assertRefreshEqual(buildReaderSummaryPublicationPayload(command), candidate, "normal Prisma command roundtrip");
       assert.throws(() => reconcileRefresh(m, [{ operation: m.operation, jobId: candidate.readerSummaryJobId,
-        artifactId: null, status: "RUNNING" }], before), /consumed/);
+        artifactId: null, status: "RUNNING", jobSha256: "0".repeat(64) }], before), /consumed/);
+      await assertRefreshReconciliationContract(summary, m.date);
       const current = (tx: PrismaReaderSummaryClient) => assertRefreshTransactionAuthority(tx, m, candidate.readerSummaryJobId, clock);
       for (const mutation of ["engagement", "config", "slot", "input"] as const) {
         await assert.rejects(summary.$transaction(async (tx) => {
@@ -101,7 +103,8 @@ async function main() {
         originalSelection, newSelection, before, after, countsBefore, countsAfter, publicationMs, writerConflicts, acquisitionMs, holderLossRejected,
         scenarios: ["actual-cutoff", "changed-input", "engagement-config-slot-input-drift", "independent-writer-commit-before-validation",
           "writer-blocked-after-publication-snapshot", "actual-holder-loss-stale-snapshot-rejected", "all-relation-orders-nowait",
-          "consumed-no-repeat", "normal-prisma-publisher-max2", "preserved-original", "replay-zero-delta"] }));
+          "consumed-no-repeat", "normal-prisma-publisher-max2", "preserved-original", "replay-zero-delta",
+          "reconciliation-schema-protected", "reconciliation-refuses-unfailed-job"] }));
     });
   } finally { await feedConnection.close(); await summary.close(); }
 }

--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -14,9 +14,9 @@ import type { AgentRuntimeClientPort, ReaderSummaryPublicationPort } from "@soci
 import type { FeedItemReadRepositoryPort, PromotionFeedItemSnapshotRepositoryPort } from "@social-monitor/feed/ports";
 import { createReaderSummaryDailyCapturePublicationWiring } from "./reader-summary-daily-story-relation-verifier";
 import { assertRefreshManifest, refreshScope, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
-import { NewInputRefreshGuard, assertRefreshEqual, reconcileRefresh } from "./reader-summary-new-input-refresh-guard";
+import { NewInputRefreshGuard, assertRefreshEqual, reconcileRefresh, refreshLiveJobs } from "./reader-summary-new-input-refresh-guard";
 import { captureRefreshAuthority, captureRefreshDatabaseAuthority, refreshPeriod, assertRefreshHasNewInput, preflightRefreshSelection } from "./reader-summary-new-input-refresh-capture";
-import { readRefreshJobs, readRefreshPrior, readRefreshCounts } from "./reader-summary-new-input-refresh-postgres";
+import { readRefreshJobs, readRefreshPrior, readRefreshCounts, readRefreshReconciliations } from "./reader-summary-new-input-refresh-postgres";
 import { createRefreshAdmission } from "./reader-summary-new-input-refresh-admission";
 import { withRefreshPublicationLocks, type RefreshSnapshotProtection } from "./reader-summary-new-input-refresh-publication-lock";
 import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
@@ -37,13 +37,24 @@ export async function executeNewInputRefresh(input: {
   const prior = await readRefreshPrior(summary, m.date, m.prior.publicationId);
   assertRefreshEqual(prior, m.prior, "preserved prior");
   input.record({ status: "before", operation: m.operation, observedThrough: m.observedThrough, prior, countsBefore });
+  // Live budget for this date, after subtracting explicitly reconciled consumed
+  // attempts. Reading both together keeps a mid-run reconciliation from ever
+  // retiring THIS attempt's own job.
+  const liveRefreshJobs = async (client: Pick<PrismaSummaryConnection, "$queryRaw"> = summary) =>
+    refreshLiveJobs(await readRefreshJobs(client, m.date),
+      await readRefreshReconciliations(client, m.date), m.operation);
   const jobs = await readRefreshJobs(summary, m.date);
-  if (reconcileRefresh(m, jobs, current) === "published") {
+  const reconciled = await readRefreshReconciliations(summary, m.date);
+  const admissionState = reconcileRefresh(m, jobs, current, reconciled);
+  if (admissionState === "published") {
     const countsAfter = await readRefreshCounts(summary, m.date);
     assertRefreshEqual(countsAfter, countsBefore, "replay counts");
     return { status: "verified_noop", before: prior, after: current, countsBefore, countsAfter,
       publicationDelta: countsAfter.publications - countsBefore.publications, outboxDelta: countsAfter.outbox - countsBefore.outbox };
   }
+  input.record({ status: "admission", operation: m.operation, admissionState,
+    reconciled: reconciled.map(({ reconciliationId, jobId, operation }) =>
+      ({ reconciliationId, jobId, operation })) });
   const assertCurrent = async (client = summary as Pick<PrismaSummaryConnection, "$queryRaw">) => {
     input.assertFences(); input.assertSource();
     assertRefreshEqual(await readRefreshPrior(client, m.date), m.prior, "old slot/content/proof");
@@ -77,7 +88,7 @@ export async function executeNewInputRefresh(input: {
     assertCurrent: async () => {
       assertRefreshManifest(m, clock.now());
       await assertCurrent();
-      if ((await readRefreshJobs(summary, m.date)).length !== 0) throw new Error("Refresh date budget consumed");
+      if ((await liveRefreshJobs()).length !== 0) throw new Error("Refresh date budget consumed");
       input.assertSource(); input.assertFences(); assertRefreshManifest(m, clock.now());
     },
   });
@@ -90,7 +101,7 @@ export async function executeNewInputRefresh(input: {
   input.record({ status: "operation_consumed", operation: m.operation, jobId: request.value.readerSummaryJobId });
   const guard = new NewInputRefreshGuard(m, request.value.readerSummaryJobId, {
     now: () => clock.now(), assertFences: input.assertFences, assertCurrent: async () => {
-      const owned = await readRefreshJobs(summary, m.date);
+      const owned = await liveRefreshJobs();
       if (owned.length !== 1 || owned[0]?.jobId !== request.value.readerSummaryJobId || owned[0].operation !== m.operation ||
           !["REQUESTED", "RUNNING"].includes(owned[0].status) || owned[0].artifactId !== null) {
         throw new Error("Refresh date has conflicting consumed operations");
@@ -142,7 +153,8 @@ export async function executeNewInputRefresh(input: {
     readerSummaryJobId: request.value.readerSummaryJobId, maxEvidenceItems: 120 });
   if (!execution.ok) throw new Error("Refresh execution failed; reconcile the consumed job");
   const after = await readRefreshPrior(summary, m.date);
-  if (reconcileRefresh(m, await readRefreshJobs(summary, m.date), after) !== "published") {
+  if (reconcileRefresh(m, await readRefreshJobs(summary, m.date), after,
+    await readRefreshReconciliations(summary, m.date)) !== "published") {
     throw new Error("Refresh publication requires reconciliation");
   }
   assertRefreshEqual(await readRefreshPrior(summary, m.date, m.prior.publicationId), m.prior, "preserved prior");
@@ -179,7 +191,8 @@ export async function assertRefreshTransactionAuthority(
   tx: Pick<PrismaSummaryConnection, "$queryRaw">, m: RefreshManifest, jobId: string, clock: Clock,
 ): Promise<void> {
   assertRefreshManifest(m, clock.now());
-  const jobs = await readRefreshJobs(tx, m.date);
+  const jobs = refreshLiveJobs(await readRefreshJobs(tx, m.date),
+    await readRefreshReconciliations(tx, m.date), m.operation);
   if (jobs.length !== 1 || jobs[0]?.jobId !== jobId || jobs[0].operation !== m.operation || jobs[0].status !== "RUNNING") {
     throw new Error("Refresh transaction lost consumed job authority");
   }

--- a/scripts/lib/reader-summary-new-input-refresh-guard.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-guard.ts
@@ -4,7 +4,8 @@ import type { ReaderSummaryJobProps } from "@social-monitor/summary/domain";
 import type { ReaderSummaryEvidenceSelectorPort } from "@social-monitor/summary/ports";
 import { assertRefreshManifest, refreshHash, type RefreshManifest } from
   "./reader-summary-new-input-refresh-manifest";
-import type { RefreshJobState } from "./reader-summary-new-input-refresh-postgres";
+import type { RefreshJobState, RefreshReconciliationState } from
+  "./reader-summary-new-input-refresh-postgres";
 
 export type RefreshGuardDependencies = Readonly<{
   now(): Date;
@@ -63,12 +64,39 @@ export class NewInputRefreshGuard implements ReaderSummaryNewInputRefreshAuthori
     } };
   }
 }
+/** Jobs of this date that still hold live budget. A reconciled job is accounted
+ * for, never completed: it stays in history, must still be the exact FAILED row
+ * that was reconciled, and can never own the operation of a new attempt. */
+export function refreshLiveJobs(jobs: readonly RefreshJobState[],
+  reconciled: readonly RefreshReconciliationState[], operation: string,
+): readonly RefreshJobState[] {
+  const settled = new Map(reconciled.map((record) => [record.jobId, record]));
+  if (settled.size !== reconciled.length) {
+    throw new Error("Refresh reconciliation set is ambiguous");
+  }
+  const live: RefreshJobState[] = [];
+  let matched = 0;
+  for (const job of jobs) {
+    const record = settled.get(job.jobId);
+    if (record === undefined) { live.push(job); continue; }
+    matched += 1;
+    if (record.operation !== job.operation || record.jobStatus !== job.status ||
+        record.jobSha256 !== job.jobSha256 || job.status !== "FAILED" ||
+        job.artifactId !== null || job.operation === operation) {
+      throw new Error("Refresh reconciled original history changed; reconcile before any attempt");
+    }
+  }
+  if (matched !== settled.size) throw new Error("Refresh reconciliation references an unknown job");
+  return live;
+}
 export function reconcileRefresh(m: RefreshManifest, jobs: readonly RefreshJobState[],
   current: { publicationId: string; artifactId: string; jobId: string },
-): "unconsumed" | "published" {
-  if (jobs.length === 0) return "unconsumed";
-  const job = jobs[0];
-  if (jobs.length !== 1 || job?.operation !== m.operation ||
+  reconciled: readonly RefreshReconciliationState[] = [],
+): "unconsumed" | "reconciled" | "published" {
+  const live = refreshLiveJobs(jobs, reconciled, m.operation);
+  if (live.length === 0) return reconciled.length === 0 ? "unconsumed" : "reconciled";
+  const job = live[0];
+  if (live.length !== 1 || job?.operation !== m.operation ||
       !["COMPLETED", "NO_SIGNAL"].includes(job.status) ||
       current.jobId !== job.jobId || current.artifactId !== job.artifactId ||
       current.publicationId !== job.artifactId) {

--- a/scripts/lib/reader-summary-new-input-refresh-manifest.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-manifest.spec.ts
@@ -38,12 +38,12 @@ describe("bounded new-input refresh authority", () => {
   });
   it("reconciles published operation before looking at the new active slot as a prior", () => {
     const m = refreshManifest();
-    expect(reconcileRefresh(m, [{ operation: m.operation, jobId: "job-new", artifactId: "new", status: "COMPLETED" }],
+    expect(reconcileRefresh(m, [{ operation: m.operation, jobId: "job-new", artifactId: "new", status: "COMPLETED", jobSha256: "a".repeat(64) }],
       { jobId: "job-new", artifactId: "new", publicationId: "new" })).toBe("published");
   });
   it.each(["REQUESTED", "RUNNING", "FAILED", "QUALITY_REJECTED"])("never retries consumed %s even with a new digest", (status) => {
     const m = refreshManifest();
-    expect(() => reconcileRefresh(m, [{ operation: m.operation, jobId: "new", artifactId: null, status }], m.prior)).toThrow(/consumed/);
-    expect(() => reconcileRefresh({ ...m, operation: "changed" }, [{ operation: m.operation, jobId: "new", artifactId: null, status }], m.prior)).toThrow(/consumed/);
+    expect(() => reconcileRefresh(m, [{ operation: m.operation, jobId: "new", artifactId: null, status, jobSha256: "a".repeat(64) }], m.prior)).toThrow(/consumed/);
+    expect(() => reconcileRefresh({ ...m, operation: "changed" }, [{ operation: m.operation, jobId: "new", artifactId: null, status, jobSha256: "a".repeat(64) }], m.prior)).toThrow(/consumed/);
   });
 });

--- a/scripts/lib/reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-postgres.ts
@@ -145,15 +145,40 @@ export async function readRefreshMutableAuthority(client: Client, date: string) 
 
 export type RefreshJobState = Readonly<{
   jobId: string; operation: string; status: string; artifactId: string | null;
+  jobSha256: string;
 }>;
+/** jobSha256 hashes the whole job row so a reconciled attempt's history can be
+ * proven byte-identical later; any edit to it fails the next refresh closed. */
 export const readRefreshJobs = async (client: Client, date: string): Promise<readonly RefreshJobState[]> =>
   client.$queryRaw<readonly RefreshJobState[]>`
     select id::text as "jobId", idempotency_key as operation, status::text as status,
-      reader_summary_artifact_id::text as "artifactId"
-    from reader_summary_jobs where tenant_id = ${refreshScope.tenantId}::uuid
+      reader_summary_artifact_id::text as "artifactId",
+      encode(sha256(convert_to(to_jsonb(j)::text, 'UTF8')), 'hex') as "jobSha256"
+    from reader_summary_jobs j where tenant_id = ${refreshScope.tenantId}::uuid
       and workspace_id = ${refreshScope.workspaceId}::uuid
       and starts_with(idempotency_key, ${refreshKeyPrefix(date)})
     order by id
+  `;
+
+export type RefreshReconciliationState = Readonly<{
+  reconciliationId: string; jobId: string; operation: string;
+  jobStatus: string; jobSha256: string;
+}>;
+/** Accounted-for consumed attempts for this date. A reconciliation never says
+ * the original job succeeded; it says its consumption is recorded. */
+export const readRefreshReconciliations = async (
+  client: Client, date: string,
+): Promise<readonly RefreshReconciliationState[]> =>
+  client.$queryRaw<readonly RefreshReconciliationState[]>`
+    select id::text as "reconciliationId", reader_summary_job_id::text as "jobId",
+      operation, job_status as "jobStatus", btrim(job_sha256) as "jobSha256"
+    from reader_summary_new_input_refresh_reconciliations
+    where tenant_id = ${refreshScope.tenantId}::uuid
+      and workspace_id = ${refreshScope.workspaceId}::uuid
+      and period_started_at = ${date}::date::timestamp at time zone 'UTC'
+      and period_ended_at = (${date}::date + 1)::timestamp at time zone 'UTC'
+      and starts_with(operation, ${refreshKeyPrefix(date)})
+    order by reader_summary_job_id
   `;
 
 export async function lockRefreshAuthority(client: Pick<PrismaReaderSummaryClient, "$queryRaw">): Promise<void> {

--- a/scripts/lib/reader-summary-new-input-refresh-reconciled-admission.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciled-admission.spec.ts
@@ -1,0 +1,87 @@
+import { reconcileRefresh, refreshLiveJobs } from "./reader-summary-new-input-refresh-guard";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+import type { RefreshJobState, RefreshReconciliationState } from
+  "./reader-summary-new-input-refresh-postgres";
+
+const manifest = refreshManifest();
+const priorOperation = `new-input-refresh:v1:${manifest.date}:${"b".repeat(64)}`;
+const consumedJob: RefreshJobState = {
+  jobId: "1767fd5c-2fe5-4fef-84e0-22c380932e81", operation: priorOperation,
+  status: "FAILED", artifactId: null, jobSha256: "f".repeat(64),
+};
+const reconciliation: RefreshReconciliationState = {
+  reconciliationId: "00000000-0000-4000-8000-0000000000aa", jobId: consumedJob.jobId,
+  operation: priorOperation, jobStatus: "FAILED", jobSha256: consumedJob.jobSha256,
+};
+const publishedCurrent = { publicationId: "p", artifactId: "p", jobId: "fresh" };
+const priorCurrent = { publicationId: manifest.prior.publicationId,
+  artifactId: manifest.prior.artifactId, jobId: manifest.prior.jobId };
+const freshPublishedJob: RefreshJobState = { jobId: "fresh", operation: manifest.operation,
+  status: "COMPLETED", artifactId: "p", jobSha256: "c".repeat(64) };
+
+describe("new-input refresh reconciled admission", () => {
+  it("keeps an unreconciled consumed failure blocked", () => {
+    expect(() => reconcileRefresh(manifest, [consumedJob], priorCurrent, []))
+      .toThrow(/generation budget is consumed/u);
+  });
+
+  it("admits exactly one fresh attempt once the consumed failure is reconciled", () => {
+    expect(reconcileRefresh(manifest, [consumedJob], priorCurrent, [reconciliation]))
+      .toBe("reconciled");
+    expect(refreshLiveJobs([consumedJob], [reconciliation], manifest.operation)).toEqual([]);
+  });
+
+  it("blocks a second live attempt while the fresh one is still running", () => {
+    const running: RefreshJobState = { jobId: "fresh", operation: manifest.operation,
+      status: "RUNNING", artifactId: null, jobSha256: "c".repeat(64) };
+    expect(refreshLiveJobs([consumedJob, running], [reconciliation], manifest.operation))
+      .toEqual([running]);
+    expect(() => reconcileRefresh(manifest, [consumedJob, running], priorCurrent, [reconciliation]))
+      .toThrow(/generation budget is consumed/u);
+  });
+
+  it("still refuses a competing operation that is not the reviewed manifest", () => {
+    const competing: RefreshJobState = { jobId: "other", operation: `${priorOperation}x`,
+      status: "REQUESTED", artifactId: null, jobSha256: "d".repeat(64) };
+    expect(() => reconcileRefresh(manifest, [consumedJob, competing], priorCurrent, [reconciliation]))
+      .toThrow(/generation budget is consumed/u);
+  });
+
+  it("reports published once the single fresh attempt owns the current publication", () => {
+    expect(reconcileRefresh(manifest, [consumedJob, freshPublishedJob], publishedCurrent,
+      [reconciliation])).toBe("published");
+  });
+
+  it("keeps an unconsumed date unconsumed", () => {
+    expect(reconcileRefresh(manifest, [], priorCurrent, [])).toBe("unconsumed");
+  });
+
+  it.each([
+    ["row digest", { ...consumedJob, jobSha256: "e".repeat(64) }],
+    ["status", { ...consumedJob, status: "COMPLETED" }],
+    ["operation", { ...consumedJob, operation: `${priorOperation}z` }],
+    ["artifact", { ...consumedJob, artifactId: "adopted" }],
+  ])("fails closed when the reconciled original %s changed", (_label, job) => {
+    expect(() => reconcileRefresh(manifest, [job], priorCurrent, [reconciliation]))
+      .toThrow(/reconciled original history changed/u);
+  });
+
+  it("refuses to let a reconciliation retire the attempt that owns this operation", () => {
+    const selfReconciled: RefreshReconciliationState = { ...reconciliation,
+      jobId: "fresh", operation: manifest.operation, jobSha256: "c".repeat(64) };
+    const failedFresh: RefreshJobState = { jobId: "fresh", operation: manifest.operation,
+      status: "FAILED", artifactId: null, jobSha256: "c".repeat(64) };
+    expect(() => refreshLiveJobs([failedFresh], [selfReconciled], manifest.operation))
+      .toThrow(/reconciled original history changed/u);
+  });
+
+  it("refuses a reconciliation that points at no job of this date", () => {
+    expect(() => reconcileRefresh(manifest, [], priorCurrent, [reconciliation]))
+      .toThrow(/references an unknown job/u);
+  });
+
+  it("refuses a duplicated reconciliation set", () => {
+    expect(() => refreshLiveJobs([consumedJob], [reconciliation, reconciliation], manifest.operation))
+      .toThrow(/set is ambiguous/u);
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-counters.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-counters.ts
@@ -1,0 +1,134 @@
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import type { IdGenerator } from "@social-monitor/shared-kernel";
+import { refreshBytesHash, refreshHash, refreshScope } from
+  "./reader-summary-new-input-refresh-manifest";
+
+/** Independently verified counters for a provider request that was ALREADY
+ * consumed by a reconciled attempt. Supplemental evidence only: it explains an
+ * existing cost, it never revives budget, never edits the reconciliation's own
+ * accounting and never asserts the attempt produced a summary. */
+export type RefreshReconciliationCountersEvidence = Readonly<{
+  format: "reader-summary-new-input-refresh-reconciliation-counters-v1";
+  tenantId: string; workspaceId: string; date: string;
+  reconciliationId: string; jobId: string;
+  requestId: string; attemptSha256: string;
+  counters: Readonly<{ inputTokens: number; outputTokens: number; totalTokens: number }>;
+  provenance: "independently_verified_provider_statement";
+  verifiedBy: string; verifiedAt: string;
+}>;
+
+const uuid = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/u;
+const sha256 = /^[0-9a-f]{64}$/u;
+const counted = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && (value as number) >= 0;
+
+export function assertRefreshReconciliationCountersEvidence(
+  evidence: RefreshReconciliationCountersEvidence, dates: readonly string[],
+): void {
+  const counters = evidence?.counters;
+  const verifiedAt = new Date(evidence?.verifiedAt ?? "");
+  if (evidence?.format !== "reader-summary-new-input-refresh-reconciliation-counters-v1" ||
+      evidence.tenantId !== refreshScope.tenantId ||
+      evidence.workspaceId !== refreshScope.workspaceId ||
+      !dates.includes(evidence.date) || !uuid.test(evidence.reconciliationId) ||
+      !uuid.test(evidence.jobId) ||
+      typeof evidence.requestId !== "string" || evidence.requestId.trim().length === 0 ||
+      !sha256.test(evidence.attemptSha256) ||
+      evidence.provenance !== "independently_verified_provider_statement" ||
+      typeof evidence.verifiedBy !== "string" || evidence.verifiedBy.trim().length === 0 ||
+      !Number.isFinite(verifiedAt.getTime()) || verifiedAt.toISOString() !== evidence.verifiedAt) {
+    throw new Error("Refresh reconciliation counters identity is invalid");
+  }
+  if (typeof counters !== "object" || counters === null ||
+      Object.keys(counters).length !== 3 ||
+      !counted(counters.inputTokens) || !counted(counters.outputTokens) ||
+      !counted(counters.totalTokens) ||
+      counters.totalTokens !== counters.inputTokens + counters.outputTokens) {
+    throw new Error("Refresh reconciliation counters are not a complete verified statement");
+  }
+}
+
+export function readReviewedRefreshReconciliationCounters(
+  path: string, expected: string, dates: readonly string[],
+): { evidence: RefreshReconciliationCountersEvidence; evidenceSha256: string } {
+  const absolute = resolve(path);
+  const stat = lstatSync(absolute);
+  if (realpathSync(absolute) !== absolute || !stat.isFile() || stat.nlink !== 1 ||
+      (stat.mode & 0o222) !== 0) {
+    throw new Error("Refresh reconciliation counters must be a regular immutable file");
+  }
+  const bytes = readFileSync(absolute);
+  const evidenceSha256 = refreshBytesHash(bytes);
+  if (evidenceSha256 !== expected) throw new Error("Reviewed refresh counters hash differs");
+  const evidence = JSON.parse(bytes.toString("utf8")) as RefreshReconciliationCountersEvidence;
+  assertRefreshReconciliationCountersEvidence(evidence, dates);
+  return { evidence, evidenceSha256 };
+}
+
+type WriteClient = Readonly<{
+  $queryRaw<T>(strings: TemplateStringsArray, ...values: readonly unknown[]): Promise<T>;
+}>;
+
+type CountersRow = Readonly<{
+  id: string; requestId: string; attemptSha256: string; counters: unknown;
+  countersSha256: string; evidenceSha256: string; provenance: string; recordedAt: Date;
+}>;
+
+export type RefreshReconciliationCountersReceipt = Readonly<{
+  status: "imported" | "already_imported";
+  countersId: string; reconciliationId: string; requestId: string;
+  attemptSha256: string; countersSha256: string; evidenceSha256: string;
+  recordedAt: string;
+}>;
+
+/** The insert only resolves against a committed reconciliation whose recorded
+ * invocation is exactly this request/attempt, so counters can never be attached
+ * to an unrelated result. */
+export async function importRefreshReconciliationCounters(input: {
+  client: WriteClient; evidence: RefreshReconciliationCountersEvidence;
+  evidenceSha256: string; now: Date; ids: IdGenerator;
+}): Promise<RefreshReconciliationCountersReceipt> {
+  const { client, evidence: e, evidenceSha256 } = input;
+  const countersSha256 = refreshHash(e.counters);
+  const inserted = await client.$queryRaw<readonly { id: string }[]>`
+    insert into reader_summary_new_input_refresh_reconciliation_counters (
+      id, reconciliation_id, tenant_id, workspace_id, request_id, attempt_sha256,
+      counters, counters_sha256, evidence_sha256, provenance, recorded_at)
+    select ${input.ids.generate()}::uuid, r.id, r.tenant_id, r.workspace_id,
+      ${e.requestId}, ${e.attemptSha256}, ${JSON.stringify(e.counters)}::jsonb,
+      ${countersSha256}, ${evidenceSha256}, ${e.provenance}, ${input.now}::timestamptz
+    from reader_summary_new_input_refresh_reconciliations r
+    where r.id = ${e.reconciliationId}::uuid
+      and r.tenant_id = ${refreshScope.tenantId}::uuid
+      and r.workspace_id = ${refreshScope.workspaceId}::uuid
+      and r.reader_summary_job_id = ${e.jobId}::uuid
+      and r.period_started_at = ${e.date}::date::timestamp at time zone 'UTC'
+      and r.invocation->>'requestId' = ${e.requestId}
+      and r.invocation->>'attemptSha256' = ${e.attemptSha256}
+    on conflict do nothing
+    returning id::text as id
+  `;
+  const rows = await client.$queryRaw<readonly CountersRow[]>`
+    select id::text as id, request_id as "requestId", btrim(attempt_sha256) as "attemptSha256",
+      counters, btrim(counters_sha256) as "countersSha256",
+      btrim(evidence_sha256) as "evidenceSha256", provenance, recorded_at as "recordedAt"
+    from reader_summary_new_input_refresh_reconciliation_counters
+    where tenant_id = ${refreshScope.tenantId}::uuid
+      and reconciliation_id = ${e.reconciliationId}::uuid
+      and request_id = ${e.requestId}
+  `;
+  const row = rows[0];
+  if (rows.length !== 1 || row === undefined) {
+    throw new Error("Refresh reconciliation counters do not reference the recorded original result");
+  }
+  if (row.attemptSha256 !== e.attemptSha256 || row.evidenceSha256 !== evidenceSha256 ||
+      row.countersSha256 !== countersSha256 || row.provenance !== e.provenance ||
+      refreshHash(row.counters) !== refreshHash(e.counters)) {
+    throw new Error("Refresh reconciliation counters conflict with the committed evidence");
+  }
+  return { status: inserted.length === 1 ? "imported" : "already_imported",
+    countersId: row.id, reconciliationId: e.reconciliationId, requestId: row.requestId,
+    attemptSha256: row.attemptSha256, countersSha256: row.countersSha256,
+    evidenceSha256: row.evidenceSha256, recordedAt: row.recordedAt.toISOString() };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-postgres-contract.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-postgres-contract.ts
@@ -1,0 +1,73 @@
+/** Parent-only native contract for the reconciliation schema. It creates no
+ * reconciliation row: it proves the schema is protected and that the reviewed
+ * insert refuses a job that is not a consumed, unpublished failure. */
+import assert from "node:assert/strict";
+import { CryptoIdGenerator } from "@social-monitor/shared-kernel";
+import { refreshScope } from "./reader-summary-new-input-refresh-manifest";
+import { readRefreshJobs, readRefreshReconciliations } from "./reader-summary-new-input-refresh-postgres";
+import { refreshLiveJobs } from "./reader-summary-new-input-refresh-guard";
+import { reconcileConsumedRefreshJob, type RefreshReconciliationEvidence } from
+  "./reader-summary-new-input-refresh-reconciliation";
+
+type Client = Readonly<{
+  $queryRaw<T>(strings: TemplateStringsArray, ...values: readonly unknown[]): Promise<T>;
+}>;
+
+const tables = [
+  "reader_summary_new_input_refresh_reconciliations",
+  "reader_summary_new_input_refresh_reconciliation_counters",
+] as const;
+
+export async function assertRefreshReconciliationContract(
+  client: Client, date: string,
+): Promise<void> {
+  const protection = await client.$queryRaw<readonly {
+    table: string; rls: boolean; force: boolean; policies: number; triggers: number;
+  }[]>`
+    select c.relname::text as table, c.relrowsecurity as rls, c.relforcerowsecurity as force,
+      (select count(*)::int from pg_policy p where p.polrelid = c.oid) as policies,
+      (select count(*)::int from pg_trigger t
+        where t.tgrelid = c.oid and not t.tgisinternal) as triggers
+    from pg_class c join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public' and c.relname = any(${[...tables]}::text[])
+    order by c.relname
+  `;
+  assert.equal(protection.length, tables.length, "reconciliation schema is missing");
+  for (const row of protection) {
+    assert.equal(row.rls, true, `${row.table} must enable RLS`);
+    assert.equal(row.force, true, `${row.table} must force RLS`);
+    assert.equal(row.policies, 1, `${row.table} must carry exactly the tenant policy`);
+    assert.equal(row.triggers, 1, `${row.table} must stay append-only`);
+  }
+  const writable = await client.$queryRaw<readonly { grantee: string; priv: string }[]>`
+    select grantee::text as grantee, privilege_type::text as priv
+    from information_schema.table_privileges
+    where table_schema = 'public' and table_name = any(${[...tables]}::text[])
+      and privilege_type in ('UPDATE', 'DELETE', 'TRUNCATE')
+  `;
+  assert.deepEqual(writable, [], "reconciliation accounting must not be updatable or deletable");
+
+  // The fixture's own job is RUNNING, not a consumed unpublished failure. The
+  // reviewed insert must refuse it and leave the date's live budget untouched.
+  const jobs = await readRefreshJobs(client, date);
+  const live = refreshLiveJobs(jobs, await readRefreshReconciliations(client, date), "");
+  assert.equal(live.length, jobs.length, "no fixture job is reconciled");
+  const target = jobs[0];
+  assert(target !== undefined, "fixture must own one consumed job");
+  const evidence: RefreshReconciliationEvidence = {
+    format: "reader-summary-new-input-refresh-reconciliation-v1",
+    ...refreshScope, date, jobId: target.jobId, operation: target.operation,
+    manifestSha256: "0".repeat(64), reason: "consumed_provider_invocation_without_summary",
+    invocation: { requestId: "contract-check", purpose: "contract-check",
+      requestSha256: "0".repeat(64), attemptSha256: "0".repeat(64),
+      consumedAt: "2026-01-01T00:00:00.000Z", returnedAt: "2026-01-01T00:00:01.000Z",
+      outcome: "completed", providerUsageReported: false },
+  };
+  await assert.rejects(reconcileConsumedRefreshJob({ client, evidence,
+    evidenceSha256: "0".repeat(64), now: new Date(), ids: new CryptoIdGenerator() }),
+  /not a consumed unpublished failure|does not exist/u);
+  assert.deepEqual(await readRefreshReconciliations(client, date), [],
+    "a refused reconciliation writes nothing");
+  assert.deepEqual(await readRefreshJobs(client, date), jobs,
+    "a refused reconciliation leaves the original job byte-identical");
+}

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec-support.ts
@@ -1,0 +1,112 @@
+import { refreshScope } from "./reader-summary-new-input-refresh-manifest";
+import type { RefreshReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
+
+export const reconciliationDate = "2026-09-03";
+export const reconciliationJobId = "1767fd5c-2fe5-4fef-84e0-22c380932e81";
+export const reconciliationOperation =
+  `new-input-refresh:v1:${reconciliationDate}:${"b".repeat(64)}`;
+
+export const reconciliationEvidence = (
+  override: Partial<RefreshReconciliationEvidence> = {},
+): RefreshReconciliationEvidence => ({
+  format: "reader-summary-new-input-refresh-reconciliation-v1",
+  ...refreshScope, date: reconciliationDate, jobId: reconciliationJobId,
+  operation: reconciliationOperation, manifestSha256: "3".repeat(64),
+  reason: "consumed_provider_invocation_without_summary",
+  invocation: { requestId: "reader-summary-story-relations:workspace:2026-09-06T23:27:45.056Z",
+    purpose: "social_monitor.reader_summary.verify_story_relations.v2",
+    requestSha256: "1".repeat(64), attemptSha256: "7".repeat(64),
+    consumedAt: "2026-09-06T23:36:47.054Z", returnedAt: "2026-09-06T23:38:27.551Z",
+    outcome: "completed", providerUsageReported: false },
+  ...override,
+});
+
+export type FakeJobRow = {
+  id: string; operation: string; status: string; artifactId: string | null;
+  date: string; sha: string; publications: number;
+};
+
+/** Models only what the reviewed statements are allowed to do. Any write to a
+ * job row, or any insert that skips a guard fragment, fails the test. */
+export class FakeReconciliationDatabase {
+  readonly reconciliations: Record<string, unknown>[] = [];
+  readonly counters: Record<string, unknown>[] = [];
+  private readonly frozen: string;
+  constructor(readonly jobs: FakeJobRow[]) { this.frozen = JSON.stringify(jobs); }
+
+  assertJobsUntouched(): void {
+    if (JSON.stringify(this.jobs) !== this.frozen) {
+      throw new Error("original job history was modified");
+    }
+  }
+
+  readonly client = {
+    $queryRaw: async <T>(strings: TemplateStringsArray, ...values: readonly unknown[]): Promise<T> => {
+      const sql = strings.join(" ? ").replace(/\s+/gu, " ").trim();
+      if (/^insert into reader_summary_new_input_refresh_reconciliations/u.test(sql)) {
+        return this.insertReconciliation(sql, values) as T;
+      }
+      if (/^insert into reader_summary_new_input_refresh_reconciliation_counters/u.test(sql)) {
+        return this.insertCounters(sql, values) as T;
+      }
+      if (/^select id::text as id, tenant_id/u.test(sql)) {
+        return this.reconciliations.filter((row) => row.readerSummaryJobId === values[2]) as T;
+      }
+      if (/^select id::text as id, request_id/u.test(sql)) {
+        return this.counters.filter((row) =>
+          row.reconciliationId === values[1] && row.requestId === values[2]) as T;
+      }
+      if (/^select j.status::text as status/u.test(sql)) {
+        const job = this.jobs.find((row) => row.id === values[0]);
+        return (job === undefined ? [] : [{ status: job.status, operation: job.operation,
+          artifactId: job.artifactId, publications: job.publications }]) as T;
+      }
+      throw new Error(`unexpected statement: ${sql.slice(0, 80)}`);
+    },
+  };
+
+  private insertReconciliation(sql: string, values: readonly unknown[]) {
+    for (const fragment of ["j.status::text = 'FAILED'", "j.reader_summary_artifact_id is null",
+      "not exists (select 1 from reader_summary_publications p", "on conflict do nothing",
+      "j.idempotency_key = ?", "j.tenant_id = ?"]) {
+      if (!sql.includes(fragment)) throw new Error(`insert lost its guard: ${fragment}`);
+    }
+    const [id, manifestSha256, evidenceSha256, reason, invocation, accounting, now, jobId,
+      tenantId, workspaceId, operation, date] = values as readonly string[];
+    const job = this.jobs.find((row) => row.id === jobId && row.operation === operation &&
+      row.date === date && row.status === "FAILED" && row.artifactId === null &&
+      row.publications === 0 && tenantId === refreshScope.tenantId &&
+      workspaceId === refreshScope.workspaceId);
+    if (job === undefined) return [];
+    if (this.reconciliations.some((row) => row.readerSummaryJobId === jobId ||
+      row.operation === operation)) return [];
+    this.reconciliations.push({ id, tenantId, workspaceId, readerSummaryJobId: job.id,
+      operation: job.operation, jobStatus: job.status, jobSha256: job.sha, manifestSha256,
+      evidenceSha256, reason, invocation: JSON.parse(invocation!) as unknown,
+      accounting: JSON.parse(accounting!) as unknown, reconciledAt: new Date(now!) });
+    return [{ id }];
+  }
+
+  private insertCounters(sql: string, values: readonly unknown[]) {
+    for (const fragment of ["r.invocation->>'requestId' = ?", "r.invocation->>'attemptSha256' = ?",
+      "on conflict do nothing"]) {
+      if (!sql.includes(fragment)) throw new Error(`counters insert lost its guard: ${fragment}`);
+    }
+    const [id, requestId, attemptSha256, counters, countersSha256, evidenceSha256, provenance,
+      now, reconciliationId, tenantId, workspaceId, jobId, date, boundRequestId,
+      boundAttemptSha256] = values as readonly string[];
+    const parent = this.reconciliations.find((row) => row.id === reconciliationId &&
+      row.tenantId === tenantId && row.workspaceId === workspaceId &&
+      row.readerSummaryJobId === jobId &&
+      (row.invocation as { requestId: string }).requestId === boundRequestId &&
+      (row.invocation as { attemptSha256: string }).attemptSha256 === boundAttemptSha256 &&
+      this.jobs.some((job) => job.id === jobId && job.date === date));
+    if (parent === undefined) return [];
+    if (this.counters.some((row) => row.reconciliationId === reconciliationId &&
+      row.requestId === requestId)) return [];
+    this.counters.push({ id, reconciliationId, tenantId, workspaceId, requestId, attemptSha256,
+      counters: JSON.parse(counters!) as unknown, countersSha256, evidenceSha256, provenance,
+      recordedAt: new Date(now!) });
+    return [{ id }];
+  }
+}

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec.ts
@@ -1,0 +1,161 @@
+import { refreshScope } from "./reader-summary-new-input-refresh-manifest";
+import { assertRefreshReconciliationEvidence, reconcileConsumedRefreshJob,
+  refreshReconciliationAccounting } from "./reader-summary-new-input-refresh-reconciliation";
+import { assertRefreshReconciliationCountersEvidence, importRefreshReconciliationCounters } from
+  "./reader-summary-new-input-refresh-reconciliation-counters";
+import { FakeReconciliationDatabase, reconciliationDate, reconciliationEvidence,
+  reconciliationJobId, reconciliationOperation, type FakeJobRow } from
+  "./reader-summary-new-input-refresh-reconciliation.spec-support";
+
+const dates = [reconciliationDate];
+const now = new Date("2026-09-07T12:00:00.000Z");
+const ids = { generate: () => "00000000-0000-4000-8000-00000000000a" };
+const consumed: FakeJobRow = { id: reconciliationJobId, operation: reconciliationOperation,
+  status: "FAILED", artifactId: null, date: reconciliationDate, sha: "f".repeat(64), publications: 0 };
+const evidenceSha256 = "9".repeat(64);
+const apply = (database: FakeReconciliationDatabase, override = {}, sha = evidenceSha256) =>
+  reconcileConsumedRefreshJob({ client: database.client, evidence: reconciliationEvidence(override),
+    evidenceSha256: sha, now, ids });
+
+describe("new-input refresh consumed-job reconciliation", () => {
+  it("records the consumed attempt as accounted for, never as completed", async () => {
+    const database = new FakeReconciliationDatabase([{ ...consumed }]);
+    const receipt = await apply(database);
+    expect(receipt).toMatchObject({ status: "reconciled", jobId: reconciliationJobId,
+      operation: reconciliationOperation, jobSha256: consumed.sha });
+    expect(receipt.accounting).toEqual(refreshReconciliationAccounting);
+    expect(receipt.accounting.providerUsage).toBe("unknown");
+    expect(receipt.accounting.summaryGenerations).toBe(0);
+    expect(database.reconciliations).toHaveLength(1);
+    expect(database.reconciliations[0]).toMatchObject({ jobStatus: "FAILED" });
+    database.assertJobsUntouched();
+  });
+
+  it("is idempotent: an exact replay returns the committed record and adds nothing", async () => {
+    const database = new FakeReconciliationDatabase([{ ...consumed }]);
+    const first = await apply(database);
+    const second = await apply(database);
+    const third = await apply(database);
+    expect(first.status).toBe("reconciled");
+    expect(second.status).toBe("already_reconciled");
+    expect(third.status).toBe("already_reconciled");
+    expect({ ...second, status: first.status }).toEqual(first);
+    expect(database.reconciliations).toHaveLength(1);
+    database.assertJobsUntouched();
+  });
+
+  it.each([
+    ["manifest", { manifestSha256: "4".repeat(64) }],
+    ["invocation", { invocation: { ...reconciliationEvidence().invocation, requestSha256: "2".repeat(64) } }],
+  ])("refuses a conflicting %s for an already reconciled job", async (_label, override) => {
+    const database = new FakeReconciliationDatabase([{ ...consumed }]);
+    await apply(database);
+    await expect(apply(database, override)).rejects.toThrow(/conflicts with the committed record/u);
+    expect(database.reconciliations).toHaveLength(1);
+    database.assertJobsUntouched();
+  });
+
+  it("refuses a different reviewed evidence document for the same job", async () => {
+    const database = new FakeReconciliationDatabase([{ ...consumed }]);
+    await apply(database);
+    await expect(apply(database, {}, "8".repeat(64)))
+      .rejects.toThrow(/conflicts with the committed record/u);
+    expect(database.reconciliations).toHaveLength(1);
+  });
+
+  it.each([
+    ["a completed job", { status: "COMPLETED" }],
+    ["a job that adopted an artifact", { artifactId: "artifact" }],
+    ["a job that already published", { publications: 1 }],
+    ["a job of another date", { date: "2026-09-04" }],
+  ])("refuses to reconcile %s", async (_label, override) => {
+    const database = new FakeReconciliationDatabase([{ ...consumed, ...override }]);
+    await expect(apply(database)).rejects.toThrow(/not a consumed unpublished failure|does not exist/u);
+    expect(database.reconciliations).toEqual([]);
+    database.assertJobsUntouched();
+  });
+
+  it("refuses a job that does not exist in this workspace", async () => {
+    const database = new FakeReconciliationDatabase([]);
+    await expect(apply(database)).rejects.toThrow(/does not exist in this workspace/u);
+  });
+
+  it.each([
+    ["a foreign tenant", { tenantId: "00000000-0000-7000-8000-000000009999" }],
+    ["an unreviewed date", { date: "2026-09-09" }],
+    ["a non-refresh operation", { operation: "durable-reader-summary-daily:abc" }],
+    ["a reported-usage invocation", { invocation: {
+      ...reconciliationEvidence().invocation, providerUsageReported: true as never } }],
+    ["a fabricated success reason", { reason: "completed" as never }],
+  ])("rejects evidence with %s before any database work", (_label, override) => {
+    expect(() => assertRefreshReconciliationEvidence(reconciliationEvidence(override), dates))
+      .toThrow(/identity is invalid/u);
+  });
+});
+
+const countersEvidence = (override = {}) => ({
+  format: "reader-summary-new-input-refresh-reconciliation-counters-v1" as const,
+  ...refreshScope, date: reconciliationDate,
+  reconciliationId: ids.generate(), jobId: reconciliationJobId,
+  requestId: reconciliationEvidence().invocation.requestId,
+  attemptSha256: reconciliationEvidence().invocation.attemptSha256,
+  counters: { inputTokens: 12_000, outputTokens: 3_000, totalTokens: 15_000 },
+  provenance: "independently_verified_provider_statement" as const,
+  verifiedBy: "provider-billing-export", verifiedAt: "2026-09-07T11:00:00.000Z",
+  ...override,
+});
+const importCounters = (database: FakeReconciliationDatabase, override = {}, sha = "a".repeat(64)) =>
+  importRefreshReconciliationCounters({ client: database.client, evidence: countersEvidence(override),
+    evidenceSha256: sha, now, ids: { generate: () => "00000000-0000-4000-8000-00000000000b" } });
+
+describe("new-input refresh supplemental provider counters", () => {
+  const reconciled = async () => {
+    const database = new FakeReconciliationDatabase([{ ...consumed }]);
+    await apply(database);
+    return database;
+  };
+
+  it("imports verified counters against the original request without changing accounting", async () => {
+    const database = await reconciled();
+    const receipt = await importCounters(database);
+    expect(receipt.status).toBe("imported");
+    expect(database.counters).toHaveLength(1);
+    expect(database.reconciliations[0]?.accounting).toEqual(refreshReconciliationAccounting);
+    database.assertJobsUntouched();
+  });
+
+  it("is idempotent for an exact re-import and refuses a divergent one", async () => {
+    const database = await reconciled();
+    const first = await importCounters(database);
+    const replay = await importCounters(database);
+    expect(replay).toEqual({ ...first, status: "already_imported" });
+    await expect(importCounters(database, { counters: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } }))
+      .rejects.toThrow(/conflict with the committed evidence/u);
+    expect(database.counters).toHaveLength(1);
+  });
+
+  it.each([
+    ["another provider request", { requestId: "some-other-request" }],
+    ["another attempt result", { attemptSha256: "5".repeat(64) }],
+    ["another reconciliation", { reconciliationId: "00000000-0000-4000-8000-0000000000ff" }],
+  ])("refuses counters bound to %s", async (_label, override) => {
+    const database = await reconciled();
+    await expect(importCounters(database, override))
+      .rejects.toThrow(/do not reference the recorded original result/u);
+    expect(database.counters).toEqual([]);
+  });
+
+  it.each([
+    ["inconsistent totals", { counters: { inputTokens: 1, outputTokens: 1, totalTokens: 3 } }],
+    ["negative counters", { counters: { inputTokens: -1, outputTokens: 1, totalTokens: 0 } }],
+    ["partial counters", { counters: { inputTokens: 1, outputTokens: 1 } as never }],
+  ])("rejects %s before any database work", (_label, override) => {
+    expect(() => assertRefreshReconciliationCountersEvidence(countersEvidence(override), dates))
+      .toThrow(/not a complete verified statement/u);
+  });
+
+  it("rejects counters that do not claim independent verification", () => {
+    expect(() => assertRefreshReconciliationCountersEvidence(
+      countersEvidence({ provenance: "self_reported" as never }), dates)).toThrow(/identity is invalid/u);
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
@@ -1,0 +1,198 @@
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import type { IdGenerator } from "@social-monitor/shared-kernel";
+import { refreshBytesHash, refreshHash, refreshKeyPrefix, refreshScope } from
+  "./reader-summary-new-input-refresh-manifest";
+
+/** Operator-reviewed statement that one consumed new-input-refresh attempt is
+ * accounted for. It asserts consumption, never success: the original job row is
+ * never written to, and provider usage stays explicitly unknown. */
+export type RefreshReconciliationEvidence = Readonly<{
+  format: "reader-summary-new-input-refresh-reconciliation-v1";
+  tenantId: string; workspaceId: string; date: string;
+  jobId: string; operation: string; manifestSha256: string;
+  reason: "consumed_provider_invocation_without_summary";
+  invocation: Readonly<{
+    requestId: string; purpose: string; requestSha256: string;
+    attemptSha256: string; consumedAt: string; returnedAt: string;
+    outcome: string; providerUsageReported: false;
+  }>;
+}>;
+
+export const refreshReconciliationAccounting = Object.freeze({
+  summaryGenerations: 0, publications: 0, artifacts: 0,
+  providerInvocations: 1, providerUsage: "unknown",
+});
+
+const uuid = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/u;
+const sha256 = /^[0-9a-f]{64}$/u;
+const isoInstant = (value: unknown): value is string => {
+  if (typeof value !== "string") return false;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+};
+
+export function assertRefreshReconciliationEvidence(
+  evidence: RefreshReconciliationEvidence, dates: readonly string[],
+): void {
+  const invocation = evidence?.invocation;
+  if (evidence?.format !== "reader-summary-new-input-refresh-reconciliation-v1" ||
+      evidence.tenantId !== refreshScope.tenantId ||
+      evidence.workspaceId !== refreshScope.workspaceId ||
+      !dates.includes(evidence.date) || !uuid.test(evidence.jobId) ||
+      typeof evidence.operation !== "string" ||
+      !evidence.operation.startsWith(refreshKeyPrefix(evidence.date)) ||
+      !sha256.test(evidence.operation.slice(refreshKeyPrefix(evidence.date).length)) ||
+      !sha256.test(evidence.manifestSha256) ||
+      evidence.reason !== "consumed_provider_invocation_without_summary") {
+    throw new Error("Refresh reconciliation evidence identity is invalid");
+  }
+  if (typeof invocation !== "object" || invocation === null ||
+      typeof invocation.requestId !== "string" || invocation.requestId.trim().length === 0 ||
+      typeof invocation.purpose !== "string" || invocation.purpose.trim().length === 0 ||
+      !sha256.test(invocation.requestSha256) || !sha256.test(invocation.attemptSha256) ||
+      !isoInstant(invocation.consumedAt) || !isoInstant(invocation.returnedAt) ||
+      Date.parse(invocation.returnedAt) < Date.parse(invocation.consumedAt) ||
+      typeof invocation.outcome !== "string" || invocation.outcome.trim().length === 0 ||
+      // A reported-usage invocation is not this failure mode and must not be
+      // laundered through the reconciliation path.
+      invocation.providerUsageReported !== false) {
+    throw new Error("Refresh reconciliation invocation identity is invalid");
+  }
+}
+
+export function readReviewedRefreshReconciliation(
+  path: string, expected: string, dates: readonly string[],
+): { evidence: RefreshReconciliationEvidence; evidenceSha256: string } {
+  const absolute = resolve(path);
+  const stat = lstatSync(absolute);
+  if (realpathSync(absolute) !== absolute || !stat.isFile() || stat.nlink !== 1 ||
+      (stat.mode & 0o222) !== 0) {
+    throw new Error("Refresh reconciliation evidence must be a regular immutable file");
+  }
+  const bytes = readFileSync(absolute);
+  const evidenceSha256 = refreshBytesHash(bytes);
+  if (evidenceSha256 !== expected) throw new Error("Reviewed refresh reconciliation hash differs");
+  const evidence = JSON.parse(bytes.toString("utf8")) as RefreshReconciliationEvidence;
+  assertRefreshReconciliationEvidence(evidence, dates);
+  return { evidence, evidenceSha256 };
+}
+
+export type RefreshReconciliationRow = Readonly<{
+  id: string; tenantId: string; workspaceId: string;
+  readerSummaryJobId: string; operation: string; jobStatus: string;
+  jobSha256: string; manifestSha256: string; evidenceSha256: string;
+  reason: string; invocation: unknown; accounting: unknown; reconciledAt: Date;
+}>;
+
+type WriteClient = Readonly<{
+  $queryRaw<T>(strings: TemplateStringsArray, ...values: readonly unknown[]): Promise<T>;
+}>;
+
+const selectReconciliation = (client: WriteClient, jobId: string) =>
+  client.$queryRaw<readonly RefreshReconciliationRow[]>`
+    select id::text as id, tenant_id::text as "tenantId", workspace_id::text as "workspaceId",
+      reader_summary_job_id::text as "readerSummaryJobId", operation,
+      job_status as "jobStatus", btrim(job_sha256) as "jobSha256",
+      btrim(manifest_sha256) as "manifestSha256", btrim(evidence_sha256) as "evidenceSha256",
+      reason, invocation, accounting, reconciled_at as "reconciledAt"
+    from reader_summary_new_input_refresh_reconciliations
+    where tenant_id = ${refreshScope.tenantId}::uuid
+      and workspace_id = ${refreshScope.workspaceId}::uuid
+      and reader_summary_job_id = ${jobId}::uuid
+  `;
+
+/** One statement decides everything: the row is inserted only if the original
+ * job is still exactly the consumed, unpublished FAILED attempt named by the
+ * reviewed evidence, and its own digest is captured from that same row. */
+const insertReconciliation = (client: WriteClient, input: {
+  id: string; evidence: RefreshReconciliationEvidence; evidenceSha256: string; now: Date;
+}) => {
+  const { evidence: e } = input;
+  return client.$queryRaw<readonly { id: string }[]>`
+    insert into reader_summary_new_input_refresh_reconciliations (
+      id, tenant_id, workspace_id, period_started_at, period_ended_at,
+      reader_summary_job_id, operation, job_status, job_sha256, manifest_sha256,
+      evidence_sha256, reason, invocation, accounting, reconciled_at)
+    select ${input.id}::uuid, j.tenant_id, j.workspace_id, j.period_started_at, j.period_ended_at,
+      j.id, j.idempotency_key, j.status::text,
+      encode(sha256(convert_to(to_jsonb(j)::text, 'UTF8')), 'hex'),
+      ${e.manifestSha256}, ${input.evidenceSha256}, ${e.reason},
+      ${JSON.stringify(e.invocation)}::jsonb,
+      ${JSON.stringify(refreshReconciliationAccounting)}::jsonb,
+      ${input.now}::timestamptz
+    from reader_summary_jobs j
+    where j.id = ${e.jobId}::uuid
+      and j.tenant_id = ${refreshScope.tenantId}::uuid
+      and j.workspace_id = ${refreshScope.workspaceId}::uuid
+      and j.idempotency_key = ${e.operation}
+      and j.status::text = 'FAILED'
+      and j.reader_summary_artifact_id is null
+      and j.cadence = 'daily' and j.scope_type = 'workspace' and j.scope_key = 'workspace'
+      and j.period_timezone = 'UTC'
+      and j.period_started_at = ${e.date}::date::timestamp at time zone 'UTC'
+      and j.period_ended_at = (${e.date}::date + 1)::timestamp at time zone 'UTC'
+      and j.interest_id is null and j.user_id is null and j.subscription_id is null
+      and not exists (select 1 from reader_summary_publications p
+        where p.reader_summary_job_id = j.id)
+      and not exists (select 1 from reader_summary_artifacts a
+        where a.id = j.reader_summary_artifact_id)
+    on conflict do nothing
+    returning id::text as id
+  `;
+};
+
+/** Why the reviewed job could not be accounted for. Read-only diagnosis; it
+ * never relaxes the insert conditions. */
+const diagnoseJob = async (client: WriteClient, evidence: RefreshReconciliationEvidence) => {
+  const rows = await client.$queryRaw<readonly {
+    status: string; operation: string; artifactId: string | null; publications: number;
+  }[]>`
+    select j.status::text as status, j.idempotency_key as operation,
+      j.reader_summary_artifact_id::text as "artifactId",
+      (select count(*)::int from reader_summary_publications p
+        where p.reader_summary_job_id = j.id) as publications
+    from reader_summary_jobs j
+    where j.id = ${evidence.jobId}::uuid
+      and j.tenant_id = ${refreshScope.tenantId}::uuid
+      and j.workspace_id = ${refreshScope.workspaceId}::uuid
+  `;
+  return rows[0];
+};
+
+export type RefreshReconciliationReceipt = Readonly<{
+  status: "reconciled" | "already_reconciled";
+  reconciliationId: string; jobId: string; operation: string;
+  jobSha256: string; evidenceSha256: string; reconciledAt: string;
+  accounting: typeof refreshReconciliationAccounting;
+}>;
+
+/** Idempotent: an exact replay returns the committed record; anything that
+ * differs is a conflict, never a second record and never a reset. */
+export async function reconcileConsumedRefreshJob(input: {
+  client: WriteClient; evidence: RefreshReconciliationEvidence;
+  evidenceSha256: string; now: Date; ids: IdGenerator;
+}): Promise<RefreshReconciliationReceipt> {
+  const { client, evidence, evidenceSha256 } = input;
+  const inserted = await insertReconciliation(client,
+    { id: input.ids.generate(), evidence, evidenceSha256, now: input.now });
+  const rows = await selectReconciliation(client, evidence.jobId);
+  const row = rows[0];
+  if (rows.length !== 1 || row === undefined) {
+    const observed = await diagnoseJob(client, evidence);
+    throw new Error(observed === undefined
+      ? "Refresh reconciliation target job does not exist in this workspace"
+      : `Refresh reconciliation target job is not a consumed unpublished failure (status=${observed.status}, publications=${observed.publications})`);
+  }
+  if (row.operation !== evidence.operation || row.jobStatus !== "FAILED" ||
+      row.manifestSha256 !== evidence.manifestSha256 ||
+      row.evidenceSha256 !== evidenceSha256 || row.reason !== evidence.reason ||
+      refreshHash(row.invocation) !== refreshHash(evidence.invocation) ||
+      refreshHash(row.accounting) !== refreshHash(refreshReconciliationAccounting)) {
+    throw new Error("Refresh reconciliation conflicts with the committed record for this job");
+  }
+  return { status: inserted.length === 1 ? "reconciled" : "already_reconciled",
+    reconciliationId: row.id, jobId: row.readerSummaryJobId, operation: row.operation,
+    jobSha256: row.jobSha256, evidenceSha256: row.evidenceSha256,
+    reconciledAt: row.reconciledAt.toISOString(), accounting: refreshReconciliationAccounting };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-selection-audit.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selection-audit.spec.ts
@@ -100,7 +100,7 @@ describe("private refresh selection receipt", () => {
       expect(select).toHaveBeenCalledTimes(1);
       expect(record).toHaveBeenCalledTimes(1);
       expect(() => reconcileRefresh(m, [{ jobId: "audit-job", operation: m.operation,
-        status: "FAILED", artifactId: null }], m.prior)).toThrow(/consumed/u);
+        status: "FAILED", artifactId: null, jobSha256: "a".repeat(64) }], m.prior)).toThrow(/consumed/u);
     } else expect(record).toHaveBeenCalledTimes(phase === "success" ? 1 : 0);
   });
 

--- a/scripts/lib/reader-summary-new-input-refresh-transaction.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-transaction.spec.ts
@@ -2,7 +2,7 @@ import { FixedClock } from "@social-monitor/shared-kernel";
 import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
 import { assertRefreshTransactionAuthority, refreshPublicationGuard } from "./reader-summary-new-input-refresh-execution";
 import { captureRefreshDatabaseAuthority } from "./reader-summary-new-input-refresh-capture";
-import { readRefreshPrior, readRefreshJobs, lockRefreshAuthority } from "./reader-summary-new-input-refresh-postgres";
+import { readRefreshPrior, readRefreshJobs, readRefreshReconciliations, lockRefreshAuthority } from "./reader-summary-new-input-refresh-postgres";
 import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
 import type { ReaderSummaryPublicationCommand } from "@social-monitor/summary/ports";
 
@@ -10,7 +10,7 @@ jest.mock("./reader-summary-new-input-refresh-capture", () => ({
   ...jest.requireActual("./reader-summary-new-input-refresh-capture"), captureRefreshDatabaseAuthority: jest.fn(),
 }));
 jest.mock("./reader-summary-new-input-refresh-postgres", () => ({
-  ...jest.requireActual("./reader-summary-new-input-refresh-postgres"), readRefreshPrior: jest.fn(), readRefreshJobs: jest.fn(),
+  ...jest.requireActual("./reader-summary-new-input-refresh-postgres"), readRefreshPrior: jest.fn(), readRefreshJobs: jest.fn(), readRefreshReconciliations: jest.fn(),
 }));
 describe("publisher authority uses only its transaction for every database read", () => {
   it.each(["unchanged", "canonicalRowsSha256", "engagementSha256", "sourceScopeSha256", "policySha256", "datasetSha256", "job", "prior"])(
@@ -26,9 +26,17 @@ describe("publisher authority uses only its transaction for every database read"
       jest.mocked(readRefreshPrior).mockImplementation(async (client) => {
         expect(client).toBe(tx); return change === "prior" ? { ...m.prior, proofSha256: "b".repeat(64) } : m.prior;
       });
+      // A reconciled consumed attempt stays visible in history here; only the
+      // single live job may hold publication authority.
+      const settled = { jobId: "consumed", operation: `${m.operation}-prior`, status: "FAILED",
+        artifactId: null, jobSha256: "d".repeat(64) };
       jest.mocked(readRefreshJobs).mockImplementation(async (client) => {
-        expect(client).toBe(tx); return [{ jobId: "new", operation: m.operation,
-          status: change === "job" ? "FAILED" : "RUNNING", artifactId: null }];
+        expect(client).toBe(tx); return [settled, { jobId: "new", operation: m.operation,
+          status: change === "job" ? "FAILED" : "RUNNING", artifactId: null, jobSha256: "c".repeat(64) }];
+      });
+      jest.mocked(readRefreshReconciliations).mockImplementation(async (client) => {
+        expect(client).toBe(tx); return [{ reconciliationId: "r1", jobId: settled.jobId,
+          operation: settled.operation, jobStatus: settled.status, jobSha256: settled.jobSha256 }];
       });
       const command = { artifact: { toSnapshot: () => ({ sourceWindow: { ingestionCutoff: new Date(m.observedThrough) } }) },
         finalJob: { toSnapshot: () => ({ id: "new" }) } } as unknown as ReaderSummaryPublicationCommand;

--- a/scripts/run-reader-summary-new-input-refresh-reconciliation.ts
+++ b/scripts/run-reader-summary-new-input-refresh-reconciliation.ts
@@ -1,0 +1,93 @@
+import { CryptoIdGenerator, SystemClock } from "@social-monitor/shared-kernel";
+import { runWithTenantDatabaseAccess, resolvePostgresRuntimePoolConfig, withPrismaWriteRetry } from "@social-monitor/platform-persistence";
+import { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
+import { requiredHistoricalPromotionSystemDatabaseUrl, assertHistoricalPromotionSystemRole } from "./lib/reader-summary-promotion-v2-system-database";
+import { refreshDates, refreshScope } from "./lib/reader-summary-new-input-refresh-manifest";
+import { assertRefreshFences, readRefreshFenceAuthority } from "./lib/reader-summary-new-input-refresh-files";
+import { readRefreshJobs, readRefreshPrior, readRefreshReconciliations } from "./lib/reader-summary-new-input-refresh-postgres";
+import { refreshLiveJobs } from "./lib/reader-summary-new-input-refresh-guard";
+import { readReviewedRefreshReconciliation, reconcileConsumedRefreshJob } from "./lib/reader-summary-new-input-refresh-reconciliation";
+import { readReviewedRefreshReconciliationCounters, importRefreshReconciliationCounters } from "./lib/reader-summary-new-input-refresh-reconciliation-counters";
+
+const sha256 = /^[0-9a-f]{64}$/u;
+export function parseReconciliationCommand(argv: readonly string[]) {
+  if (argv.length === 3 && argv[0] === "--inspect" && argv[1] === "--date" &&
+      refreshDates.includes(argv[2]!)) {
+    return { mode: "inspect", date: argv[2]! } as const;
+  }
+  for (const [flag, mode] of [["--reconcile", "reconcile"], ["--import-counters", "counters"]] as const) {
+    if (argv.length === 4 && argv[0] === flag && argv[2] === "--sha256" && sha256.test(argv[3]!)) {
+      return { mode, path: argv[1]!, sha256: argv[3]! } as const;
+    }
+  }
+  throw new Error("Use --inspect --date ACCEPTED_DATE, --reconcile EVIDENCE --sha256 HASH, or --import-counters EVIDENCE --sha256 HASH");
+}
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const command = parseReconciliationCommand(process.argv.slice(2));
+  const clock = new SystemClock();
+  const ids = new CryptoIdGenerator();
+  const fencePaths = {
+    globalLock: required("READER_SUMMARY_REFRESH_GLOBAL_LOCK"),
+    dateDirectory: required("READER_SUMMARY_REFRESH_DATE_LOCK_DIR"),
+    fenceDirectory: required("READER_SUMMARY_REFRESH_FENCE_DIR"),
+  };
+  const config = resolvePostgresRuntimePoolConfig({ ...process.env,
+    DATABASE_URL: requiredHistoricalPromotionSystemDatabaseUrl(process.env),
+    POSTGRES_RUNTIME_PROCESS: "daily-runner", POSTGRES_RUNTIME_POOL_MIN: "0", POSTGRES_RUNTIME_POOL_MAX: "2" });
+  const summary = await PrismaSummaryConnection.create(config);
+  try {
+    await runWithTenantDatabaseAccess(refreshScope, async () => {
+      await assertHistoricalPromotionSystemRole(summary);
+      if (command.mode === "inspect") {
+        const jobs = await readRefreshJobs(summary, command.date);
+        const reconciled = await readRefreshReconciliations(summary, command.date);
+        console.log(JSON.stringify({ date: command.date, jobs, reconciled,
+          live: refreshLiveJobs(jobs, reconciled, ""),
+          prior: await readRefreshPrior(summary, command.date) }));
+        return;
+      }
+      // Both writes gate a later paid attempt, so they run under exactly the
+      // canonical held global/date flocks the refresh itself requires.
+      const date = command.mode === "reconcile"
+        ? readReviewedRefreshReconciliation(command.path, command.sha256, refreshDates).evidence.date
+        : readReviewedRefreshReconciliationCounters(command.path, command.sha256, refreshDates).evidence.date;
+      assertRefreshFences(date, fencePaths, process.env.READER_SUMMARY_DATE_FENCE_TOKEN,
+        readRefreshFenceAuthority(fencePaths));
+      const receipt = await withPrismaWriteRetry(() => summary.$transaction(async (tx) => {
+        assertRefreshFences(date, fencePaths, process.env.READER_SUMMARY_DATE_FENCE_TOKEN,
+          readRefreshFenceAuthority(fencePaths));
+        if (command.mode === "reconcile") {
+          const { evidence, evidenceSha256 } = readReviewedRefreshReconciliation(
+            command.path, command.sha256, refreshDates);
+          return await reconcileConsumedRefreshJob({ client: tx, evidence, evidenceSha256,
+            now: clock.now(), ids });
+        }
+        const { evidence, evidenceSha256 } = readReviewedRefreshReconciliationCounters(
+          command.path, command.sha256, refreshDates);
+        return await importRefreshReconciliationCounters({ client: tx, evidence, evidenceSha256,
+          now: clock.now(), ids });
+      }, { isolationLevel: "Serializable", maxWait: 30_000, timeout: 120_000 }));
+      console.log(JSON.stringify({ ...receipt, date, evidenceSha256: command.sha256 }));
+    });
+  } finally { await summary.close(); }
+}
+
+if (require.main === module) {
+  void main().catch((error: unknown) => {
+    // Reconciliation must never look successful. Only this module's own
+    // messages are echoed; SQL and provider errors can carry payloads or
+    // credentials, so they are reported as an opaque class.
+    const message = error instanceof Error && error.message.startsWith("Refresh")
+      ? error.message
+      : "database or environment error";
+    console.error(`Reader summary refresh reconciliation stopped: ${message}. Do not reset the original job budget.`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/run-reader-summary-new-input-refresh.ts
+++ b/scripts/run-reader-summary-new-input-refresh.ts
@@ -13,9 +13,9 @@ import { refreshScope, refreshDates, refreshOperation, refreshBytesHash,
   assertRefreshManifest, type RefreshManifest } from "./lib/reader-summary-new-input-refresh-manifest";
 import { refreshSourceSha256, readReviewedRefresh, assertRefreshFences, readRefreshFenceAuthority } from "./lib/reader-summary-new-input-refresh-files";
 import { captureRefreshAuthority, preflightRefreshSelection, assertRefreshHasNewInput, refreshPeriod } from "./lib/reader-summary-new-input-refresh-capture";
-import { readRefreshJobs, readRefreshPrior } from "./lib/reader-summary-new-input-refresh-postgres";
+import { readRefreshJobs, readRefreshPrior, readRefreshReconciliations } from "./lib/reader-summary-new-input-refresh-postgres";
 import { refreshGenerationSha256 } from "./lib/reader-summary-new-input-refresh-model";
-import { assertRefreshEqual } from "./lib/reader-summary-new-input-refresh-guard";
+import { assertRefreshEqual, refreshLiveJobs } from "./lib/reader-summary-new-input-refresh-guard";
 import { executeNewInputRefresh } from "./lib/reader-summary-new-input-refresh-execution";
 import { resolveReaderSummaryServingAuthority } from "./lib/reader-summary-serving-authority";
 
@@ -61,7 +61,8 @@ async function main(): Promise<void> {
       await assertHistoricalPromotionSystemRole(summary);
       if (command.mode === "prepare") {
         for (const date of command.dates) {
-          if ((await readRefreshJobs(summary, date)).length > 0) {
+          const reconciled = await readRefreshReconciliations(summary, date);
+          if (refreshLiveJobs(await readRefreshJobs(summary, date), reconciled, "").length > 0) {
             console.log(JSON.stringify({ date, status: "consumed_use_original_manifest_to_reconcile" }));
             continue;
           }
@@ -82,6 +83,13 @@ async function main(): Promise<void> {
           };
           const manifest: RefreshManifest = { ...value, operation: refreshOperation(value) };
           assertRefreshManifest(manifest, clock.now());
+          // Identical prior/input authority reproduces a reconciled operation.
+          // That is the already-consumed identity, not a fresh attempt.
+          if (reconciled.some((record) => record.operation === manifest.operation)) {
+            console.log(JSON.stringify({ date, status: "reconciled_identity_unchanged_requires_new_input",
+              operation: manifest.operation }));
+            continue;
+          }
           const bytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
           const sha256 = refreshBytesHash(bytes);
           const path = join(output, `${date}.${sha256}.json`);


### PR DESCRIPTION
## Why

The 2026-09-05 new-input refresh attempt (job `1767fd5c-2fe5-4fef-84e0-22c380932e81`, operation `new-input-refresh:v1:2026-09-05:bccf05c7…`) consumed a real, paid `verify_story_relations.v2` invocation, got a `completed` response with **no `usage`**, and stopped with `Refresh invocation budget requires reconciliation`. Summary generation was never reached; nothing was published.

`reconcileRefresh` only recognises *unconsumed* or *already published*. A FAILED-but-consumed job throws, so the date is wedged: there is no way forward that does not reset consumed history — which is exactly what must never happen.

## What this adds

**Reconciliation accounting (append-only, two new tables)**

- `reader_summary_new_input_refresh_reconciliations` — one row per consumed attempt that produced no summary. It records that the attempt is **accounted for**, never that it succeeded:
  - the original job row is **never written to**; its full-row `to_jsonb(j)` digest is captured as an immutability witness,
  - `ON DELETE/UPDATE RESTRICT` FK to `reader_summary_jobs` means the consumed original cannot be deleted while accounted for,
  - `accounting` is CHECK-pinned to `summaryGenerations: 0, publications: 0, artifacts: 0, providerInvocations: 1, providerUsage: "unknown"` — usage is **unknown**, never fabricated as zero,
  - `invocation.providerUsageReported` is CHECK-pinned to `false`, so an invocation that *did* report usage cannot be laundered through this path.
- `reader_summary_new_input_refresh_reconciliation_counters` — immutable supplemental evidence. Independently verified provider counters can only be attached to a committed reconciliation whose recorded `requestId` **and** attempt digest match, i.e. they reference the original result. They never edit the reconciliation's accounting and never grant budget.
- Both tables: `FORCE ROW LEVEL SECURITY` + `tenant_isolation`, `SELECT`/`INSERT` only for the refresh runtime role, `UPDATE`/`DELETE` rejected by trigger.

**Guard/execution (minimum needed for this one transition)**

`refreshLiveJobs(jobs, reconciled, operation)` subtracts reconciled jobs from a date's live budget, but only while each one is still:
- byte-identical to the row that was reconciled (`jobSha256`),
- `FAILED` with `artifactId === null`,
- **not** the owner of the operation of the new attempt.

Otherwise it fails closed. `reconcileRefresh` gains a `"reconciled"` outcome. Admission, the execution guard and `assertRefreshTransactionAuthority` now all read *live* jobs.

## Double-generation / double-billing analysis

- **Two live attempts for one date:** impossible. Admission still requires **zero** live jobs; the guard still requires **exactly one** live job that is its own; the publication transaction re-checks the same thing inside the Serializable transaction. Reconciled jobs are only ever subtracted, never added.
- **A mid-run reconciliation retiring the running attempt:** impossible. `refreshLiveJobs` throws if a reconciled record carries the current manifest's operation, and the running job carries exactly that operation.
- **Reusing the consumed identity:** impossible twice over — `refreshLiveJobs` rejects it, and `reader_summary_jobs (tenant_id, idempotency_key)` is unique. `--prepare` now reports `reconciled_identity_unchanged_requires_new_input` when unchanged prior/input authority would reproduce a reconciled operation.
- **Reconciling a successful date to regenerate it:** impossible. The insert only resolves against a job that is `FAILED`, has no artifact, and has no publication row.
- **Original history mutated:** never by this code (no UPDATE/DELETE of jobs anywhere), and any external mutation is detected by the digest and fails the next refresh closed.
- Both writes run under the canonical **held** global/date flocks (`assertRefreshFences`, re-checked inside the transaction) in a SERIALIZABLE transaction, are idempotent on exact replay, and refuse divergent evidence as a conflict.

## Evidence

- `npx tsc -p tsconfig.build.json --noEmit` — OK
- `jest scripts/lib/reader-summary-new-input-refresh` — **18 suites / 363 tests passed** (36 new), offline/fake only, no provider calls
  - new: `reader-summary-new-input-refresh-reconciled-admission.spec.ts` (blocked → reconciled → exactly one fresh attempt → published; fails closed on any drift of the reconciled original)
  - new: `reader-summary-new-input-refresh-reconciliation.spec.ts` (idempotent replay, conflict refusal, refuses non-failed/published/foreign jobs, counters binding + idempotency; the fake asserts the SQL keeps its guard fragments and that no job row is ever modified)
- `check:architecture`, `check:code-quality`, `check:source-line-cap`, `check:tenant-db-guards`, `check:migrations` — all OK
- **Migration applied and verified on real PostgreSQL 18** via `check:tenant-rls-postgres` against a disposable database: it passes only if both new tables exist with RLS enabled+forced and a `tenant_isolation` policy.
- `check:reader-summary-new-input-refresh:postgres` extended with `assertRefreshReconciliationContract` (parent-run native gate: schema protection, no UPDATE/DELETE grants, and a refused reconciliation of a non-failed job writing nothing).

## Not in this PR

Executing the reconciliation and the fresh 2026-09-05 attempt in production. Aug 30 – Sep 4 and the daily-timer check are later steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reconciliation for failed refresh attempts where a provider invocation was consumed but no summary was published.
  - Added support for importing independently verified provider usage counters.
  - Added inspection and reconciliation commands for reviewing historical refresh attempts.

- **Bug Fixes**
  - Reconciled attempts no longer consume the active refresh budget or block eligible future attempts.
  - Added safeguards to prevent modifying original job history and to reject invalid or conflicting reconciliations.

- **Tests**
  - Expanded coverage for reconciliation, validation, duplicate handling, and concurrent refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->