### PR TITLE
fix(ci): shard production affected backend tests

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -327,9 +327,49 @@ jobs:
           npm run check:reader-summary-daily-scan-terminal-repair-c1-postgres
           npm run check:reader-summary-daily-canonical-recovery-production
           npm run check:reader-summary-publication-signal-regression
+  verify_backend_shards:
+    name: Test affected backend shard ${{ matrix.shard }}/4
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    # Keep jobs successful with skipped steps when backend is unchanged.
+    # A skipped/cancelled/failed matrix job is never accepted by verify_backend.
+    steps:
+      - name: Check out the release commit
+        if: needs.plan.outputs.backend == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with: {fetch-depth: 0, ref: '${{ github.sha }}'}
+      - name: Set up Node.js
+        if: needs.plan.outputs.backend == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with: {node-version: 22, cache: npm}
+      - name: Prepare the same backend source and generated dependencies
+        if: needs.plan.outputs.backend == 'true'
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          npm ci
+          npm run prisma:generate
+          npm run build
+      - name: Test affected backend modules
+        if: needs.plan.outputs.backend == 'true'
+        env:
+          BACKEND_BASE: ${{ needs.plan.outputs.backend_base }}
+        run: |
+          set -euo pipefail
+          base=$BACKEND_BASE
+          if [[ $base == 0000000000000000000000000000000000000000 ]]; then
+            base=$(git rev-list --max-parents=0 "$GITHUB_SHA" | tail -n 1)
+          fi
+          npm test -- --changedSince="$base" --shard=${{ matrix.shard }}/4
   verify_backend:
     name: Verify backend, collector and deploy control
-    needs: plan
+    needs: [plan, verify_backend_shards]
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     services:
@@ -347,6 +387,8 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
+      - name: Require every affected backend shard to succeed
+        run: test "${{ needs.verify_backend_shards.result }}" = "success"
       - name: Check out the release commit
         if: needs.plan.outputs.backend == 'true' || needs.plan.outputs.control == 'true' || needs.plan.outputs.x_collector == 'true' || needs.plan.outputs.recovery_transition == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -635,16 +677,6 @@ jobs:
             echo "::error title=Publication bridge transition failed::The c071/7185 B-to-F fixture failed with status $publication_bridge_status."
             exit "$publication_bridge_status"
           fi
-      - name: Test affected backend modules
-        if: needs.plan.outputs.backend == 'true'
-        env:
-          BACKEND_BASE: ${{ needs.plan.outputs.backend_base }}
-        run: |
-          base=$BACKEND_BASE
-          if [[ $base == 0000000000000000000000000000000000000000 ]]; then
-            base=$(git rev-list --max-parents=0 "$GITHUB_SHA" | tail -n 1)
-          fi
-          npm test -- --changedSince="$base"
       - name: Set up Python for X collector verification
         if: needs.plan.outputs.x_collector == 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -349,6 +349,9 @@ jobs:
         with: {node-version: 22, cache: npm}
       - name: Prepare the same backend source and generated dependencies
         if: needs.plan.outputs.backend == 'true'
+        env:
+          # Inert test DSN for offline Prisma config loading; no database service needed.
+          DATABASE_URL: postgresql://fixture:fixture@127.0.0.1:5432/fixture
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -2,36 +2,11 @@ name: Production deploy
 on:
   push:
     branches: [main]
-    paths:
-      - .dockerignore
-      - .github/workflows/production-deploy.yml
-      - apps/api-gateway/**
-      - apps/agent-runtime/**
-      - apps/delivery-service/**
-      - apps/event-relay/**
-      - apps/frontend/**
-      - apps/ingestion-worker/**
-      - apps/intelligence-worker/**
-      - apps/social-research-grpc/**
-      - apps/social-research-mcp/**
-      - apps/social-research-runtime/**
-      - apps/x-collector/**
-      - libs/**
-      - ops/deploy/**
-      - ops/evals/**
-      - ops/observability/**
-      - prisma/**
-      - scripts/**
-      - test/**
-      - vendor/**
-      - Dockerfile
-      - docker-compose.yml
-      - package.json
-      - package-lock.json
-      - pnpm-lock.yaml
-      - prisma.config.ts
-      - tsconfig.json
-      - tsconfig.build.json
+    paths: [
+      .dockerignore, .github/workflows/production-deploy.yml, apps/api-gateway/**, apps/agent-runtime/**, apps/delivery-service/**, apps/event-relay/**, apps/frontend/**, apps/ingestion-worker/**, apps/intelligence-worker/**, apps/social-research-grpc/**,
+      apps/social-research-mcp/**, apps/social-research-runtime/**, apps/x-collector/**, libs/**, ops/deploy/**, ops/evals/**, ops/observability/**, prisma/**, scripts/**, test/**,
+      vendor/**, Dockerfile, docker-compose.yml, package.json, package-lock.json, pnpm-lock.yaml, prisma.config.ts, tsconfig.json, tsconfig.build.json,
+    ]
   workflow_dispatch:
     inputs:
       maintenance_action:
@@ -289,12 +264,8 @@ jobs:
     services:
       postgres:
         image: postgres:18.4-alpine
-        env:
-          POSTGRES_USER: social_monitor_publication_ci_admin
-          POSTGRES_PASSWORD: social_monitor_local_password
-          POSTGRES_DB: social_monitor_publication_ci_admin
-        ports:
-          - 5432:5432
+        env: {POSTGRES_USER: social_monitor_publication_ci_admin, POSTGRES_PASSWORD: social_monitor_local_password, POSTGRES_DB: social_monitor_publication_ci_admin}
+        ports: [5432:5432]
         options: >-
           --health-cmd "pg_isready -U social_monitor_publication_ci_admin -d social_monitor_publication_ci_admin"
           --health-interval 5s
@@ -334,8 +305,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
+      matrix: {shard: [1, 2, 3, 4]}
     # Keep jobs successful with skipped steps when backend is unchanged.
     # A skipped/cancelled/failed matrix job is never accepted by verify_backend.
     steps:
@@ -351,7 +321,7 @@ jobs:
         if: needs.plan.outputs.backend == 'true'
         env:
           # Inert test DSN for offline Prisma config loading; no database service needed.
-          DATABASE_URL: postgresql://fixture:fixture@127.0.0.1:5432/fixture
+          DATABASE_URL: postgresql://fixture:social_monitor_local_password@127.0.0.1:5432/fixture
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
@@ -360,8 +330,7 @@ jobs:
           npm run build
       - name: Test affected backend modules
         if: needs.plan.outputs.backend == 'true'
-        env:
-          BACKEND_BASE: ${{ needs.plan.outputs.backend_base }}
+        env: {BACKEND_BASE: '${{ needs.plan.outputs.backend_base }}'}
         run: |
           set -euo pipefail
           base=$BACKEND_BASE
@@ -378,12 +347,8 @@ jobs:
     services:
       postgres:
         image: postgres:18.4-alpine
-        env:
-          POSTGRES_USER: social_monitor_pool_ci
-          POSTGRES_PASSWORD: social_monitor_local_password
-          POSTGRES_DB: social_monitor_pool_ci
-        ports:
-          - 5432:5432
+        env: {POSTGRES_USER: social_monitor_pool_ci, POSTGRES_PASSWORD: social_monitor_local_password, POSTGRES_DB: social_monitor_pool_ci}
+        ports: [5432:5432]
         options: >-
           --health-cmd "pg_isready -U social_monitor_pool_ci -d social_monitor_pool_ci"
           --health-interval 5s

--- a/scripts/production-deploy-sharding.spec.ts
+++ b/scripts/production-deploy-sharding.spec.ts
@@ -30,7 +30,7 @@ function check(text: string) {
       { name: 'Set up Node.js', if: condition, uses: setup,
         with: { 'node-version': 22, cache: 'npm' } },
       { name: 'Prepare the same backend source and generated dependencies', if: condition,
-        env: { DATABASE_URL: 'postgresql://fixture:fixture@127.0.0.1:5432/fixture' },
+        env: { DATABASE_URL: 'postgresql://fixture:social_monitor_local_password@127.0.0.1:5432/fixture' },
         run: 'set -euo pipefail\ntest "$(git rev-parse HEAD)" = "$GITHUB_SHA"\nnpm ci\nnpm run prisma:generate\nnpm run build\n' },
       { name: 'Test affected backend modules', if: condition,
         env: { BACKEND_BASE: '${{ needs.plan.outputs.backend_base }}' }, run: affectedCommand },
@@ -56,6 +56,21 @@ function check(text: string) {
 
 describe('production affected-test shards', () => {
   it('keeps the exact affected selector, dependency preparation and strict deploy gate', () => check(source));
+  it('keeps the lifecycle workflow line budget without dropping shard safety', () => {
+    expect(source.match(/\n/g)!.length).toBeLessThan(1000);
+    check(source);
+  });
+  it.each([
+    ['secrets', process.execPath, ['scripts/check-secrets.mjs']],
+    ['maintenance dispatch lifecycle', 'bash', ['ops/deploy/github-production-maintenance-dispatch.test.sh']],
+  ])('passes the focused %s CI integration gate offline', (_name, command, args) => {
+    const run = spawnSync(command as string, args as string[], {
+      env: process.env,
+      encoding: 'utf8', timeout: 30000,
+    });
+    expect(run.error).toBeUndefined();
+    expect({ status: run.status, stderr: run.stderr }).toEqual({ status: 0, stderr: '' });
+  });
   it.each([false, true])('loads actual Prisma config offline with preparation env supplied=%s', (supplied) => {
     const preparation = yaml.load(source).jobs.verify_backend_shards.steps[2];
     // A fresh process receives only the explicit fixture env, never ambient credentials.
@@ -90,10 +105,14 @@ describe('production affected-test shards', () => {
       : { name: 'PrismaConfigEnvError', message: 'Cannot resolve environment variable: DATABASE_URL.' });
   });
   it.each([
-    ['          DATABASE_URL: postgresql://fixture:fixture@127.0.0.1:5432/fixture\n', ''],
+    ['          DATABASE_URL: postgresql://fixture:social_monitor_local_password@127.0.0.1:5432/fixture\n', ''],
     ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3]'],
+    ['timeout-minutes: 45', 'timeout-minutes: 90'],
+    ['test "$(git rev-parse HEAD)" = "$GITHUB_SHA"', 'true'],
+    ['npm ci\n          npm run prisma:generate\n          npm run build', 'npm ci\n          npm run build'],
+    ['--changedSince="$base"', '--changedSince=HEAD'],
     ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3, 3]'],
-    ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3, 4]\n        exclude: [{shard: 4}]'],
+    ['matrix: {shard: [1, 2, 3, 4]}', 'matrix: {shard: [1, 2, 3, 4], exclude: [{shard: 4}]}'],
     ['fail-fast: false', 'fail-fast: true'],
     ['--shard=${{ matrix.shard }}/4', '--shard=${{ matrix.shard }}/5'],
     ['--shard=${{ matrix.shard }}/4', '--shard=${{ matrix.shard }}/4 --passWithNoTests'],

--- a/scripts/production-deploy-sharding.spec.ts
+++ b/scripts/production-deploy-sharding.spec.ts
@@ -1,0 +1,138 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import { runInNewContext } from 'node:vm';
+
+const yaml = createRequire(`${process.cwd()}/package.json`)('js-yaml');
+const source = readFileSync('.github/workflows/production-deploy.yml', 'utf8');
+const condition = "needs.plan.outputs.backend == 'true'";
+const checkout = 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10';
+const setup = 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e';
+const affectedCommand = `set -euo pipefail
+base=$BACKEND_BASE
+if [[ $base == 0000000000000000000000000000000000000000 ]]; then
+  base=$(git rev-list --max-parents=0 "$GITHUB_SHA" | tail -n 1)
+fi
+npm test -- --changedSince="$base" --shard=\${{ matrix.shard }}/4
+`;
+
+// Like check-review-ci, parse the complete YAML and keep execution keys exact:
+// extra conditions, matrix exclusions, filters or continue-on-error can lose tests.
+function check(text: string) {
+  const { jobs } = yaml.load(text, { json: false });
+  expect(jobs.verify_backend_shards).toEqual({
+    name: 'Test affected backend shard ${{ matrix.shard }}/4',
+    needs: 'plan', 'runs-on': 'ubuntu-latest', 'timeout-minutes': 45,
+    strategy: { 'fail-fast': false, matrix: { shard: [1, 2, 3, 4] } },
+    steps: [
+      { name: 'Check out the release commit', if: condition, uses: checkout,
+        with: { 'fetch-depth': 0, ref: '${{ github.sha }}' } },
+      { name: 'Set up Node.js', if: condition, uses: setup,
+        with: { 'node-version': 22, cache: 'npm' } },
+      { name: 'Prepare the same backend source and generated dependencies', if: condition,
+        run: 'set -euo pipefail\ntest "$(git rev-parse HEAD)" = "$GITHUB_SHA"\nnpm ci\nnpm run prisma:generate\nnpm run build\n' },
+      { name: 'Test affected backend modules', if: condition,
+        env: { BACKEND_BASE: '${{ needs.plan.outputs.backend_base }}' }, run: affectedCommand },
+    ],
+  });
+  expect(jobs.verify_backend.needs).toEqual(['plan', 'verify_backend_shards']);
+  expect(jobs.verify_backend.if).toBe("${{ !cancelled() && needs.plan.result == 'success' }}");
+  expect(jobs.verify_backend['continue-on-error']).toBeUndefined();
+  expect(jobs.verify_backend.steps[0]).toEqual({
+    name: 'Require every affected backend shard to succeed',
+    run: 'test "${{ needs.verify_backend_shards.result }}" = "success"',
+  });
+  for (const id of ['release_a', 'deploy']) {
+    expect(jobs[id].needs).toContain('verify_backend');
+    expect(jobs[id].if).toBeUndefined(); // implicit success() rejects fail/cancel/skip
+    expect(jobs[id]['continue-on-error']).toBeUndefined();
+  }
+  expect(jobs.plan.if).toBe("${{ github.event_name != 'workflow_dispatch' || inputs.maintenance_action == 'none' }}");
+  expect(JSON.parse(readFileSync('package.json', 'utf8')).scripts.test).toBe(
+    'node scripts/run-with-timeout.mjs --timeout-ms 600000 --node-options --max-old-space-size=2048 -- jest --config jest.config.ts --runInBand',
+  );
+}
+
+describe('production affected-test shards', () => {
+  it('keeps the exact affected selector, dependency preparation and strict deploy gate', () => check(source));
+  it.each([
+    ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3]'],
+    ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3, 3]'],
+    ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3, 4]\n        exclude: [{shard: 4}]'],
+    ['fail-fast: false', 'fail-fast: true'],
+    ['--shard=${{ matrix.shard }}/4', '--shard=${{ matrix.shard }}/5'],
+    ['--shard=${{ matrix.shard }}/4', '--shard=${{ matrix.shard }}/4 --passWithNoTests'],
+    ['--shard=${{ matrix.shard }}/4', '--shard=${{ matrix.shard }}/4 --testPathPatterns=small'],
+    ['needs: [plan, verify_backend_shards]', 'needs: plan'],
+    ['!cancelled()', 'success()'],
+    ['= "success"', '!= "failure"'],
+    ['= "success"', '= "success" || true'],
+    ['    strategy:', '    continue-on-error: true\n    strategy:'],
+    ['    strategy:', '    if: false\n    strategy:'],
+    ["ref: '${{ github.sha }}'", 'ref: main'],
+    ['jobs:\n', 'jobs: [\n'],
+  ])('rejects unsafe mutation %s', (before, after) => {
+    expect(source).toContain(before);
+    expect(() => check(source.replace(before, after))).toThrow();
+  });
+  it.each(['success', 'failure', 'cancelled', 'skipped', ''])('aggregate result %s fails closed', (result) => {
+    const gate = yaml.load(source).jobs.verify_backend.steps[0].run;
+    const run = spawnSync('bash', ['-e', '-c', gate.replace('${{ needs.verify_backend_shards.result }}', result)]);
+    expect(run.status).toBe(result === 'success' ? 0 : 1);
+  });
+  it.each(['backend', 'control', 'frontend', 'x_collector', 'maintenance'])('preserves %s skip semantics', (mode) => {
+    const { jobs } = yaml.load(source);
+    // Successful plan always schedules four jobs. Backend=false skips their
+    // individual steps, yielding success, not a skipped matrix dependency.
+    expect(jobs.verify_backend_shards.if).toBeUndefined();
+    expect(jobs.verify_backend_shards.needs).toBe('plan');
+    for (const step of jobs.verify_backend_shards.steps) expect(step.if).toBe(condition);
+    const evaluate = (expression: string, planResult = 'success') => runInNewContext(
+      expression.replace(/^\$\{\{ | \}\}$/g, ''), {
+        github: { event_name: mode === 'maintenance' ? 'workflow_dispatch' : 'push' },
+        inputs: { maintenance_action: mode === 'maintenance' ? 'disk-report' : 'none' },
+        needs: { plan: { result: planResult, outputs: { backend: mode === 'backend' ? 'true' : 'false' } } },
+        cancelled: () => false,
+      },
+    );
+    const planRuns = evaluate(jobs.plan.if);
+    expect(planRuns).toBe(mode !== 'maintenance');
+    for (const step of jobs.verify_backend_shards.steps) {
+      expect(planRuns && evaluate(step.if)).toBe(mode === 'backend');
+    }
+    expect(evaluate(jobs.verify_backend.if, planRuns ? 'success' : 'skipped')).toBe(planRuns);
+    for (const result of ['failure', 'cancelled', 'skipped']) {
+      expect(evaluate(jobs.verify_backend.if, result)).toBe(false);
+    }
+  });
+  it.each([0, 1, 2, 3, 4, 5, 34, 796])('Jest partitions %s files without loss or overlap', (count) => {
+    const Sequencer = createRequire(`${process.cwd()}/package.json`)('@jest/test-sequencer').default;
+    const sequencer = new Sequencer();
+    const tests = Array.from({ length: count }, (_, i) => ({
+      path: `/repo/test-${i}.spec.ts`, context: { config: { rootDir: '/repo' } },
+    }));
+    const shards = [1, 2, 3, 4].map(shardIndex => sequencer.shard(tests, { shardIndex, shardCount: 4 }));
+    const union = shards.flat().map((test: { path: string }) => test.path);
+    expect(union.sort()).toEqual(tests.map(test => test.path).sort());
+    expect(new Set(union).size).toBe(count);
+  });
+  it.each(['844192f9cc745da8e9bf2428cd1c936852d220b0', '0'.repeat(40)])(
+    'passes exactly the original selector for base %s', (base) => {
+      const script = affectedCommand.replace('${{ matrix.shard }}', '3');
+      const stubs = 'git() { printf "root-sha\\n"; }; npm() { printf "<%s>\\n" "$@"; };\n';
+      const run = spawnSync('bash', ['-e', '-c', stubs + script], {
+        env: { ...process.env, BACKEND_BASE: base, GITHUB_SHA: 'target-sha' }, encoding: 'utf8',
+      });
+      expect(run.status).toBe(0);
+      expect(run.stdout).toBe(`<test>\n<-->\n<--changedSince=${base === '0'.repeat(40) ? 'root-sha' : base}>\n<--shard=3/4>\n`);
+    },
+  );
+  it('propagates selector resolution and test-command failures', () => {
+    for (const stubs of ['git() { return 7; }; npm() { exit 0; };', 'git() { echo root; }; npm() { return 9; };']) {
+      const run = spawnSync('bash', ['-c', stubs + '\n' + affectedCommand.replace('${{ matrix.shard }}', '1')], {
+        env: { ...process.env, BACKEND_BASE: '0'.repeat(40), GITHUB_SHA: 'target' },
+      });
+      expect(run.status).not.toBe(0);
+    }
+  });
+});

--- a/scripts/production-deploy-sharding.spec.ts
+++ b/scripts/production-deploy-sharding.spec.ts
@@ -30,6 +30,7 @@ function check(text: string) {
       { name: 'Set up Node.js', if: condition, uses: setup,
         with: { 'node-version': 22, cache: 'npm' } },
       { name: 'Prepare the same backend source and generated dependencies', if: condition,
+        env: { DATABASE_URL: 'postgresql://fixture:fixture@127.0.0.1:5432/fixture' },
         run: 'set -euo pipefail\ntest "$(git rev-parse HEAD)" = "$GITHUB_SHA"\nnpm ci\nnpm run prisma:generate\nnpm run build\n' },
       { name: 'Test affected backend modules', if: condition,
         env: { BACKEND_BASE: '${{ needs.plan.outputs.backend_base }}' }, run: affectedCommand },
@@ -55,7 +56,41 @@ function check(text: string) {
 
 describe('production affected-test shards', () => {
   it('keeps the exact affected selector, dependency preparation and strict deploy gate', () => check(source));
+  it.each([false, true])('loads actual Prisma config offline with preparation env supplied=%s', (supplied) => {
+    const preparation = yaml.load(source).jobs.verify_backend_shards.steps[2];
+    // A fresh process receives only the explicit fixture env, never ambient credentials.
+    // Evaluate the checked-in config with real prisma/config, stubbing only dotenv/config.
+    const probe = `
+      const ts = require('typescript');
+      const source = require('node:fs').readFileSync('prisma.config.ts', 'utf8');
+      const code = ts.transpileModule(source, {
+        compilerOptions: { module: ts.ModuleKind.CommonJS },
+      }).outputText;
+      const exports = {};
+      try {
+        require('node:vm').runInNewContext(code, { exports, require(id) {
+          if (id === 'dotenv/config') return {};
+          if (id === 'prisma/config') return require('prisma/config');
+          throw new Error('Unexpected config import: ' + id);
+        } });
+        process.stdout.write(JSON.stringify({ url: exports.default.datasource.url }));
+      } catch (error) {
+        process.stdout.write(JSON.stringify({ name: error.name, message: error.message }));
+        process.exitCode = 1;
+      }
+    `;
+    const run = spawnSync(process.execPath, ['-e', probe], {
+      env: supplied ? preparation.env : {}, encoding: 'utf8', timeout: 10000,
+    });
+    expect(run.error).toBeUndefined();
+    expect(run.stderr).toBe('');
+    expect(run.status).toBe(supplied ? 0 : 1);
+    expect(JSON.parse(run.stdout)).toEqual(supplied
+      ? { url: preparation.env.DATABASE_URL }
+      : { name: 'PrismaConfigEnvError', message: 'Cannot resolve environment variable: DATABASE_URL.' });
+  });
   it.each([
+    ['          DATABASE_URL: postgresql://fixture:fixture@127.0.0.1:5432/fixture\n', ''],
     ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3]'],
     ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3, 3]'],
     ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3, 4]\n        exclude: [{shard: 4}]'],


### PR DESCRIPTION
Production deployment 34207225766 stopped before deployment when serial affected backend tests exceeded the 600s command limit, after 26 passing suites and no failed assertions. Split the identical changedSince selector into four native Jest shards and require every shard to succeed before the existing backend and deployment gates.

Each shard verifies the event SHA, installs locked dependencies, generates Prisma with an explicit documented test configuration and builds. Test deadlines, all affected tests, publication gates, source-bound artifacts, maintenance behavior and rollback remain intact. Equivalent YAML formatting preserves the existing workflow line limit.

Validation: independent review approved exact head 2695a5737cd3f263164fb41749745d5a63b12cde; 69 focused tests, secrets scan, maintenance dispatch contract and strict focused TypeScript pass. Discovery proves 34 affected files partition into 9/9/8/8 with exact union and no overlap. First CI exposed the test password convention and workflow line limit; both were corrected without weakening their checks. Final CI 34213095098 is running. Actual production affected-shard timing and deployment are pending.

Refs #294
