### PR TITLE
fix(summary): qualify support before materializing promotion slate

### DIFF
--- a/libs/summary/adapters/evidence/reader-summary-editorial-slate.ts
+++ b/libs/summary/adapters/evidence/reader-summary-editorial-slate.ts
@@ -1,3 +1,5 @@
+import { readerPostPromotionEvidenceInput } from "../../domain/services/reader-post-promotion-evidence-input";
+import { isEligibleIndependentSupport } from "../../domain/services/reader-post-promotion-independent-support";
 import {
   rankReaderPromotionV2,
   type AdmittedReaderPromotionV2,
@@ -6,7 +8,6 @@ import {
 
 import {
   READER_SUMMARY_EDITORIAL_SLATE_VERSION,
-  readerPostProviderFamily,
   type ReaderSummaryEditorialPlacement,
   type ReaderSummaryEditorialSlate,
   type ReaderSummaryEditorialSlateEntry,
@@ -211,8 +212,16 @@ export const materializeReaderSummaryEditorialSlate = (params: {
       .filter((item) =>
         isEligibleReaderSummarySameStorySupport(item, params.selection))
       .filter((item) =>
-        readerPostProviderFamily(item.providerKey) !==
-          readerPostProviderFamily(lead.providerKey),
+        // Citations are generated from these backend bindings after selection.
+        // This token checks pre-citation eligibility only; it is never emitted.
+        isEligibleIndependentSupport(
+          readerPostPromotionEvidenceInput(
+            item, params.selection.sourceWindow, item.feedItemId, true,
+          ),
+          readerPostPromotionEvidenceInput(
+            lead, params.selection.sourceWindow, lead.feedItemId, true,
+          ),
+        ),
       )
       .sort((left, right) => left.feedItemId.localeCompare(right.feedItemId));
     const members = [lead, ...support];

--- a/libs/summary/adapters/evidence/reader-summary-support-citation-parity.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-support-citation-parity.spec.ts
@@ -16,12 +16,20 @@ type Change = (item: SummaryEvidenceItem) => SummaryEvidenceItem;
 const facts = (overrides: Partial<NonNullable<SummaryEvidenceItem["promotionFacts"]>>): Change =>
   (item) => ({ ...item, promotionFacts: { ...item.promotionFacts!, ...overrides } });
 
-const fixture = (change: Change = (item) => item) => {
+type Placement = "top" | "additional";
+const fixture = (
+  change: Change = (item) => item,
+  placement: Placement = "top",
+  omitSupport = false,
+) => {
   const base = dailyEvidenceSelection(50);
   const evidence = base.selectedEvidence.map((item) => ({
     ...item,
     promotionFacts: {
       ...item.promotionFacts!, authorityAttestation: trust,
+      freshnessProvenance: { ...item.promotionFacts!.freshnessProvenance!,
+        exactIngestionCutoff: "2026-07-05T09:00:00.000000Z",
+      },
       engagementAuthority: {
         observedAt: item.observedAt, regressionState: "stable" as const,
       },
@@ -32,22 +40,39 @@ const fixture = (change: Change = (item) => item) => {
     ...base.clusters[0]!, duplicateFeedItemIds: [evidence[1]!.feedItemId],
     providerKeys: ["reddit", "hacker-news"],
   };
+  // Eight stronger, distinct stories fill Top through the real composer.
+  // The target remains a representative and naturally overflows to Additional.
+  const fillers = placement === "additional" ? Array.from({ length: 8 }, (_, index) => {
+    const lead = evidence[1]!;
+    return { ...lead, feedItemId: `filler-${index}`, sourceItemId: `source-filler-${index}`,
+      canonicalUrl: `https://example.test/filler-${index}`,
+      promotionFacts: { ...lead.promotionFacts!,
+        canonicalIdentity: `story:filler-${index}`,
+        metrics: { provider: "hacker_news" as const, points: 500 },
+      },
+    };
+  }) : [];
+  const clusters = [cluster, ...fillers.map((item) => storyCluster(item.feedItemId, [item]))];
   const selection = {
-    ...base, editorialSlate: undefined, selectedEvidence: evidence,
-    clusters: [cluster],
-    sourceWindow: { ...base.sourceWindow, storyClusterIds: [cluster.id] },
+    ...base, editorialSlate: undefined,
+    selectedEvidence: [...(omitSupport ? evidence.slice(1) : evidence), ...fillers],
+    clusters,
+    sourceWindow: { ...base.sourceWindow, storyClusterIds: clusters.map((item) => item.id) },
   };
   const slate = composeReaderSummaryEditorialSlate({ selection });
-  const materialized = admitReaderPostPromotionEvidence(
-    materializeReaderSummaryEditorialSlate({ selection, slate }),
-  );
+  assert.deepEqual(slate[placement].map((entry) => entry.candidateId), ["feed-publication-2"]);
+  assert.deepEqual(slate.top.map((entry) => entry.candidateId), placement === "top"
+    ? ["feed-publication-2"] : fillers.map((item) => item.feedItemId));
+  assert.equal(slate.additional.length, placement === "additional" ? 1 : 0);
+  const upstream = materializeReaderSummaryEditorialSlate({ selection, slate });
+  const materialized = admitReaderPostPromotionEvidence(upstream);
   const citations = materialized.selectedEvidence.map((item, index) => ({
     citationId: `fixture-citation-${index}`, feedItemId: item.feedItemId,
     sourceItemId: item.sourceItemId, providerKey: item.providerKey,
     canonicalUrl: item.canonicalUrl, field: "canonicalUrl" as const,
   }));
   return {
-    evidence: materialized.selectedEvidence, clusters: materialized.clusters,
+    upstream, placement, evidence: materialized.selectedEvidence, clusters: materialized.clusters,
     citations, sourceWindow: materialized.sourceWindow, editorialSlate: slate,
   };
 };
@@ -57,20 +82,58 @@ const assertParity = (params: ReturnType<typeof fixture>, retained: boolean) => 
     attestationBinding: { artifactId: "fixture-artifact", sourceWindow: params.sourceWindow },
   });
   const expected = readerSummaryPromotionPublicationOracle(params);
-  assert.deepEqual(params.editorialSlate.orderedCandidateIds, ["feed-publication-2"]);
-  assert.deepEqual(params.clusters[0]!.duplicateFeedItemIds,
+  const target = params.placement === "top" ? actual.topReads[0]! : actual.additionalPosts[0]!;
+  const leadIds = params.editorialSlate.orderedCandidateIds;
+  const evidenceIds = [...leadIds, ...(retained ? ["feed-publication-1"] : [])].sort();
+  for (const materialized of [params.upstream, {
+    selectedEvidence: params.evidence, clusters: params.clusters, sourceWindow: params.sourceWindow,
+  }]) {
+    assert.deepEqual(materialized.selectedEvidence.map((item) => item.feedItemId).sort(), evidenceIds);
+    assert.deepEqual([...materialized.sourceWindow.selectedFeedItemIds].sort(), evidenceIds);
+    const cluster = materialized.clusters.find((item) =>
+      item.representativeFeedItemId === "feed-publication-2")!;
+    assert.deepEqual(cluster.duplicateFeedItemIds, retained ? ["feed-publication-1"] : []);
+    assert.deepEqual(cluster.providerKeys, retained ? ["hacker-news", "reddit"] : ["hacker-news"]);
+  }
+  for (const [cards, entries] of [[actual.topReads, expected.top],
+    [actual.additionalPosts, expected.additional]] as const) {
+    assert.deepEqual(cards.map((card) => ({
+      candidateId: card.promotionCandidateId,
+      canonicalIdentity: card.promotionCanonicalIdentity,
+      placement: card.promotionTier, citationIds: card.citationIds,
+    })), entries);
+    for (const card of cards) assert.deepEqual(card.citationIds, [...card.citationIds].sort());
+  }
+  const targetIds = ["feed-publication-2", ...(retained ? ["feed-publication-1"] : [])];
+  assert.deepEqual(target.citationIds, params.citations.filter((citation) =>
+    targetIds.includes(citation.feedItemId)).map((citation) => citation.citationId).sort());
+  assert.deepEqual(actual.attestedEvidenceFacts.map((item) => item.candidateId).sort(), evidenceIds);
+  assert.equal(actual.attestations.length, leadIds.length);
+  const attestation = actual.attestations.find((item) => item.candidateId === "feed-publication-2")!;
+  assert.equal(attestation.placement, params.placement);
+  assert.equal(attestation.providerCount, retained ? 2 : 1);
+  assert.equal(attestation.confidence, target.confidence.score);
+  assert.deepEqual(attestation.citationIds, target.citationIds);
+  assert.deepEqual(attestation.supportFacts, actual.attestedEvidenceFacts.filter((item) =>
+    item.candidateId === "feed-publication-1"));
+  assert.deepEqual(attestation.supportFacts.map((item) => item.candidateId),
     retained ? ["feed-publication-1"] : []);
-  assert.equal(params.evidence.length, retained ? 2 : 1);
-  assert.deepEqual(actual.topReads[0]!.citationIds,
-    retained ? ["fixture-citation-0", "fixture-citation-1"] : ["fixture-citation-0"]);
-  assert.deepEqual(actual.topReads.map((card) => ({
-    candidateId: card.promotionCandidateId,
-    canonicalIdentity: card.promotionCanonicalIdentity,
-    placement: card.promotionTier, citationIds: card.citationIds,
-  })), expected.top);
-  assert.equal(actual.attestedEvidenceFacts.length, retained ? 2 : 1);
-  assert.equal(actual.topReads[0]!.confirmedProviderKeys.length, retained ? 2 : 1);
-  if (!retained) assert.equal(actual.topReads[0]!.confidence.score, 0.42);
+  if (retained) {
+    const support = attestation.supportFacts[0]!;
+    assert.deepEqual(support.authorityAttestation, trust);
+    assert.equal(support.citationValid, true);
+    assert.equal(support.safetyValid, true);
+    assert.equal(support.freshnessValid, true);
+  }
+  assert.deepEqual(target.confirmedProviderKeys, retained ? ["hacker-news", "reddit"] : ["hacker-news"]);
+  if (!retained) {
+    const baselineParams = fixture(undefined, params.placement, true);
+    const baseline = buildReaderPostPromotionProjection(baselineParams);
+    assert.deepEqual(actual.topReads, baseline.topReads);
+    assert.deepEqual(actual.additionalPosts, baseline.additionalPosts);
+    assert.deepEqual(actual.attestedEvidenceFacts, baseline.attestedEvidenceFacts);
+    assert.equal(target.confidence.score, 0.42);
+  }
   assert.deepEqual(promotionPublicationFindings({
     actualTop: actual.topReads, actualSelected: actual.additionalPosts,
     expectedTop: expected.top, expectedAdditional: expected.additional,
@@ -79,6 +142,7 @@ const assertParity = (params: ReturnType<typeof fixture>, retained: boolean) => 
 };
 
 const invalidSupport: readonly (readonly [string, Change])[] = [
+  ["missing promotion facts", (item) => ({ ...item, promotionFacts: undefined })],
   ["missing catalog authority", facts({ authorityAttestation: undefined })],
   ["untrusted catalog authority", facts({ authorityAttestation: { ...trust, trusted: false } })],
   ["producer claimed authority", facts({ authorityAttestation: {
@@ -114,24 +178,48 @@ const invalidSupport: readonly (readonly [string, Change])[] = [
   ),
 ];
 
-describe("V2 upstream support qualification", () => {
+describe.each<Placement>(["top", "additional"])("V2 upstream %s support qualification", (placement) => {
   for (const [label, change] of invalidSupport) {
-    it(`excludes ${label} before publication`, () => assertParity(fixture(change), false));
+    it(`excludes ${label} before publication`, () => assertParity(fixture(change, placement), false));
   }
-  it("retains qualified catalog support", () => assertParity(fixture(), true));
-  it("keeps the independent oracle rejecting missing support citations", () => {
-    const params = fixture();
-    const actual = buildReaderPostPromotionProjection({ ...params,
-    attestationBinding: { artifactId: "fixture-artifact", sourceWindow: params.sourceWindow },
+  it("retains qualified catalog support", () => assertParity(fixture(undefined, placement), true));
+  it.each([
+    ["minus one microsecond", "2026-07-05T08:59:59.999999Z", true],
+    ["equal", "2026-07-05T09:00:00.000000Z", true],
+    ["plus one microsecond", "2026-07-05T09:00:00.000001Z", false],
+  ] as const)("observed at cutoff %s with matching exact cutoff provenance", (_label, observedAt, retained) => {
+    const change: Change = (item) => ({ ...item, observedAt: new Date(observedAt),
+      promotionFacts: { ...item.promotionFacts!,
+        engagementAuthority: { observedAt: new Date(observedAt), regressionState: "stable" },
+        freshnessProvenance: {
+          status: "observed", publishedAt: item.publishedAt, observedAt: new Date(observedAt),
+          ingestionCutoff: new Date("2026-07-05T09:00:00.000Z"),
+          exactPublishedAt: "2026-07-05T08:00:00.000000Z",
+          exactObservedAt: observedAt, exactIngestionCutoff: "2026-07-05T09:00:00.000000Z",
+        },
+      },
+    });
+    assertParity(fixture(change, placement), retained);
   });
+  it("keeps the independent oracle rejecting missing support citations", () => {
+    const params = fixture(undefined, placement);
+    assertParity(params, true);
+    const actual = buildReaderPostPromotionProjection(params);
     const expected = readerSummaryPromotionPublicationOracle(params);
+    const supportCitationId = params.citations.find((citation) =>
+      citation.feedItemId === "feed-publication-1")!.citationId;
+    const removeSupport = (cards: typeof actual.topReads) => cards.map((card) => ({
+      ...card, citationIds: card.citationIds.filter((id) => id !== supportCitationId),
+    }));
     const findings = promotionPublicationFindings({
-      actualTop: actual.topReads.map((card) => ({ ...card, citationIds: ["fixture-citation-0"] })),
-      actualSelected: actual.additionalPosts,
+      actualTop: placement === "top" ? removeSupport(actual.topReads) : actual.topReads,
+      actualSelected: placement === "additional" ? removeSupport(actual.additionalPosts) : actual.additionalPosts,
       expectedTop: expected.top, expectedAdditional: expected.additional,
       expectedPolicyVersion: "reader_post_promotion.v2",
     });
-    assert(findings.some((finding) => finding.reason.includes("Top array differs")));
+    assert(findings.some((finding) => finding.reason.includes(
+      placement === "top" ? "Top array differs" : "Additional array differs",
+    )));
   });
 });
 

--- a/libs/summary/adapters/evidence/reader-summary-support-citation-parity.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-support-citation-parity.spec.ts
@@ -1,0 +1,183 @@
+import { admitReaderPostPromotionEvidence } from "../../domain/services/reader-post-promotion-evidence-admission";
+import { selection, storyCluster, xEvidence, redditEvidence, hackerNewsEvidence } from "./reader-summary-editorial-slate.spec-support";
+import { strict as assert } from "node:assert";
+import type { SummaryEvidenceItem } from "../../domain/value-objects/summary-evidence-item";
+import { dailyEvidenceSelection } from "../../domain/policies/reader-summary-publication-evidence-test-fixtures";
+import { composeReaderSummaryEditorialSlate, materializeReaderSummaryEditorialSlate } from "./reader-summary-editorial-slate";
+import { buildReaderPostPromotionProjection } from "../../domain/services/reader-post-promotion-projection";
+import { readerSummaryPromotionPublicationOracle } from "../../domain/policies/reader-summary-promotion-publication-oracle";
+import { promotionPublicationFindings } from "../../domain/policies/reader-summary-promotion-publication-verification";
+
+const trust = {
+  status: "attested" as const, trusted: true, official: false,
+  attestedBy: "source_catalog" as const,
+};
+type Change = (item: SummaryEvidenceItem) => SummaryEvidenceItem;
+const facts = (overrides: Partial<NonNullable<SummaryEvidenceItem["promotionFacts"]>>): Change =>
+  (item) => ({ ...item, promotionFacts: { ...item.promotionFacts!, ...overrides } });
+
+const fixture = (change: Change = (item) => item) => {
+  const base = dailyEvidenceSelection(50);
+  const evidence = base.selectedEvidence.map((item) => ({
+    ...item,
+    promotionFacts: {
+      ...item.promotionFacts!, authorityAttestation: trust,
+      engagementAuthority: {
+        observedAt: item.observedAt, regressionState: "stable" as const,
+      },
+    },
+  }));
+  evidence[0] = change(evidence[0]!) as typeof evidence[number];
+  const cluster = {
+    ...base.clusters[0]!, duplicateFeedItemIds: [evidence[1]!.feedItemId],
+    providerKeys: ["reddit", "hacker-news"],
+  };
+  const selection = {
+    ...base, editorialSlate: undefined, selectedEvidence: evidence,
+    clusters: [cluster],
+    sourceWindow: { ...base.sourceWindow, storyClusterIds: [cluster.id] },
+  };
+  const slate = composeReaderSummaryEditorialSlate({ selection });
+  const materialized = admitReaderPostPromotionEvidence(
+    materializeReaderSummaryEditorialSlate({ selection, slate }),
+  );
+  const citations = materialized.selectedEvidence.map((item, index) => ({
+    citationId: `fixture-citation-${index}`, feedItemId: item.feedItemId,
+    sourceItemId: item.sourceItemId, providerKey: item.providerKey,
+    canonicalUrl: item.canonicalUrl, field: "canonicalUrl" as const,
+  }));
+  return {
+    evidence: materialized.selectedEvidence, clusters: materialized.clusters,
+    citations, sourceWindow: materialized.sourceWindow, editorialSlate: slate,
+  };
+};
+
+const assertParity = (params: ReturnType<typeof fixture>, retained: boolean) => {
+  const actual = buildReaderPostPromotionProjection({ ...params,
+    attestationBinding: { artifactId: "fixture-artifact", sourceWindow: params.sourceWindow },
+  });
+  const expected = readerSummaryPromotionPublicationOracle(params);
+  assert.deepEqual(params.editorialSlate.orderedCandidateIds, ["feed-publication-2"]);
+  assert.deepEqual(params.clusters[0]!.duplicateFeedItemIds,
+    retained ? ["feed-publication-1"] : []);
+  assert.equal(params.evidence.length, retained ? 2 : 1);
+  assert.deepEqual(actual.topReads[0]!.citationIds,
+    retained ? ["fixture-citation-0", "fixture-citation-1"] : ["fixture-citation-0"]);
+  assert.deepEqual(actual.topReads.map((card) => ({
+    candidateId: card.promotionCandidateId,
+    canonicalIdentity: card.promotionCanonicalIdentity,
+    placement: card.promotionTier, citationIds: card.citationIds,
+  })), expected.top);
+  assert.equal(actual.attestedEvidenceFacts.length, retained ? 2 : 1);
+  assert.equal(actual.topReads[0]!.confirmedProviderKeys.length, retained ? 2 : 1);
+  if (!retained) assert.equal(actual.topReads[0]!.confidence.score, 0.42);
+  assert.deepEqual(promotionPublicationFindings({
+    actualTop: actual.topReads, actualSelected: actual.additionalPosts,
+    expectedTop: expected.top, expectedAdditional: expected.additional,
+    expectedPolicyVersion: "reader_post_promotion.v2",
+  }), []);
+};
+
+const invalidSupport: readonly (readonly [string, Change])[] = [
+  ["missing catalog authority", facts({ authorityAttestation: undefined })],
+  ["untrusted catalog authority", facts({ authorityAttestation: { ...trust, trusted: false } })],
+  ["producer claimed authority", facts({ authorityAttestation: {
+    ...trust, attestedBy: "producer",
+  } as unknown as typeof trust })],
+  ["malformed official flag", facts({ authorityAttestation: {
+    ...trust, official: "false",
+  } as unknown as typeof trust })],
+  ["unattested authority", facts({ authorityAttestation: {
+    ...trust, status: "unattested",
+  } as unknown as typeof trust })],
+  ["missing metrics", facts({ metrics: undefined, metricsState: "missing" })],
+  ["conflicting metrics", facts({ metrics: { provider: "hacker_news", points: 100 } })],
+  ["low metrics", facts({ metrics: { provider: "reddit", score: 1 } })],
+  ["invalid safety", facts({ safetyValid: false })],
+  ["invalid freshness", facts({ freshnessValid: false })],
+  ["invalid quality", (item) => ({ ...item, contentQuality: {
+    ...item.contentQuality!, eligibleForTopRead: false,
+  } })],
+  ["unavailable source", (item) => ({
+    ...item, title: "selected evidence", bodyPreview: "selected evidence", sourceText: undefined,
+  })],
+  ...["2026-07-05T08:59:59.999999Z", "2026-07-05T09:00:00.000001Z"].map(
+    (cutoff): readonly [string, Change] => [`mismatched exact cutoff ${cutoff}`, (item) => ({
+      ...item, promotionFacts: { ...item.promotionFacts!, freshnessProvenance: {
+        status: "observed", publishedAt: item.publishedAt, observedAt: item.observedAt,
+        ingestionCutoff: new Date("2026-07-05T09:00:00.000Z"),
+        exactPublishedAt: "2026-07-05T08:00:00.000000Z",
+        exactObservedAt: "2026-07-05T08:05:00.000000Z",
+        exactIngestionCutoff: cutoff,
+      } },
+    })],
+  ),
+];
+
+describe("V2 upstream support qualification", () => {
+  for (const [label, change] of invalidSupport) {
+    it(`excludes ${label} before publication`, () => assertParity(fixture(change), false));
+  }
+  it("retains qualified catalog support", () => assertParity(fixture(), true));
+  it("keeps the independent oracle rejecting missing support citations", () => {
+    const params = fixture();
+    const actual = buildReaderPostPromotionProjection({ ...params,
+    attestationBinding: { artifactId: "fixture-artifact", sourceWindow: params.sourceWindow },
+  });
+    const expected = readerSummaryPromotionPublicationOracle(params);
+    const findings = promotionPublicationFindings({
+      actualTop: actual.topReads.map((card) => ({ ...card, citationIds: ["fixture-citation-0"] })),
+      actualSelected: actual.additionalPosts,
+      expectedTop: expected.top, expectedAdditional: expected.additional,
+      expectedPolicyVersion: "reader_post_promotion.v2",
+    });
+    assert(findings.some((finding) => finding.reason.includes("Top array differs")));
+  });
+});
+
+
+describe("V2 support at editorial capacity", () => {
+  it("preserves Top and Additional order and trusted support across permutations", () => {
+    const leads = Array.from({ length: 9 }, (_, index) => [
+      xEvidence(`x-${index}`, 500), hackerNewsEvidence(`hn-${index}`, 500),
+    ]).flat();
+    const groups = leads.map((lead) => [lead, facts({ authorityAttestation: trust })(
+      redditEvidence(`support-${lead.feedItemId}`, 50),
+    )]);
+    const source = selection(groups.flat(), groups.map((items, index) =>
+      storyCluster(`capacity-${index}`, items)));
+    const slate = composeReaderSummaryEditorialSlate({ selection: source });
+    assert.equal(slate.top.length, 8);
+    assert.equal(slate.additional.length, 8);
+    const outputs = [source, { ...source, selectedEvidence: [...source.selectedEvidence].reverse() }]
+      .map((input) => {
+        const materialized = admitReaderPostPromotionEvidence(materializeReaderSummaryEditorialSlate({
+          selection: input, slate: composeReaderSummaryEditorialSlate({ selection: input }),
+        }));
+        const params = {
+          evidence: materialized.selectedEvidence, clusters: materialized.clusters,
+          sourceWindow: materialized.sourceWindow, editorialSlate: materialized.editorialSlate!,
+          citations: materialized.selectedEvidence.map((item, index) => ({
+            citationId: `c${index + 1}`, feedItemId: item.feedItemId,
+            sourceItemId: item.sourceItemId, providerKey: item.providerKey,
+            canonicalUrl: item.canonicalUrl, field: "canonicalUrl" as const,
+          })),
+          attestationBinding: { artifactId: "capacity-artifact", sourceWindow: materialized.sourceWindow },
+        };
+        const actual = buildReaderPostPromotionProjection(params);
+        const expected = readerSummaryPromotionPublicationOracle(params);
+        assert.equal(actual.attestations.length, 16);
+        for (const [cards, entries] of [[actual.topReads, expected.top],
+          [actual.additionalPosts, expected.additional]] as const) {
+          assert.deepEqual(cards.map((card) => ({
+            candidateId: card.promotionCandidateId,
+            canonicalIdentity: card.promotionCanonicalIdentity,
+            placement: card.promotionTier, citationIds: card.citationIds,
+          })), entries);
+          assert(cards.every((card) => card.citationIds.length === 2));
+        }
+        return { top: expected.top, additional: expected.additional };
+      });
+    assert.deepEqual(outputs[0], outputs[1]);
+  });
+});

--- a/libs/summary/adapters/evidence/relevance-reader-summary-fresh-relation-composition.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-fresh-relation-composition.spec.ts
@@ -57,7 +57,7 @@ const selectFreshPair = (
   hackerNewsTitle: string,
 ) => new RelevanceReaderSummaryEvidenceSelector(
   ranker([
-    ranked("x", "x-twitter", 2, xTitle),
+    syntheticCatalogRanked("x", "x-twitter", 2, xTitle),
     ranked("hn", "hacker-news", 1.9, hackerNewsTitle),
   ]),
   emptyFeedRepository(),
@@ -148,3 +148,24 @@ const ranked = (
     reason: "Strong fixture evidence",
   },
 });
+
+// Explicit synthetic post-catalog output; ordinary ranked fixtures remain untrusted.
+const syntheticCatalogRanked = (
+  id: string,
+  providerKey: "x-twitter" | "hacker-news",
+  score: number,
+  title: string,
+): RankedFeedItemView => {
+  const item = ranked(id, providerKey, score, title);
+  return {
+    ...item,
+    providerMetadata: {
+      ...item.providerMetadata,
+      promotionAuthority: {
+        official: false,
+        trusted: true,
+        attestedBy: "source_catalog",
+      },
+    },
+  };
+};

--- a/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-verification.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-verification.spec.ts
@@ -1,3 +1,4 @@
+import { buildReaderPostPromotionProjection } from "../../domain/services/reader-post-promotion-projection";
 import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
 import type { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
 import type { RankedFeedItemView } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.result";
@@ -45,7 +46,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       ranker([
         ranked("hn", "hacker-news", 2),
-        ranked("rss", "x-twitter", 1.9),
+        syntheticCatalogRanked("rss", "x-twitter", 1.9),
       ]),
       emptyFeedRepository(),
       { now: () => now },
@@ -203,7 +204,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       ranker([
         ranked("hn", "hacker-news", 2.1),
-        ranked("rss", "x-twitter", 2),
+        syntheticCatalogRanked("rss", "x-twitter", 2),
         {
           ...ranked("reddit", "reddit", 1.9),
           title:
@@ -341,7 +342,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
       title: "Database maintenance release notes",
       bodyPreview: "A routine database patch changes backup defaults.",
     };
-    const relatedRss = ranked("rss-related", "x-twitter", 1.9);
+    const relatedRss = syntheticCatalogRanked("rss-related", "x-twitter", 1.9);
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       ranker([hn, unrelatedRss, relatedRss]),
       emptyFeedRepository(),
@@ -607,7 +608,7 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       ranker([
         ranked("hn", "hacker-news", 2),
-        ranked("rss", "x-twitter", 1.9),
+        syntheticCatalogRanked("rss", "x-twitter", 1.9),
       ]),
       emptyFeedRepository(),
       { now: () => now },
@@ -630,6 +631,71 @@ describe("RelevanceReaderSummaryEvidenceSelector story verification", () => {
         }),
       ],
     });
+  });
+});
+
+describe("approved relation selector-to-writer catalog authority", () => {
+  it.each([
+    ["missing authority", undefined, false],
+    ["untrusted catalog", { official: false, trusted: false, attestedBy: "source_catalog" }, false],
+    ["producer claim", { official: false, trusted: true, attestedBy: "producer" }, false],
+    ["trusted non-official catalog", { official: false, trusted: true, attestedBy: "source_catalog" }, true],
+  ] as const)("preserves lead and relation with %s", async (_name, authority, qualified) => {
+    const support = ranked("rss", "x-twitter", 1.9);
+    const selection = await new RelevanceReaderSummaryEvidenceSelector(
+      ranker([
+        ranked("hn", "hacker-news", 2),
+        {
+          ...support,
+          providerMetadata: {
+            ...support.providerMetadata,
+            ...(authority ? { promotionAuthority: authority } : {}),
+          },
+        },
+      ]),
+      emptyFeedRepository(),
+      { now: () => now },
+      new CapturingMetrics(),
+      new ApprovingVerifier(),
+    ).select({
+      tenantId: tenantId("tenant-story-verification"),
+      workspaceId: workspaceId("workspace-story-verification"),
+      scope: { type: "workspace" },
+      period,
+      maxItems: 2,
+    });
+    expect(selection.approvedSameStoryRelations).toEqual([{
+      leftFeedItemId: "hn",
+      rightFeedItemId: "rss",
+      confidence: 0.97,
+    }]);
+    expect(selection.editorialSlate?.orderedCandidateIds).toEqual(["hn"]);
+    expect(selection.clusters).toHaveLength(1);
+    expect(selection.clusters[0]?.providerKeys).toEqual(
+      qualified ? ["hacker-news", "x-twitter"] : ["hacker-news"],
+    );
+    expect(selection.selectedEvidence.map((item) => item.feedItemId)).toEqual(
+      qualified ? ["hn", "rss"] : ["hn"],
+    );
+    const projected = buildReaderPostPromotionProjection({
+      evidence: selection.selectedEvidence,
+      clusters: selection.clusters,
+      sourceWindow: selection.sourceWindow,
+      editorialSlate: selection.editorialSlate,
+      approvedSameStoryRelations: selection.approvedSameStoryRelations,
+      citations: selection.selectedEvidence.map((item) => ({
+        citationId: `cite-${item.feedItemId}`,
+        feedItemId: item.feedItemId,
+        sourceItemId: item.sourceItemId,
+        providerKey: item.providerKey,
+        canonicalUrl: item.canonicalUrl,
+        field: "canonicalUrl" as const,
+      })),
+    });
+    expect(projected.topReads).toHaveLength(1);
+    expect(projected.topReads[0]?.citationIds).toEqual(
+      qualified ? ["cite-hn", "cite-rss"] : ["cite-hn"],
+    );
   });
 });
 
@@ -710,6 +776,26 @@ const ranked = (
     reason: "Strong fixture evidence",
   },
 });
+
+// Explicit synthetic post-catalog output; ordinary ranked fixtures remain untrusted.
+const syntheticCatalogRanked = (
+  id: string,
+  providerKey: string,
+  score: number,
+): RankedFeedItemView => {
+  const item = ranked(id, providerKey, score);
+  return {
+    ...item,
+    providerMetadata: {
+      ...item.providerMetadata,
+      promotionAuthority: {
+        official: false,
+        trusted: true,
+        attestedBy: "source_catalog",
+      },
+    },
+  };
+};
 
 class ApprovingVerifier implements ReaderSummaryStoryRelationVerifierPort {
   readonly inputs: ReaderSummaryStoryRelationVerifierInput[] = [];

--- a/libs/summary/domain/services/reader-post-promotion-editorial-slate-selection.ts
+++ b/libs/summary/domain/services/reader-post-promotion-editorial-slate-selection.ts
@@ -3,17 +3,13 @@ import {
   type SelectedReaderPostPromotion,
 } from "../policies/reader-post-promotion-selection";
 import {
-  evaluateReaderPostPromotion,
-  readerPostPromotionTimestampMicros,
-  readerPostProviderFamily,
   READER_POST_PROMOTION_POLICY_VERSION,
   type ReaderPostPromotionInput,
   type ReaderPostPromotionResult,
 } from "../policies/reader-post-promotion-policy";
 import { readerPostPromotionEvidenceConfidence } from
   "../policies/reader-post-promotion-confidence-policy";
-import { isTrustedReaderPostPromotionSupport } from
-  "../policies/reader-post-promotion-support-authority";
+import { isEligibleIndependentSupport } from "./reader-post-promotion-independent-support";
 import type { ReaderSummaryEditorialSlate } from
   "../value-objects/reader-summary-editorial-slate";
 
@@ -118,56 +114,6 @@ export const readerPostPromotionSelectionFromEditorialSlate = (
     decisions: inputs.map(decision),
   };
 };
-
-/**
- * Slate rematerialization is a second trust boundary: the slate only fixes
- * lead order, it does not attest support. Re-run the complete V1 admission
- * policy for each support candidate with an explicit same-story relation, and
- * require the same exact selection window and source-catalog authority.
- */
-const isEligibleIndependentSupport = (
-  support: ReaderPostPromotionInput,
-  lead: ReaderPostPromotionInput,
-): boolean => {
-  if (!isTrustedReaderPostPromotionSupport(support) ||
-      readerPostProviderFamily(support.provider) === undefined ||
-      readerPostProviderFamily(lead.provider) === undefined ||
-      readerPostProviderFamily(support.provider) ===
-        readerPostProviderFamily(lead.provider) ||
-      !sameSelectionWindow(support, lead)) {
-    return false;
-  }
-  const evaluation = evaluateReaderPostPromotion({
-    ...support,
-    relation: {
-      kind: "same_story",
-      targetCanonicalIdentity: lead.canonicalIdentity,
-      confidence: 1,
-      approved: true,
-    },
-  });
-  return evaluation.decision === "support_only" &&
-    evaluation.authoritativeSameStory;
-};
-
-const sameSelectionWindow = (
-  support: ReaderPostPromotionInput,
-  lead: ReaderPostPromotionInput,
-): boolean => promotionMicros(support, "start") ===
-    promotionMicros(lead, "start") &&
-  promotionMicros(support, "end") === promotionMicros(lead, "end") &&
-  promotionMicros(support, "cutoff") === promotionMicros(lead, "cutoff");
-
-const promotionMicros = (
-  input: ReaderPostPromotionInput,
-  field: "start" | "end" | "cutoff",
-): bigint | undefined => readerPostPromotionTimestampMicros(
-  field === "start"
-    ? input.exactPeriodStart ?? input.periodStart
-    : field === "end"
-      ? input.exactPeriodEnd ?? input.periodEnd
-      : input.exactIngestionCutoff ?? input.ingestionCutoff,
-);
 
 const uniquePromotionStrings = (
   values: readonly string[],

--- a/libs/summary/domain/services/reader-post-promotion-evidence-input.ts
+++ b/libs/summary/domain/services/reader-post-promotion-evidence-input.ts
@@ -1,0 +1,71 @@
+import type { SummaryEvidenceItem, SummarySourceWindow } from "../value-objects/summary-evidence-item";
+import type { ReaderPostPromotionInput } from "../policies/reader-post-promotion-policy";
+import { buildReaderPostPromotionTitle, hasReaderFacingPromotionSource } from "./reader-post-promotion-title";
+import { readerPostPromotionBoundary, readerPostPromotionFreshnessIsValid } from "./reader-post-promotion-freshness";
+
+/** Maps the same evidence facts at producer admission and writer validation. */
+export const readerPostPromotionEvidenceInput = (
+  item: SummaryEvidenceItem,
+  sourceWindow: SummarySourceWindow,
+  citationId: string,
+  citationValid: boolean,
+  clusterId?: string,
+): ReaderPostPromotionInput => {
+  const periodStart = sourceWindow.periodStartedAt ??
+    sourceWindow.startedAt;
+  const periodEnd = sourceWindow.periodEndedAt ??
+    sourceWindow.endedAt;
+  const ingestionCutoff = sourceWindow.ingestionCutoff ?? periodEnd;
+  const quality = item.contentQuality;
+  const facts = item.promotionFacts;
+  return {
+    candidateId: item.feedItemId,
+    provider: item.providerKey,
+    contentKind: facts?.contentKind ?? "unknown",
+    canonicalIdentity: facts?.canonicalIdentity ?? "",
+    citationId,
+    publishedAt: item.publishedAt,
+    observedAt: item.observedAt,
+    ...(facts?.checkedAt === undefined ? {} : { checkedAt: facts.checkedAt }),
+    periodStart,
+    periodEnd,
+    ingestionCutoff,
+    exactPeriodStart: readerPostPromotionBoundary(periodStart),
+    exactPeriodEnd: readerPostPromotionBoundary(periodEnd),
+    exactPublishedAt: facts?.freshnessProvenance?.status === "observed"
+      ? facts.freshnessProvenance.exactPublishedAt
+      : undefined,
+    exactObservedAt: facts?.freshnessProvenance?.status === "observed"
+      ? facts.freshnessProvenance.exactObservedAt
+      : undefined,
+    exactIngestionCutoff: facts?.freshnessProvenance?.status === "observed"
+      ? facts.freshnessProvenance.exactIngestionCutoff
+      : undefined,
+    freshnessValid: readerPostPromotionFreshnessIsValid({
+      facts,
+      publishedAt: item.publishedAt,
+      observedAt: item.observedAt,
+      ingestionCutoff,
+    }),
+    qualityScore: quality?.qualityScore ?? Number.NaN,
+    relevanceScore: quality?.interestRelevanceScore ?? Number.NaN,
+    integrityScore: quality?.engagementIntegrityScore ?? Number.NaN,
+    qualityValid: hasReaderFacingPromotionSource(item) &&
+      quality?.eligibleForSummary === true &&
+      quality.eligibleForTopRead === true &&
+      quality.needsLlmReview === false &&
+      quality.decision !== "downrank" &&
+      quality.decision !== "reject",
+    safetyValid: facts?.safetyValid === true,
+    citationValid,
+    ...(facts?.authorityAttestation === undefined
+      ? {}
+      : { authorityAttestation: facts.authorityAttestation }),
+    metricsState: facts?.metricsState ??
+      (facts?.metrics === undefined ? "missing" : "observed"),
+    ...(facts?.metrics === undefined ? {} : { metrics: facts.metrics }),
+    whyImportant: item.whyImportant.find((reason) => reason.trim().length > 0) ??
+      buildReaderPostPromotionTitle({ lead: item }),
+    clusterId,
+  };
+};

--- a/libs/summary/domain/services/reader-post-promotion-independent-support.ts
+++ b/libs/summary/domain/services/reader-post-promotion-independent-support.ts
@@ -1,0 +1,52 @@
+import { evaluateReaderPostPromotion, readerPostPromotionTimestampMicros, readerPostProviderFamily, type ReaderPostPromotionInput } from "../policies/reader-post-promotion-policy";
+import { isTrustedReaderPostPromotionSupport } from "../policies/reader-post-promotion-support-authority";
+
+/**
+ * The slate fixes lead order, but does not attest support. Both producer
+ * qualification and writer validation run the complete V1 admission
+ * policy for each support candidate with an explicit same-story relation, and
+ * require the same exact selection window and source-catalog authority.
+ */
+export const isEligibleIndependentSupport = (
+  support: ReaderPostPromotionInput,
+  lead: ReaderPostPromotionInput,
+): boolean => {
+  if (!isTrustedReaderPostPromotionSupport(support) ||
+      readerPostProviderFamily(support.provider) === undefined ||
+      readerPostProviderFamily(lead.provider) === undefined ||
+      readerPostProviderFamily(support.provider) ===
+        readerPostProviderFamily(lead.provider) ||
+      !sameSelectionWindow(support, lead)) {
+    return false;
+  }
+  const evaluation = evaluateReaderPostPromotion({
+    ...support,
+    relation: {
+      kind: "same_story",
+      targetCanonicalIdentity: lead.canonicalIdentity,
+      confidence: 1,
+      approved: true,
+    },
+  });
+  return evaluation.decision === "support_only" &&
+    evaluation.authoritativeSameStory;
+};
+
+const sameSelectionWindow = (
+  support: ReaderPostPromotionInput,
+  lead: ReaderPostPromotionInput,
+): boolean => promotionMicros(support, "start") ===
+    promotionMicros(lead, "start") &&
+  promotionMicros(support, "end") === promotionMicros(lead, "end") &&
+  promotionMicros(support, "cutoff") === promotionMicros(lead, "cutoff");
+
+const promotionMicros = (
+  input: ReaderPostPromotionInput,
+  field: "start" | "end" | "cutoff",
+): bigint | undefined => readerPostPromotionTimestampMicros(
+  field === "start"
+    ? input.exactPeriodStart ?? input.periodStart
+    : field === "end"
+      ? input.exactPeriodEnd ?? input.periodEnd
+      : input.exactIngestionCutoff ?? input.ingestionCutoff,
+);

--- a/libs/summary/domain/services/reader-post-promotion-projection.ts
+++ b/libs/summary/domain/services/reader-post-promotion-projection.ts
@@ -28,7 +28,6 @@ import { compactUnique } from "../value-objects/summary-text";
 import { buildMatchedRules } from "./reader-summary-source-lineage";
 import {
   buildReaderPostPromotionTitle,
-  hasReaderFacingPromotionSource,
 } from "./reader-post-promotion-title";
 import {
   buildReaderPostPromotionAttestations,
@@ -39,10 +38,7 @@ import { projectReaderPostPromotionAdmittedClusters } from
 import { readerPostPromotionSelectionFromEditorialSlate } from
   "./reader-post-promotion-editorial-slate-selection";
 import { buildReaderPostPromotionReasons } from "./reader-post-promotion-reasons";
-import {
-  readerPostPromotionBoundary,
-  readerPostPromotionFreshnessIsValid,
-} from "./reader-post-promotion-freshness";
+import { readerPostPromotionEvidenceInput } from "./reader-post-promotion-evidence-input";
 
 export type ReaderPostPromotionProjection = {
   readonly topReads: readonly TopRead[];
@@ -76,65 +72,13 @@ export const buildReaderPostPromotionProjection = (params: {
   const evidenceById = uniqueEvidenceById(params.evidence);
   const citationByFeedItemId = citationByEvidenceId(params.citations);
   const clusterByEvidenceId = clusterMembership(params.clusters);
-  const periodStart = params.sourceWindow.periodStartedAt ??
-    params.sourceWindow.startedAt;
-  const periodEnd = params.sourceWindow.periodEndedAt ??
-    params.sourceWindow.endedAt;
-  const ingestionCutoff = params.sourceWindow.ingestionCutoff ?? periodEnd;
-  const baseInputs = params.evidence.map((item): ReaderPostPromotionInput => {
-    const quality = item.contentQuality;
-    const facts = item.promotionFacts;
+  const baseInputs = params.evidence.map((item) => {
     const citation = citationByFeedItemId.get(item.feedItemId);
-    return {
-      candidateId: item.feedItemId,
-      provider: item.providerKey,
-      contentKind: facts?.contentKind ?? "unknown",
-      canonicalIdentity: facts?.canonicalIdentity ?? "",
-      citationId: citation?.citationId ?? "",
-      publishedAt: item.publishedAt,
-      observedAt: item.observedAt,
-      ...(facts?.checkedAt === undefined ? {} : { checkedAt: facts.checkedAt }),
-      periodStart,
-      periodEnd,
-      ingestionCutoff,
-      exactPeriodStart: readerPostPromotionBoundary(periodStart),
-      exactPeriodEnd: readerPostPromotionBoundary(periodEnd),
-      exactPublishedAt: facts?.freshnessProvenance?.status === "observed"
-        ? facts.freshnessProvenance.exactPublishedAt
-        : undefined,
-      exactObservedAt: facts?.freshnessProvenance?.status === "observed"
-        ? facts.freshnessProvenance.exactObservedAt
-        : undefined,
-      exactIngestionCutoff: facts?.freshnessProvenance?.status === "observed"
-        ? facts.freshnessProvenance.exactIngestionCutoff
-        : undefined,
-      freshnessValid: readerPostPromotionFreshnessIsValid({
-        facts,
-        publishedAt: item.publishedAt,
-        observedAt: item.observedAt,
-        ingestionCutoff,
-      }),
-      qualityScore: quality?.qualityScore ?? Number.NaN,
-      relevanceScore: quality?.interestRelevanceScore ?? Number.NaN,
-      integrityScore: quality?.engagementIntegrityScore ?? Number.NaN,
-      qualityValid: hasReaderFacingPromotionSource(item) &&
-        quality?.eligibleForSummary === true &&
-        quality.eligibleForTopRead === true &&
-        quality.needsLlmReview === false &&
-        quality.decision !== "downrank" &&
-        quality.decision !== "reject",
-      safetyValid: facts?.safetyValid === true,
-      citationValid: citation !== undefined && citationMatchesEvidence(citation, item),
-      ...(facts?.authorityAttestation === undefined
-        ? {}
-        : { authorityAttestation: facts.authorityAttestation }),
-      metricsState: facts?.metricsState ??
-        (facts?.metrics === undefined ? "missing" : "observed"),
-      ...(facts?.metrics === undefined ? {} : { metrics: facts.metrics }),
-      whyImportant: item.whyImportant.find((reason) => reason.trim().length > 0) ??
-        buildReaderPostPromotionTitle({ lead: item }),
-      clusterId: clusterByEvidenceId.get(item.feedItemId),
-    };
+    return readerPostPromotionEvidenceInput(
+      item, params.sourceWindow, citation?.citationId ?? "",
+      citation !== undefined && citationMatchesEvidence(citation, item),
+      clusterByEvidenceId.get(item.feedItemId),
+    );
   });
   const relationByEvidenceId = params.editorialSlate === undefined
     ? promotionRelations({

--- a/scripts/lib/reader-summary-new-input-refresh-selection-audit.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selection-audit.spec.ts
@@ -20,9 +20,23 @@ const job = ReaderSummaryJob.request({ ...query, id: "audit-job", idempotencyKey
 
 describe("private refresh selection receipt", () => {
   it("captures actual ranking, duplicate and capacity exclusions without changing selected/support evidence", async () => {
+    const support = redditEvidence("support", 80, { canonicalIdentity: "story:x-0" });
+    // Only this intended support item models synthetic trusted catalog output.
+    const catalogSupport: SummaryEvidenceItem = {
+      ...support,
+      promotionFacts: {
+        ...support.promotionFacts!,
+        authorityAttestation: {
+          status: "attested",
+          official: false,
+          trusted: true,
+          attestedBy: "source_catalog",
+        },
+      },
+    };
     const result = canonical([
       ...Array.from({ length: 18 }, (_, i) => xEvidence(`x-${i}`, 1_000 - i)),
-      redditEvidence("support", 80, { canonicalIdentity: "story:x-0" }),
+      catalogSupport,
       xEvidence("viral-irrelevant", 9_999_999, { relevanceScore: 0.49 }),
     ]);
     const before = refreshHash(result);


### PR DESCRIPTION
Reader Promotion V2 could materialize a same-story support post rejected by the strict downstream writer, leaving identical Top candidates with different citation lists at publication. Qualify support upstream using the existing writer trust, exact-window, quality and metrics contract. Lead ranking, thresholds and the independent oracle remain unchanged.

Independent review approved 68048452ba95113bbb76d74ad45399f249974947 after completing the Top/Additional negative support matrix. Writer: 290 Jest tests across 8 suites. Independent reviewer: 41 composed tests, targeted semantic typecheck and lint; prior full implementation review ran 266 tests before the test-only expansion.

Current head fa909a1c2017e56bb6c20e72f78d9d63047159e6 integrates reviewed/merged PR #320 from current main without conflicts. All six support source/test files are byte-identical to the approved commit; the additional three usage files come from approved #320. Final combined-head CI on fa909 failed seven positive fixture assertions. Independent audit proved those fixtures lacked the catalog authority already required by the strict writer. Commit 35cc44ea565193a9a74948dcf65e9debb3116025 adds explicit opt-in synthetic catalog authority and four selector-to-writer trust controls; all 95 original assertions remain byte-identical. Independent exact-commit review APPROVE: 245/245 tests in six suites, focused TypeScript/lint and architecture/quality/line-cap checks passed. Every production blob is unchanged from fa909. Final exact-head CI 34170951166 passed all 10 checks on 35cc44ea565193a9a74948dcf65e9debb3116025. No production recovery or incident causality proof is claimed.

Refs #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support citation eligibility so only independently validated, trusted, and properly attested sources are included.
  * Prevented invalid, mismatched, or insufficiently verified support citations from appearing in reader post-promotion results.
  * Preserved support ordering, trust, and cutoff-boundary behavior when editorial capacity is reached.

* **Tests**
  * Added comprehensive coverage for support citation validation, evidence quality, freshness, authority, availability, cutoff handling, and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->