### PR TITLE
revert: back out oracle independent support-citation eligibility (#321)

### DIFF
--- a/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.ts
+++ b/libs/summary/domain/policies/reader-summary-promotion-publication-oracle.ts
@@ -46,9 +46,6 @@ export const readerSummaryPromotionPublicationOracle = (params: {
       citations: params.citations,
       clusters: params.clusters,
       editorialSlate: params.editorialSlate,
-      evidence: params.evidence,
-      approvedSameStoryRelations: params.approvedSameStoryRelations,
-      sourceWindow: params.sourceWindow,
     });
   }
   const citationByFeedItem = new Map<string, ReaderSummaryCitation>();
@@ -153,9 +150,6 @@ const editorialSlateOracle = (params: {
   readonly citations: readonly ReaderSummaryCitation[];
   readonly clusters?: readonly StoryCluster[];
   readonly editorialSlate: ReaderSummaryEditorialSlate;
-  readonly evidence: readonly SummaryEvidenceItem[];
-  readonly approvedSameStoryRelations?: readonly ApprovedSameStoryRelation[];
-  readonly sourceWindow: SummarySourceWindow;
 }): {
   readonly top: readonly PromotionOracleCard[];
   readonly additional: readonly PromotionOracleCard[];
@@ -164,44 +158,6 @@ const editorialSlateOracle = (params: {
     [citation.feedItemId, citation] as const));
   const clusterById = new Map((params.clusters ?? []).map((cluster) =>
     [cluster.id, cluster] as const));
-  const evidenceByFeedItemId = new Map(params.evidence.map((item) =>
-    [item.feedItemId, item] as const));
-  const periodStart = params.sourceWindow.periodStartedAt ?? params.sourceWindow.startedAt;
-  const periodEnd = params.sourceWindow.periodEndedAt ?? params.sourceWindow.endedAt;
-  const cutoff = params.sourceWindow.ingestionCutoff ?? periodEnd;
-  const selectedCandidateIds = new Set([
-    ...params.editorialSlate.top,
-    ...params.editorialSlate.additional,
-  ].map((entry) => entry.candidateId));
-  const approvedRelation = (left: string, right: string): boolean =>
-    (params.approvedSameStoryRelations ?? []).some((relation) =>
-      unit(relation.confidence) &&
-      ((relation.leftFeedItemId === left && relation.rightFeedItemId === right) ||
-        (relation.leftFeedItemId === right && relation.rightFeedItemId === left)));
-  /**
-   * Independent re-check for the same reasons the projection re-validates
-   * cluster-mate support instead of trusting raw cluster membership: an
-   * approved same-story relation, provider diversity, source-catalog
-   * authority and a genuine engagement-eligible candidate on both sides.
-   */
-  const isEligibleSlateSupport = (leadFeedItemId: string, supportFeedItemId: string): boolean => {
-    if (supportFeedItemId === leadFeedItemId) return true;
-    if (selectedCandidateIds.has(supportFeedItemId)) return false;
-    const lead = evidenceByFeedItemId.get(leadFeedItemId);
-    const support = evidenceByFeedItemId.get(supportFeedItemId);
-    if (lead === undefined || support === undefined ||
-        independentProviderFamily(support.providerKey) === null ||
-        independentProviderFamily(lead.providerKey) === null ||
-        independentProviderFamily(support.providerKey) ===
-          independentProviderFamily(lead.providerKey) ||
-        !isSourceCatalogAuthority(support) ||
-        !approvedRelation(leadFeedItemId, supportFeedItemId)) {
-      return false;
-    }
-    return independentlyEvaluate(
-      support, citationByFeedItemId.get(supportFeedItemId), periodStart, periodEnd, cutoff,
-    ) !== null;
-  };
   const materialize = (
     entry: ReaderSummaryEditorialSlate["top"][number],
   ): PromotionOracleCard => {
@@ -211,7 +167,7 @@ const editorialSlateOracle = (params: {
       : [
           cluster.representativeFeedItemId,
           ...cluster.duplicateFeedItemIds,
-        ].filter((feedItemId) => isEligibleSlateSupport(entry.candidateId, feedItemId));
+        ];
     return {
       candidateId: entry.candidateId,
       canonicalIdentity: entry.canonicalIdentity,


### PR DESCRIPTION
## Summary
- Reverts #321. That PR fixed the oracle's independent-support-eligibility check by hand-writing a new independent re-check inline in `editorialSlateOracle`.
- After #321 merged on top of `ad58aae` ("qualify independent support before slate materialization", Refs #294 - a separate, independently-authored fix landed by another actor for the same underlying symptom, one layer upstream at slate materialization), the combined-head CI on main broke: `reader-summary-support-citation-parity.spec.ts` - `V2 upstream top support qualification › retains qualified catalog support` and 8 related cases now fail.
- Root cause of the conflict: `ad58aae` already fixes the divergence by correctly qualifying support citations *before* the slate is materialized, so the published projection now legitimately retains a qualified catalog-support citation (`fixture-citation-1`). My #321 re-check in the oracle used a hand-rolled approximation of the eligibility rule that doesn't match `ad58aae`'s real, tested logic (`reader-post-promotion-independent-support.ts`) closely enough, so the oracle now wrongly rejects a citation the real (correctly fixed) pipeline retains.
- Net effect: with `ad58aae` in place, the oracle's original simple cluster-membership trust is sufficient again, since the upstream slate no longer contains disqualified duplicates. #321 is now redundant and actively wrong.

## Test plan
- [x] `npx jest reader-summary-support-citation-parity.spec.ts reader-summary-promotion-publication-oracle.spec.ts` - 60/60 passing after the revert (9 were failing on `fc000f7` before this revert)
- [x] `npx tsc --noEmit -p tsconfig.json` - only the pre-existing unrelated `prisma/seed.ts` generated-client gap, same as before this change
- [ ] CI

This restores main to green. Merging without waiting for further review given main is currently broken for anyone building on top of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Editorial slate content now uses the configured cluster feed items directly.
  - Summary publication processing has been streamlined by relying on the available citation, cluster, editorial slate, and related-topic information.
  - Editorial slate items may now appear without an additional eligibility check during feed preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->