### PR TITLE
fix(agent-runtime): discard conflicting usage and preserve output

### DIFF
--- a/apps/agent-runtime/bin/codex-worker-cli-usage-sanitization.test.mjs
+++ b/apps/agent-runtime/bin/codex-worker-cli-usage-sanitization.test.mjs
@@ -21,7 +21,7 @@ for (const [name, metadata] of cases) {
       warnings: Object.freeze([]), customField: "retained", ...metadata,
       telemetry: Object.freeze({ durationMs: 123, providerField: "retained", ...metadata.telemetry }),
     });
-    const before = structuredClone(original);
+    const before = globalThis.structuredClone(original);
     const events = [];
     const worker = withTrustedCodexWorkerUsage({
       start(...args) { events.push(["start", ...args]); return "started"; },
@@ -55,7 +55,7 @@ test("absent usage and valid equal blocks remain unchanged in meaning", async (t
   const diagnostic = t.mock.method(console, "error", () => {});
   for (const metadata of [{}, { usage }, { telemetry: { usage } }, { usage, telemetry: { usage: { ...usage } } }]) {
     const original = { outputText: "fixture", ...metadata };
-    const before = structuredClone(original);
+    const before = globalThis.structuredClone(original);
     const result = await withTrustedCodexWorkerUsage({ run: async () => original }).run();
     if (Object.keys(metadata).length === 0) assert.equal(result, original);
     else assert.deepEqual(result.telemetry.usage, usage);

--- a/apps/agent-runtime/bin/codex-worker-cli-usage-sanitization.test.mjs
+++ b/apps/agent-runtime/bin/codex-worker-cli-usage-sanitization.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withTrustedCodexWorkerUsage } from "./codex-worker-cli-usage.mjs";
+
+const usage = Object.freeze({ inputTokens: 12, outputTokens: 5, totalTokens: 17 });
+const otherUsage = Object.freeze({ inputTokens: 1, outputTokens: 2, totalTokens: 3 });
+const cases = [
+  ["malformed root", { usage: null }],
+  ["malformed telemetry", { telemetry: { usage: {} } }],
+  ["malformed root with valid telemetry", { usage: {}, telemetry: { usage } }],
+  ["malformed telemetry with valid root", { usage, telemetry: { usage: [] } }],
+  ["conflicting valid blocks", { usage, telemetry: { usage: otherUsage } }],
+];
+
+for (const [name, metadata] of cases) {
+  test(`wrapper removes both usage locations: ${name}`, async (t) => {
+    const diagnostic = t.mock.method(console, "error", () => {});
+    const original = Object.freeze({
+      status: "completed", outputText: "completed fixture output",
+      structuredOutput: Object.freeze({ usage: "model content is not accounting" }),
+      warnings: Object.freeze([]), customField: "retained", ...metadata,
+      telemetry: Object.freeze({ durationMs: 123, providerField: "retained", ...metadata.telemetry }),
+    });
+    const before = structuredClone(original);
+    const events = [];
+    const worker = withTrustedCodexWorkerUsage({
+      start(...args) { events.push(["start", ...args]); return "started"; },
+      seedCodexAuthJsonFile(...args) { events.push(["seed", ...args]); return "seeded"; },
+      async run(...args) { events.push(["run", ...args]); return original; },
+      dispose(...args) { events.push(["dispose", ...args]); return "disposed"; },
+    });
+    assert.equal(worker.start("fixture"), "started");
+    assert.equal(worker.seedCodexAuthJsonFile("fixture-path"), "seeded");
+    const result = await worker.run("fixture-job");
+    assert.equal(worker.dispose("fixture"), "disposed");
+    assert.deepEqual(events, [["start", "fixture"], ["seed", "fixture-path"],
+      ["run", "fixture-job"], ["dispose", "fixture"]]);
+    assert.equal(Object.hasOwn(result, "usage"), false);
+    assert.equal(Object.hasOwn(result.telemetry, "usage"), false);
+    const expected = { ...before, telemetry: { ...before.telemetry } };
+    delete expected.usage;
+    delete expected.telemetry.usage;
+    assert.deepEqual(result, expected);
+    assert.notEqual(result, original);
+    assert.notEqual(result.telemetry, original.telemetry);
+    assert.equal(result.structuredOutput, original.structuredOutput);
+    assert.equal(result.warnings, original.warnings);
+    assert.deepEqual(original, before);
+    assert.deepEqual(diagnostic.mock.calls.map(({ arguments: args }) => args),
+      [["codex-worker-cli-usage: dropping untrusted usage"]]);
+  });
+}
+
+test("absent usage and valid equal blocks remain unchanged in meaning", async (t) => {
+  const diagnostic = t.mock.method(console, "error", () => {});
+  for (const metadata of [{}, { usage }, { telemetry: { usage } }, { usage, telemetry: { usage: { ...usage } } }]) {
+    const original = { outputText: "fixture", ...metadata };
+    const before = structuredClone(original);
+    const result = await withTrustedCodexWorkerUsage({ run: async () => original }).run();
+    if (Object.keys(metadata).length === 0) assert.equal(result, original);
+    else assert.deepEqual(result.telemetry.usage, usage);
+    assert.deepEqual(original, before);
+  }
+  assert.equal(diagnostic.mock.callCount(), 0);
+});
+
+test("unrelated worker and metadata implementation errors propagate without diagnostics", async (t) => {
+  const diagnostic = t.mock.method(console, "error", () => {});
+  // Matching text is deliberately insufficient to identify our validation error.
+  const error = new Error("Malformed trusted Codex usage");
+  for (const run of [
+    async () => { throw error; },
+    async () => ({ get usage() { throw error; } }),
+    async () => ({ usage: { get inputTokens() { throw error; } } }),
+    async () => ({ usage, get outputText() { throw error; } }),
+  ]) {
+    await assert.rejects(withTrustedCodexWorkerUsage({ run }).run(), (caught) => caught === error);
+  }
+  assert.equal(diagnostic.mock.callCount(), 0);
+});
+
+test("malformed root preserves absent or null nonusage telemetry", async (t) => {
+  t.mock.method(console, "error", () => {});
+  for (const metadata of [{}, { telemetry: null }]) {
+    const original = Object.freeze({ outputText: "fixture", usage: null, ...metadata });
+    const result = await withTrustedCodexWorkerUsage({ run: async () => original }).run();
+    assert.deepEqual(result, { outputText: "fixture", ...metadata });
+    assert.equal(original.usage, null);
+  }
+});

--- a/apps/agent-runtime/bin/codex-worker-cli-usage.mjs
+++ b/apps/agent-runtime/bin/codex-worker-cli-usage.mjs
@@ -1,9 +1,11 @@
+class TrustedCodexUsageValidationError extends Error {}
+
 // This boundary accepts runtime worker metadata only, never model-authored JSON.
 export function trustedCodexWorkerResultToCli(result) {
   const root = readUsage(result.usage);
   const telemetry = readUsage(result.telemetry?.usage);
   if (root && telemetry && Object.keys(root).some((key) => root[key] !== telemetry[key])) {
-    throw new Error("Conflicting trusted Codex usage");
+    throw new TrustedCodexUsageValidationError("Conflicting trusted Codex usage");
   }
   const usage = root ?? telemetry;
   return usage === undefined ? result : {
@@ -19,18 +21,20 @@ export function withTrustedCodexWorkerUsage(worker) {
     seedCodexAuthJsonFile: (...args) => worker.seedCodexAuthJsonFile(...args),
     run: async (...args) => {
       const result = await worker.run(...args);
-      // Usage-tracking integrity is enforced separately by
-      // trustedCodexWorkerResultToCli (fail closed on malformed/conflicting
-      // usage). A billing-only enrichment failure must not take down the
-      // underlying task result -- drop the untrusted usage and let the
-      // already-completed work through instead of losing it.
+      // Preserve completed output while keeping invalid accounting unknown.
+      // Only our validator's failures are recoverable at this boundary.
       try {
         return trustedCodexWorkerResultToCli(result);
       } catch (error) {
-        console.error(
-          `codex-worker-cli-usage: dropping untrusted usage (${error.message})`,
-        );
-        return result;
+        if (!(error instanceof TrustedCodexUsageValidationError)) throw error;
+        const sanitized = { ...result };
+        delete sanitized.usage;
+        if (result.telemetry !== null && typeof result.telemetry === "object") {
+          sanitized.telemetry = { ...result.telemetry };
+          delete sanitized.telemetry.usage;
+        }
+        console.error("codex-worker-cli-usage: dropping untrusted usage");
+        return sanitized;
       }
     },
   };
@@ -39,13 +43,13 @@ export function withTrustedCodexWorkerUsage(worker) {
 function readUsage(value) {
   if (value === undefined) return undefined;
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("Malformed trusted Codex usage");
+    throw new TrustedCodexUsageValidationError("Malformed trusted Codex usage");
   }
   const { inputTokens, outputTokens, totalTokens } = value;
   if (![inputTokens, outputTokens, totalTokens].every(
     (count) => Number.isSafeInteger(count) && count >= 0,
   ) || totalTokens !== inputTokens + outputTokens) {
-    throw new Error("Malformed trusted Codex usage");
+    throw new TrustedCodexUsageValidationError("Malformed trusted Codex usage");
   }
   return { inputTokens, outputTokens, totalTokens };
 }

--- a/apps/agent-runtime/bin/codex-worker-cli-usage.test.mjs
+++ b/apps/agent-runtime/bin/codex-worker-cli-usage.test.mjs
@@ -45,19 +45,27 @@ test("shared outer factory covers every selection and preserves single invocatio
   }
 });
 
-test("real CLI serialization and application parser retain trusted worker-root counts", async () => {
+test("real CLI serialization and application parser preserve output and unknown or trusted usage", async () => {
   const { createRequire } = await import("node:module");
   const require = createRequire(import.meta.url);
   require("ts-node").register({ transpileOnly: true, compilerOptions: { rootDir: process.cwd() } });
   require("tsconfig-paths/register");
   const { parseSubscriptionRuntimeCliResult } = require("../src/subscription-runtime-cli-support.ts");
   const { runSubscriptionAgentTaskCli } = await import("../../../node_modules/@vioxen/subscription-runtime/dist/worker-local/agent-task-runner-cli.js");
-  for (const mapped of [false, true]) {
+  for (const [mapped, metadata, expectedUsage] of [
+    [false, { usage }, undefined],
+    [true, { usage }, usage],
+    [true, {}, undefined],
+    [true, { usage, telemetry: { usage: { ...usage } } }, usage],
+    [true, { usage: null }, undefined],
+    [true, { telemetry: { usage: {} } }, undefined],
+    [true, { usage, telemetry: { usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 } } }, undefined],
+  ]) {
     let stdout = "";
     let runs = 0;
     const worker = {
       async start() {}, async dispose() {},
-      async run() { runs++; return { outputText: "fake", usage, warnings: [] }; },
+      async run() { runs++; return { outputText: "fake", warnings: [], ...metadata }; },
     };
     const code = await runSubscriptionAgentTaskCli(
       ["--provider", "codex", "--ephemeral", "--format", "result-json"],
@@ -71,7 +79,15 @@ test("real CLI serialization and application parser retain trusted worker-root c
     );
     assert.equal(code, 0, stdout);
     assert.equal(runs, 1);
-    assert.deepEqual(parseSubscriptionRuntimeCliResult(stdout).usage,
-      mapped ? { ...usage, estimatedCostUsd: 0 } : undefined);
+    const parsed = parseSubscriptionRuntimeCliResult(stdout);
+    assert.equal(parsed.status, "completed");
+    assert.equal(parsed.outputText, "fake");
+    assert.deepEqual(parsed.usage,
+      expectedUsage ? { ...expectedUsage, estimatedCostUsd: 0 } : undefined);
+    if (mapped && expectedUsage === undefined) {
+      const serialized = JSON.parse(stdout);
+      assert.equal(Object.hasOwn(serialized, "usage"), false);
+      assert.equal(Object.hasOwn(serialized.telemetry ?? {}, "usage"), false);
+    }
   }
 });


### PR DESCRIPTION
The PR #314 fallback returned the original result after detecting invalid usage, retaining conflicting root and telemetry counts. Remove both untrusted usage blocks while preserving completed output and unrelated metadata; propagate unrelated implementation errors. Unknown usage stays absent.

Independent review APPROVE on exact f823e9570cb73fb27a2876e7a08ead203e20a4ae. Verified 25 tests including the actual CLI serializer/application parser matrix with the checked-in main.41 runtime, plus 5 parser tests, focused lint and runtime-profile guards. V8 execution evidence confirms seven matrix cases execute the real conversion, JSON serialization and application parser. Runtime archive members and lockfile SHA512 were verified. Other dependencies were borrowed read-only; this was not a full locked npm installation or production/provider test. All 10 exact-head CI jobs passed in run 34167427360. Merged as 41ca7b3e88ae51266c4e9a85b48fd5f9e80c40b1; production deploy 34167934698 is in progress.

Architecture, quality, line-cap and strict validation evidence from the unchanged production implementation is retained. Fixed the two test lint errors found by independent review.

Refs #294
