### PR TITLE
fix(agent-runtime): usage-tracking failures must not block summary generation

### DIFF
--- a/apps/agent-runtime/bin/codex-worker-cli-usage.mjs
+++ b/apps/agent-runtime/bin/codex-worker-cli-usage.mjs
@@ -17,7 +17,22 @@ export function withTrustedCodexWorkerUsage(worker) {
     start: (...args) => worker.start(...args),
     dispose: (...args) => worker.dispose(...args),
     seedCodexAuthJsonFile: (...args) => worker.seedCodexAuthJsonFile(...args),
-    run: async (...args) => trustedCodexWorkerResultToCli(await worker.run(...args)),
+    run: async (...args) => {
+      const result = await worker.run(...args);
+      // Usage-tracking integrity is enforced separately by
+      // trustedCodexWorkerResultToCli (fail closed on malformed/conflicting
+      // usage). A billing-only enrichment failure must not take down the
+      // underlying task result -- drop the untrusted usage and let the
+      // already-completed work through instead of losing it.
+      try {
+        return trustedCodexWorkerResultToCli(result);
+      } catch (error) {
+        console.error(
+          `codex-worker-cli-usage: dropping untrusted usage (${error.message})`,
+        );
+        return result;
+      }
+    },
   };
 }
 

--- a/apps/agent-runtime/bin/usage-path-contract.test.mjs
+++ b/apps/agent-runtime/bin/usage-path-contract.test.mjs
@@ -363,3 +363,47 @@ test("absent usage flows as undefined through the full path without throwing", (
   const parsed = parseCliTelemetryUsage(cliJson);
   assert.equal(parsed, undefined, "no usage yields undefined without error");
 });
+
+// ---------------------------------------------------------------------------
+// withTrustedCodexWorkerUsage must not let a usage-integrity failure take
+// down the underlying task result: a billing-only concern should degrade to
+// "no usage recorded", not "no summary generated".
+// ---------------------------------------------------------------------------
+
+test("withTrustedCodexWorkerUsage drops malformed usage instead of failing the whole task", async () => {
+  const fakeWorker = {
+    async start() {},
+    async dispose() {},
+    async seedCodexAuthJsonFile() {},
+    async run() {
+      return {
+        outputText: "real generated content",
+        usage: { inputTokens: 1, outputTokens: 2 }, // missing totalTokens: malformed
+        warnings: [],
+      };
+    },
+  };
+
+  const wrapped = withTrustedCodexWorkerUsage(fakeWorker);
+  const result = await wrapped.run({ prompt: "anything" });
+
+  assert.equal(result.outputText, "real generated content", "task output must survive a usage-tracking failure");
+  assert.equal(result.telemetry?.usage, undefined, "malformed usage must not be forwarded as trusted telemetry");
+});
+
+test("withTrustedCodexWorkerUsage still promotes valid usage normally", async () => {
+  const validUsage = { inputTokens: 5, outputTokens: 3, totalTokens: 8 };
+  const fakeWorker = {
+    async start() {},
+    async dispose() {},
+    async seedCodexAuthJsonFile() {},
+    async run() {
+      return { outputText: "ok", usage: validUsage, warnings: [] };
+    },
+  };
+
+  const wrapped = withTrustedCodexWorkerUsage(fakeWorker);
+  const result = await wrapped.run({ prompt: "anything" });
+
+  assert.deepEqual(result.telemetry?.usage, validUsage);
+});

--- a/apps/agent-runtime/src/subscription-runtime-cli-executor.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-executor.ts
@@ -308,7 +308,9 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
       retryable: result.failure?.retryable,
       reconnectRequired: result.failure?.reconnectRequired,
       causeCategory: result.failure?.causeCategory,
-      failureDetails: result.failure?.details,
+      failureDetails: result.failure?.details
+        ? JSON.stringify(result.failure.details)
+        : undefined,
     };
     if (result.status === "completed") {
       this.logger.info("agent runtime task completed", fields);

--- a/apps/agent-runtime/src/subscription-runtime-cli-executor.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-executor.ts
@@ -307,6 +307,8 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
       failureCode: result.failure?.code,
       retryable: result.failure?.retryable,
       reconnectRequired: result.failure?.reconnectRequired,
+      causeCategory: result.failure?.causeCategory,
+      failureDetails: result.failure?.details,
     };
     if (result.status === "completed") {
       this.logger.info("agent runtime task completed", fields);


### PR DESCRIPTION
Live production issue today: reader-summary generation (verify_story_relations.v2/generate.v2) failed every invocation with `failureCode=unknown_runtime_failure, retryable=false`, no diagnostic detail, blocking rolling+daily publication.

Two changes:
1. `subscription-runtime-cli-executor.ts`: `logResult()` now logs `causeCategory`/`failure.details` (already-sanitized allowlisted fields, no secrets) -- makes this class of failure diagnosable from logs instead of requiring live prod debugging.
2. `codex-worker-cli-usage.mjs`: `withTrustedCodexWorkerUsage()` now catches a throw from `trustedCodexWorkerResultToCli()` and falls back to the unenriched task result. The adapter itself is unchanged (still fails closed on malformed/conflicting usage -- billing integrity preserved, existing tests untouched). A usage-tracking problem is billing-only and must not take down an already-successful summary generation.

Not 100% confirmed this was the exact root cause of today's outage (logs didn't carry enough detail before this PR to tell for certain) -- change (1) makes it diagnosable going forward regardless, change (2) removes this specific failure mode either way.

Refs #294
