### PR TITLE
fix(summary): name the exact candidate/citation mismatch behind a Top-array rejection

### DIFF
--- a/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.spec.ts
+++ b/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.spec.ts
@@ -322,6 +322,57 @@ describe("ReaderSummaryPublicationPolicy Promotion V2 authority", () => {
     });
   });
 
+  it("names the length mismatch when the Top array is short an entry", () => {
+    const fixture = promotionPublicationFixture(25);
+    const snapshot = fixture.artifact.toSnapshot();
+    const artifactWithoutBoundaryCard = withUncheckedPublicationCards(
+      fixture.artifact,
+      { topReads: snapshot.content!.topReads.slice(0, 1) },
+    );
+    expect(
+      policy.evaluate({
+        artifact: artifactWithoutBoundaryCard,
+        evidence: fixture.evidence,
+      }),
+    ).toMatchObject({
+      status: "rejected",
+      findings: expect.arrayContaining([
+        expect.objectContaining({
+          reason: expect.stringContaining("lengths differ: actual=1 expected=2"),
+        }),
+      ]),
+    });
+  });
+
+  it("names the exact candidate and citation mismatch when a Top card's citations diverge", () => {
+    const fixture = promotionPublicationFixture(25);
+    const snapshot = fixture.artifact.toSnapshot();
+    const divergentCitations = {
+      ...snapshot.content!.topReads[0]!,
+      citationIds: ["citation-not-in-oracle"],
+    };
+    expect(
+      policy.evaluate({
+        artifact: withUncheckedPublicationCards(fixture.artifact, {
+          topReads: [divergentCitations, ...snapshot.content!.topReads.slice(1)],
+          selectedPosts: snapshot.content!.selectedPosts,
+        }),
+        evidence: fixture.evidence,
+      }),
+    ).toMatchObject({
+      status: "rejected",
+      findings: expect.arrayContaining([
+        expect.objectContaining({
+          reason: expect.stringContaining(
+            "[index=0 actualCandidateId=feed-publication-1 expectedCandidateId=feed-publication-1" +
+            " actualTier=top expectedTier=top" +
+            " actualCitationIds=citation-not-in-oracle expectedCitationIds=citation-publication-1]",
+          ),
+        }),
+      ]),
+    });
+  });
+
   it.each([
     ["tier", { promotionTier: "additional" }],
     ["policy version", { promotionPolicyVersion: "reader_post_promotion.v0" }],

--- a/libs/summary/domain/policies/reader-summary-promotion-publication-verification.ts
+++ b/libs/summary/domain/policies/reader-summary-promotion-publication-verification.ts
@@ -49,10 +49,16 @@ export const promotionPublicationFindings = (params: {
     addFinding("Reader summary promoted posts exceed the immutable promotion caps.");
   }
   if (!sameOrderedOraclePromotions(params.actualTop, params.expectedTop)) {
-    addFinding("Reader summary Top array differs in order or membership from the authoritative promotion verification.");
+    addFinding(
+      `Reader summary Top array differs in order or membership from the authoritative promotion verification. ${
+        describeOraclePromotionDiff(params.actualTop, params.expectedTop)}`,
+    );
   }
   if (!sameOrderedOraclePromotions(actualAdditional, params.expectedAdditional)) {
-    addFinding("Reader summary Additional array differs in order or membership from the authoritative promotion verification.");
+    addFinding(
+      `Reader summary Additional array differs in order or membership from the authoritative promotion verification. ${
+        describeOraclePromotionDiff(actualAdditional, params.expectedAdditional)}`,
+    );
   }
   if (new Set([...params.actualTop, ...params.actualSelected].map((item) =>
     item.promotionCanonicalIdentity)).size !==
@@ -73,6 +79,34 @@ const sameOrderedOraclePromotions = (
     item.citationIds.every((citationId, citationIndex) =>
       citationId === oracle.citationIds[citationIndex]);
 });
+
+/** Internal identifiers only -- never raw model prose or evidence content. */
+const describeOraclePromotionDiff = (
+  actual: readonly TopRead[], expected: readonly PromotionOracleCard[],
+): string => {
+  if (actual.length !== expected.length) {
+    return `[lengths differ: actual=${actual.length} expected=${expected.length}]`;
+  }
+  const mismatches = actual.flatMap((item, index) => {
+    const oracle = expected[index]!;
+    if (item.promotionCandidateId === oracle.candidateId &&
+        item.promotionCanonicalIdentity === oracle.canonicalIdentity &&
+        item.promotionTier === oracle.placement &&
+        item.citationIds.length === oracle.citationIds.length &&
+        item.citationIds.every((citationId, citationIndex) =>
+          citationId === oracle.citationIds[citationIndex])) {
+      return [];
+    }
+    return [`[index=${index}` +
+      ` actualCandidateId=${item.promotionCandidateId}` +
+      ` expectedCandidateId=${oracle.candidateId}` +
+      ` actualTier=${item.promotionTier}` +
+      ` expectedTier=${oracle.placement}` +
+      ` actualCitationIds=${item.citationIds.join(",")}` +
+      ` expectedCitationIds=${oracle.citationIds.join(",")}]`];
+  });
+  return mismatches.join(" ");
+};
 
 const canonicalPublicationIdentity = (value: string | undefined): string => {
   if (value === undefined) return "";


### PR DESCRIPTION
## Summary
- The pre-publish quality gate is correctly and fail-closed rejecting today's reader summary, but only with a generic "Top array differs in order or membership" message with no detail.
- Two independent Reader Promotion V2 code paths compute a top-read's `citationIds` from the same editorial slate differently: the projection that lands in the published artifact re-runs the full independent same-story support policy per candidate (`reader-post-promotion-editorial-slate-selection.ts`), while the publication oracle derives citations from raw story-cluster membership (`reader-summary-promotion-publication-oracle.ts`). It is not yet established from reading the code alone whether this divergence is a real bug or intentional, so this PR does not change which side wins - it only makes the next rejection self-diagnosing.
- No behavior change to the pass/fail decision: still rejects exactly the same cases, just with the specific index/candidateId/tier/citationIds spelled out on both sides.

## Test plan
- [x] `npx jest reader-summary-promotion-publication-oracle.spec.ts` - 19/19 passing, including two new tests covering the length-mismatch and per-index citation-mismatch diagnostic text
- [x] `npx tsc --noEmit -p tsconfig.json` clean (after `prisma generate`)
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Promotion verification findings now provide detailed explanations when Top or Additional entries differ from the authoritative results.
  - Reports identify length discrepancies and mismatches in candidate, tier, and citation details, making validation failures easier to understand.
- **Tests**
  - Added coverage for shortened Top results and citation mismatches to ensure precise rejection messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->