### PR TITLE
fix(ops): raise broker status timeout so account pool checks can complete

### DIFF
--- a/ops/deploy/host/refresh-codex-auth.sh
+++ b/ops/deploy/host/refresh-codex-auth.sh
@@ -58,7 +58,7 @@ elif ((EUID == 0)); then
   TARGET_GROUP=1000
   TARGET_MODE=0440
   POOL_REGISTRY_PREFIX=/var/data/social-monitor/worker-jobs/
-  BROKER_STATUS_TIMEOUT_SECONDS=30
+  BROKER_STATUS_TIMEOUT_SECONDS=120
   unset SOCIAL_MONITOR_AUTH_REFRESH_TEST_MODE SOCIAL_MONITOR_AUTH_ROOT \
     SOCIAL_MONITOR_AUTH_TARGET_DIR SOCIAL_MONITOR_AUTH_REGISTRY_ROOT \
     SOCIAL_MONITOR_AUTH_PROJECT_ROOT \
@@ -75,8 +75,8 @@ else
 fi
 
 [[ $BROKER_STATUS_TIMEOUT_SECONDS =~ ^[1-9][0-9]*$ ]] \
-  && ((BROKER_STATUS_TIMEOUT_SECONDS <= 30)) || {
-  echo 'auth-refresh-error: broker status timeout must be between 1 and 30 seconds' >&2
+  && ((BROKER_STATUS_TIMEOUT_SECONDS <= 120)) || {
+  echo 'auth-refresh-error: broker status timeout must be between 1 and 120 seconds' >&2
   exit 1
 }
 


### PR DESCRIPTION
## What

social-monitor-rolling.service repeatedly failed at capture:durable-reader-summary with
`Durable reader summary capture failed: Safe execution has no attempts remaining.`

## Root cause (confirmed, not hypothesis)

The message is misleading. The account itself was fine to *try* — the real problem is
upstream: `refresh-codex-auth.sh` calls `subscription-runtime-codex-goal tool
codex_goal_accounts_status` to check pool health, wrapped in a hardcoded
`timeout 30`. With 18 accounts in the live pool, that status check now takes 40-50s.
When it exceeds 30s, the script falls back to reusing whatever auth was already live
instead of rotating - so a rate-limited/unavailable account just keeps getting reused,
consuming its single safe-execution attempt every run.

Verified directly: running `codex_goal_accounts_status` with a 60s timeout returns
correctly (`ok: true`) in ~40-50s for the current 18-account pool.

## Fix

Minimal - raise the timeout ceiling, no new mechanism. Production default and the
validation ceiling both go from 30s to 120s (comfortable margin over the observed
40-50s for the current pool; test-mode env override behavior is unchanged).

## Verified

- `bash ops/deploy/refresh-codex-auth.test.sh` passes.
- `shellcheck -S warning` clean.
- Live-validated on production host: temporarily bumped this same value, ran a real
  pool rotation (selected account-q), reverted the script back to the committed 30s
  before this PR existed, then this PR makes that bump permanent and reviewed.

Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the production broker status timeout allowance to up to 120 seconds.
  - Updated validation messaging to reflect the expanded timeout range.
  - Preserved the existing 30-second default in test mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->