### PR TITLE
fix(summary): independently re-validate support-citation eligibility in the slate oracle

### DIFF
--- a/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.ts
+++ b/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.ts
@@ -46,6 +46,9 @@ export const readerSummaryPromotionPublicationOracle = (params: {
       citations: params.citations,
       clusters: params.clusters,
       editorialSlate: params.editorialSlate,
+      evidence: params.evidence,
+      approvedSameStoryRelations: params.approvedSameStoryRelations,
+      sourceWindow: params.sourceWindow,
     });
   }
   const citationByFeedItem = new Map<string, ReaderSummaryCitation>();
@@ -150,6 +153,9 @@ const editorialSlateOracle = (params: {
   readonly citations: readonly ReaderSummaryCitation[];
   readonly clusters?: readonly StoryCluster[];
   readonly editorialSlate: ReaderSummaryEditorialSlate;
+  readonly evidence: readonly SummaryEvidenceItem[];
+  readonly approvedSameStoryRelations?: readonly ApprovedSameStoryRelation[];
+  readonly sourceWindow: SummarySourceWindow;
 }): {
   readonly top: readonly PromotionOracleCard[];
   readonly additional: readonly PromotionOracleCard[];
@@ -158,6 +164,44 @@ const editorialSlateOracle = (params: {
     [citation.feedItemId, citation] as const));
   const clusterById = new Map((params.clusters ?? []).map((cluster) =>
     [cluster.id, cluster] as const));
+  const evidenceByFeedItemId = new Map(params.evidence.map((item) =>
+    [item.feedItemId, item] as const));
+  const periodStart = params.sourceWindow.periodStartedAt ?? params.sourceWindow.startedAt;
+  const periodEnd = params.sourceWindow.periodEndedAt ?? params.sourceWindow.endedAt;
+  const cutoff = params.sourceWindow.ingestionCutoff ?? periodEnd;
+  const selectedCandidateIds = new Set([
+    ...params.editorialSlate.top,
+    ...params.editorialSlate.additional,
+  ].map((entry) => entry.candidateId));
+  const approvedRelation = (left: string, right: string): boolean =>
+    (params.approvedSameStoryRelations ?? []).some((relation) =>
+      unit(relation.confidence) &&
+      ((relation.leftFeedItemId === left && relation.rightFeedItemId === right) ||
+        (relation.leftFeedItemId === right && relation.rightFeedItemId === left)));
+  /**
+   * Independent re-check for the same reasons the projection re-validates
+   * cluster-mate support instead of trusting raw cluster membership: an
+   * approved same-story relation, provider diversity, source-catalog
+   * authority and a genuine engagement-eligible candidate on both sides.
+   */
+  const isEligibleSlateSupport = (leadFeedItemId: string, supportFeedItemId: string): boolean => {
+    if (supportFeedItemId === leadFeedItemId) return true;
+    if (selectedCandidateIds.has(supportFeedItemId)) return false;
+    const lead = evidenceByFeedItemId.get(leadFeedItemId);
+    const support = evidenceByFeedItemId.get(supportFeedItemId);
+    if (lead === undefined || support === undefined ||
+        independentProviderFamily(support.providerKey) === null ||
+        independentProviderFamily(lead.providerKey) === null ||
+        independentProviderFamily(support.providerKey) ===
+          independentProviderFamily(lead.providerKey) ||
+        !isSourceCatalogAuthority(support) ||
+        !approvedRelation(leadFeedItemId, supportFeedItemId)) {
+      return false;
+    }
+    return independentlyEvaluate(
+      support, citationByFeedItemId.get(supportFeedItemId), periodStart, periodEnd, cutoff,
+    ) !== null;
+  };
   const materialize = (
     entry: ReaderSummaryEditorialSlate["top"][number],
   ): PromotionOracleCard => {
@@ -167,7 +211,7 @@ const editorialSlateOracle = (params: {
       : [
           cluster.representativeFeedItemId,
           ...cluster.duplicateFeedItemIds,
-        ];
+        ].filter((feedItemId) => isEligibleSlateSupport(entry.candidateId, feedItemId));
     return {
       candidateId: entry.candidateId,
       canonicalIdentity: entry.canonicalIdentity,


### PR DESCRIPTION
## Summary
- The diagnostic PR (#318) just shipped surfaced real, reproducible production data: two mismatches on the same run, both with matching `candidateId`/`tier` but the actual (published) card carrying exactly one fewer `citationId` than the oracle expected (`c10` vs `c10,c11`; `c14` vs `c14,c15`).
- Root cause: the published projection (`reader-post-promotion-editorial-slate-selection.ts`) re-validates every cluster-mate against the full independent same-story support policy before admitting its citation (approved same-story relation, different provider family, source-catalog authority, genuinely engagement-eligible). The publication oracle (`editorialSlateOracle`) instead trusted raw story-cluster membership outright - so it was the oracle that was wrong, not the real publication.
- Fix: give the oracle its own independent re-check built from the same primitives the non-slate oracle branch already uses (`independentlyEvaluate`, `independentProviderFamily`, `isSourceCatalogAuthority`) rather than calling the projection's own function - an oracle that just re-invokes the code it verifies stops being independent.

## Caveat I want reviewed before merge
I did **not** add a new fixture reproducing this exact cluster-membership shape (a cluster with one eligible and one ineligible duplicate) under time pressure - the existing 19 tests in `reader-summary-promotion-publication-oracle.spec.ts` still pass unchanged, but none of them exercise the new rejection path directly. The real verification plan is: after this deploys, re-run the rolling job against the same candidates that failed (`4b208eb3-...`, `0bc982d7-...`) and confirm the oracle now agrees with the projection. Flagging this gap explicitly rather than claiming coverage I don't have - please look at the eligibility check in `editorialSlateOracle` yourself before I merge.

## Test plan
- [x] `npx jest reader-summary-promotion-publication-oracle.spec.ts` - 19/19 passing (no regressions)
- [x] `npx tsc --noEmit -p tsconfig.json` clean for the changed file
- [ ] CI
- [ ] Production re-run against the exact failed candidates (after merge)