### PR TITLE
fix(collection): bound accumulated GitHub snapshot evidence

### DIFF
--- a/scripts/lib/github-trending-capacity-native-scenario.ts
+++ b/scripts/lib/github-trending-capacity-native-scenario.ts
@@ -1,0 +1,20 @@
+import { buildGitHubTrendingPostgresCandidates } from "./github-trending-durable-snapshot-reuse-postgres-fixture";
+import type { GitHubTrendingDurableSnapshotCandidate } from "./github-trending-durable-snapshot-reuse";
+
+// Distinct complete generations on the fixture's closed day, oldest first.
+export const buildGitHubTrendingCapacityGenerations = (
+  count: number,
+): GitHubTrendingDurableSnapshotCandidate[] => {
+  if (!Number.isInteger(count) || count < 1 || count > 20) {
+    throw new Error("capacity fixture requires 1..20 generations");
+  }
+  return Array.from({ length: count }, (_, hour) => {
+    const prefix = `2026-07-23T${String(hour).padStart(2, "0")}`;
+    return buildGitHubTrendingPostgresCandidates({
+      groupKey: `capacity-${hour}`,
+      fetchStartedAt: `${prefix}:00:00.000Z`,
+      checkedAt: `${prefix}:01:00.000Z`,
+      observedAt: `${prefix}:01:01.000Z`,
+    });
+  }).flat();
+};

--- a/scripts/lib/github-trending-durable-snapshot-budget-fixture.ts
+++ b/scripts/lib/github-trending-durable-snapshot-budget-fixture.ts
@@ -1,0 +1,84 @@
+import type { GitHubTrendingDurableSnapshotCandidate } from "./github-trending-durable-snapshot-reuse";
+
+const uuid = (value: number): string =>
+  `00000000-0000-7000-8000-${String(value).padStart(12, "0")}`;
+export const scope = {
+  tenantId: uuid(6101), workspaceId: uuid(6102), sourceBindingId: uuid(6111),
+};
+
+// Synthetic content only. Match the incident's measured normalized array size,
+// not any production payload. All 15 generations are independently valid.
+export const richCandidates = (count = 15): GitHubTrendingDurableSnapshotCandidate[] => {
+  const rows = Array.from({ length: count }, (_, hour) => generation(hour)).flat();
+  let remaining = Math.floor(342_536 * count / 15) - Buffer.byteLength(JSON.stringify(rows), "utf8");
+  if (remaining < 0) throw new Error("synthetic baseline exceeds incident size");
+  return rows.map((row, index) => {
+    // Updating the byte-count number can add decimal digits; settle afterwards.
+    const padding = Math.floor(remaining / (rows.length - index));
+    const bodyPreview = row.bodyPreview + " synthetic".repeat(Math.ceil(padding / 10)).slice(0, padding);
+    const next = { ...row, bodyPreview, bodyPreviewBytes: Buffer.byteLength(bodyPreview, "utf8") };
+    remaining -= Buffer.byteLength(JSON.stringify(next), "utf8") - Buffer.byteLength(JSON.stringify(row), "utf8");
+    if (index === rows.length - 1 && remaining !== 0) {
+      const adjusted = bodyPreview.slice(0, bodyPreview.length + remaining);
+      return { ...next, bodyPreview: adjusted, bodyPreviewBytes: Buffer.byteLength(adjusted, "utf8") };
+    }
+    return next;
+  });
+};
+
+const generation = (hour: number): GitHubTrendingDurableSnapshotCandidate[] =>
+  Array.from({ length: 10 }, (_, index) => {
+    const rank = index + 1;
+    const scanJobId = uuid(100 + hour);
+    const fetchStartedAt = `2026-09-07T${String(hour).padStart(2, "0")}:00:00.000Z`;
+    const checkedAt = `2026-09-07T${String(hour).padStart(2, "0")}:01:00.000Z`;
+    const repository = `owner/repository-${rank}`;
+    const title = `${repository} is #${rank} on GitHub Trending`;
+    const bodyPreview = `Visible summary for ${repository}.`;
+    return {
+      tenantId: scope.tenantId,
+      workspaceId: scope.workspaceId,
+      sourceTenantId: scope.tenantId,
+      sourceWorkspaceId: scope.workspaceId,
+      feedItemId: uuid(1000 + hour * 10 + rank),
+      sourceItemId: uuid(2000 + hour * 10 + rank),
+      feedSourceBindingId: scope.sourceBindingId,
+      sourceSourceBindingId: scope.sourceBindingId,
+      feedProviderKey: "github-trending-page",
+      sourceProviderKey: "github-trending-page",
+      feedStatus: "VISIBLE",
+      providerItemId: `github-trending-page:daily:${scanJobId}:${repository}`,
+      canonicalUrl: `https://github.com/${repository}`,
+      metadataKind: "github_trending_page_repository",
+      repositoryFullName: repository,
+      repositoryUrl: `https://github.com/${repository}`,
+      rank,
+      starsGained: 1_001 + rank,
+      totalStars: 10_000 + rank,
+      window: "daily",
+      scanJobId: scanJobId,
+      feedScanJobId: scanJobId,
+      fetchStartedAt: fetchStartedAt,
+      feedFetchStartedAt: fetchStartedAt,
+      checkedAt: checkedAt,
+      feedCheckedAt: checkedAt,
+      publishedAt: checkedAt,
+      sourcePublishedAt: checkedAt,
+      feedObservedAt: checkedAt,
+      sourceObservedAt: checkedAt,
+      scanJobStatus: "SUCCEEDED",
+      scanJobTenantId: scope.tenantId,
+      scanJobWorkspaceId: scope.workspaceId,
+      scanJobSourceBindingId: scope.sourceBindingId,
+      sourceContentHash: "a".repeat(64),
+      sourceProviderContentHash: "b".repeat(64),
+      sourceTitle: title,
+      feedTitle: title,
+      bodyPreview,
+      sourceTitleBytes: Buffer.byteLength(title, "utf8"),
+      feedTitleBytes: Buffer.byteLength(title, "utf8"),
+      bodyPreviewBytes: Buffer.byteLength(bodyPreview, "utf8"),
+      feedSnapshotSourceBindingId: scope.sourceBindingId,
+      feedSnapshotProviderKey: "github-trending-page",
+    };
+  });

--- a/scripts/lib/github-trending-durable-snapshot-candidate-budget.md
+++ b/scripts/lib/github-trending-durable-snapshot-candidate-budget.md
@@ -1,0 +1,124 @@
+# GitHub durable candidate capacity
+
+This reader admits the existing 200-row transport capacity without rejecting a
+valid day's repeated captures merely because their full JSON exceeds 256 KiB.
+The Sep 8 parent read on audited source `ad58` measured 150 candidates, 15
+generations and 342,536 normalized UTF-8 JSON bytes for Sep 7, scope 6101/6102,
+binding 6111. These measurements are parent-supplied evidence, not a query run by
+this implementation worker. The old 262,144-byte gate failed before generation
+selection. At 150 rows it allowed only 1,747.63 bytes per candidate; the measured
+average was 2,283.57. Keeping that gate retains the demonstrated false failure.
+
+## Decision and equivalence
+
+Use the permitted derived-capacity adjustment, with independent allocation
+bounds, rather than moving text equality, control-character and hashing policy
+into SQL. This keeps JavaScript's exact existing Unicode, trimming, byte-length,
+case and digest behavior and avoids introducing SQL/JavaScript equivalence
+assumptions into the proof. No content is summarized, normalized or omitted.
+
+The exhaustive typed field budget matches all 44 statement result fields:
+
+- Eleven UUID columns: 36 code points each (native UUID text is ASCII).
+- Four normalized native timestamps: at most 27 characters, including extended
+  years. Metadata timestamps retain their existing 64-code-point caps.
+- All other text: existing SQL `left` caps, plus 64 for the two provider keys and
+  32 for the two statuses which previously lacked explicit transport caps.
+- Six numeric fields: three bounded 32-character metadata values converted with
+  `Number`, and three `octet_length` integers converted with `Number`.
+
+The exact per-field mapping is executable in
+`github-trending-durable-snapshot-candidate-budget.ts`; the SQL projection test
+checks every alias against its cap or native typed source. The type mapping is
+exhaustive, so adding a candidate field requires adding a corresponding bound.
+
+The four added SQL caps cannot turn invalid evidence into a valid constant:
+`github-trending-page` has 20 characters, `VISIBLE` seven and `SUCCEEDED` nine,
+all strictly shorter than their respective caps. An overlong string remains
+longer than the valid constant after truncation. These fields do not participate
+in ordering or generation identity. SQL NULL remains NULL (the pre-existing
+scan-status coalesce remains unchanged). The broad six-arm day predicate,
+source/feed binding OR, scoped join, left scan join, feed-id order and LIMIT 201
+are unchanged. There are no status/visibility filters and no newest-ten SQL
+shortcut. All evidence still comes from one statement snapshot.
+
+Selection, newest-invalid rejection, lineage, tenant/workspace/binding guards,
+visible-text and declared-byte validation, content hashes, proof fields and
+canonical proof digest are unchanged. A sentinel truncated title/preview still
+fails the existing full byte-count/length checks. Resource bounds do not certify
+content: even a maximum-sized transport envelope must pass the existing verifier.
+
+## Derivation and allocation bounds
+
+For each capped string of N Unicode code points, JSON needs at most `2 + 6*N`
+UTF-8 bytes. ASCII is one byte, unescaped Unicode at most four, quote/backslash
+escapes two, and control escapes such as `\u0001` six. A lone UTF-16 surrogate
+also serializes to six bytes; PostgreSQL does not emit these, but fake/custom
+readers are bounded too. NULL uses four bytes and fits every string field's
+bound. The application checks code-point counts without allocating a character
+array, with an initial O(1) UTF-16-length bound of `2*N`.
+
+Each JavaScript Number serializes to at most 25 ASCII bytes: the longest fixed
+form has sign, `0.`, five leading zeroes and 17 significant digits (25); the
+exponent form is shorter. Nonfinite values serialize to `null` (four bytes) and
+remain ineligible wherever the original verifier requires a valid integer.
+
+For each property, add its quoted ASCII key, colon, value, and comma. Replacing
+the last comma with `}` leaves one additional byte for `{`. Summing all 44 fields
+(8,347 capped string code points and six numbers) yields **51,110 bytes per row**.
+The 200-row array bound is `1 + 200*(51,110+1)` = **10,222,201 bytes**. This is
+an attained worst case in the executable boundary test, not a rounded threshold.
+Replacing one six-byte escape with seven ASCII bytes proves exact +1 rejection.
+
+The larger logical ceiling is a capacity tradeoff, not a 10 MB JSON allocation:
+
+- SQL returns at most 201 rows, with independently capped text columns. Overflow
+  is rejected before visiting rows or serializing values.
+- Every accepted transport row has exactly the expected own keys and primitive
+  types (or SQL NULL for text), with a per-field code-point bound.
+- Only a captured, already bounded primitive is serialized to count bytes. No
+  candidate object or candidate array is serialized. The largest temporary JSON
+  string is the 4,097-code-point preview: at most 24,584 characters/UTF-8 bytes,
+  or 49,168 bytes of UTF-16 character storage.
+- Row and cumulative byte ceilings are checked independently of the row and
+  per-field ceilings. For nonempty arrays of ordinary plain records, this count equals the full
+  normalized array's JSON byte length, regardless of property order.
+- A conservative string-character-storage bound for 201 mapped rows is
+  `201*8,347*4` = **6,710,988 bytes**, excluding object/driver overhead and native
+  numbers/Dates. Raw and normalized rows share text strings through the existing
+  spread mapper. This is not a measured process-RSS or concurrency guarantee.
+  Up to 10,222,201 bytes of cumulative serialization work can produce temporary
+  garbage before GC; the small per-value allocation bound is not a peak-heap bound.
+  Database scan/TOAST work and driver overhead are not bounded by this calculation;
+  they also existed before this change. Native parent verification remains needed.
+
+The old gate allocated the entire candidate JSON before checking its size and
+had no corresponding application per-field preflight. The new guards bound
+allocation before serialization and close the four uncapped SQL text columns.
+No row ceiling is increased: twenty ten-row captures fit; a twenty-first still
+fails. There is no change to scheduling, retention, ranking or freshness.
+
+## Deterministic evidence and release boundary
+
+The synthetic fixture uses UUID-shaped identities and generated, non-production
+text. Fifteen individually valid ten-row captures serialize to exactly 342,536
+bytes; this matches the incident size without pretending to reconstruct its
+content. Fourteen, fifteen and twenty distinct generations all select the same
+latest-ten proof as reading their latest ten alone, in fake Prisma and in-memory
+readers. The fifteen-generation proof digest is pinned to the unchanged audited
+reader's digest for those same synthetic latest-ten rows:
+`sha256:425e9c71ca1e1c25da6dc9dc258de95fa28958aced8114ff1d00a5bb43ccf7cc`.
+The unchanged reader rejects the complete synthetic fifteen-generation array.
+
+Tests cover exact maximum/+1 bytes, 200/201 rows, every text cap/+1 for ASCII,
+multibyte Unicode, surrogate and JSON escape forms; malformed shapes; SQL
+projection caps; malformed older ordering; newest failed/missing/incomplete,
+hidden and mismatched evidence; control characters; 512/513 title and 4096/4097
+preview bytes; exact declared byte counts; equal-length unequal titles; Unicode
+normalization differences; and invalid provider/status truncation prefixes.
+Existing reader/acquisition/quality tests remain required.
+
+No DB, migration, provider-network, auth, runtime, install, commit, push or deploy
+operation is part of this patch. Observations and historical captures are
+unchanged. Parent native/live read-only parity, independent review and mechanical
+commit are required before release; fake tests do not establish production repair.

--- a/scripts/lib/github-trending-durable-snapshot-candidate-budget.spec.ts
+++ b/scripts/lib/github-trending-durable-snapshot-candidate-budget.spec.ts
@@ -1,0 +1,178 @@
+import type { Pool } from "pg";
+
+import {
+  githubTrendingCandidateFieldBounds as bounds,
+  githubTrendingCandidateJsonByteLimit,
+  githubTrendingCandidateRowJsonByteLimit,
+  githubTrendingDurableSnapshotCandidatesFitBudget as fits,
+} from "./github-trending-durable-snapshot-candidate-budget";
+import { richCandidates, scope } from "./github-trending-durable-snapshot-budget-fixture";
+import {
+  InMemoryGitHubTrendingDurableSnapshotReader,
+  PrismaGitHubTrendingDurableSnapshotReader,
+  reuseGitHubTrendingDurableSnapshot,
+  type GitHubTrendingDurableSnapshotCandidate as Candidate,
+  type GitHubTrendingDurableSnapshotReader as Reader,
+} from "./github-trending-durable-snapshot-reuse";
+
+const reuse = (reader: Reader) => reuseGitHubTrendingDurableSnapshot({
+  reader, ...scope, requestedUtcDay: "2026-09-07",
+  observedThrough: new Date("2026-09-08T00:56:39.850Z"),
+});
+const memory = (rows: Candidate[]) => new InMemoryGitHubTrendingDurableSnapshotReader(rows);
+const prismaRow = (row: Candidate) => ({
+  ...row, rank: String(row.rank), starsGained: String(row.starsGained),
+  totalStars: String(row.totalStars), sourceTitleBytes: String(row.sourceTitleBytes),
+  feedTitleBytes: String(row.feedTitleBytes), bodyPreviewBytes: String(row.bodyPreviewBytes),
+  publishedAt: new Date(row.publishedAt), sourcePublishedAt: new Date(row.sourcePublishedAt),
+  feedObservedAt: new Date(row.feedObservedAt), sourceObservedAt: new Date(row.sourceObservedAt),
+});
+const prisma = (rows: Candidate[]) => {
+  const query = jest.fn().mockResolvedValue({ rows: rows.map(prismaRow) });
+  return { query, reader: new PrismaGitHubTrendingDurableSnapshotReader({ query } as unknown as Pick<Pool, "query">) };
+};
+
+describe("GitHub accumulated candidate allocation budget", () => {
+  it.each([14, 15, 20])("admits %i rich ten-row captures with the identical latest-ten proof", async (count) => {
+    const original = richCandidates();
+    expect(Buffer.byteLength(JSON.stringify(original), "utf8")).toBe(342_536);
+    const rows = richCandidates(count);
+    expect(Buffer.byteLength(JSON.stringify(rows), "utf8")).toBeGreaterThan(262_144);
+    const latest = rows.slice(-10);
+    const expected = await reuse(memory(latest));
+    const database = prisma(rows);
+    expect(await reuse(database.reader)).toEqual(expected);
+    expect(await reuse(memory(rows.reverse()))).toEqual(expected);
+    expect(database.query).toHaveBeenCalledTimes(1);
+    expect(database.query.mock.calls[0]?.[1]?.[5]).toBe(201);
+    expect(expected.rows).toHaveLength(10);
+    expect(expected.group.scanJobId).toBe(latest[0]!.scanJobId);
+    if (count === 15) {
+      // Captured with the unchanged audited reader on these same latest ten rows.
+      expect(expected.proofSha256).toBe("sha256:425e9c71ca1e1c25da6dc9dc258de95fa28958aced8114ff1d00a5bb43ccf7cc");
+    }
+  });
+
+  it("keeps every SQL result field independently bounded in the single statement", async () => {
+    const database = prisma(richCandidates());
+    await reuse(database.reader);
+    const sql = database.query.mock.calls[0]?.[0] as string;
+    const projections = [...sql.matchAll(/^ {4}(.+) as "(\w+)"[,]?$/gmu)];
+    expect(projections).toHaveLength(Object.keys(bounds).length);
+    const dates = new Set(["publishedAt", "sourcePublishedAt", "feedObservedAt", "sourceObservedAt"]);
+    for (const [, expression, alias] of projections) {
+      const key = alias as keyof typeof bounds;
+      const bound = bounds[key];
+      if (bound === "number") {
+        expect(expression).toMatch(/(?:left\(.+, 32\)|octet_length\(.+\)::text)$/u);
+      } else if (bound === 36) {
+        expect(expression).toMatch(/(?:\w+\.\w+::text|coalesce\(\w+\.\w+::text, ''\))$/u);
+      } else if (dates.has(key)) {
+        expect(expression).toMatch(/^(?:fi|si)\.(?:published_at|observed_at)$/u);
+      } else {
+        expect(expression!.startsWith("left(")).toBe(true);
+        expect(expression!.endsWith(`, ${bound})`)).toBe(true);
+      }
+    }
+    expect(sql).toContain("left join scan_jobs");
+    expect(sql).toContain("order by fi.id asc\n  limit $6");
+    expect(sql).not.toMatch(/(?:status\s*=|limit 10)/iu);
+    expect(sql.match(/>= \$4(?:::timestamptz|::text)/gu)).toHaveLength(6);
+    expect(sql).toContain("or si.source_binding_id = $3::uuid");
+  });
+
+  it("rejects 201 before visiting any row or serializing an array", () => {
+    const rows = Array.from({ length: 201 }, () => new Proxy({} as Candidate, {
+      ownKeys: () => { throw new Error("must reject count first"); },
+    }));
+    expect(fits(rows)).toBe(false);
+  });
+
+  it("derives an attainable exact JSON byte ceiling and rejects ceiling +1", () => {
+    const worst = Object.fromEntries(Object.entries(bounds).map(([key, bound]) =>
+      [key, bound === "number" ? -0.0000012345678901234567 : "\u0001".repeat(bound)],
+    )) as Candidate;
+    const rowBytes = Buffer.byteLength(JSON.stringify(worst), "utf8");
+    expect(rowBytes).toBe(githubTrendingCandidateRowJsonByteLimit);
+    const rows = Array.from({ length: 200 }, () => worst);
+    expect(Buffer.byteLength(JSON.stringify(rows), "utf8")).toBe(githubTrendingCandidateJsonByteLimit);
+    expect(fits(rows)).toBe(true);
+    // Replacing a six-byte escape with seven ASCII bytes adds exactly one byte.
+    const overflow = { ...worst, bodyPreview: worst.bodyPreview.slice(1) + "abcdefg" };
+    const tooLarge = [...rows.slice(1), overflow];
+    expect(Buffer.byteLength(JSON.stringify(tooLarge), "utf8")).toBe(githubTrendingCandidateJsonByteLimit + 1);
+    expect(fits(tooLarge)).toBe(false);
+  });
+
+  it.each(Object.entries(bounds).filter((entry) => typeof entry[1] === "number"))(
+    "bounds %s by code points before JSON allocation", (key, bound) => {
+      const row = richCandidates()[0]!;
+      const cap = bound as number;
+      for (const character of ["a", "é", "界", "😀", "\u0001", "\ud800", '"', "\\", "\n"]) {
+        expect(fits([{ ...row, [key]: character.repeat(cap) }])).toBe(true);
+        expect(fits([{ ...row, [key]: character.repeat(cap + 1) }])).toBe(false);
+      }
+    },
+  );
+
+  it("rejects malformed shape and extra payload before serialization", () => {
+    const row = richCandidates()[0]!;
+    expect(fits([{ ...row, extra: "payload" } as Candidate])).toBe(false);
+    expect(fits([{ ...row, rank: {} } as unknown as Candidate])).toBe(false);
+    expect(fits([{ ...row, feedTitle: undefined } as unknown as Candidate])).toBe(false);
+    expect(fits([{ ...row, feedTitle: "a".repeat(1_000_000) }])).toBe(false);
+  });
+
+  it.each([
+    ["scanJobStatus", "FAILED", "selected_group_invalid"],
+    ["scanJobStatus", "", "selected_group_invalid"],
+    ["feedStatus", "HIDDEN", "selected_group_invalid"],
+    ["feedTitle", "different title", "selected_group_invalid"],
+    ["sourceContentHash", "z".repeat(64), "selected_group_invalid"],
+    ["bodyPreview", "bad\u0001text", "selected_group_invalid"],
+    ["feedSnapshotSourceBindingId", "wrong-binding", "selected_group_invalid"],
+    ["checkedAt", "2026-09-07T14:01:00.000", "invalid_ordering_identity"],
+  ])("keeps newest %s invalid with older valid captures present", async (key, value, error) => {
+    const rows = richCandidates().map((row, index) => index >= 140 ? { ...row, [key]: value } : row);
+    await expect(reuse(memory(rows))).rejects.toThrow(error);
+    await expect(reuse(prisma(rows).reader)).rejects.toThrow(error);
+  });
+
+  it("keeps newest incomplete and malformed older ordering blocking", async () => {
+    const rows = richCandidates();
+    await expect(reuse(memory(rows.slice(0, -1)))).rejects.toThrow("partial_group");
+    rows[0] = { ...rows[0]!, feedCheckedAt: "2026-09-07T00:01:00.000" };
+    await expect(reuse(memory(rows))).rejects.toThrow("invalid_ordering_identity");
+  });
+
+  it("does not confuse equal-length text, Unicode normalization, or sentinel truncation", async () => {
+    const rows = richCandidates().slice(-10);
+    for (const [sourceTitle, feedTitle] of [["abc", "abd"], ["é", "é"]]) {
+      const changed = rows.map((row) => ({ ...row, sourceTitle: sourceTitle!, feedTitle: feedTitle!,
+        sourceTitleBytes: Buffer.byteLength(sourceTitle!), feedTitleBytes: Buffer.byteLength(feedTitle!),
+      }));
+      await expect(reuse(memory(changed))).rejects.toThrow("selected_group_invalid");
+    }
+    for (const key of ["feedProviderKey", "sourceProviderKey", "feedStatus", "scanJobStatus"] as const) {
+      const changed = rows.map((row) => ({ ...row, [key]: (row[key] + "x".repeat(100)).slice(0, bounds[key]) }));
+      await expect(reuse(prisma(changed).reader)).rejects.toThrow("selected_group_invalid");
+    }
+  });
+
+  it("retains UTF-8 text limits, controls and exact declared lengths", async () => {
+    const rows = richCandidates().slice(-10);
+    for (const text of ["😀".repeat(129), "x".repeat(513), "bad\u007ftext"]) {
+      const changed = rows.map((row) => ({ ...row, sourceTitle: text, feedTitle: text,
+        sourceTitleBytes: Buffer.byteLength(text), feedTitleBytes: Buffer.byteLength(text),
+      }));
+      await expect(reuse(memory(changed))).rejects.toThrow("selected_group_invalid");
+    }
+    const text = "😀".repeat(128);
+    const valid = rows.map((row) => ({ ...row, sourceTitle: text, feedTitle: text,
+      sourceTitleBytes: 512, feedTitleBytes: 512, bodyPreview: "x".repeat(4096), bodyPreviewBytes: 4096,
+    }));
+    expect((await reuse(memory(valid))).rows[0]?.titleBytes).toBe(512);
+    await expect(reuse(memory(valid.map((row) => ({ ...row, bodyPreview: row.bodyPreview + "x", bodyPreviewBytes: 4097 }))))).rejects.toThrow("selected_group_invalid");
+    await expect(reuse(memory(valid.map((row) => ({ ...row, feedTitleBytes: 511 }))))).rejects.toThrow("selected_group_invalid");
+  });
+});

--- a/scripts/lib/github-trending-durable-snapshot-candidate-budget.spec.ts
+++ b/scripts/lib/github-trending-durable-snapshot-candidate-budget.spec.ts
@@ -1,5 +1,3 @@
-import type { Pool } from "pg";
-
 import {
   githubTrendingCandidateFieldBounds as bounds,
   githubTrendingCandidateJsonByteLimit,
@@ -29,7 +27,7 @@ const prismaRow = (row: Candidate) => ({
 });
 const prisma = (rows: Candidate[]) => {
   const query = jest.fn().mockResolvedValue({ rows: rows.map(prismaRow) });
-  return { query, reader: new PrismaGitHubTrendingDurableSnapshotReader({ query } as unknown as Pick<Pool, "query">) };
+  return { query, reader: new PrismaGitHubTrendingDurableSnapshotReader({ query } as unknown as ConstructorParameters<typeof PrismaGitHubTrendingDurableSnapshotReader>[0]) };
 };
 
 describe("GitHub accumulated candidate allocation budget", () => {

--- a/scripts/lib/github-trending-durable-snapshot-candidate-budget.ts
+++ b/scripts/lib/github-trending-durable-snapshot-candidate-budget.ts
@@ -1,0 +1,159 @@
+export type GitHubTrendingDurableSnapshotCandidate = {
+  readonly tenantId: string;
+  readonly workspaceId: string;
+  readonly sourceTenantId: string;
+  readonly sourceWorkspaceId: string;
+  readonly feedItemId: string;
+  readonly sourceItemId: string;
+  readonly feedSourceBindingId: string;
+  readonly sourceSourceBindingId: string;
+  readonly feedProviderKey: string;
+  readonly sourceProviderKey: string;
+  readonly feedStatus: string;
+  readonly providerItemId: string;
+  readonly canonicalUrl: string;
+  readonly metadataKind: string;
+  readonly repositoryFullName: string;
+  readonly repositoryUrl: string;
+  readonly rank: number;
+  readonly starsGained: number;
+  readonly totalStars: number;
+  readonly window: string;
+  readonly scanJobId: string;
+  readonly feedScanJobId: string;
+  readonly fetchStartedAt: string;
+  readonly feedFetchStartedAt: string;
+  readonly checkedAt: string;
+  readonly feedCheckedAt: string;
+  readonly publishedAt: string;
+  readonly sourcePublishedAt: string;
+  readonly feedObservedAt: string;
+  readonly sourceObservedAt: string;
+  readonly scanJobStatus: string;
+  readonly scanJobTenantId: string;
+  readonly scanJobWorkspaceId: string;
+  readonly scanJobSourceBindingId: string;
+  readonly sourceContentHash: string;
+  readonly sourceProviderContentHash: string;
+  readonly sourceTitle: string;
+  readonly feedTitle: string;
+  readonly bodyPreview: string;
+  readonly sourceTitleBytes: number;
+  readonly feedTitleBytes: number;
+  readonly bodyPreviewBytes: number;
+  readonly feedSnapshotSourceBindingId: string;
+  readonly feedSnapshotProviderKey: string;
+};
+
+export const githubTrendingDurableSnapshotRowLimit = 200;
+
+// PostgreSQL left(text, n) counts Unicode code points, not UTF-16 units.
+// UUIDs have 36 ASCII characters; normalized Date ISO strings need at most 27.
+// These are transport bounds (including invalid-value sentinels), not eligibility.
+export const githubTrendingCandidateFieldBounds = {
+  tenantId: 36,
+  workspaceId: 36,
+  sourceTenantId: 36,
+  sourceWorkspaceId: 36,
+  feedItemId: 36,
+  sourceItemId: 36,
+  feedSourceBindingId: 36,
+  sourceSourceBindingId: 36,
+  feedProviderKey: 64,
+  sourceProviderKey: 64,
+  feedStatus: 32,
+  providerItemId: 256,
+  canonicalUrl: 256,
+  metadataKind: 128,
+  repositoryFullName: 256,
+  repositoryUrl: 256,
+  rank: "number",
+  starsGained: "number",
+  totalStars: "number",
+  window: 32,
+  scanJobId: 256,
+  feedScanJobId: 256,
+  fetchStartedAt: 64,
+  feedFetchStartedAt: 64,
+  checkedAt: 64,
+  feedCheckedAt: 64,
+  publishedAt: 27,
+  sourcePublishedAt: 27,
+  feedObservedAt: 27,
+  sourceObservedAt: 27,
+  scanJobStatus: 32,
+  scanJobTenantId: 36,
+  scanJobWorkspaceId: 36,
+  scanJobSourceBindingId: 36,
+  sourceContentHash: 128,
+  sourceProviderContentHash: 128,
+  sourceTitle: 513,
+  feedTitle: 513,
+  bodyPreview: 4097,
+  sourceTitleBytes: "number",
+  feedTitleBytes: "number",
+  bodyPreviewBytes: "number",
+  feedSnapshotSourceBindingId: 256,
+  feedSnapshotProviderKey: 64,
+} as const satisfies {
+  readonly [K in keyof GitHubTrendingDurableSnapshotCandidate]:
+    GitHubTrendingDurableSnapshotCandidate[K] extends number ? "number" : number;
+};
+
+const fields = Object.entries(githubTrendingCandidateFieldBounds);
+// A code point takes <=4 UTF-8 bytes unescaped, <=6 as a JSON control escape.
+// Lone UTF-16 surrogates also serialize as six bytes. Quotes/backslashes take two.
+// NumberToString takes <=25 ASCII bytes (sign + fixed/exponent notation).
+// Each property contributes its quoted key, colon, value, and comma; the final
+// comma is replaced by '}', leaving one extra byte for the opening '{'.
+export const githubTrendingCandidateRowJsonByteLimit = 1 + fields.reduce(
+  (bytes, [key, bound]) => bytes + Buffer.byteLength(JSON.stringify(key), "utf8") +
+    2 + (bound === "number" ? 25 : 2 + 6 * bound),
+  0,
+);
+export const githubTrendingCandidateJsonByteLimit = 1 +
+  githubTrendingDurableSnapshotRowLimit * (githubTrendingCandidateRowJsonByteLimit + 1);
+
+export const githubTrendingDurableSnapshotCandidatesFitBudget = (
+  rows: readonly GitHubTrendingDurableSnapshotCandidate[],
+): boolean => {
+  // Check count BEFORE visiting rows or allocating JSON. The SQL fetches only
+  // 201 rows, with independently bounded columns, to expose overflow.
+  if (rows.length > githubTrendingDurableSnapshotRowLimit) return false;
+  let jsonBytes = 1;
+  for (const row of rows) {
+    if (row === null || typeof row !== "object") return false;
+    const keys = Object.keys(row);
+    if (keys.length !== fields.length ||
+      keys.some((key) => !Object.hasOwn(githubTrendingCandidateFieldBounds, key))) return false;
+    let rowBytes = 1;
+    for (const [key, bound] of fields) {
+      const value: unknown = row[key as keyof GitHubTrendingDurableSnapshotCandidate];
+      if (bound === "number") {
+        if (typeof value !== "number") return false;
+      } else if (value !== null && !boundedCodePoints(value, bound)) {
+        // SQL NULL is bounded evidence too; the existing verifier decides its
+        // eligibility. Never coalesce nullable content into apparently valid text.
+        return false;
+      }
+      // Capture and serialize only this bounded primitive, so neither an array
+      // nor an object serializer can allocate an unchecked payload. Keys are ASCII.
+      rowBytes += key.length + 4 + Buffer.byteLength(JSON.stringify(value), "utf8");
+    }
+    if (rowBytes > githubTrendingCandidateRowJsonByteLimit) return false;
+    jsonBytes += rowBytes + 1;
+    if (jsonBytes > githubTrendingCandidateJsonByteLimit) return false;
+  }
+  return true;
+};
+
+const boundedCodePoints = (value: unknown, limit: number): boolean => {
+  if (typeof value !== "string" || value.length > 2 * limit) return false;
+  let count = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    count += 1;
+    if (count > limit) return false;
+    if (value.codePointAt(index)! > 0xffff) index += 1;
+  }
+  return true;
+};

--- a/scripts/lib/github-trending-durable-snapshot-reuse.postgres.spec.ts
+++ b/scripts/lib/github-trending-durable-snapshot-reuse.postgres.spec.ts
@@ -1,3 +1,6 @@
+import { deepStrictEqual } from "node:assert";
+import { buildGitHubTrendingCapacityGenerations } from "./github-trending-capacity-native-scenario";
+import { githubTrendingDurableSnapshotCandidatesFitBudget } from "./github-trending-durable-snapshot-candidate-budget";
 import { randomUUID } from "node:crypto";
 
 import { type Pool } from "pg";
@@ -30,6 +33,10 @@ export const githubTrendingPostgresScenarioNames = [
   "observedAt mismatch rejection",
   "invalid UUID scope rejection by PostgreSQL casts",
   "row-limit overflow rejection and parity",
+  "newest invalid and incomplete captures have no fallback",
+  "SQL NULL and missing metadata remain invalid",
+  "SQL Unicode caps and original octet lengths",
+  "200 accumulated valid rows and 201 sentinel",
 ] as const;
 
 export const runGitHubTrendingDurableSnapshotPostgresScenarios = async (
@@ -45,6 +52,10 @@ export const runGitHubTrendingDurableSnapshotPostgresScenarios = async (
   await observedAtMismatchIsRejected(pool);
   await invalidUuidScopeIsRejected(pool);
   await rowLimitOverflowIsRejected(pool);
+  await accumulatedCapacityAndSentinel(pool);
+  await unicodeCapsAndOctets(pool);
+  await nullAndMissingMetadata(pool);
+  await newestInvalidCaptures(pool);
 };
 
 const coherentTop10AndParity = async (pool: Pool): Promise<void> => {
@@ -254,6 +265,133 @@ const rowLimitOverflowIsRejected = async (pool: Pool): Promise<void> => {
   });
 };
 
+
+const readNativeCandidates = (pool: Pool) =>
+  new PrismaGitHubTrendingDurableSnapshotReader(pool).readCandidates({
+    ...githubTrendingPostgresFixtureScope,
+    requestedUtcDay: "2026-07-23",
+  });
+
+const accumulatedCapacityAndSentinel = async (pool: Pool): Promise<void> => {
+  const candidates = buildGitHubTrendingCapacityGenerations(20);
+  await prepare(pool, candidates);
+  const mapped = await readNativeCandidates(pool);
+  assert(mapped.length === 200, "native reader must retain all 200 candidates");
+  deepStrictEqual([...mapped].sort(byFeedId), [...candidates].sort(byFeedId),
+    "all 44 native fields must match the accumulated fixture");
+  const log = new ActualPostgresStatementLog(pool);
+  const proof = await reuse(log.reader());
+  assertOneStatementSnapshot(log);
+  assertDeepEqual(proof, await reuse(new InMemoryGitHubTrendingDurableSnapshotReader(candidates)),
+    "200-row native proof must match full memory proof");
+  assertDeepEqual(proof, await reuse(new InMemoryGitHubTrendingDurableSnapshotReader(candidates.slice(-10))),
+    "accumulation must preserve the exact latest-ten proof");
+  assert(githubTrendingDurableSnapshotProofPassesInvariants(proof), "capacity proof invariants");
+  const sentinel = buildGitHubTrendingPostgresCandidates({ groupKey: "sentinel", rowCount: 1 });
+  await seedGitHubTrendingPostgresCandidates(pool, sentinel);
+  assert((await readNativeCandidates(pool)).length === 201, "native overflow sentinel must be returned");
+  await assertPostgresAndMemoryReject({ pool, candidates: [...candidates, ...sentinel],
+    expectedMessage: "candidate_bound_exceeded" });
+};
+
+const byFeedId = (a: GitHubTrendingDurableSnapshotCandidate, b: GitHubTrendingDurableSnapshotCandidate) =>
+  a.feedItemId.localeCompare(b.feedItemId, "en-US");
+
+const unicodeCapsAndOctets = async (pool: Pool): Promise<void> => {
+  // Include supplementary code points, escaped controls, quotes and backslashes.
+  // U+0000 is not PostgreSQL text; U+0001 exercises JSON escaping natively.
+  for (const character of ["😀", "\u0001", '"', "\\"]) {
+    const title = character.repeat(514);
+    const body = character.repeat(4098);
+    const candidates = buildGitHubTrendingPostgresCandidates({ mutate: (row) => ({
+      ...row, sourceTitle: title, feedTitle: title, bodyPreview: body,
+      sourceTitleBytes: Buffer.byteLength(title), feedTitleBytes: Buffer.byteLength(title),
+      bodyPreviewBytes: Buffer.byteLength(body), feedProviderKey: character.repeat(65),
+      sourceProviderKey: character.repeat(65), feedStatus: character.repeat(33),
+      scanJobStatus: character.repeat(33), feedSnapshotProviderKey: character.repeat(65),
+    }) });
+    await prepare(pool, candidates);
+    const rows = await readNativeCandidates(pool);
+    assert(rows.length === 10, "invalid provider/status rows must not be filtered out by SQL");
+    for (const row of rows) {
+      assertDeepEqual([row.sourceTitle, row.feedTitle, row.bodyPreview],
+        [character.repeat(513), character.repeat(513), character.repeat(4097)],
+        "SQL left must count Unicode code points");
+      assertDeepEqual([row.sourceTitleBytes, row.feedTitleBytes, row.bodyPreviewBytes],
+        [Buffer.byteLength(title), Buffer.byteLength(title), Buffer.byteLength(body)],
+        "octet_length must retain original untruncated UTF8 sizes");
+      assertDeepEqual([row.feedProviderKey, row.sourceProviderKey, row.feedSnapshotProviderKey,
+        row.feedStatus, row.scanJobStatus], [character.repeat(64), character.repeat(64),
+        character.repeat(64), character.repeat(32), character.repeat(32)], "new SQL caps must match");
+    }
+    assert(githubTrendingDurableSnapshotCandidatesFitBudget(rows), "native capped values must fit transport budget");
+    await assertPostgresAndMemoryReject({ pool, candidates: rows, expectedMessage: "selected_group_invalid" });
+  }
+  // Isolate visible-text checks from provider/status rejection, with no truncation.
+  for (const text of ["é😀\t\n", "visible\u0001control", "😀".repeat(129)]) {
+    const candidates = buildGitHubTrendingPostgresCandidates({ mutate: (row) => ({
+      ...row, sourceTitle: text, feedTitle: text, bodyPreview: text,
+      sourceTitleBytes: Buffer.byteLength(text), feedTitleBytes: Buffer.byteLength(text),
+      bodyPreviewBytes: Buffer.byteLength(text),
+    }) });
+    await prepare(pool, candidates);
+    if (text === "é😀\t\n") {
+      assertDeepEqual(await reuse(new PrismaGitHubTrendingDurableSnapshotReader(pool)),
+        await reuse(new InMemoryGitHubTrendingDurableSnapshotReader(candidates)), "valid multibyte proof parity");
+    } else {
+      await assertPostgresAndMemoryReject({ pool, candidates, expectedMessage: "selected_group_invalid" });
+    }
+  }
+};
+
+const nullAndMissingMetadata = async (pool: Pool): Promise<void> => {
+  const cases = [
+    { sql: "update feed_items set provider_metadata = NULL", field: "feedCheckedAt", value: null,
+      error: "invalid_ordering_identity" },
+    { sql: "update source_items set metadata = metadata - 'kind'", field: "metadataKind", value: null,
+      error: "selected_group_invalid" },
+    { sql: `update source_items set metadata = jsonb_set(metadata, '{kind}', 'null'::jsonb)`,
+      field: "metadataKind", value: null, error: "selected_group_invalid" },
+    { sql: "update source_items set provider_content_hash = NULL", field: "sourceProviderContentHash", value: "",
+      error: "selected_group_invalid" },
+    { sql: "update source_items set metadata = metadata #- '{trending,rank}'", field: "rank", value: 0,
+      error: "selected_group_invalid" },
+  ] as const;
+  for (const scenario of cases) {
+    const candidates = buildGitHubTrendingCapacityGenerations(20);
+    await prepare(pool, candidates);
+    const metadataColumn = scenario.sql.startsWith("update feed_items") ? "provider_metadata" : "metadata";
+    await pool.query(`${scenario.sql} where ${metadataColumn}->'trending'->>'scanJobId' = $1`,
+      [candidates.at(-1)!.scanJobId]);
+    const rows = await readNativeCandidates(pool);
+    const newestIds = new Set(candidates.slice(-10).map((row) => row.feedItemId));
+    const newest = rows.filter((row) => newestIds.has(row.feedItemId));
+    assert(rows.length === 200 && newest.length === 10, "NULL newest evidence must remain alongside older fallback");
+    assert(newest.every((row) => row[scenario.field] === scenario.value), "native NULL/missing mapping parity");
+    assert(githubTrendingDurableSnapshotCandidatesFitBudget(rows), "NULL evidence fits transport budget");
+    await assertPostgresAndMemoryReject({ pool, candidates: rows, expectedMessage: scenario.error });
+  }
+};
+
+const newestInvalidCaptures = async (pool: Pool): Promise<void> => {
+  const cases = [
+    ["update source_items set metadata = jsonb_set(metadata, '{trending,fetchStartedAt}', '\"malformed\"'::jsonb) where metadata->'trending'->>'scanJobId' <> $1", "invalid_ordering_identity"],
+    ["update scan_jobs set status = 'FAILED' where id = $1::uuid", "selected_group_invalid"],
+    ["delete from scan_jobs where id = $1::uuid", "selected_group_invalid"],
+    ["update feed_items set status = 'HIDDEN' where provider_metadata->'trending'->>'scanJobId' = $1", "selected_group_invalid"],
+    ["delete from feed_items where id = (select id from feed_items where provider_metadata->'trending'->>'scanJobId' = $1 limit 1)", "partial_group"],
+    ["update feed_items set title = 'mismatch' where provider_metadata->'trending'->>'scanJobId' = $1", "selected_group_invalid"],
+  ] as const;
+  for (const [sql, expectedMessage] of cases) {
+    const candidates = buildGitHubTrendingCapacityGenerations(20);
+    await prepare(pool, candidates);
+    await pool.query(sql, [candidates.at(-1)!.scanJobId]);
+    const mapped = await readNativeCandidates(pool);
+    assert(mapped.length >= 199, "newest invalid evidence and older fallback must remain visible");
+    await assertPostgresAndMemoryReject({ pool, candidates: mapped, expectedMessage });
+  }
+};
+
 const prepare = async (
   pool: Pool,
   candidates: readonly GitHubTrendingDurableSnapshotCandidate[],
@@ -399,6 +537,10 @@ if (typeof describe === "function") {
         "observedAt mismatch rejection",
         "invalid UUID scope rejection by PostgreSQL casts",
         "row-limit overflow rejection and parity",
+        "newest invalid and incomplete captures have no fallback",
+        "SQL NULL and missing metadata remain invalid",
+        "SQL Unicode caps and original octet lengths",
+        "200 accumulated valid rows and 201 sentinel",
       ]);
     });
   });

--- a/scripts/lib/github-trending-durable-snapshot-reuse.ts
+++ b/scripts/lib/github-trending-durable-snapshot-reuse.ts
@@ -2,11 +2,16 @@ import { createHash } from "node:crypto";
 
 import type { Pool } from "pg";
 
-export const githubTrendingDurableSnapshotRowLimit = 200;
+import {
+  githubTrendingDurableSnapshotCandidatesFitBudget,
+  githubTrendingDurableSnapshotRowLimit,
+  type GitHubTrendingDurableSnapshotCandidate,
+} from "./github-trending-durable-snapshot-candidate-budget";
+
+export { githubTrendingDurableSnapshotRowLimit } from "./github-trending-durable-snapshot-candidate-budget";
 const proofVersion = "github-trending-durable-snapshot-proof-v1" as const;
 const providerKey = "github-trending-page" as const;
 const expectedRepositoryCount = 10;
-const maxCandidateBytes = 262_144;
 const maxIdentityBytes = 256;
 const maxTitleBytes = 512;
 const maxBodyPreviewBytes = 4_096;
@@ -21,52 +26,7 @@ export const githubTrendingDurableSnapshotBindingFingerprint = (
   return hash.toString(16).padStart(8, "0");
 };
 
-export type GitHubTrendingDurableSnapshotCandidate = {
-  readonly tenantId: string;
-  readonly workspaceId: string;
-  readonly sourceTenantId: string;
-  readonly sourceWorkspaceId: string;
-  readonly feedItemId: string;
-  readonly sourceItemId: string;
-  readonly feedSourceBindingId: string;
-  readonly sourceSourceBindingId: string;
-  readonly feedProviderKey: string;
-  readonly sourceProviderKey: string;
-  readonly feedStatus: string;
-  readonly providerItemId: string;
-  readonly canonicalUrl: string;
-  readonly metadataKind: string;
-  readonly repositoryFullName: string;
-  readonly repositoryUrl: string;
-  readonly rank: number;
-  readonly starsGained: number;
-  readonly totalStars: number;
-  readonly window: string;
-  readonly scanJobId: string;
-  readonly feedScanJobId: string;
-  readonly fetchStartedAt: string;
-  readonly feedFetchStartedAt: string;
-  readonly checkedAt: string;
-  readonly feedCheckedAt: string;
-  readonly publishedAt: string;
-  readonly sourcePublishedAt: string;
-  readonly feedObservedAt: string;
-  readonly sourceObservedAt: string;
-  readonly scanJobStatus: string;
-  readonly scanJobTenantId: string;
-  readonly scanJobWorkspaceId: string;
-  readonly scanJobSourceBindingId: string;
-  readonly sourceContentHash: string;
-  readonly sourceProviderContentHash: string;
-  readonly sourceTitle: string;
-  readonly feedTitle: string;
-  readonly bodyPreview: string;
-  readonly sourceTitleBytes: number;
-  readonly feedTitleBytes: number;
-  readonly bodyPreviewBytes: number;
-  readonly feedSnapshotSourceBindingId: string;
-  readonly feedSnapshotProviderKey: string;
-};
+export type { GitHubTrendingDurableSnapshotCandidate } from "./github-trending-durable-snapshot-candidate-budget";
 
 export type GitHubTrendingDurableSnapshotProofRow = {
   readonly rank: number;
@@ -188,8 +148,7 @@ export const reuseGitHubTrendingDurableSnapshot = async (params: {
   const candidates = await params.reader.readCandidates(params);
   if (
     candidates.length === 0 ||
-    candidates.length > githubTrendingDurableSnapshotRowLimit ||
-    Buffer.byteLength(JSON.stringify(candidates), "utf8") > maxCandidateBytes
+    !githubTrendingDurableSnapshotCandidatesFitBudget(candidates)
   ) {
     throw invalidSnapshot(
       candidates.length === 0 ? "snapshot_missing" : "candidate_bound_exceeded",
@@ -724,9 +683,9 @@ const prismaCandidateQuery = `
     si.id::text as "sourceItemId",
     fi.source_binding_id::text as "feedSourceBindingId",
     si.source_binding_id::text as "sourceSourceBindingId",
-    fi.provider_key as "feedProviderKey",
-    si.provider_key as "sourceProviderKey",
-    fi.status::text as "feedStatus",
+    left(fi.provider_key, 64) as "feedProviderKey",
+    left(si.provider_key, 64) as "sourceProviderKey",
+    left(fi.status::text, 32) as "feedStatus",
     left(si.provider_item_id, 256) as "providerItemId",
     left(fi.canonical_url, 256) as "canonicalUrl",
     left(si.metadata->>'kind', 128) as "metadataKind",
@@ -746,7 +705,7 @@ const prismaCandidateQuery = `
     si.published_at as "sourcePublishedAt",
     fi.observed_at as "feedObservedAt",
     si.observed_at as "sourceObservedAt",
-    coalesce(sj.status::text, '') as "scanJobStatus",
+    left(coalesce(sj.status::text, ''), 32) as "scanJobStatus",
     coalesce(sj.tenant_id::text, '') as "scanJobTenantId",
     coalesce(sj.workspace_id::text, '') as "scanJobWorkspaceId",
     coalesce(sj.source_binding_id::text, '') as "scanJobSourceBindingId",


### PR DESCRIPTION
GitHub snapshot reuse rejected 150 real retained candidates (342,536 bytes) before selecting the latest ten, stopping the daily collection quality gate. Derive capacity from exhaustive field bounds while preserving the 200-row ceiling, bounded primitive allocations and all existing authority/proof checks.

Validation:
- Independent production-code review approved c8dae767; rebased production code is unchanged.
- Full compiler, focused tests and architecture/quality checks passed.
- All 14 native PostgreSQL 18.4 scenarios passed, including 200/201 rows, Unicode caps/original byte lengths, missing metadata and invalid latest captures.
- Read-only production comparison returned identical 150 candidates and an identical latest-ten proof using the old verifier.
- Ten serial native reads: representative150 maximum query24.5ms and sampled RSS348.6 to354.8MiB; bounded-invalid maximum200 query53.5ms and RSS373.6 to427.6MiB. Measurements include ts-node/test setup, can miss transient peaks and exclude PostgreSQL server memory; no global concurrency guarantee.

Final CI is running on c1f8b62122a14c6c63e802e3b8399951eafb6536. Deployment and natural daily verification remain separate; historical seven-day E2E is not claimed complete.

Refs #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - GitHub Trending snapshot processing now supports captures of up to 200 candidate rows.
  - Larger valid snapshots can be handled without being rejected solely because of their serialized size.
  - Snapshot data is validated more consistently, including field types, text lengths, Unicode content, and malformed records.
  - Oversized text fields are safely truncated during database reads.
  - Invalid or incomplete newest captures continue to be rejected to preserve snapshot accuracy.

- **Tests**
  - Added extensive coverage for capacity limits, byte sizing, Unicode, truncation, and invalid data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->