### PR TITLE
fix(ops): register refresh reconciliation tables in the backup/restore contract

### DIFF
--- a/ops/recovery/backup-restore-contract.json
+++ b/ops/recovery/backup-restore-contract.json
@@ -82,7 +82,9 @@
     "outbox_events",
     "inbox_records",
     "idempotency_keys",
-    "social_research_result_cache_entries"
+    "social_research_result_cache_entries",
+    "reader_summary_new_input_refresh_reconciliations",
+    "reader_summary_new_input_refresh_reconciliation_counters"
   ],
   "operationalStateTables": [
     "api_keys",


### PR DESCRIPTION
Follow-up to #313.

`check:backup-restore` requires every Prisma table to be listed in `ops/recovery/backup-restore-contract.json` under `backupIncludes`. The two tables added in #313 were missing, so the production deploy of `0d2bff1c` failed at *Verify backend and deployment contract*:

```
ops/recovery/backup-restore-contract.json: backupIncludes missing Prisma table "reader_summary_new_input_refresh_reconciliations"
ops/recovery/backup-restore-contract.json: backupIncludes missing Prisma table "reader_summary_new_input_refresh_reconciliation_counters"
```

That gate runs only in the production-deploy workflow, not in pull-request CI, which is why #313 was green.

Both tables are durable accounting for consumed, paid provider invocations, so they belong in the backup set.

Evidence: `npm run check:backup-restore` — 13/13 pass; `check:migrations`, `check:tenant-db-guards`, `check:architecture`, `check:secrets`, `check:container`, `check:runtime-compose`, `check:runtime-profile-guards` all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)