### PR TITLE
fix(agent-runtime): report the Codex capacity reason behind an exhausted safe-execution budget

### DIFF
--- a/apps/agent-runtime/bin/codex-auth-pool-routing.mjs
+++ b/apps/agent-runtime/bin/codex-auth-pool-routing.mjs
@@ -12,6 +12,52 @@ export const codexAuthPoolExecutionPolicy = Object.freeze({
 export const codexAuthPoolTaskHash = (taskId) =>
   createHash("sha256").update(taskId).digest("hex");
 
+/**
+ * Detail keys that are safe to echo into an operator-visible failure message.
+ * Provider stdout/stderr tails and raw causes stay out on purpose: they can
+ * carry prompt or account material.
+ */
+const reportableCodexAuthPoolFailureDetails = Object.freeze([
+  "availability",
+  "reason",
+  "cooldownUntil",
+  "accountId",
+  "quotaReason",
+  "quotaPlanType",
+  "quotaWindowKinds",
+]);
+
+/**
+ * `Safe execution has no attempts remaining.` is the policy-level message the
+ * subscription runtime returns once the attempt budget is spent. On a
+ * single-account pool that budget is one attempt, so a capacity block that
+ * never reached the provider surfaces as the generic exhaustion text and hides
+ * the reason an operator actually needs (revoked session, cooldown, quota).
+ * Keep the safe message, but always carry the classified reason and the
+ * capacity details next to it.
+ */
+export const describeCodexAuthPoolRunFailure = (input) => {
+  const safeMessage = typeof input.safeMessage === "string"
+    ? input.safeMessage.trim()
+    : "";
+  const reason = typeof input.reason === "string" ? input.reason.trim() : "";
+  const details = input.failureDetails ?? {};
+  const reported = reportableCodexAuthPoolFailureDetails
+    .filter((key) => typeof details[key] === "string" && details[key].trim())
+    .map((key) => `${key}=${details[key].trim()}`);
+  if (Number.isInteger(input.attemptCount) && Number.isInteger(input.accountCount)) {
+    reported.push(`attempts=${input.attemptCount}/${input.accountCount}`);
+  }
+  const head = reason
+    ? `Codex auth pool run failed (${reason})`
+    : "Codex auth pool run failed";
+  return [
+    head,
+    ...(safeMessage ? [`: ${safeMessage}`] : [": no safe message"]),
+    ...(reported.length > 0 ? [` [${reported.join(" ")}]`] : []),
+  ].join("");
+};
+
 export const orderCodexAuthAccountsForTask = (accounts, taskId) => {
   if (accounts.length < 2) {
     return [...accounts];

--- a/apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs
+++ b/apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs
@@ -10,6 +10,7 @@ import {
 
 import {
   codexAuthPoolExecutionPolicy,
+  describeCodexAuthPoolRunFailure,
   orderCodexAuthAccountsForTask,
 } from "./codex-auth-pool-routing.mjs";
 
@@ -89,6 +90,65 @@ test("pool retries a quota failure on another account with the exact same job", 
   } finally {
     await pool.dispose();
   }
+});
+
+test("exhausted attempt budget reports the capacity reason that blocked the run", () => {
+  const message = describeCodexAuthPoolRunFailure({
+    safeMessage: "Safe execution has no attempts remaining.",
+    reason: "account_unavailable",
+    failureDetails: {
+      workerId: "social-monitor-agent-task:abc:slot-1",
+      availability: "cooldown",
+      reason: "quota_recheck_identity_changed",
+      cooldownUntil: "2026-09-07T16:39:54.675Z",
+      accountId: "account-i",
+    },
+    attemptCount: 1,
+    accountCount: 1,
+  });
+
+  assert.match(message, /account_unavailable/u);
+  assert.match(message, /Safe execution has no attempts remaining\./u);
+  assert.match(message, /availability=cooldown/u);
+  assert.match(message, /reason=quota_recheck_identity_changed/u);
+  assert.match(message, /cooldownUntil=2026-09-07T16:39:54\.675Z/u);
+  assert.match(message, /accountId=account-i/u);
+  assert.match(message, /attempts=1\/1/u);
+});
+
+test("failure message keeps provider output and raw causes out of the message", () => {
+  const message = describeCodexAuthPoolRunFailure({
+    safeMessage: "Safe execution has no attempts remaining.",
+    reason: "unknown_error",
+    failureDetails: {
+      availability: "cooldown",
+      stderrTail: "sk-secret-looking-tail",
+      stdoutTail: "reader summary prompt bytes",
+      rawCause: "token=should-not-leak",
+    },
+    attemptCount: 1,
+    accountCount: 1,
+  });
+
+  assert.match(message, /availability=cooldown/u);
+  assert.doesNotMatch(message, /secret-looking-tail/u);
+  assert.doesNotMatch(message, /prompt bytes/u);
+  assert.doesNotMatch(message, /should-not-leak/u);
+});
+
+test("failure message survives a runtime result without classified details", () => {
+  assert.equal(
+    describeCodexAuthPoolRunFailure({
+      safeMessage: "Safe execution will not retry external side effects.",
+      reason: "budget_exceeded",
+    }),
+    "Codex auth pool run failed (budget_exceeded): " +
+      "Safe execution will not retry external side effects.",
+  );
+  assert.equal(
+    describeCodexAuthPoolRunFailure({}),
+    "Codex auth pool run failed: no safe message",
+  );
 });
 
 test("safe executor retries clean failures with the exact original job", () => {

--- a/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
+++ b/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
@@ -22,6 +22,7 @@ import { loadCodexAuthPoolFromEnv } from "./codex-auth-pool-manifest.mjs";
 import {
   codexAuthPoolExecutionPolicy,
   codexAuthPoolTaskHash,
+  describeCodexAuthPoolRunFailure,
   orderCodexAuthAccountsForTask,
 } from "./codex-auth-pool-routing.mjs";
 
@@ -304,7 +305,13 @@ function createPooledCodexWorker({ input, model, authPool }) {
         }
         throw new SubscriptionWorkerError(
           "subscription_worker_run_failed",
-          result.safeMessage,
+          describeCodexAuthPoolRunFailure({
+            safeMessage: result.safeMessage,
+            reason: result.reason,
+            failureDetails: result.failureDetails,
+            attemptCount: result.attempts?.length,
+            accountCount: authPool.accounts.length,
+          }),
           {
             details: {
               reason: result.reason,

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -14,7 +14,7 @@ import {
 export const approvedSubscriptionRuntimePackageVersion =
   "0.1.0-main.41";
 export const approvedSubscriptionRuntimeLauncherSha256 =
-  "648b5b5f36697419fae0a14123871807420ae494a5428b497a773672b6d7fb6e";
+  "205b17650fbb72207c524a7102da7b7a88fa21335aa1caca8f889472608ec3bb";
 
 export type SubscriptionRuntimeInstallationIdentity = {
   /** Exact real path that was admitted and must be passed to spawn. */


### PR DESCRIPTION
## Exact cause of the rolling-capture failure (evidence, not hypothesis)

`social-monitor-rolling.service` failed every run at `capture:durable-reader-summary` with
`Durable reader summary capture failed: Safe execution has no attempts remaining.`

The premise that this is a persisted attempt budget keyed by
`readerSummaryProductionDayAttemptIdentity` does not hold. Evidence from the production
attempt journal (`/var/lib/subscription-runtime/attempt-journal`):

- The safe-execution task id is `reader-summary:<tenant>:<workspace>:workspace:<job requestedAt ISO>`,
  and every failing run has a **fresh** journal record with exactly one attempt. No stale
  budget is being reused, and no runtime version is part of that key.
- Each of those single attempts is `status: blocked`, `failureReason: account_unavailable`,
  `failureDetails.reason: quota_recheck_identity_changed`, `availability: cooldown`,
  `accountId: account-i`.
- `AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST` lists **one** account. `run-codex-subscription-runtime-agent-task.mjs`
  sets `maxAttempts: authPool.accounts.length` and `maxAccountCycles: 1`, so the budget is 1.
  The capacity claim is checked *before* the provider call, so the block spends the only
  attempt and `shouldContinueSafeExecutionAfterFailure` replaces the classified reason with
  the generic `Safe execution has no attempts remaining.`
- The account itself is unusable, not the attempt accounting: the capacity rechecker only
  emits `quota_recheck_identity_changed` when the live observation returns an auth session
  without an account identity, which for a fallback-capable observer means the Codex
  app-server returned relogin-required. The offline auth.json identity still resolves to the
  stored capacity id (`codex-provider:2e05d3...`), so the pool file is intact - the session
  behind it is not. Last successful Codex task: 2026-09-07T08:23Z; first
  `quota_recheck_identity_changed`: 12:23Z; the second pool account (`account-m`) is
  `quota_exhausted` until 2026-09-12.

So the deploy blocker is an account/session condition, and what this repo actually got wrong
is that it reported an attempt counter instead of that condition for hours.

## Change

Narrow and observability-only. No retry, budget, identity or publication behavior changes.

- `describeCodexAuthPoolRunFailure()` in `codex-auth-pool-routing.mjs` composes the operator
  message: classified reason + safe message + allowlisted capacity details
  (`availability`, `reason`, `cooldownUntil`, `accountId`, quota facts) + `attempts=N/M`.
- The pooled Codex CLI throws that message instead of the bare `result.safeMessage`.
  Error code and `details` are unchanged, so downstream classification is untouched.
- `stderrTail` / `stdoutTail` / `rawCause` are deliberately excluded - they can carry prompt
  or account material.

Next failing run will read, e.g.:
`Codex auth pool run failed (account_unavailable): Safe execution has no attempts remaining. [availability=cooldown reason=quota_recheck_identity_changed cooldownUntil=... accountId=account-i attempts=1/1]`

## Not done here (deliberately)

Raising the single-account attempt budget was rejected: the runtime does not wait for
`cooldownUntil` between attempts, so extra attempts would re-block instantly and only add
provider spend. Restoring the rolling summary needs the Codex account session re-authorized
(or a second healthy account in the pool) - an operator action, not a code change.

## Tests (offline, no provider calls)

`apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs`:
exhausted-budget message carries the capacity reason; sensitive detail keys stay out;
missing-details and missing-message results degrade safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex authentication pool failure messages with clearer reasons, availability details, cooldown information, account context, and attempt counts.
  - Added fallback messaging when failure details are unavailable.
  - Prevented provider output and raw error causes from appearing in operator-visible failure messages, reducing the risk of exposing sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->