### PR TITLE
fix(relevance): use scoped configured intent for promotion

### DIFF
--- a/libs/monitoring/interfaces/rest/monitoring-rest.module.spec.ts
+++ b/libs/monitoring/interfaces/rest/monitoring-rest.module.spec.ts
@@ -79,6 +79,7 @@ describe('MonitoringRestModule composition', () => {
       ListSourceBindingScansUseCase,
       RecordScanExecutionUseCase,
       InMemoryQueuePublisher,
+      MONITORING_INTEREST_REPOSITORY,
       MONITORING_CONFIG_PROTECTOR,
       MONITORING_SOURCE_BINDING_REPOSITORY,
       MONITORING_SOURCE_CREDENTIAL_RESOLVER,

--- a/libs/monitoring/interfaces/rest/monitoring-rest.module.ts
+++ b/libs/monitoring/interfaces/rest/monitoring-rest.module.ts
@@ -20,6 +20,7 @@ import { monitoringInterestProviders } from './monitoring-interest.providers';
 import { monitoringPersistenceProviders } from './monitoring-persistence.providers';
 import { MonitoringPrismaClientModule } from './monitoring-prisma-client.module';
 import {
+  MONITORING_INTEREST_REPOSITORY,
   MONITORING_CONFIG_PROTECTOR,
   MONITORING_SOURCE_BINDING_REPOSITORY,
   MONITORING_SOURCE_CREDENTIAL_RESOLVER,
@@ -76,6 +77,7 @@ import { SourceCredentialController } from './source-credential.controller';
     ListSourceBindingScansUseCase,
     RecordScanExecutionUseCase,
     InMemoryQueuePublisher,
+    MONITORING_INTEREST_REPOSITORY,
     MONITORING_CONFIG_PROTECTOR,
     MONITORING_SOURCE_BINDING_REPOSITORY,
     MONITORING_SOURCE_CREDENTIAL_RESOLVER,

--- a/libs/relevance/README.md
+++ b/libs/relevance/README.md
@@ -30,3 +30,35 @@ Layout is fixed as:
 - `ports`
 - `adapters`
 - `interfaces`
+
+## Configured interest authority for promotion
+
+Every new `reader_post_promotion` ranking invocation reads current Monitoring
+configuration independently, once per tenant/workspace/interest represented in
+its primary and supplemental snapshot. This also applies to an explicitly
+requested replacement generation for an older window. The content/engagement
+cutoff does not reconstruct historical interest configuration. Different
+interests are separate reads, not a transactionally consistent configuration
+snapshot. A later invocation may see an edited query.
+
+`ConfiguredInterestReaderPort` is a narrow Relevance capability backed by the
+existing scoped Monitoring repository. Missing/deleted, unavailable and
+mismatched authority return `operation.conflict`; an omitted capability never
+falls back to provider metadata or no-topic ranking. Monitoring archive removes
+the row from ordinary reads through `deletedAt`; disabled, nondeleted interests
+retain the repository's existing readable semantics.
+
+Configured query is intent, including literal short queries, not a claim of
+human authorship. Promotion projects that independently resolved query into the
+existing quality policy's literal `query` input. Stored interest snapshots,
+source-query modes/descriptors and copied top-level query fields are not
+promotion topic authority. Legitimate GitHub native `topics` remain provider
+content. Primary canonical native metrics, supplemental native fields, safety,
+crypto and admission floors retain their existing policies.
+
+Immutable publication recovery must consume its captured evidence and output;
+it must not invoke this current-configuration capability. Frozen daily
+`output_text` recovery returns before constructing a ranker. Legacy recovery
+without sufficient captured evidence cannot silently use today's configuration:
+it fails closed. Current intent is not a historical revision, and new ranking
+results must never overwrite an existing publication's bytes, IDs or hashes.

--- a/libs/relevance/adapters/monitoring/monitoring-configured-interest.reader.spec.ts
+++ b/libs/relevance/adapters/monitoring/monitoring-configured-interest.reader.spec.ts
@@ -1,0 +1,44 @@
+import { Interest } from "@social-monitor/monitoring/domain";
+import { InMemoryInterestRepository } from "@social-monitor/monitoring/adapters/persistence/in-memory-interest.repository";
+import { PrismaInterestRepository } from "@social-monitor/monitoring/adapters/persistence/prisma/prisma-interest.repository";
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { MonitoringConfiguredInterestReader } from "./monitoring-configured-interest.reader";
+
+const scope = { tenantId: tenantId("fixture-tenant"), workspaceId: workspaceId("fixture-workspace"), interestId: "fixture-interest" };
+const interest = Interest.create({ ...scope, id: scope.interestId, name: "Configured interest",
+  query: "best", createdAt: new Date("2026-09-08T00:00:00Z") });
+
+describe("Monitoring configured interest read integration", () => {
+  it("reads current configured query and respects archive and each scope dimension", async () => {
+    const repository = new InMemoryInterestRepository();
+    await repository.save(interest);
+    const reader = new MonitoringConfiguredInterestReader(repository);
+    expect(await reader.readCurrent(scope)).toEqual({ kind: "available", interest: { ...scope, query: "best" } });
+    for (const change of [{ tenantId: tenantId("other") }, { workspaceId: workspaceId("other") }, { interestId: "other" }]) {
+      expect(await reader.readCurrent({ ...scope, ...change })).toEqual({ kind: "missing" });
+    }
+    await repository.save(interest.updateDetails({ name: "Updated", query: "bread recipes" }));
+    expect(await reader.readCurrent(scope)).toMatchObject({ interest: { query: "bread recipes" } });
+    await repository.archive({ ...scope, archivedAt: new Date("2026-09-08T01:00:00Z") });
+    expect(await reader.readCurrent(scope)).toEqual({ kind: "missing" });
+  });
+
+  it("uses the durable repository's scoped, nondeleted read without leaking records", async () => {
+    const findFirst = jest.fn().mockResolvedValue({ ...interest.toSnapshot(), deletedAt: null, status: "ENABLED" });
+    const reader = new MonitoringConfiguredInterestReader(new PrismaInterestRepository({
+      interest: { findFirst },
+    } as unknown as ConstructorParameters<typeof PrismaInterestRepository>[0]));
+    expect(await reader.readCurrent(scope)).toEqual({ kind: "available", interest: { ...scope, query: "best" } });
+    expect(findFirst).toHaveBeenCalledWith({ where: { tenantId: scope.tenantId,
+      workspaceId: scope.workspaceId, id: scope.interestId, deletedAt: null } });
+    findFirst.mockResolvedValueOnce(null);
+    expect(await reader.readCurrent(scope)).toEqual({ kind: "missing" });
+  });
+
+  it("fails closed for repository failure and wrongly scoped records", async () => {
+    const failure = new MonitoringConfiguredInterestReader({ findById: async () => { throw new Error("database unavailable"); } });
+    expect(await failure.readCurrent(scope)).toEqual({ kind: "unavailable" });
+    const mismatched = new MonitoringConfiguredInterestReader({ findById: async () => interest });
+    expect(await mismatched.readCurrent({ ...scope, workspaceId: workspaceId("other") })).toEqual({ kind: "unavailable" });
+  });
+});

--- a/libs/relevance/adapters/monitoring/monitoring-configured-interest.reader.ts
+++ b/libs/relevance/adapters/monitoring/monitoring-configured-interest.reader.ts
@@ -1,0 +1,23 @@
+import type { InterestRepositoryPort } from "@social-monitor/monitoring/ports";
+import type {
+  ConfiguredInterestReaderPort, ConfiguredInterestRead, ConfiguredInterestScope,
+} from "../../ports";
+
+export class MonitoringConfiguredInterestReader implements ConfiguredInterestReaderPort {
+  constructor(private readonly interests: Pick<InterestRepositoryPort, "findById">) {}
+
+  async readCurrent(scope: ConfiguredInterestScope): Promise<ConfiguredInterestRead> {
+    try {
+      const interest = await this.interests.findById(scope);
+      if (interest === null) return { kind: "missing" };
+      const value = interest.toSnapshot();
+      if (value.tenantId !== scope.tenantId || value.workspaceId !== scope.workspaceId ||
+          value.id !== scope.interestId || value.query.trim().length === 0) {
+        return { kind: "unavailable" };
+      }
+      return { kind: "available", interest: Object.freeze({ ...scope, query: value.query }) };
+    } catch {
+      return { kind: "unavailable" };
+    }
+  }
+}

--- a/libs/relevance/domain/source-content-quality-normalizer-mode.spec.ts
+++ b/libs/relevance/domain/source-content-quality-normalizer-mode.spec.ts
@@ -1,0 +1,44 @@
+import type { JsonObject, JsonValue } from "@social-monitor/shared-kernel";
+import { normalizeSourceContentQualityInput } from "./source-content-quality-normalizer";
+
+const normalize = (providerMetadata: JsonObject) => normalizeSourceContentQualityInput({
+  providerKey: "hacker-news",
+  title: "Local bakers share their best bread recipes with neighbors",
+  canonicalUrl: "https://example.test/bread",
+  providerMetadata,
+});
+
+describe("source query mode topic extraction", () => {
+  it.each<JsonValue | undefined>([
+    "listing", "account_feed", "thread", "url", "unknown", undefined,
+    null, "", 5, [], {}, "SEARCH", " search ",
+  ])("excludes keywords, short topics and literal terms for mode %j", (mode) => {
+    const sourceQuery = { query: "best ai Go job", ...(mode === undefined ? {} : { mode }) };
+    const metadata = { sourceBindingSnapshot: { sourceQuery } };
+    expect(normalize(metadata)).toMatchObject({ topicTerms: [], missingTopicContext: true });
+    expect(metadata.sourceBindingSnapshot.sourceQuery).toEqual(sourceQuery);
+  });
+
+  it("excludes the short AI token embedded in an acquisition URL", () => {
+    expect(normalize({ sourceBindingSnapshot: {
+      sourceQuery: { mode: "url", query: "https://example.test/ai" },
+    } }).topicTerms).toEqual([]);
+  });
+
+  it("keeps both keyword and literal branches for explicit search", () => {
+    expect(normalize({ sourceBindingSnapshot: {
+      sourceQuery: { mode: "search", query: "best ai Go job" },
+    } }).topicTerms).toEqual(expect.arrayContaining(["best", "ai", "go", "job"]));
+  });
+
+  it.each(["searchQuery", "query"])("preserves the existing top-level %s contract", (key) => {
+    expect(normalize({ [key]: "Go" }).topicTerms).toEqual(["go"]);
+  });
+
+  it("preserves interest terms independently of the acquisition mode", () => {
+    expect(normalize({
+      interestQuerySnapshot: { query: "Mistral financing" },
+      sourceBindingSnapshot: { sourceQuery: { mode: "listing", query: "best" } },
+    })).toMatchObject({ topicTerms: ["financing", "mistral"], weakTopicMatch: true });
+  });
+});

--- a/libs/relevance/domain/source-content-quality-normalizer.ts
+++ b/libs/relevance/domain/source-content-quality-normalizer.ts
@@ -140,7 +140,11 @@ const topicTermsFromMetadata = (
   const searchQuery = readString(metadata?.searchQuery);
   const query = readString(metadata?.query);
   const interestQuery = readString(interestQuerySnapshot?.query);
-  const sourceQueryText = readString(sourceQuery?.query);
+  // Acquisition descriptors are not topic intent. Gate once, before both
+  // keyword/short-topic extraction and literal search-term extraction.
+  const sourceQueryText = sourceQuery?.mode === "search"
+    ? readString(sourceQuery.query)
+    : undefined;
   const values = [
     searchQuery,
     query,
@@ -152,9 +156,7 @@ const topicTermsFromMetadata = (
   const literalSearchValues = [
     searchQuery,
     query,
-    sourceQueryModeAllowsLiteralTerms(sourceQuery)
-      ? sourceQueryText
-      : undefined,
+    sourceQueryText,
   ].filter((value): value is string => value !== undefined);
   const terms = [
     ...values.flatMap((value) => [
@@ -193,14 +195,6 @@ const readObject = (value: JsonValue | undefined): JsonObject | undefined =>
   !Array.isArray(value)
     ? (value as JsonObject)
     : undefined;
-
-const sourceQueryModeAllowsLiteralTerms = (
-  sourceQuery: JsonObject | undefined,
-): boolean => {
-  const mode = readString(sourceQuery?.mode)?.toLocaleLowerCase("en-US");
-
-  return mode === undefined || mode !== "url";
-};
 
 const literalTopicTermsFromSearchQuery = (value: string): readonly string[] => {
   if (urlPresencePattern.test(value) || value.length > 160) {

--- a/libs/relevance/features/rank-feed-items/rank-feed-item-projection.ts
+++ b/libs/relevance/features/rank-feed-items/rank-feed-item-projection.ts
@@ -15,6 +15,10 @@ import {
   presentSourceContentSafety,
 } from "../shared/relevance-presenter";
 import type { RankedFeedItemView } from "./rank-feed-items.result";
+import {
+  type PromotionTopicScope,
+  trustedPromotionTopicContext,
+} from "./trusted-promotion-topic-context";
 
 type FeedItemSnapshot = ReturnType<FeedItem["toSnapshot"]>;
 
@@ -89,13 +93,19 @@ const providerSignalScore = (
 export const promotionSafeProviderMetadata = (
   providerKey: string,
   providerMetadata: FeedItemSnapshot["providerMetadata"],
+  scope?: PromotionTopicScope,
 ): JsonObject | undefined => {
   const eligibility = classifyFeedPromotionEligibility({
     providerKey,
     providerMetadata,
   });
   if (!eligibility.eligible) return providerMetadata;
-  return canonicalProviderMetadata(eligibility);
+  return {
+    ...canonicalProviderMetadata(eligibility),
+    ...trustedPromotionTopicContext(
+      providerMetadata, scope?.providerKey === providerKey ? scope : undefined,
+    ),
+  };
 };
 
 const canonicalProviderMetadata = (

--- a/libs/relevance/features/rank-feed-items/rank-feed-item-projection.ts
+++ b/libs/relevance/features/rank-feed-items/rank-feed-item-projection.ts
@@ -10,6 +10,7 @@ import type {
   RankedRelevanceCandidate,
   RankingCandidate,
 } from "../../domain";
+import type { ConfiguredInterest } from "../../ports";
 import {
   presentSourceContentQuality,
   presentSourceContentSafety,
@@ -19,6 +20,7 @@ import {
   type PromotionTopicScope,
   trustedPromotionTopicContext,
 } from "./trusted-promotion-topic-context";
+
 
 type FeedItemSnapshot = ReturnType<FeedItem["toSnapshot"]>;
 
@@ -94,16 +96,21 @@ export const promotionSafeProviderMetadata = (
   providerKey: string,
   providerMetadata: FeedItemSnapshot["providerMetadata"],
   scope?: PromotionTopicScope,
+  interest?: ConfiguredInterest,
 ): JsonObject | undefined => {
   const eligibility = classifyFeedPromotionEligibility({
     providerKey,
     providerMetadata,
   });
-  if (!eligibility.eligible) return providerMetadata;
+  if (scope === undefined && !eligibility.eligible) return providerMetadata;
+  const native = eligibility.eligible ? canonicalProviderMetadata(eligibility)
+    : supplementalProviderMetadata(providerMetadata);
   return {
-    ...canonicalProviderMetadata(eligibility),
+    ...native,
+    ...(scope !== undefined && ["github-repo-radar", "github-trending-page"].includes(providerKey) && providerMetadata?.topics !== undefined
+      ? { topics: providerMetadata.topics } : {}),
     ...trustedPromotionTopicContext(
-      providerMetadata, scope?.providerKey === providerKey ? scope : undefined,
+      scope?.providerKey === providerKey ? scope : undefined, interest,
     ),
   };
 };
@@ -144,4 +151,13 @@ const canonicalProviderMetadata = (
         }, ...authority };
     }
   }
+};
+
+// Supplemental provider fields retain their existing metric/rendering semantics;
+// application/acquisition topic slots cannot contribute topical evidence.
+const supplementalProviderMetadata = (metadata: JsonObject | undefined): JsonObject => {
+  const result = { ...metadata };
+  for (const key of ["query", "searchQuery", "topic", "topics", "interestQuerySnapshot",
+    "sourceBindingSnapshot", "workspaceScopeSnapshot"]) delete result[key];
+  return result;
 };

--- a/libs/relevance/features/rank-feed-items/rank-feed-items-forbidden-metrics.spec.ts
+++ b/libs/relevance/features/rank-feed-items/rank-feed-items-forbidden-metrics.spec.ts
@@ -88,6 +88,8 @@ const rank = async (
     repository,
     profiles,
     new FixedClock(new Date("2026-08-19T00:00:00.000Z")),
+      undefined, undefined, undefined, undefined, undefined,
+      { readCurrent: async (scope) => ({ kind: "available", interest: { ...scope, query: "AI developer tools" } }) },
   ).execute({
     tenantId: tenant,
     workspaceId: workspace,

--- a/libs/relevance/features/rank-feed-items/rank-feed-items.use-case.spec-support.ts
+++ b/libs/relevance/features/rank-feed-items/rank-feed-items.use-case.spec-support.ts
@@ -1,0 +1,202 @@
+import { classifyFeedPromotionEligibility, FeedItem } from "@social-monitor/feed/domain";
+import type { FeedItemReadRepositoryPort, ListFeedItemsQuery, ListFeedItemsResult, ReadPromotionFeedItemSnapshotQuery } from "@social-monitor/feed/ports";
+import type { tenantId, workspaceId, JsonObject } from "@social-monitor/shared-kernel";
+import type { UserRelevanceProfile as UserRelevanceProfileEntity } from "../../domain";
+import type {
+  BuildRelevanceMemoryGuidanceQuery, RelevanceMemoryGuidanceReaderPort,
+  RelevanceMemoryGuidanceResult, SourceContentQualityReviewerPort,
+  SourceContentQualityReviewRequest, SourceContentQualityReviewResult,
+  UserRelevanceProfileRepositoryPort,
+} from "../../ports";
+
+export const addFeedItem = (
+  repository: FakeFeedItemReadRepository,
+  props: {
+    readonly id: string;
+    readonly tenantId: ReturnType<typeof tenantId>;
+    readonly workspaceId: ReturnType<typeof workspaceId>;
+    readonly interestId: string;
+    readonly providerKey: string;
+    readonly title: string;
+    readonly bodyPreview: string;
+    readonly canonicalUrl: string;
+    readonly publishedAt: Date;
+    readonly authorHandle?: string;
+    readonly observedAt?: Date;
+    readonly providerMetadata?: JsonObject;
+  },
+): void => {
+  repository.upsert(
+    FeedItem.publish({
+      ...props,
+      sourceItemId: `${props.id}:source`,
+      sourceBindingId: `${props.providerKey}:binding`,
+      observedAt:
+        props.observedAt ?? new Date(props.publishedAt.getTime() + 60_000),
+      authorHandle: props.authorHandle,
+      providerMetadata: props.providerMetadata,
+    }),
+  );
+};
+
+export class FakeFeedItemReadRepository implements FeedItemReadRepositoryPort {
+  readonly queries: ListFeedItemsQuery[] = [];
+  private readonly items: FeedItem[] = [];
+
+  upsert(item: FeedItem): void {
+    this.items.push(item);
+  }
+
+  async list(query: ListFeedItemsQuery): Promise<ListFeedItemsResult> {
+    this.queries.push(query);
+    const offset = query.cursor === undefined ? 0 : Number(query.cursor);
+    const items = this.items
+      .filter((item) => {
+        const snapshot = item.toSnapshot();
+
+        return (
+          snapshot.tenantId === query.tenantId &&
+          snapshot.workspaceId === query.workspaceId &&
+          (query.interestId === undefined ||
+            snapshot.interestId === query.interestId) &&
+          (query.observedAfter === undefined ||
+            snapshot.observedAt.getTime() > query.observedAfter.getTime()) &&
+          (query.observedBefore === undefined ||
+            snapshot.observedAt.getTime() < query.observedBefore.getTime()) &&
+          (query.publishedAtOrAfter === undefined ||
+            snapshot.publishedAt.getTime() >=
+              query.publishedAtOrAfter.getTime()) &&
+          (query.publishedBefore === undefined ||
+            snapshot.publishedAt.getTime() < query.publishedBefore.getTime())
+        );
+      })
+      .sort(
+        (left, right) =>
+          right.toSnapshot().publishedAt.getTime() -
+          left.toSnapshot().publishedAt.getTime(),
+      );
+    const records = items.slice(offset, offset + query.limit + 1);
+    const page = records.slice(0, query.limit);
+    const nextOffset = offset + page.length;
+
+    return {
+      items: page,
+      nextCursor: records.length === query.limit + 1
+        ? String(nextOffset)
+        : undefined,
+    };
+  }
+
+  async readPromotionSnapshot(query: ReadPromotionFeedItemSnapshotQuery) {
+    const ordered = [...this.items].filter((item) => {
+      const snapshot = item.toSnapshot();
+      const timestamp = query.timestampPolicy === "published_at"
+        ? snapshot.publishedAt
+        : snapshot.observedAt;
+      return snapshot.tenantId === query.tenantId &&
+        snapshot.workspaceId === query.workspaceId &&
+        (query.interestId === undefined ||
+          snapshot.interestId === query.interestId) &&
+        timestamp >= query.windowStartedAt && timestamp < query.windowEndedAt &&
+        snapshot.observedAt <= query.observedThrough;
+    }).sort((left, right) => {
+      const leftSnapshot = left.toSnapshot();
+      const rightSnapshot = right.toSnapshot();
+      const leftTimestamp = query.timestampPolicy === "published_at"
+        ? leftSnapshot.publishedAt
+        : leftSnapshot.observedAt;
+      const rightTimestamp = query.timestampPolicy === "published_at"
+        ? rightSnapshot.publishedAt
+        : rightSnapshot.observedAt;
+      return rightTimestamp.getTime() - leftTimestamp.getTime() ||
+        rightSnapshot.id.localeCompare(leftSnapshot.id);
+    });
+    const candidates = ordered.flatMap((item) => {
+      const snapshot = item.toSnapshot();
+      const canonical = classifyFeedPromotionEligibility({
+        providerKey: snapshot.providerKey,
+        providerMetadata: snapshot.providerMetadata,
+      });
+      return canonical.eligible ? [{ item, canonical }] : [];
+    });
+    if (candidates.length > 1_000) return {
+      ok: false as const,
+      reason: "eligible_item_ceiling_exceeded" as const,
+      physicalRowsRead: ordered.length,
+      eligibleItemCount: candidates.length,
+      exhausted: true,
+    };
+    return {
+      ok: true as const,
+      candidates,
+      sourceContent: ordered.map((item) => {
+        const snapshot = item.toSnapshot();
+        return {
+          feedItemId: snapshot.id,
+          sourceItemId: snapshot.sourceItemId,
+          body: snapshot.bodyPreview,
+        };
+      }),
+      physicalRowsRead: ordered.length,
+      exhausted: true as const,
+    };
+  }
+
+  async findById(): Promise<FeedItem | null> {
+    return null;
+  }
+}
+
+export class FakeUserRelevanceProfileRepository implements UserRelevanceProfileRepositoryPort {
+  private readonly profiles = new Map<string, UserRelevanceProfileEntity>();
+
+  async save(profile: UserRelevanceProfileEntity): Promise<void> {
+    const snapshot = profile.toSnapshot();
+    this.profiles.set(
+      `${snapshot.tenantId}:${snapshot.workspaceId}:${snapshot.userId}`,
+      profile,
+    );
+  }
+
+  async findByUser(params: {
+    readonly tenantId: string;
+    readonly workspaceId: string;
+    readonly userId: string;
+  }): Promise<UserRelevanceProfileEntity | null> {
+    return (
+      this.profiles.get(
+        `${params.tenantId}:${params.workspaceId}:${params.userId}`,
+      ) ?? null
+    );
+  }
+}
+
+export class CapturingMemoryGuidanceReader implements RelevanceMemoryGuidanceReaderPort {
+  readonly queries: BuildRelevanceMemoryGuidanceQuery[] = [];
+
+  constructor(private readonly result: RelevanceMemoryGuidanceResult) {}
+
+  async buildGuidance(
+    query: BuildRelevanceMemoryGuidanceQuery,
+  ): Promise<RelevanceMemoryGuidanceResult> {
+    this.queries.push(query);
+
+    return this.result;
+  }
+}
+
+export class CapturingSourceContentQualityReviewer implements SourceContentQualityReviewerPort {
+  readonly requests: SourceContentQualityReviewRequest[] = [];
+
+  constructor(
+    private readonly reviews: readonly SourceContentQualityReviewResult[],
+  ) {}
+
+  async reviewBatch(
+    requests: readonly SourceContentQualityReviewRequest[],
+  ): Promise<readonly SourceContentQualityReviewResult[]> {
+    this.requests.push(...requests);
+
+    return this.reviews;
+  }
+}

--- a/libs/relevance/features/rank-feed-items/rank-feed-items.use-case.spec.ts
+++ b/libs/relevance/features/rank-feed-items/rank-feed-items.use-case.spec.ts
@@ -1,35 +1,11 @@
-import {
-  classifyFeedPromotionEligibility,
-  FeedItem,
-} from "@social-monitor/feed/domain";
-import type {
-  FeedItemReadRepositoryPort,
-  ListFeedItemsQuery,
-  ListFeedItemsResult,
-  ReadPromotionFeedItemSnapshotQuery,
-} from "@social-monitor/feed/ports";
-import {
-  FixedClock,
-  tenantId,
-  workspaceId,
-  type JsonObject,
-} from "@social-monitor/shared-kernel";
-
-import {
-  RankingPolicy,
-  UserRelevanceProfile,
-  type UserRelevanceProfile as UserRelevanceProfileEntity,
-} from "../../domain";
-import type {
-  BuildRelevanceMemoryGuidanceQuery,
-  RelevanceMemoryGuidanceReaderPort,
-  RelevanceMemoryGuidanceResult,
-  SourceContentQualityReviewerPort,
-  SourceContentQualityReviewRequest,
-  SourceContentQualityReviewResult,
-  UserRelevanceProfileRepositoryPort,
-} from "../../ports";
+import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { RankingPolicy, UserRelevanceProfile } from "../../domain";
 import { RankFeedItemsUseCase } from "./rank-feed-items.use-case";
+import {
+  addFeedItem, FakeFeedItemReadRepository, FakeUserRelevanceProfileRepository,
+  CapturingMemoryGuidanceReader, CapturingSourceContentQualityReviewer,
+} from "./rank-feed-items.use-case.spec-support";
 
 describe("RankFeedItemsUseCase", () => {
   it("ranks by user weights, clusters similar items and sandboxes unsafe source text", async () => {
@@ -625,6 +601,8 @@ describe("RankFeedItemsUseCase", () => {
       feedItems,
       new FakeUserRelevanceProfileRepository(),
       new FixedClock(new Date("2026-08-18T12:00:00.000Z")),
+      undefined, undefined, undefined, undefined, undefined,
+      { readCurrent: async (scope) => ({ kind: "available", interest: { ...scope, query: "AI developer tools" } }) },
     );
 
     const result = await useCase.execute({
@@ -679,6 +657,8 @@ describe("RankFeedItemsUseCase", () => {
       repository,
       new FakeUserRelevanceProfileRepository(),
       new FixedClock(new Date("2026-08-18T12:00:00.000Z")),
+      undefined, undefined, undefined, undefined, undefined,
+      { readCurrent: async (scope) => ({ kind: "available", interest: { ...scope, query: "AI developer tools" } }) },
     ).execute({
       tenantId: tenant,
       workspaceId: workspace,
@@ -709,6 +689,8 @@ describe("RankFeedItemsUseCase", () => {
       repository,
       new FakeUserRelevanceProfileRepository(),
       new FixedClock(new Date("2026-08-18T13:00:00.000Z")),
+      undefined, undefined, undefined, undefined, undefined,
+      { readCurrent: async (scope) => ({ kind: "available", interest: { ...scope, query: "AI developer tools" } }) },
     ).execute({
       tenantId: tenantId("tenant-promotion-transaction-failure"),
       workspaceId: workspaceId("workspace-promotion-transaction-failure"),
@@ -753,6 +735,8 @@ describe("RankFeedItemsUseCase", () => {
       feedItems,
       new FakeUserRelevanceProfileRepository(),
       new FixedClock(new Date("2026-08-18T13:00:00.000Z")),
+      undefined, undefined, undefined, undefined, undefined,
+      { readCurrent: async (scope) => ({ kind: "available", interest: { ...scope, query: "AI developer tools" } }) },
     ).execute({
       tenantId: tenant,
       workspaceId: workspace,
@@ -789,6 +773,8 @@ describe("RankFeedItemsUseCase", () => {
       repository,
       new FakeUserRelevanceProfileRepository(),
       new FixedClock(new Date("2026-08-18T13:00:00.000Z")),
+      undefined, undefined, undefined, undefined, undefined,
+      { readCurrent: async (scope) => ({ kind: "available", interest: { ...scope, query: "AI developer tools" } }) },
     ).execute({
       tenantId: tenant,
       workspaceId: workspace,
@@ -804,195 +790,3 @@ describe("RankFeedItemsUseCase", () => {
   });
 
 });
-
-const addFeedItem = (
-  repository: FakeFeedItemReadRepository,
-  props: {
-    readonly id: string;
-    readonly tenantId: ReturnType<typeof tenantId>;
-    readonly workspaceId: ReturnType<typeof workspaceId>;
-    readonly interestId: string;
-    readonly providerKey: string;
-    readonly title: string;
-    readonly bodyPreview: string;
-    readonly canonicalUrl: string;
-    readonly publishedAt: Date;
-    readonly authorHandle?: string;
-    readonly observedAt?: Date;
-    readonly providerMetadata?: JsonObject;
-  },
-): void => {
-  repository.upsert(
-    FeedItem.publish({
-      ...props,
-      sourceItemId: `${props.id}:source`,
-      sourceBindingId: `${props.providerKey}:binding`,
-      observedAt:
-        props.observedAt ?? new Date(props.publishedAt.getTime() + 60_000),
-      authorHandle: props.authorHandle,
-      providerMetadata: props.providerMetadata,
-    }),
-  );
-};
-
-class FakeFeedItemReadRepository implements FeedItemReadRepositoryPort {
-  readonly queries: ListFeedItemsQuery[] = [];
-  private readonly items: FeedItem[] = [];
-
-  upsert(item: FeedItem): void {
-    this.items.push(item);
-  }
-
-  async list(query: ListFeedItemsQuery): Promise<ListFeedItemsResult> {
-    this.queries.push(query);
-    const offset = query.cursor === undefined ? 0 : Number(query.cursor);
-    const items = this.items
-      .filter((item) => {
-        const snapshot = item.toSnapshot();
-
-        return (
-          snapshot.tenantId === query.tenantId &&
-          snapshot.workspaceId === query.workspaceId &&
-          (query.interestId === undefined ||
-            snapshot.interestId === query.interestId) &&
-          (query.observedAfter === undefined ||
-            snapshot.observedAt.getTime() > query.observedAfter.getTime()) &&
-          (query.observedBefore === undefined ||
-            snapshot.observedAt.getTime() < query.observedBefore.getTime()) &&
-          (query.publishedAtOrAfter === undefined ||
-            snapshot.publishedAt.getTime() >=
-              query.publishedAtOrAfter.getTime()) &&
-          (query.publishedBefore === undefined ||
-            snapshot.publishedAt.getTime() < query.publishedBefore.getTime())
-        );
-      })
-      .sort(
-        (left, right) =>
-          right.toSnapshot().publishedAt.getTime() -
-          left.toSnapshot().publishedAt.getTime(),
-      );
-    const records = items.slice(offset, offset + query.limit + 1);
-    const page = records.slice(0, query.limit);
-    const nextOffset = offset + page.length;
-
-    return {
-      items: page,
-      nextCursor: records.length === query.limit + 1
-        ? String(nextOffset)
-        : undefined,
-    };
-  }
-
-  async readPromotionSnapshot(query: ReadPromotionFeedItemSnapshotQuery) {
-    const ordered = [...this.items].filter((item) => {
-      const snapshot = item.toSnapshot();
-      const timestamp = query.timestampPolicy === "published_at"
-        ? snapshot.publishedAt
-        : snapshot.observedAt;
-      return snapshot.tenantId === query.tenantId &&
-        snapshot.workspaceId === query.workspaceId &&
-        (query.interestId === undefined ||
-          snapshot.interestId === query.interestId) &&
-        timestamp >= query.windowStartedAt && timestamp < query.windowEndedAt &&
-        snapshot.observedAt <= query.observedThrough;
-    }).sort((left, right) => {
-      const leftSnapshot = left.toSnapshot();
-      const rightSnapshot = right.toSnapshot();
-      const leftTimestamp = query.timestampPolicy === "published_at"
-        ? leftSnapshot.publishedAt
-        : leftSnapshot.observedAt;
-      const rightTimestamp = query.timestampPolicy === "published_at"
-        ? rightSnapshot.publishedAt
-        : rightSnapshot.observedAt;
-      return rightTimestamp.getTime() - leftTimestamp.getTime() ||
-        rightSnapshot.id.localeCompare(leftSnapshot.id);
-    });
-    const candidates = ordered.flatMap((item) => {
-      const snapshot = item.toSnapshot();
-      const canonical = classifyFeedPromotionEligibility({
-        providerKey: snapshot.providerKey,
-        providerMetadata: snapshot.providerMetadata,
-      });
-      return canonical.eligible ? [{ item, canonical }] : [];
-    });
-    if (candidates.length > 1_000) return {
-      ok: false as const,
-      reason: "eligible_item_ceiling_exceeded" as const,
-      physicalRowsRead: ordered.length,
-      eligibleItemCount: candidates.length,
-      exhausted: true,
-    };
-    return {
-      ok: true as const,
-      candidates,
-      sourceContent: ordered.map((item) => {
-        const snapshot = item.toSnapshot();
-        return {
-          feedItemId: snapshot.id,
-          sourceItemId: snapshot.sourceItemId,
-          body: snapshot.bodyPreview,
-        };
-      }),
-      physicalRowsRead: ordered.length,
-      exhausted: true as const,
-    };
-  }
-
-  async findById(): Promise<FeedItem | null> {
-    return null;
-  }
-}
-
-class FakeUserRelevanceProfileRepository implements UserRelevanceProfileRepositoryPort {
-  private readonly profiles = new Map<string, UserRelevanceProfileEntity>();
-
-  async save(profile: UserRelevanceProfileEntity): Promise<void> {
-    const snapshot = profile.toSnapshot();
-    this.profiles.set(
-      `${snapshot.tenantId}:${snapshot.workspaceId}:${snapshot.userId}`,
-      profile,
-    );
-  }
-
-  async findByUser(params: {
-    readonly tenantId: string;
-    readonly workspaceId: string;
-    readonly userId: string;
-  }): Promise<UserRelevanceProfileEntity | null> {
-    return (
-      this.profiles.get(
-        `${params.tenantId}:${params.workspaceId}:${params.userId}`,
-      ) ?? null
-    );
-  }
-}
-
-class CapturingMemoryGuidanceReader implements RelevanceMemoryGuidanceReaderPort {
-  readonly queries: BuildRelevanceMemoryGuidanceQuery[] = [];
-
-  constructor(private readonly result: RelevanceMemoryGuidanceResult) {}
-
-  async buildGuidance(
-    query: BuildRelevanceMemoryGuidanceQuery,
-  ): Promise<RelevanceMemoryGuidanceResult> {
-    this.queries.push(query);
-
-    return this.result;
-  }
-}
-
-class CapturingSourceContentQualityReviewer implements SourceContentQualityReviewerPort {
-  readonly requests: SourceContentQualityReviewRequest[] = [];
-
-  constructor(
-    private readonly reviews: readonly SourceContentQualityReviewResult[],
-  ) {}
-
-  async reviewBatch(
-    requests: readonly SourceContentQualityReviewRequest[],
-  ): Promise<readonly SourceContentQualityReviewResult[]> {
-    this.requests.push(...requests);
-
-    return this.reviews;
-  }
-}

--- a/libs/relevance/features/rank-feed-items/rank-feed-items.use-case.ts
+++ b/libs/relevance/features/rank-feed-items/rank-feed-items.use-case.ts
@@ -19,6 +19,7 @@ import {
   type SourceContentQualityVerdict,
 } from "../../domain";
 import type {
+  ConfiguredInterestReaderPort,
   RelevanceMemoryGuidanceReaderPort,
   SourceContentQualityReviewerPort,
   UserRelevanceProfileRepositoryPort,
@@ -55,6 +56,7 @@ export class RankFeedItemsUseCase {
     private readonly qualityPolicy = new SourceContentQualityPolicy(),
     private readonly qualityReviewer: SourceContentQualityReviewerPort = NOOP_SOURCE_CONTENT_QUALITY_REVIEWER,
     private readonly safetyPolicy = new SourceContentSafetyPolicy(),
+    private readonly configuredInterests?: ConfiguredInterestReaderPort,
   ) {}
 
   async execute(
@@ -63,6 +65,7 @@ export class RankFeedItemsUseCase {
     if (command.rankingProfile === "reader_post_promotion") {
       return rankPromotionSnapshot({
         command,
+        configuredInterests: this.configuredInterests,
         feedItems: this.feedItems,
         clock: this.clock,
         qualityPolicy: this.qualityPolicy,

--- a/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.spec.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.spec.ts
@@ -28,6 +28,7 @@ describe("promotion snapshot reader reasons", () => {
     const canonical = classifyFeedPromotionEligibility({ providerKey, providerMetadata });
     if (!canonical.eligible) throw new Error("Expected eligible fixture metrics");
     const result = await rankPromotionSnapshot({
+      configuredInterests: { readCurrent: async (scope) => ({ kind: "available", interest: { ...scope, query: "Agent sessions" } }) },
       command: { tenantId: tenant, workspaceId: workspace, limit: 1,
         publishedAtOrAfter: new Date("2026-09-06T00:00:00.000Z"),
         publishedBefore: new Date("2026-09-07T00:00:00.000Z") },

--- a/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
@@ -105,16 +105,18 @@ export const rankPromotionSnapshot = async (params: {
       bodyPreview: sourceContent.body.slice(0, PROMOTION_SOURCE_TEXT_SAFETY_CAP),
       canonicalUrl: item.canonicalUrl,
     });
+    const providerMetadata = promotionSafeProviderMetadata(
+      item.providerKey,
+      item.providerMetadata,
+      item,
+    );
     const quality = params.qualityPolicy.evaluate({
       providerKey: item.providerKey,
       canonicalUrl: safety.sanitizedCanonicalUrl ?? item.canonicalUrl,
       title: safety.sanitizedTitle,
       bodyPreview: safety.sanitizedBodyPreview,
       authorHandle: item.authorHandle,
-      providerMetadata: promotionSafeProviderMetadata(
-        item.providerKey,
-        item.providerMetadata,
-      ),
+      providerMetadata,
     });
     return {
       feedItemId: item.id,
@@ -130,10 +132,7 @@ export const rankPromotionSnapshot = async (params: {
           0, PROMOTION_SOURCE_TEXT_SAFETY_CAP,
         ),
       }),
-      providerMetadata: promotionSafeProviderMetadata(
-        item.providerKey,
-        item.providerMetadata,
-      ),
+      providerMetadata,
       authorHandle: item.authorHandle,
       publishedAt: item.publishedAt.toISOString(),
       observedAt: item.observedAt.toISOString(),

--- a/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
@@ -26,9 +26,13 @@ import type {
 } from "./rank-feed-items.result";
 import { promotionSafeProviderMetadata } from "./rank-feed-item-projection";
 
+import type { ConfiguredInterestReaderPort } from "../../ports";
+import { resolvePromotionInterests } from "./resolve-promotion-interests";
+
 const PROMOTION_SOURCE_TEXT_SAFETY_CAP = 256_000;
 
 export const rankPromotionSnapshot = async (params: {
+  readonly configuredInterests?: ConfiguredInterestReaderPort;
   readonly command: RankFeedItemsCommand;
   readonly feedItems: FeedItemReadRepositoryPort;
   readonly clock: Clock;
@@ -91,6 +95,10 @@ export const rankPromotionSnapshot = async (params: {
       },
     ));
   }
+  const interests = await resolvePromotionInterests(command,
+    [...snapshot.candidates.map(({ item }) => item), ...(snapshot.supplementalItems ?? [])],
+    params.configuredInterests);
+  if (!interests.ok) return interests;
   const sourceContentById = new Map(snapshot.sourceContent.map((content) =>
     [content.feedItemId, content] as const));
   const projected = snapshot.candidates.map((candidate) => {
@@ -109,6 +117,7 @@ export const rankPromotionSnapshot = async (params: {
       item.providerKey,
       item.providerMetadata,
       item,
+      interests.value.get(item.interestId),
     );
     const quality = params.qualityPolicy.evaluate({
       providerKey: item.providerKey,
@@ -171,13 +180,16 @@ export const rankPromotionSnapshot = async (params: {
       bodyPreview: sourceContent.body.slice(0, PROMOTION_SOURCE_TEXT_SAFETY_CAP),
       canonicalUrl: item.canonicalUrl,
     });
+    const providerMetadata = promotionSafeProviderMetadata(
+      item.providerKey, item.providerMetadata, item, interests.value.get(item.interestId),
+    );
     const quality = params.qualityPolicy.evaluate({
       providerKey: item.providerKey,
       canonicalUrl: safety.sanitizedCanonicalUrl ?? item.canonicalUrl,
       title: safety.sanitizedTitle,
       bodyPreview: safety.sanitizedBodyPreview,
       authorHandle: item.authorHandle,
-      providerMetadata: item.providerMetadata,
+      providerMetadata,
     });
     return {
       feedItemId: item.id,
@@ -193,7 +205,7 @@ export const rankPromotionSnapshot = async (params: {
           0, PROMOTION_SOURCE_TEXT_SAFETY_CAP,
         ),
       }),
-      providerMetadata: item.providerMetadata,
+      providerMetadata,
       authorHandle: item.authorHandle,
       publishedAt: item.publishedAt.toISOString(),
       observedAt: item.observedAt.toISOString(),

--- a/libs/relevance/features/rank-feed-items/rank-promotion-topic-context.spec-support.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-topic-context.spec-support.ts
@@ -18,10 +18,7 @@ export const context = {
   workspaceScopeSnapshot: { tenantId: scope.tenantId, workspaceId: scope.workspaceId },
 };
 export const nativeMetadata = { kind: "hacker_news_story", contentKind: "story", points: 338 };
-export const projectedContext = {
-  interestQuerySnapshot: { query: "Mistral financing" },
-  sourceBindingSnapshot: { sourceQuery: { mode: "search", query: "Mistral financing" } },
-};
+export const projectedContext = { query: "Mistral financing" };
 export const feedItem = (overrides: Partial<ReturnType<FeedItem["toSnapshot"]>> = {}): FeedItem =>
   FeedItem.rehydrate({
     ...scope, id: "synthetic-feed", sourceItemId: "synthetic-source",
@@ -32,7 +29,7 @@ export const feedItem = (overrides: Partial<ReturnType<FeedItem["toSnapshot"]>> 
 
 export const rankItems = async (
   items: readonly FeedItem[],
-  options: { readonly authority?: "stable" | "unresolved_regression" | "missing" } = {},
+  options: { readonly query?: string; readonly authority?: "stable" | "unresolved_regression" | "missing" } = {},
 ) => {
   const qualityPolicy = new SourceContentQualityPolicy();
   const qualityInput = jest.spyOn(qualityPolicy, "evaluate");
@@ -55,6 +52,8 @@ export const rankItems = async (
           sourceItemId: item.toSnapshot().sourceItemId, body: item.toSnapshot().bodyPreview })),
       }),
     },
+    configuredInterests: { readCurrent: async () => ({ kind: "available",
+      interest: { ...scope, query: options.query ?? "Mistral financing" } }) },
     clock: new FixedClock(now), qualityPolicy, safetyPolicy: new SourceContentSafetyPolicy(),
   });
   if (!result.ok) throw result.error;

--- a/libs/relevance/features/rank-feed-items/rank-promotion-topic-context.spec-support.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-topic-context.spec-support.ts
@@ -1,0 +1,105 @@
+import type { ReaderPromotionV2Candidate, ReaderPromotionV2ObservedMetrics } from "@social-monitor/feed/domain";
+import type { RankedFeedItemView } from "./rank-feed-items.result";
+import { classifyFeedPromotionEligibility, FeedItem } from "@social-monitor/feed/domain";
+import { FixedClock, tenantId, workspaceId, type JsonObject } from "@social-monitor/shared-kernel";
+import { SourceContentQualityPolicy, SourceContentSafetyPolicy } from "../../domain";
+import { rankPromotionSnapshot } from "./rank-promotion-snapshot";
+
+export const now = new Date("2026-09-08T08:00:00.000Z");
+export const scope = {
+  tenantId: tenantId("synthetic-tenant"), workspaceId: workspaceId("synthetic-workspace"),
+  interestId: "synthetic-interest", sourceBindingId: "synthetic-binding", providerKey: "hacker-news",
+};
+export const matchingTitle = "Mistral raises three billion in new financing round";
+export const context = {
+  interestQuerySnapshot: { interestId: scope.interestId, query: "Mistral financing" },
+  sourceBindingSnapshot: { sourceBindingId: scope.sourceBindingId, providerKey: scope.providerKey,
+    sourceQuery: { mode: "search", query: "Mistral financing" } },
+  workspaceScopeSnapshot: { tenantId: scope.tenantId, workspaceId: scope.workspaceId },
+};
+export const nativeMetadata = { kind: "hacker_news_story", contentKind: "story", points: 338 };
+export const projectedContext = {
+  interestQuerySnapshot: { query: "Mistral financing" },
+  sourceBindingSnapshot: { sourceQuery: { mode: "search", query: "Mistral financing" } },
+};
+export const feedItem = (overrides: Partial<ReturnType<FeedItem["toSnapshot"]>> = {}): FeedItem =>
+  FeedItem.rehydrate({
+    ...scope, id: "synthetic-feed", sourceItemId: "synthetic-source",
+    canonicalUrl: "https://example.test/synthetic-financing", title: matchingTitle,
+    bodyPreview: "", publishedAt: now, observedAt: now,
+    providerMetadata: { ...nativeMetadata, ...context }, ...overrides,
+  });
+
+export const rankItems = async (
+  items: readonly FeedItem[],
+  options: { readonly authority?: "stable" | "unresolved_regression" | "missing" } = {},
+) => {
+  const qualityPolicy = new SourceContentQualityPolicy();
+  const qualityInput = jest.spyOn(qualityPolicy, "evaluate");
+  const result = await rankPromotionSnapshot({
+    command: { tenantId: scope.tenantId, workspaceId: scope.workspaceId, limit: items.length,
+      publishedAtOrAfter: new Date("2026-09-08T00:00:00Z"),
+      publishedBefore: new Date("2026-09-09T00:00:00Z") },
+    feedItems: {
+      list: async () => ({ items: [] }), findById: async () => null,
+      readPromotionSnapshot: async () => ({
+        ok: true, exhausted: true, physicalRowsRead: items.length,
+        candidates: items.map((item) => {
+          const canonical = classifyFeedPromotionEligibility(item.toSnapshot());
+          if (!canonical.eligible) throw new Error("Expected canonical fixture");
+          return { item, canonical, ...(options.authority === "missing" ? {} : {
+            metricAuthority: { observedAt: now, regressionState: options.authority ?? "stable" },
+          }) };
+        }),
+        sourceContent: items.map((item) => ({ feedItemId: item.toSnapshot().id,
+          sourceItemId: item.toSnapshot().sourceItemId, body: item.toSnapshot().bodyPreview })),
+      }),
+    },
+    clock: new FixedClock(now), qualityPolicy, safetyPolicy: new SourceContentSafetyPolicy(),
+  });
+  if (!result.ok) throw result.error;
+  for (const item of result.value.items) {
+    const input = qualityInput.mock.calls.find(([input]) => input.canonicalUrl === item.canonicalUrl)?.[0];
+    expect(input?.providerMetadata).toBe(item.providerMetadata);
+  }
+  return result.value.items;
+};
+
+export const metadataWith = (patch: JsonObject): JsonObject => ({ ...nativeMetadata, ...context, ...patch });
+
+// Exercise the public V2 domain contract with actual ranked quality and metrics.
+// Summary adapter integration is also replayed separately in the audit artifact.
+export const v2Candidate = (item: RankedFeedItemView): ReaderPromotionV2Candidate => {
+  const canonical = classifyFeedPromotionEligibility(item);
+  if (!canonical.eligible) throw new Error("Expected canonical fixture");
+  const native = canonical.metrics;
+  let metrics: ReaderPromotionV2ObservedMetrics;
+  switch (native.kind) {
+    case "hacker_news_story": metrics = { provider: "hacker_news", points: native.points }; break;
+    case "reddit_post": metrics = { provider: "reddit", score: native.score, upvoteRatio: native.upvoteRatio }; break;
+    case "x_post": metrics = { provider: "x", likes: native.likes!, reposts: native.reposts! }; break;
+    case "github_repository": metrics = { provider: "github", window: "24h", checkedAt: native.checkedAt!,
+      starsDelta: native.trendingDelta.value!, forksDelta: native.forkTrendDeltas[0]!.value! }; break;
+  }
+  const authority = native.kind === "github_repository"
+    ? { source: "github_checked_at" as const, observedAt: native.checkedAt!, regressionState: "stable" as const }
+    : item.engagementAuthority === undefined ? undefined
+      : { source: "durable_projection" as const, ...item.engagementAuthority };
+  const quality = item.contentQuality;
+  return {
+    candidateId: item.feedItemId, canonicalIdentity: item.canonicalUrl,
+    provider: metrics.provider, contentKind: canonical.contentKind,
+    publishedAt: item.publishedAt, engagementCutoffAt: now.toISOString(),
+    admission: {
+      relevanceFloorMet: quality.eligibleForSummary,
+      qualityFloorMet: quality.eligibleForTopRead && !quality.needsLlmReview &&
+        quality.decision !== "downrank" && quality.decision !== "reject",
+      integrityFloorMet: Number.isFinite(quality.engagementIntegrityScore),
+      safetyFloorMet: item.safety.status !== "blocked",
+      freshnessFloorMet: item.publishedAt <= now.toISOString() && item.publishedAt >= "2026-09-08T00:00:00.000Z",
+    },
+    engagement: { state: "observed", authoritative: authority !== undefined, authority, metrics },
+    relevanceScore: quality.interestRelevanceScore, evidenceQualityScore: quality.qualityScore,
+    integrityScore: quality.engagementIntegrityScore, freshnessScore: 1,
+  };
+};

--- a/libs/relevance/features/rank-feed-items/rank-promotion-topic-context.spec.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-topic-context.spec.ts
@@ -11,11 +11,11 @@ import {
 describe("promotion snapshot verified topic context through reader V2", () => {
   it("restores relevant nonlegacy literal query matching without changing native metrics", async () => {
     const [bound] = await rankItems([feedItem()]);
-    const [unbound] = await rankItems([feedItem({ providerMetadata: nativeMetadata })]);
+    const [unbound] = await rankItems([feedItem({ providerMetadata: nativeMetadata })], { query: "bread recipes" });
     expect(bound!.providerMetadata).toEqual({ ...nativeMetadata, ...projectedContext });
     expect(bound!.contentQuality).toMatchObject({ interestRelevanceScore: 0.9,
       qualityScore: 0.95, engagementIntegrityScore: 0.92, decision: "promote", eligibleForTopRead: true });
-    expect(unbound!.contentQuality).toMatchObject({ interestRelevanceScore: 0.49, decision: "downrank" });
+    expect(unbound!.contentQuality).toMatchObject({ interestRelevanceScore: 0.38, decision: "downrank" });
     expect(evaluateReaderPromotionV2(v2Candidate(bound!))).toMatchObject({ admitted: true, topQualified: true, providerSignal: 338 });
     expect(evaluateReaderPromotionV2(v2Candidate(unbound!))).toMatchObject({ admitted: false,
       reasons: expect.arrayContaining(["relevance_floor_not_met", "quality_floor_not_met"]) });
@@ -47,19 +47,23 @@ describe("promotion snapshot verified topic context through reader V2", () => {
     ["interest", { interestId: "other-interest" }],
     ["binding", { sourceBindingId: "other-binding" }],
   ] as const)("rejects stored context transplanted onto a different hydrated %s", async (_name, change) => {
-    const [item] = await rankItems([feedItem(change)]);
-    expect(item!.providerMetadata).toEqual(nativeMetadata);
-    expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
+    if (_name === "binding") {
+      const [item] = await rankItems([feedItem(change)], { query: "bread recipes" });
+      expect(item!.providerMetadata).toEqual({ ...nativeMetadata, query: "bread recipes" });
+      expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
+    } else {
+      await expect(rankItems([feedItem(change)])).rejects.toMatchObject({ code: "operation.conflict" });
+    }
   });
 
   const malformed: readonly (JsonValue | undefined)[] = [undefined, null, [], "forged", 123, {}, { query: matchingTitle }];
   for (const field of ["interestQuerySnapshot", "sourceBindingSnapshot", "workspaceScopeSnapshot"] as const) {
-    it.each(malformed)(`strips all context when ${field} is malformed: %j`, async (value) => {
+    it.each(malformed)(`ignores malformed stored ${field} with independently unrelated intent: %j`, async (value) => {
       const metadata: Record<string, JsonValue> = { ...nativeMetadata, ...context };
       if (value === undefined) delete metadata[field];
       else metadata[field] = value;
-      const [item] = await rankItems([feedItem({ providerMetadata: metadata })]);
-      expect(item!.providerMetadata).toEqual(nativeMetadata);
+      const [item] = await rankItems([feedItem({ providerMetadata: metadata })], { query: "bread recipes" });
+      expect(item!.providerMetadata).toEqual({ ...nativeMetadata, query: "bread recipes" });
       expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
     });
   }
@@ -76,18 +80,17 @@ describe("promotion snapshot verified topic context through reader V2", () => {
       sourceBindingSnapshot: { ...context.sourceBindingSnapshot, sourceQuery },
     })),
   ])("rejects malformed or mismatched nested query contracts %j", async (patch) => {
-    const [item] = await rankItems([feedItem({ providerMetadata: metadataWith(patch) })]);
-    expect(item!.providerMetadata).toEqual(nativeMetadata);
+    const [item] = await rankItems([feedItem({ providerMetadata: metadataWith(patch) })], { query: "bread recipes" });
+    expect(item!.providerMetadata).toEqual({ ...nativeMetadata, query: "bread recipes" });
     expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
   });
 
-  it.each(["search", "listing", "account_feed", "thread", "url"])("preserves the existing %s source query mode", async (mode) => {
+  it.each(["search", "listing", "account_feed", "thread", "url"])("uses configured intent independently of %s acquisition mode", async (mode) => {
     const [item] = await rankItems([feedItem({ providerMetadata: metadataWith({
       sourceBindingSnapshot: { ...context.sourceBindingSnapshot, sourceQuery: { mode, query: "Mistral financing" } },
     }) })]);
     expect(item!.providerMetadata).toEqual({ ...nativeMetadata,
-      interestQuerySnapshot: projectedContext.interestQuerySnapshot,
-      sourceBindingSnapshot: { sourceQuery: { mode, query: "Mistral financing" } },
+      query: "Mistral financing",
     });
     expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(true);
   });
@@ -124,7 +127,10 @@ describe("promotion snapshot verified topic context through reader V2", () => {
     const metadata = metadataWith(patch);
     expect(classifyFeedPromotionEligibility({ providerKey: scope.providerKey, providerMetadata: metadata }).eligible).toBe(false);
     // The canonical gate still rejects before context can be projected.
-    expect(promotionSafeProviderMetadata(scope.providerKey, metadata, scope)).toBe(metadata);
+    const projected = promotionSafeProviderMetadata(scope.providerKey, metadata, scope);
+    expect(classifyFeedPromotionEligibility({ providerKey: scope.providerKey, providerMetadata: projected }).eligible).toBe(false);
+    expect(projected).toMatchObject({ ...nativeMetadata, ...patch });
+    expect(projected).not.toHaveProperty("interestQuerySnapshot");
   });
 
   it.each(["producer", "source_catalog"])("preserves existing %s authority attestation", async (attestedBy) => {

--- a/libs/relevance/features/rank-feed-items/rank-promotion-topic-context.spec.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-topic-context.spec.ts
@@ -1,0 +1,171 @@
+import {
+  classifyFeedPromotionEligibility, evaluateReaderPromotionV2, rankReaderPromotionV2,
+} from "@social-monitor/feed/domain";
+import { tenantId, workspaceId, type JsonObject, type JsonValue } from "@social-monitor/shared-kernel";
+import { promotionSafeProviderMetadata } from "./rank-feed-item-projection";
+import {
+  context, feedItem, matchingTitle, metadataWith, nativeMetadata, now,
+  projectedContext, rankItems, scope, v2Candidate,
+} from "./rank-promotion-topic-context.spec-support";
+
+describe("promotion snapshot verified topic context through reader V2", () => {
+  it("restores relevant nonlegacy literal query matching without changing native metrics", async () => {
+    const [bound] = await rankItems([feedItem()]);
+    const [unbound] = await rankItems([feedItem({ providerMetadata: nativeMetadata })]);
+    expect(bound!.providerMetadata).toEqual({ ...nativeMetadata, ...projectedContext });
+    expect(bound!.contentQuality).toMatchObject({ interestRelevanceScore: 0.9,
+      qualityScore: 0.95, engagementIntegrityScore: 0.92, decision: "promote", eligibleForTopRead: true });
+    expect(unbound!.contentQuality).toMatchObject({ interestRelevanceScore: 0.49, decision: "downrank" });
+    expect(evaluateReaderPromotionV2(v2Candidate(bound!))).toMatchObject({ admitted: true, topQualified: true, providerSignal: 338 });
+    expect(evaluateReaderPromotionV2(v2Candidate(unbound!))).toMatchObject({ admitted: false,
+      reasons: expect.arrayContaining(["relevance_floor_not_met", "quality_floor_not_met"]) });
+    expect(classifyFeedPromotionEligibility({ providerKey: scope.providerKey, providerMetadata: bound!.providerMetadata }))
+      .toEqual(classifyFeedPromotionEligibility(feedItem().toSnapshot()));
+  });
+
+  it("lets higher native metrics compete only after independent relevance and quality pass", async () => {
+    const items = await rankItems([
+      feedItem({ id: "low", canonicalUrl: "https://example.test/low", providerMetadata: metadataWith({ points: 63 }) }),
+      feedItem({ id: "high", canonicalUrl: "https://example.test/high" }),
+      feedItem({ id: "irrelevant", canonicalUrl: "https://example.test/irrelevant",
+        title: "Local football stadium serves sandwiches after weekend matches",
+        providerMetadata: metadataWith({ points: 999999 }) }),
+    ]);
+    const ranking = rankReaderPromotionV2(items.map(v2Candidate));
+    expect(ranking.orderedCandidateIds).toEqual(["high", "low"]);
+    expect(ranking.ranked.every((item) => item.topQualified)).toBe(true);
+    expect(ranking.ranked[0]!.components.total).toBeGreaterThan(ranking.ranked[1]!.components.total);
+    expect(ranking.rejected).toMatchObject([{ candidateId: "irrelevant", reasons: expect.arrayContaining(["relevance_floor_not_met"]) }]);
+    expect(items.find((item) => item.feedItemId === "irrelevant")!.contentQuality).toMatchObject({
+      interestRelevanceScore: 0.38, decision: "downrank", flags: expect.arrayContaining(["weak_topic_match"]),
+    });
+  });
+
+  it.each([
+    ["tenant", { tenantId: tenantId("other-tenant") }],
+    ["workspace", { workspaceId: workspaceId("other-workspace") }],
+    ["interest", { interestId: "other-interest" }],
+    ["binding", { sourceBindingId: "other-binding" }],
+  ] as const)("rejects stored context transplanted onto a different hydrated %s", async (_name, change) => {
+    const [item] = await rankItems([feedItem(change)]);
+    expect(item!.providerMetadata).toEqual(nativeMetadata);
+    expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
+  });
+
+  const malformed: readonly (JsonValue | undefined)[] = [undefined, null, [], "forged", 123, {}, { query: matchingTitle }];
+  for (const field of ["interestQuerySnapshot", "sourceBindingSnapshot", "workspaceScopeSnapshot"] as const) {
+    it.each(malformed)(`strips all context when ${field} is malformed: %j`, async (value) => {
+      const metadata: Record<string, JsonValue> = { ...nativeMetadata, ...context };
+      if (value === undefined) delete metadata[field];
+      else metadata[field] = value;
+      const [item] = await rankItems([feedItem({ providerMetadata: metadata })]);
+      expect(item!.providerMetadata).toEqual(nativeMetadata);
+      expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
+    });
+  }
+
+  it.each<JsonObject>([
+    { sourceBindingSnapshot: { ...context.sourceBindingSnapshot, providerKey: "reddit" } },
+    { sourceBindingSnapshot: { ...context.sourceBindingSnapshot, sourceBindingId: "" } },
+    { interestQuerySnapshot: { ...context.interestQuerySnapshot, query: "   " } },
+    { interestQuerySnapshot: { ...context.interestQuerySnapshot, query: 5 } },
+    ...([null, [], "search", {}, { query: "Mistral financing" },
+      { mode: "search", query: " " }, { mode: "search", query: 5 },
+      { mode: "", query: "Mistral financing" }, { mode: 5, query: "Mistral financing" },
+      { mode: "invented", query: "Mistral financing" }] as JsonValue[]).map((sourceQuery) => ({
+      sourceBindingSnapshot: { ...context.sourceBindingSnapshot, sourceQuery },
+    })),
+  ])("rejects malformed or mismatched nested query contracts %j", async (patch) => {
+    const [item] = await rankItems([feedItem({ providerMetadata: metadataWith(patch) })]);
+    expect(item!.providerMetadata).toEqual(nativeMetadata);
+    expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
+  });
+
+  it.each(["search", "listing", "account_feed", "thread", "url"])("preserves the existing %s source query mode", async (mode) => {
+    const [item] = await rankItems([feedItem({ providerMetadata: metadataWith({
+      sourceBindingSnapshot: { ...context.sourceBindingSnapshot, sourceQuery: { mode, query: "Mistral financing" } },
+    }) })]);
+    expect(item!.providerMetadata).toEqual({ ...nativeMetadata,
+      interestQuerySnapshot: projectedContext.interestQuerySnapshot,
+      sourceBindingSnapshot: { sourceQuery: { mode, query: "Mistral financing" } },
+    });
+    expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(true);
+  });
+
+  it("does not infer independent scope or provider identity from the metadata", () => {
+    const metadata = metadataWith({});
+    expect(promotionSafeProviderMetadata(scope.providerKey, metadata)).toEqual(nativeMetadata);
+    expect(promotionSafeProviderMetadata(scope.providerKey, metadata, { ...scope, providerKey: "reddit" })).toEqual(nativeMetadata);
+    for (const key of ["tenantId", "workspaceId", "interestId", "sourceBindingId", "providerKey"] as const) {
+      expect(promotionSafeProviderMetadata(scope.providerKey, metadata, { ...scope, [key]: "" })).toEqual(nativeMetadata);
+    }
+  });
+
+  it("maps only approved query fields and keeps forged authority and arbitrary metadata out", async () => {
+    const [item] = await rankItems([feedItem({ providerMetadata: metadataWith({
+      searchQuery: "football", query: "football", topic: "football", topics: ["football"],
+      community: "football", comments: 999999, views: 999999, arbitrary: { value: "untrusted" },
+      official: true, trusted: true,
+      interestQuerySnapshot: { ...context.interestQuerySnapshot, extra: "untrusted" },
+      sourceBindingSnapshot: { ...context.sourceBindingSnapshot, extra: "untrusted",
+        sourceQuery: { ...context.sourceBindingSnapshot.sourceQuery, extra: "untrusted" } },
+      workspaceScopeSnapshot: { ...context.workspaceScopeSnapshot, extra: "untrusted" },
+    }) })]);
+    expect(item!.providerMetadata).toEqual({ ...nativeMetadata, ...projectedContext });
+    expect(evaluateReaderPromotionV2(v2Candidate(item!))).toMatchObject({ admitted: true, providerSignal: 338 });
+  });
+
+  it.each<JsonObject>([
+    { promotionAuthority: { official: true, trusted: true, attestedBy: "provider" } },
+    { contentKind: "comment" },
+    { kind: "hacker_news_comment" },
+    { points: "338" },
+  ])("retains canonical rejection for contaminated provenance or metrics %j", (patch) => {
+    const metadata = metadataWith(patch);
+    expect(classifyFeedPromotionEligibility({ providerKey: scope.providerKey, providerMetadata: metadata }).eligible).toBe(false);
+    // The canonical gate still rejects before context can be projected.
+    expect(promotionSafeProviderMetadata(scope.providerKey, metadata, scope)).toBe(metadata);
+  });
+
+  it.each(["producer", "source_catalog"])("preserves existing %s authority attestation", async (attestedBy) => {
+    const promotionAuthority = { official: true, trusted: true, attestedBy };
+    const [item] = await rankItems([feedItem({ providerMetadata: metadataWith({ promotionAuthority }) })]);
+    expect(item!.providerMetadata).toEqual({ ...nativeMetadata, ...projectedContext, promotionAuthority });
+    expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(true);
+  });
+
+  it.each(["missing", "unresolved_regression"] as const)("does not let context override %s metric authority", async (authority) => {
+    const [item] = await rankItems([feedItem()], { authority });
+    expect(item!.contentQuality!.decision).toBe("promote");
+    expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
+  });
+
+  it("retains X crypto promotion rejection even with matching context and high native signal", async () => {
+    const query = "Crypto rewards";
+    const [item] = await rankItems([feedItem({ providerKey: "x-twitter",
+      title: "Crypto rewards giveaway offers trading prizes for everyone joining today",
+      providerMetadata: { kind: "x_post", contentKind: "original_post", likes: 1024, reposts: 78,
+        ...context, interestQuerySnapshot: { interestId: scope.interestId, query },
+        sourceBindingSnapshot: { ...context.sourceBindingSnapshot, providerKey: "x-twitter", sourceQuery: { mode: "search", query } } },
+    })]);
+    expect(item!.contentQuality).toMatchObject({ decision: "reject", flags: expect.arrayContaining(["crypto_promo"]) });
+    expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
+    expect(classifyFeedPromotionEligibility({ providerKey: "x-twitter", providerMetadata: item!.providerMetadata }))
+      .toMatchObject({ eligible: true, metrics: { likes: 1024, reposts: 78 } });
+  });
+
+  it.each<[string, JsonObject]>([
+    ["x-twitter", { kind: "x_post", contentKind: "original_post", likes: 124, reposts: 9 }],
+    ["reddit", { kind: "reddit_post", score: 87, upvoteRatio: 0.9 }],
+    ["hacker-news", nativeMetadata],
+    ["github-repo-radar", { kind: "github_repository_trend", repository: { forksCount: 9 },
+      trend: { primaryWindow: "24h", checkedAt: now.toISOString(), totalStars: 500, stars24h: 42, forks24h: 8 } }],
+  ])("preserves %s canonical metrics through context projection and V2", async (providerKey, native) => {
+    const original = feedItem({ providerKey, providerMetadata: { ...native, ...context,
+      sourceBindingSnapshot: { ...context.sourceBindingSnapshot, providerKey } } });
+    const [item] = await rankItems([original]);
+    expect(classifyFeedPromotionEligibility({ providerKey, providerMetadata: item!.providerMetadata }))
+      .toEqual(classifyFeedPromotionEligibility(original.toSnapshot()));
+    expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(true);
+  });
+});

--- a/libs/relevance/features/rank-feed-items/rank-promotion-topic-mode.spec.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-topic-mode.spec.ts
@@ -1,0 +1,91 @@
+import { evaluateReaderPromotionV2 } from "@social-monitor/feed/domain";
+import type { JsonObject, JsonValue } from "@social-monitor/shared-kernel";
+import { normalizeSourceContentQualityInput } from "../../domain/source-content-quality-normalizer";
+import {
+  context, feedItem, metadataWith, nativeMetadata, rankItems, v2Candidate,
+} from "./rank-promotion-topic-context.spec-support";
+
+const breadTitle = "Local bakers share their best bread recipes with neighbors";
+const metadataFor = (sourceQuery: JsonObject, interestQuery = "Mistral financing") => metadataWith({
+  interestQuerySnapshot: { ...context.interestQuerySnapshot, query: interestQuery },
+  sourceBindingSnapshot: { ...context.sourceBindingSnapshot, sourceQuery },
+});
+
+const cases = [
+  ["listing", "best", breadTitle],
+  ["listing", "show", "Local bakers show their bread recipes to neighbors every weekend"],
+  ["listing", "job", "Local bakers describe each job involved in baking bread for neighbors"],
+  ["listing", "top", "Local bakers list top bread recipes enjoyed by neighbors every weekend"],
+  ["listing", "BreadBaking", "BreadBaking neighbors exchange recipes and compare loaves at their annual festival"],
+  ["account_feed", "bakers", breadTitle],
+  ["thread", "recipes", breadTitle],
+  ["url", "https://example.test/ai", "AI painters display colorful pictures at the neighborhood gallery this weekend"],
+] as const;
+
+describe("actual promotion caller source query modes", () => {
+  it.each(cases)("does not qualify from %s acquisition %s", async (mode, query, title) => {
+    // For URL/AI, a developer interest corroborates HN community context but
+    // does not match the story. Ungated URL tokenization would activate AI.
+    const interest = mode === "url" ? "developer" : "Mistral financing";
+    const [item] = await rankItems([feedItem({ title,
+      providerMetadata: metadataFor({ mode, query }, interest),
+    })], { query: interest });
+    expect(item!.contentQuality).toMatchObject({ interestRelevanceScore: 0.38,
+      decision: "downrank", eligibleForTopRead: false,
+      flags: expect.arrayContaining(["weak_topic_match"]),
+    });
+    expect(evaluateReaderPromotionV2(v2Candidate(item!))).toMatchObject({
+      admitted: false, reasons: expect.arrayContaining(["relevance_floor_not_met"]),
+    });
+    expect(item!.providerMetadata).toEqual({ ...nativeMetadata,
+      query: interest,
+    });
+    expect(normalizeSourceContentQualityInput({ providerKey: item!.providerKey,
+      title, providerMetadata: item!.providerMetadata,
+    }).topicTerms).not.toContain(mode === "url" ? "ai" : query.toLowerCase());
+  });
+
+  it.each<JsonValue | undefined>(["unknown", undefined, null, "", 5])(
+    "keeps unrelated independent intent despite missing/invalid acquisition mode %j", async (mode) => {
+      const sourceQuery = { query: "best", ...(mode === undefined ? {} : { mode }) };
+      const [item] = await rankItems([feedItem({ title: breadTitle,
+        providerMetadata: metadataFor(sourceQuery),
+      })]);
+      expect(item!.providerMetadata).toEqual({ ...nativeMetadata, query: "Mistral financing" });
+      expect(item!.contentQuality.flags).toContain("weak_topic_match");
+      expect(evaluateReaderPromotionV2(v2Candidate(item!)).admitted).toBe(false);
+    },
+  );
+
+  it.each([
+    ["best", breadTitle],
+    ["Go", "Go compiler engineers publish detailed performance measurements for their latest implementation"],
+    ["ai", "AI painters display colorful pictures at the neighborhood gallery this weekend"],
+  ])("keeps explicit search %s positive through the caller", async (query, title) => {
+    const [item] = await rankItems([feedItem({ title,
+      providerMetadata: metadataFor({ mode: "search", query }, "developer"),
+    })], { query });
+    expect(item!.contentQuality.interestRelevanceScore).toBe(0.9);
+    expect(evaluateReaderPromotionV2(v2Candidate(item!))).toMatchObject({ admitted: true, topQualified: true });
+  });
+
+  it.each(["listing", "account_feed", "thread", "url"])(
+    "keeps independently configured interest positive with %s acquisition", async (mode) => {
+      // The configured query is injected independently of copied metadata.
+      const [item] = await rankItems([feedItem({ title: breadTitle,
+        providerMetadata: metadataFor({ mode, query: "unrelated" }, "bread recipes"),
+      })], { query: "bread recipes" });
+      expect(item!.contentQuality.interestRelevanceScore).toBe(0.9);
+      expect(evaluateReaderPromotionV2(v2Candidate(item!))).toMatchObject({ admitted: true, topQualified: true });
+    },
+  );
+
+  it.each(["best", "bread recipes"])("uses independent %s intent despite identical copied listing metadata", async (query) => {
+    const copied = feedItem({ title: breadTitle,
+      providerMetadata: metadataFor({ mode: "listing", query: "best" }, "best") });
+    const [negative] = await rankItems([copied], { query: "Mistral financing" });
+    const [positive] = await rankItems([copied], { query });
+    expect(evaluateReaderPromotionV2(v2Candidate(negative!)).admitted).toBe(false);
+    expect(evaluateReaderPromotionV2(v2Candidate(positive!))).toMatchObject({ admitted: true, topQualified: true });
+  });
+});

--- a/libs/relevance/features/rank-feed-items/resolve-promotion-interests.ts
+++ b/libs/relevance/features/rank-feed-items/resolve-promotion-interests.ts
@@ -1,0 +1,38 @@
+import type { FeedItem } from "@social-monitor/feed/domain";
+import { DomainError, err, ok, type Result } from "@social-monitor/shared-kernel";
+import type { ConfiguredInterest, ConfiguredInterestReaderPort } from "../../ports";
+import type { RankFeedItemsCommand } from "./rank-feed-items.command";
+
+export async function resolvePromotionInterests(
+  command: RankFeedItemsCommand,
+  items: readonly FeedItem[],
+  reader: ConfiguredInterestReaderPort | undefined,
+): Promise<Result<ReadonlyMap<string, ConfiguredInterest>, DomainError>> {
+  const conflict = (reason: string) => err(new DomainError(
+    "operation.conflict", "Configured interest authority could not be resolved", { reason },
+  ));
+  if (reader === undefined) return conflict("configured_interest_reader_unavailable");
+  const resolved = new Map<string, ConfiguredInterest>();
+  for (const item of items) {
+    const scope = item.toSnapshot();
+    if (scope.tenantId !== command.tenantId || scope.workspaceId !== command.workspaceId ||
+        !scope.sourceBindingId.trim() || !scope.providerKey.trim() ||
+        !scope.interestId.trim() || (command.interestId?.trim() &&
+        scope.interestId !== command.interestId.trim())) return conflict("configured_interest_scope_mismatch");
+    if (resolved.has(scope.interestId)) continue;
+    try {
+      const result = await reader.readCurrent({ tenantId: command.tenantId,
+        workspaceId: command.workspaceId, interestId: scope.interestId });
+      if (result.kind !== "available") return conflict(`configured_interest_${result.kind}`);
+      const value = result.interest;
+      if (value.tenantId !== command.tenantId || value.workspaceId !== command.workspaceId ||
+          value.interestId !== scope.interestId || !value.query.trim()) {
+        return conflict("configured_interest_scope_mismatch");
+      }
+      resolved.set(scope.interestId, Object.freeze({ ...value }));
+    } catch {
+      return conflict("configured_interest_unavailable");
+    }
+  }
+  return ok(resolved);
+}

--- a/libs/relevance/features/rank-feed-items/trusted-promotion-topic-context.ts
+++ b/libs/relevance/features/rank-feed-items/trusted-promotion-topic-context.ts
@@ -1,0 +1,49 @@
+import type { FeedItem } from "@social-monitor/feed/domain";
+import type { JsonObject } from "@social-monitor/shared-kernel";
+
+export type PromotionTopicScope = Pick<ReturnType<FeedItem["toSnapshot"]>,
+  "tenantId" | "workspaceId" | "interestId" | "sourceBindingId" | "providerKey">;
+
+// Stored application snapshots are usable only when bound to the hydrated row.
+// Their own identity claims must never supply the scope used for validation.
+export const trustedPromotionTopicContext = (
+  metadata: JsonObject | undefined,
+  scope: PromotionTopicScope | undefined,
+): JsonObject => {
+  if (scope === undefined || !Object.values({
+    tenantId: scope.tenantId, workspaceId: scope.workspaceId,
+    interestId: scope.interestId, sourceBindingId: scope.sourceBindingId,
+    providerKey: scope.providerKey,
+  }).every(nonemptyString)) return {};
+
+  const interest = readObject(metadata?.interestQuerySnapshot);
+  const binding = readObject(metadata?.sourceBindingSnapshot);
+  const workspace = readObject(metadata?.workspaceScopeSnapshot);
+  const sourceQuery = readObject(binding?.sourceQuery);
+  if (interest?.interestId !== scope.interestId ||
+      binding?.sourceBindingId !== scope.sourceBindingId ||
+      binding?.providerKey !== scope.providerKey ||
+      workspace?.tenantId !== scope.tenantId ||
+      workspace?.workspaceId !== scope.workspaceId ||
+      !nonemptyString(interest.query) ||
+      !nonemptyString(sourceQuery?.query) ||
+      !nonemptyString(sourceQuery?.mode) ||
+      !["search", "listing", "account_feed", "thread", "url"].includes(sourceQuery.mode)) {
+    return {};
+  }
+
+  // Only the existing query contract reaches quality and returned metadata.
+  return {
+    interestQuerySnapshot: { query: interest.query },
+    sourceBindingSnapshot: {
+      sourceQuery: { mode: sourceQuery.mode, query: sourceQuery.query },
+    },
+  };
+};
+
+const readObject = (value: unknown): JsonObject | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as JsonObject : undefined;
+
+const nonemptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;

--- a/libs/relevance/features/rank-feed-items/trusted-promotion-topic-context.ts
+++ b/libs/relevance/features/rank-feed-items/trusted-promotion-topic-context.ts
@@ -1,49 +1,19 @@
 import type { FeedItem } from "@social-monitor/feed/domain";
 import type { JsonObject } from "@social-monitor/shared-kernel";
+import type { ConfiguredInterest } from "../../ports";
 
 export type PromotionTopicScope = Pick<ReturnType<FeedItem["toSnapshot"]>,
   "tenantId" | "workspaceId" | "interestId" | "sourceBindingId" | "providerKey">;
 
-// Stored application snapshots are usable only when bound to the hydrated row.
-// Their own identity claims must never supply the scope used for validation.
+// The resolved value comes from the application read capability, never metadata.
+// `query` uses the existing literal configured-query normalization contract.
 export const trustedPromotionTopicContext = (
-  metadata: JsonObject | undefined,
   scope: PromotionTopicScope | undefined,
+  interest: ConfiguredInterest | undefined,
 ): JsonObject => {
-  if (scope === undefined || !Object.values({
-    tenantId: scope.tenantId, workspaceId: scope.workspaceId,
-    interestId: scope.interestId, sourceBindingId: scope.sourceBindingId,
-    providerKey: scope.providerKey,
-  }).every(nonemptyString)) return {};
-
-  const interest = readObject(metadata?.interestQuerySnapshot);
-  const binding = readObject(metadata?.sourceBindingSnapshot);
-  const workspace = readObject(metadata?.workspaceScopeSnapshot);
-  const sourceQuery = readObject(binding?.sourceQuery);
-  if (interest?.interestId !== scope.interestId ||
-      binding?.sourceBindingId !== scope.sourceBindingId ||
-      binding?.providerKey !== scope.providerKey ||
-      workspace?.tenantId !== scope.tenantId ||
-      workspace?.workspaceId !== scope.workspaceId ||
-      !nonemptyString(interest.query) ||
-      !nonemptyString(sourceQuery?.query) ||
-      !nonemptyString(sourceQuery?.mode) ||
-      !["search", "listing", "account_feed", "thread", "url"].includes(sourceQuery.mode)) {
-    return {};
-  }
-
-  // Only the existing query contract reaches quality and returned metadata.
-  return {
-    interestQuerySnapshot: { query: interest.query },
-    sourceBindingSnapshot: {
-      sourceQuery: { mode: sourceQuery.mode, query: sourceQuery.query },
-    },
-  };
+  if (scope === undefined || interest === undefined ||
+      !([scope.tenantId, scope.workspaceId, scope.interestId, scope.sourceBindingId, scope.providerKey]).every((value) => typeof value === "string" && value.trim()) ||
+      scope.tenantId !== interest.tenantId || scope.workspaceId !== interest.workspaceId ||
+      scope.interestId !== interest.interestId || !interest.query.trim()) return {};
+  return { query: interest.query };
 };
-
-const readObject = (value: unknown): JsonObject | undefined =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-    ? value as JsonObject : undefined;
-
-const nonemptyString = (value: unknown): value is string =>
-  typeof value === "string" && value.trim().length > 0;

--- a/libs/relevance/interfaces/rest/configured-interest-composition.spec.ts
+++ b/libs/relevance/interfaces/rest/configured-interest-composition.spec.ts
@@ -1,0 +1,37 @@
+import "reflect-metadata";
+import { MODULE_METADATA } from "@nestjs/common/constants";
+import { MonitoringRestModule } from "@social-monitor/monitoring/interfaces/rest/monitoring-rest.module";
+import { MONITORING_INTEREST_REPOSITORY } from "@social-monitor/monitoring/interfaces/rest/monitoring-provider-tokens";
+import { Interest } from "@social-monitor/monitoring/domain";
+import { InMemoryInterestRepository } from "@social-monitor/monitoring/adapters/persistence/in-memory-interest.repository";
+import { CONFIGURED_INTEREST_READER, type ConfiguredInterestReaderPort } from "../../ports";
+import { InMemoryUserRelevanceProfileRepository } from "../../adapters/persistence/in-memory-user-relevance-profile.repository";
+import { RankFeedItemsUseCase } from "../../features/rank-feed-items/rank-feed-items.use-case";
+import { scope, now } from "../../features/rank-feed-items/rank-promotion-topic-context.spec-support";
+import { RelevanceRestModule } from "./relevance-rest.module";
+
+describe("REST configured interest composition", () => {
+  it("wires the existing Monitoring repository into the Relevance capability and ranking constructor", async () => {
+    const providers = Reflect.getMetadata(MODULE_METADATA.PROVIDERS, RelevanceRestModule) as Array<{
+      provide?: unknown; inject?: unknown[]; useFactory: (...args: unknown[]) => unknown;
+    }>;
+    expect(Reflect.getMetadata(MODULE_METADATA.IMPORTS, RelevanceRestModule)).toContain(MonitoringRestModule);
+    expect(Reflect.getMetadata(MODULE_METADATA.EXPORTS, MonitoringRestModule)).toContain(MONITORING_INTEREST_REPOSITORY);
+    const provider = providers.find((provider) => provider.provide === CONFIGURED_INTEREST_READER)!;
+    expect(provider.inject).toEqual([MONITORING_INTEREST_REPOSITORY]);
+    const interests = new InMemoryInterestRepository();
+    await interests.save(Interest.create({ ...scope, id: scope.interestId, name: "Fixture", query: "best", createdAt: now }));
+    const reader = provider.useFactory(interests) as ConfiguredInterestReaderPort;
+    expect(await reader.readCurrent(scope)).toMatchObject({ kind: "available", interest: { query: "best" } });
+    const ranking = providers.find((provider) => provider.provide === RankFeedItemsUseCase)!;
+    expect(ranking.inject?.at(-1)).toBe(CONFIGURED_INTEREST_READER);
+    const readCurrent = jest.spyOn(reader, "readCurrent");
+    const useCase = ranking.useFactory({ list: async () => ({ items: [] }), findById: async () => null,
+      readPromotionSnapshot: async () => ({ ok: true, exhausted: true, physicalRowsRead: 0, candidates: [], sourceContent: [] }) },
+    new InMemoryUserRelevanceProfileRepository(), undefined, undefined, reader) as RankFeedItemsUseCase;
+    const result = await useCase.execute({ ...scope, rankingProfile: "reader_post_promotion", limit: 10,
+      publishedAtOrAfter: now, publishedBefore: new Date("2026-09-09T00:00:00Z") });
+    expect(result.ok).toBe(true);
+    expect(readCurrent).not.toHaveBeenCalled();
+  });
+});

--- a/libs/relevance/interfaces/rest/relevance-rest.module.ts
+++ b/libs/relevance/interfaces/rest/relevance-rest.module.ts
@@ -1,3 +1,8 @@
+import { MonitoringRestModule } from '@social-monitor/monitoring/interfaces/rest/monitoring-rest.module';
+import { MONITORING_INTEREST_REPOSITORY } from '@social-monitor/monitoring/interfaces/rest/monitoring-provider-tokens';
+import type { InterestRepositoryPort } from '@social-monitor/monitoring/ports';
+import { MonitoringConfiguredInterestReader } from '../../adapters/monitoring/monitoring-configured-interest.reader';
+import { CONFIGURED_INTEREST_READER, type ConfiguredInterestReaderPort } from '../../ports';
 import { Module } from '@nestjs/common';
 import { resolvePostgresRuntimePoolConfig } from '@social-monitor/platform-persistence';
 import { FeedRestModule } from '@social-monitor/feed/interfaces/rest/feed-rest.module';
@@ -73,9 +78,15 @@ import {
 } from './relevance-provider-tokens';
 
 @Module({
-  imports: [FeedRestModule, IdentityRestModule],
+  imports: [FeedRestModule, IdentityRestModule, MonitoringRestModule],
   controllers: [RelevanceController],
   providers: [
+    {
+      provide: CONFIGURED_INTEREST_READER,
+      useFactory: (interests: InterestRepositoryPort): ConfiguredInterestReaderPort =>
+        new MonitoringConfiguredInterestReader(interests),
+      inject: [MONITORING_INTEREST_REPOSITORY],
+    },
     relevancePersistenceModeProvider,
     relevanceMemoryProjectionModeProvider,
     relevanceContentQualityReviewerModeProvider,
@@ -205,6 +216,7 @@ import {
         profiles: UserRelevanceProfileRepositoryPort,
         memoryGuidance: RelevanceMemoryGuidanceReaderPort,
         qualityReviewer: SourceContentQualityReviewerPort,
+        configuredInterests: ConfiguredInterestReaderPort,
       ) =>
         new RankFeedItemsUseCase(
           feedItems,
@@ -214,12 +226,15 @@ import {
           memoryGuidance,
           undefined,
           qualityReviewer,
+          undefined,
+          configuredInterests,
         ),
       inject: [
         FEED_ITEM_READ_REPOSITORY,
         USER_RELEVANCE_PROFILE_REPOSITORY,
         RELEVANCE_MEMORY_GUIDANCE_READER,
         SOURCE_CONTENT_QUALITY_REVIEWER,
+        CONFIGURED_INTEREST_READER,
       ],
     },
     {

--- a/libs/relevance/ports/configured-interest-reader.port.ts
+++ b/libs/relevance/ports/configured-interest-reader.port.ts
@@ -1,0 +1,19 @@
+import type { TenantId, WorkspaceId } from "@social-monitor/shared-kernel";
+
+export const CONFIGURED_INTEREST_READER = Symbol("CONFIGURED_INTEREST_READER");
+
+export type ConfiguredInterestScope = Readonly<{
+  tenantId: TenantId;
+  workspaceId: WorkspaceId;
+  interestId: string;
+}>;
+export type ConfiguredInterest = ConfiguredInterestScope & Readonly<{ query: string }>;
+export type ConfiguredInterestRead =
+  | Readonly<{ kind: "available"; interest: ConfiguredInterest }>
+  | Readonly<{ kind: "missing" | "unavailable" }>;
+
+// Current configuration, not ingestion-time reconstruction. New generations
+// resolve once per scoped interest; immutable publication recovery uses evidence.
+export interface ConfiguredInterestReaderPort {
+  readCurrent(scope: ConfiguredInterestScope): Promise<ConfiguredInterestRead>;
+}

--- a/libs/relevance/ports/index.ts
+++ b/libs/relevance/ports/index.ts
@@ -7,3 +7,4 @@ export * from './relevance-memory-projection-repository.port';
 export * from './relevance-memory-projector.port';
 export * from './source-content-quality-reviewer.port';
 export * from './user-relevance-profile-repository.port';
+export * from './configured-interest-reader.port';

--- a/libs/summary/adapters/evidence/relevance-reader-summary-scan-exhaustion.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-scan-exhaustion.spec.ts
@@ -16,8 +16,58 @@ import type {
   ReaderSummaryStoryRelationVerifierPort,
 } from "../../ports";
 import { FakeStoryRankingMetrics } from "./relevance-reader-summary-evidence-test-fixtures";
+import { configuredPromotionInterests } from
+  "../../test-fixtures/configured-promotion-interests.spec-support";
 
 describe("reader-summary promotion upstream scan exhaustion", () => {
+  it("rejects promotion when the configured interest reader is omitted", async () => {
+    const tenant = tenantId("tenant-promotion-missing-reader");
+    const workspace = workspaceId("workspace-promotion-missing-reader");
+    const now = new Date("2026-08-18T12:00:00.000Z");
+    const repository = new InMemoryFeedItemReadRepository();
+    publishOriginal(repository, {
+      id: "topical-original-without-reader", tenantId: tenant, workspaceId: workspace,
+      providerKey: "x-twitter", title: "AI agent runtime adds deterministic recovery",
+      publishedAt: new Date("2026-08-18T08:00:00.000Z"),
+      providerMetadata: {
+        kind: "x_post", contentKind: "original_post", likes: 500, reposts: 100,
+        query: "AI agents",
+      },
+    });
+    attestDurableMetricAuthority(repository, now);
+    const result = await new RankFeedItemsUseCase(
+      repository, new InMemoryUserRelevanceProfileRepository(), new FixedClock(now),
+    ).execute({
+      tenantId: tenant, workspaceId: workspace, interestId: "interest-ai", limit: 10,
+      rankingProfile: "reader_post_promotion",
+      observedAtOrAfter: new Date("2026-08-18T00:00:00.000Z"),
+      observedBefore: now,
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "operation.conflict",
+        details: { reason: "configured_interest_reader_unavailable" },
+      },
+    });
+  });
+
+  it.each(["tenantId", "workspaceId", "interestId"] as const)(
+    "does not provide fixture authority for a different %s",
+    async (field) => {
+      const interest = {
+        tenantId: tenantId("tenant-scoped-interest"),
+        workspaceId: workspaceId("workspace-scoped-interest"),
+        interestId: "interest-ai", query: "AI agents",
+      };
+      const reader = configuredPromotionInterests([interest]);
+      expect(await reader.readCurrent({ ...interest, [field]: "different-scope" }))
+        .toEqual({ kind: "missing" });
+      expect(await reader.readCurrent(interest))
+        .toEqual({ kind: "available", interest });
+    },
+  );
+
   it("finds originals behind more than 1,000 forbidden conversation units", async () => {
     const tenant = tenantId("tenant-promotion-scan-exhaustion");
     const workspace = workspaceId("workspace-promotion-scan-exhaustion");
@@ -84,6 +134,11 @@ describe("reader-summary promotion upstream scan exhaustion", () => {
       repository,
       new InMemoryUserRelevanceProfileRepository(),
       new FixedClock(now),
+      undefined, undefined, undefined, undefined, undefined,
+      configuredPromotionInterests([{
+        tenantId: tenant, workspaceId: workspace, interestId: "interest-ai",
+        query: "AI agents",
+      }]),
     );
     const ranked = await ranker.execute({
       tenantId: tenant,
@@ -202,6 +257,11 @@ describe("reader-summary promotion upstream scan exhaustion", () => {
       repository,
       new InMemoryUserRelevanceProfileRepository(),
       new FixedClock(now),
+      undefined, undefined, undefined, undefined, undefined,
+      configuredPromotionInterests([{
+        tenantId: tenant, workspaceId: workspace, interestId: "interest-ai",
+        query: "AI agents",
+      }]),
     );
     const ranked = await ranker.execute({
       tenantId: tenant,
@@ -306,6 +366,11 @@ describe("reader-summary promotion upstream scan exhaustion", () => {
       repository,
       new InMemoryUserRelevanceProfileRepository(),
       new FixedClock(now),
+      undefined, undefined, undefined, undefined, undefined,
+      configuredPromotionInterests([{
+        tenantId: tenant, workspaceId: workspace, interestId: "interest-ai",
+        query: "AI agents",
+      }]),
     );
     const selection = await new RelevanceReaderSummaryEvidenceSelector(
       ranker,

--- a/libs/summary/interfaces/rest/reader-summary-v2-publication-path.spec.ts
+++ b/libs/summary/interfaces/rest/reader-summary-v2-publication-path.spec.ts
@@ -63,6 +63,8 @@ import {
   readerSummaryV2DailyPublicationCandidates,
 } from
   "../../test-fixtures/reader-summary-v2-daily-publication.fixture";
+import { configuredPromotionInterests } from
+  "../../test-fixtures/configured-promotion-interests.spec-support";
 
 describe("ExecuteReaderSummaryJobUseCase V2 combined publication path", () => {
   it("persists one immutable real-selector slate without changing order, lane, digest, or confidence", async () => {
@@ -115,6 +117,12 @@ describe("ExecuteReaderSummaryJobUseCase V2 combined publication path", () => {
         feedItems,
         new InMemoryUserRelevanceProfileRepository(),
         clock,
+        undefined, undefined, undefined, undefined, undefined,
+        configuredPromotionInterests([{
+          tenantId: tenant, workspaceId: workspace,
+          interestId: "interest-engineering",
+          query: "Software engineering tools: database compiler runtime storage SDK CLI API cache worker",
+        }]),
       ),
       feedItems,
       clock,
@@ -327,6 +335,19 @@ describe("ExecuteReaderSummaryJobUseCase V2 combined publication path", () => {
         feedItems,
         new InMemoryUserRelevanceProfileRepository(),
         clock,
+        undefined, undefined, undefined, undefined, undefined,
+        configuredPromotionInterests([
+          {
+            tenantId: tenant, workspaceId: workspace,
+            interestId: "interest-reliable-systems",
+            query: "Reliable systems: compiler runtime storage cache scheduler",
+          },
+          {
+            tenantId: tenant, workspaceId: workspace,
+            interestId: "interest-developer-workflows",
+            query: "Developer workflows: database API SDK CLI proxy",
+          },
+        ]),
       ),
       feedItems,
       clock,

--- a/libs/summary/test-fixtures/configured-promotion-interests.spec-support.ts
+++ b/libs/summary/test-fixtures/configured-promotion-interests.spec-support.ts
@@ -1,0 +1,21 @@
+import type {
+  ConfiguredInterest,
+  ConfiguredInterestReaderPort,
+} from "@social-monitor/relevance/ports";
+
+// Test configuration is declared by each scenario, independently of feed rows
+// and provider acquisition metadata. Unknown scopes fail closed.
+export const configuredPromotionInterests = (
+  interests: readonly ConfiguredInterest[],
+): ConfiguredInterestReaderPort => ({
+  async readCurrent(scope) {
+    const interest = interests.find((candidate) =>
+      candidate.tenantId === scope.tenantId &&
+      candidate.workspaceId === scope.workspaceId &&
+      candidate.interestId === scope.interestId,
+    );
+    return interest === undefined
+      ? { kind: "missing" }
+      : { kind: "available", interest };
+  },
+});

--- a/scripts/capture-durable-reader-summary-from-postgres.ts
+++ b/scripts/capture-durable-reader-summary-from-postgres.ts
@@ -1,3 +1,6 @@
+import { PrismaMonitoringConnection } from "@social-monitor/monitoring/adapters/persistence/prisma/prisma-monitoring-connection";
+import { PrismaInterestRepository } from "@social-monitor/monitoring/adapters/persistence/prisma/prisma-interest.repository";
+import { MonitoringConfiguredInterestReader } from "@social-monitor/relevance/adapters/monitoring/monitoring-configured-interest.reader";
 import { createHash } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
@@ -258,7 +261,10 @@ async function main(): Promise<void> {
   const summaryConnection =
     await PrismaSummaryConnection.create(runtimePoolConfig);
 
+  let monitoringConnection: PrismaMonitoringConnection | undefined;
   try {
+    monitoringConnection = dailyReplay === null
+      ? await PrismaMonitoringConnection.create(runtimePoolConfig) : undefined;
     const datasetGuard = recoveryTimestampPolicy.active
       ? buildDatasetGuard({
           client: summaryConnection,
@@ -306,6 +312,8 @@ async function main(): Promise<void> {
     const publicationWiring =
       createReaderSummaryDailyCapturePublicationWiring({
         replay: dailyReplay,
+        configuredInterests: monitoringConnection === undefined ? undefined
+          : new MonitoringConfiguredInterestReader(new PrismaInterestRepository(monitoringConnection)),
         feedItems,
         summaryClient: summaryConnection,
         clock,
@@ -633,7 +641,7 @@ async function main(): Promise<void> {
       ].join("\n"),
     );
   } finally {
-    await Promise.all([feedConnection.close(), summaryConnection.close()]);
+    await Promise.all([feedConnection.close(), summaryConnection.close(), monitoringConnection?.close()]);
   }
 }
 

--- a/scripts/check-reader-summary-new-input-refresh-postgres.ts
+++ b/scripts/check-reader-summary-new-input-refresh-postgres.ts
@@ -1,3 +1,6 @@
+import { PrismaMonitoringConnection } from "@social-monitor/monitoring/adapters/persistence/prisma/prisma-monitoring-connection";
+import { PrismaInterestRepository } from "@social-monitor/monitoring/adapters/persistence/prisma/prisma-interest.repository";
+import { MonitoringConfiguredInterestReader } from "@social-monitor/relevance/adapters/monitoring/monitoring-configured-interest.reader";
 /** Parent-only native gate: a migrated disposable fixture, never a server,
  * provider, model, or production connection. Uses the actual Prisma publisher. */
 import assert from "node:assert/strict";
@@ -51,18 +54,21 @@ async function main() {
   const summary = await PrismaSummaryConnection.create(config);
   const feedConnection = await PrismaFeedConnection.create(config);
   const feed = new PrismaFeedItemReadRepository(feedConnection);
+  let monitoring: PrismaMonitoringConnection | undefined;
   try {
+    monitoring = await PrismaMonitoringConnection.create(config);
+    const configuredInterests = new MonitoringConfiguredInterestReader(new PrismaInterestRepository(monitoring));
     await runWithTenantDatabaseAccess(refreshScope, async () => {
       assert.deepEqual(getPostgresRuntimePoolDiagnostics(), {
-        poolInstances: 1, prismaClientInstances: 1, activeConnectionLeases: 2, closing: false,
+        poolInstances: 1, prismaClientInstances: 1, activeConnectionLeases: 3, closing: false,
       });
       const before = await readRefreshPrior(summary, m.date);
       assertRefreshEqual(before, m.prior, "fixture prior");
       await assertRefreshHasNewInput(summary, m.date, before.observedThrough, m.observedThrough);
       assertRefreshEqual(await captureRefreshAuthority({ client: summary, feed, date: m.date,
         observedThrough: new Date(m.observedThrough), clock }), m.authority, "fixture full current input");
-      const originalSelection = await preflightRefreshSelection({ feed, date: m.date, clock, observedThrough: new Date(before.observedThrough) });
-      const newSelection = await preflightRefreshSelection({ feed, date: m.date, clock, observedThrough: new Date(m.observedThrough) });
+      const originalSelection = await preflightRefreshSelection({ configuredInterests, feed, date: m.date, clock, observedThrough: new Date(before.observedThrough) });
+      const newSelection = await preflightRefreshSelection({ configuredInterests, feed, date: m.date, clock, observedThrough: new Date(m.observedThrough) });
       if (before.status === "NO_SIGNAL") assert.equal(originalSelection, 0, "original cutoff has no eligible metric authority");
       assert(newSelection > 0, "new cutoff selects current full canonical inputs");
       const command = await fixtureCommand(summary, candidate);
@@ -106,7 +112,7 @@ async function main() {
           "consumed-no-repeat", "normal-prisma-publisher-max2", "preserved-original", "replay-zero-delta",
           "reconciliation-schema-protected", "reconciliation-refuses-unfailed-job"] }));
     });
-  } finally { await feedConnection.close(); await summary.close(); }
+  } finally { await Promise.all([monitoring?.close(), feedConnection.close(), summary.close()]); }
 }
 async function fixtureCommand(summary: PrismaSummaryConnection, p: ReaderSummaryPublicationPayload): Promise<ReaderSummaryPublicationCommand> {
   const job = await new PrismaReaderSummaryJobRepository(summary).findById({ tenantId: tenantId(p.tenantId),

--- a/scripts/lib/reader-summary-configured-interest-composition.spec.ts
+++ b/scripts/lib/reader-summary-configured-interest-composition.spec.ts
@@ -1,0 +1,49 @@
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { FeedItem, classifyFeedPromotionEligibility } from "@social-monitor/feed/domain";
+import type { ConfiguredInterestReaderPort } from "@social-monitor/relevance/ports";
+import { createReaderSummaryDailyPublicationExecutionWiring } from "./reader-summary-daily-publication-finalizer";
+import { preflightRefreshSelection, refreshPeriod } from "./reader-summary-new-input-refresh-capture";
+import { refreshScope } from "./reader-summary-new-input-refresh-manifest";
+
+const clock = new FixedClock(new Date("2026-09-04T00:00:00Z"));
+const scope = { tenantId: tenantId(refreshScope.tenantId), workspaceId: workspaceId(refreshScope.workspaceId) };
+const item = FeedItem.rehydrate({ ...scope, id: "synthetic-feed", sourceItemId: "synthetic-source",
+  interestId: "synthetic-interest", sourceBindingId: "synthetic-binding", providerKey: "hacker-news",
+  canonicalUrl: "https://example.test/bread", title: "Local bakers share their best bread recipes with neighbors",
+  bodyPreview: "", publishedAt: new Date("2026-09-03T12:00:00Z"), observedAt: new Date("2026-09-03T12:00:00Z"),
+  providerMetadata: { kind: "hacker_news_story", points: 338, interestQuerySnapshot: { query: "best" } },
+});
+const feed = { list: async () => ({ items: [] }), findById: async () => null,
+  readPromotionSnapshot: async () => {
+    const canonical = classifyFeedPromotionEligibility(item.toSnapshot());
+    if (!canonical.eligible) throw new Error("Invalid fixture");
+    return { ok: true as const, exhausted: true as const, physicalRowsRead: 1,
+      candidates: [{ item, canonical, metricAuthority: { observedAt: new Date("2026-09-04T00:00:00Z"), regressionState: "stable" as const } }],
+      sourceContent: [{ feedItemId: "synthetic-feed", sourceItemId: "synthetic-source", body: "" }] };
+  } };
+const reader = (query: string) => ({ readCurrent: jest.fn<ReturnType<ConfiguredInterestReaderPort["readCurrent"]>,
+  Parameters<ConfiguredInterestReaderPort["readCurrent"]>>(async (scope) => ({ kind: "available", interest: { ...scope, query } })) });
+
+describe("new daily generation configured interest composition", () => {
+  it("requires authority and actually resolves it through the canonical daily selector", async () => {
+    const input = { replay: null, feedItems: feed, summaryClient: {} as never, clock,
+      attestationSink: { record: jest.fn() }, storyRelationVerifier: null };
+    expect(() => createReaderSummaryDailyPublicationExecutionWiring(input)).toThrow("configured interest authority");
+    const configuredInterests = reader("Mistral financing");
+    const wiring = createReaderSummaryDailyPublicationExecutionWiring({ ...input, configuredInterests });
+    const selected = await wiring.evidenceSelector.select({ ...scope, scope: { type: "workspace" },
+      period: refreshPeriod("2026-09-03"), observedThrough: new Date("2026-09-04T00:00:00Z"), maxItems: 120 });
+    expect(selected.selectedEvidence).toHaveLength(0);
+    expect(configuredInterests.readCurrent).toHaveBeenCalledTimes(1);
+    expect(configuredInterests.readCurrent).toHaveBeenCalledWith({ ...scope, interestId: "synthetic-interest" });
+  });
+
+  it("wires historical replacement preflight with current intent independently of copied metadata", async () => {
+    const configuredInterests = reader("best");
+    expect(await preflightRefreshSelection({ feed, date: "2026-09-03",
+      observedThrough: new Date("2026-09-04T00:00:00Z"), clock, configuredInterests })).toBe(1);
+    expect(configuredInterests.readCurrent).toHaveBeenCalledTimes(1);
+    expect(await preflightRefreshSelection({ feed, date: "2026-09-03",
+      observedThrough: new Date("2026-09-04T00:00:00Z"), clock, configuredInterests: reader("Mistral financing") })).toBe(0);
+  });
+});

--- a/scripts/lib/reader-summary-daily-frozen-publication-input.spec.ts
+++ b/scripts/lib/reader-summary-daily-frozen-publication-input.spec.ts
@@ -312,6 +312,7 @@ describe("reader summary daily frozen publication input", () => {
     const queryRaw = jest.fn(() => {
       throw new Error("live Prisma read must not occur");
     });
+    const readCurrent = jest.fn(async () => { throw new Error("Current interest must not be read during recovery"); });
     const wiring = createReaderSummaryDailyPublicationExecutionWiring({
       replay: {
         ...replay,
@@ -319,6 +320,7 @@ describe("reader summary daily frozen publication input", () => {
         outputKind: "output_text",
       },
       summaryClient: { $queryRaw: queryRaw } as never,
+      configuredInterests: { readCurrent },
       clock: fixedClock,
       attestationSink: { record: jest.fn(async () => undefined) },
     });
@@ -328,6 +330,7 @@ describe("reader summary daily frozen publication input", () => {
       .rejects.toThrow(/unavailable/u);
     expect(wiring.recoveryProvenance).toBeDefined();
     expect(queryRaw).not.toHaveBeenCalled();
+    expect(readCurrent).not.toHaveBeenCalled();
   });
 
   it("rejects a tampered canonical authority before recovery wiring exists", () => {

--- a/scripts/lib/reader-summary-daily-publication-finalizer.ts
+++ b/scripts/lib/reader-summary-daily-publication-finalizer.ts
@@ -247,13 +247,10 @@ export const createReaderSummaryDailyPublicationExecutionWiring = (input: {
       inventory: feedInventoryFromAuthority(input.replay.authority.items),
     });
   }
-  if (
-    input.replay !== null &&
-    isReaderSummaryDailySourceAuthorityV2(input.replay.authority)
-  ) {
-    throw new Error("Daily immutable authority v2 recovery requires output_text");
+  if (input.replay !== null) {
+    throw new Error("Daily immutable replay recovery requires output_text");
   }
-  if (input.replay === null && input.storyRelationVerifier === undefined) {
+  if (input.storyRelationVerifier === undefined) {
     throw new Error(
       "Fresh daily publication must explicitly configure its story relation verifier",
     );
@@ -263,7 +260,7 @@ export const createReaderSummaryDailyPublicationExecutionWiring = (input: {
   if (input.feedItems === undefined) {
     throw new Error("Daily publication requires a feed repository outside output_text recovery");
   }
-  if (input.replay === null && input.configuredInterests === undefined) {
+  if (input.configuredInterests === undefined) {
     throw new Error("Fresh daily publication requires configured interest authority");
   }
   // Immutable recovery cannot silently use today's configuration. Frozen
@@ -273,26 +270,16 @@ export const createReaderSummaryDailyPublicationExecutionWiring = (input: {
     new InMemoryUserRelevanceProfileRepository(),
     input.clock,
     undefined, undefined, undefined, undefined, undefined,
-    input.replay === null ? input.configuredInterests : undefined,
+    input.configuredInterests,
   );
   const evidenceSelector = new RelevanceReaderSummaryEvidenceSelector(
     rankFeedItems,
     input.feedItems,
     input.clock,
     new StoryRankingMetricsRecorder(new InMemoryMetricsRecorder()),
-    input.replay === null
-      ? input.storyRelationVerifier ?? undefined
-      : undefined,
+    input.storyRelationVerifier ?? undefined,
   );
-  if (input.replay === null) {
-    return Object.freeze({ evidenceSelector, githubProjectionReader });
-  }
-  return createReaderSummaryDailyPublicationWiring({
-    replay: input.replay,
-    evidenceSelector,
-    githubProjectionReader,
-    attestationSink: input.attestationSink,
-  });
+  return Object.freeze({ evidenceSelector, githubProjectionReader });
 };
 
 type ReaderSummaryDailyPublicationExecutionWiring = Readonly<{

--- a/scripts/lib/reader-summary-daily-publication-finalizer.ts
+++ b/scripts/lib/reader-summary-daily-publication-finalizer.ts
@@ -1,3 +1,4 @@
+import type { ConfiguredInterestReaderPort } from "@social-monitor/relevance/ports";
 import { createHash, randomUUID } from "node:crypto";
 import {
   mkdirSync,
@@ -208,6 +209,7 @@ export const createReaderSummaryDailyPublicationWiring = (input: {
 export const createReaderSummaryDailyPublicationExecutionWiring = (input: {
   readonly replay: ReaderSummaryDailyReplayInput | null;
   readonly feedItems?: FeedItemReadRepositoryPort;
+  readonly configuredInterests?: ConfiguredInterestReaderPort;
   readonly summaryClient: ConstructorParameters<
     typeof PrismaReaderSummaryGitHubProjectionReader
   >[0];
@@ -261,10 +263,17 @@ export const createReaderSummaryDailyPublicationExecutionWiring = (input: {
   if (input.feedItems === undefined) {
     throw new Error("Daily publication requires a feed repository outside output_text recovery");
   }
+  if (input.replay === null && input.configuredInterests === undefined) {
+    throw new Error("Fresh daily publication requires configured interest authority");
+  }
+  // Immutable recovery cannot silently use today's configuration. Frozen
+  // output_text above reuses captured evidence without constructing a ranker.
   const rankFeedItems = new RankFeedItemsUseCase(
     input.feedItems,
     new InMemoryUserRelevanceProfileRepository(),
     input.clock,
+    undefined, undefined, undefined, undefined, undefined,
+    input.replay === null ? input.configuredInterests : undefined,
   );
   const evidenceSelector = new RelevanceReaderSummaryEvidenceSelector(
     rankFeedItems,

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -41,7 +41,8 @@ const period = buildReaderSummaryPeriod({
 describe("reader summary daily story relation production wiring", () => {
   it("fails fresh live wiring closed and keeps non-live paths verifier-free", async () => {
     expect(() => createReaderSummaryDailyCapturePublicationWiring({
-      replay: null,
+      configuredInterests: { readCurrent: async (scope) => ({ kind: "available" as const, interest: { ...scope, query: "TypeScript Cursor Claude coding agents" } }) },
+    replay: null,
       feedItems: feedRepository(),
       summaryClient: {} as never,
       clock,
@@ -55,7 +56,8 @@ describe("reader summary daily story relation production wiring", () => {
 
     const localRuntime = new FakeRuntime(true, true);
     const localWiring = createReaderSummaryDailyCapturePublicationWiring({
-      replay: null,
+      configuredInterests: { readCurrent: async (scope) => ({ kind: "available" as const, interest: { ...scope, query: "TypeScript Cursor Claude coding agents" } }) },
+    replay: null,
       feedItems: feedRepository(),
       summaryClient: {} as never,
       clock,
@@ -195,7 +197,8 @@ describe("reader summary daily story relation production wiring", () => {
       });
       expect(selected.runtime.storyCommands).toHaveLength(1);
       expect(finalizer).toHaveBeenCalledWith(expect.objectContaining({
-        replay: null,
+        configuredInterests: expect.objectContaining({ readCurrent: expect.any(Function) }),
+    replay: null,
         storyRelationVerifier: expect.any(Object),
       }));
     } finally {
@@ -288,6 +291,7 @@ const selectDailyEvidence = async (input: {
     void value;
   });
   const wiring = createReaderSummaryDailyCapturePublicationWiring({
+    configuredInterests: { readCurrent: async (scope) => ({ kind: "available" as const, interest: { ...scope, query: "TypeScript Cursor Claude coding agents" } }) },
     replay: null,
     feedItems: feedRepository({
       firstTitle: input.firstTitle,

--- a/scripts/lib/reader-summary-daily-unsupported-replay.spec.ts
+++ b/scripts/lib/reader-summary-daily-unsupported-replay.spec.ts
@@ -1,0 +1,87 @@
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { buildReaderSummaryPeriod } from "@social-monitor/summary/domain";
+
+import {
+  createReaderSummaryDailyPublicationExecutionWiring,
+  createReaderSummaryDailyPublicationWiring,
+} from "./reader-summary-daily-publication-finalizer";
+import { verifiedUnsupportedDailyReplay } from "./support/reader-summary-unsupported-replay";
+
+const clock = new FixedClock(new Date("2026-08-02T09:30:00.000Z"));
+const unsupported = "Daily immutable replay recovery requires output_text";
+const forbidden = (name: string) => jest.fn((): never => {
+  throw new Error(`Unexpected live dependency: ${name}`);
+});
+
+describe("unsupported daily immutable replay", () => {
+  it.each([false, true])(
+    "rejects verified v1 structured replay before live calls (current authority supplied: %s)",
+    async (supplyCurrentAuthority) => {
+      const replay = verifiedUnsupportedDailyReplay();
+      const list = forbidden("feed list");
+      const findById = forbidden("feed item");
+      const readPromotionSnapshot = forbidden("feed snapshot");
+      const readSourceContent = forbidden("source content");
+      const readCurrent = forbidden("current interest");
+      const $queryRaw = forbidden("GitHub projection");
+      const record = forbidden("attestation sink");
+      const select = forbidden("fixture selector");
+      const read = forbidden("fixture GitHub reader");
+      // Prove the receipt passes the actual persisted-model verifier. A malformed
+      // receipt must not accidentally make this boundary regression pass.
+      const verified = createReaderSummaryDailyPublicationWiring({
+        replay,
+        evidenceSelector: { select },
+        githubProjectionReader: { read },
+        attestationSink: { record },
+      });
+      expect(replay.authority.schemaVersion).toBe(1);
+      expect(verified.model.estimate({} as never, {} as never)).toMatchObject({ inputTokens: 120, outputTokens: 30 });
+
+      const attempt = async () => {
+        const wiring = createReaderSummaryDailyPublicationExecutionWiring({
+          replay,
+          feedItems: { list, findById, readPromotionSnapshot, readSourceContent },
+          ...(supplyCurrentAuthority ? { configuredInterests: { readCurrent } } : {}),
+          summaryClient: { $queryRaw },
+          clock,
+          attestationSink: { record },
+        });
+        // On the unfixed implementation this historical selection reaches the
+        // throwing feed fake, reproducing the independent review's live read.
+        await wiring.evidenceSelector.select({
+          tenantId: tenantId(replay.authority.tenantId),
+          workspaceId: workspaceId(replay.authority.workspaceId),
+          scope: { type: "workspace" },
+          period: buildReaderSummaryPeriod({
+            cadence: "daily",
+            startedAt: new Date("2026-07-31T00:00:00.000Z"),
+            endedAt: new Date("2026-08-01T00:00:00.000Z"),
+            timezone: "UTC",
+          }),
+          maxItems: 200,
+          observedThrough: clock.now(),
+        });
+      };
+      await expect(attempt()).rejects.toThrow(unsupported);
+      for (const dependency of [list, findById, readPromotionSnapshot,
+        readSourceContent, readCurrent, $queryRaw, record, select, read]) {
+        expect(dependency).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("rejects before even accessing live construction inputs or fresh capability checks", () => {
+    const access = forbidden("live construction input");
+    expect(() => createReaderSummaryDailyPublicationExecutionWiring({
+      replay: verifiedUnsupportedDailyReplay(),
+      get feedItems(): never { return access(); },
+      get configuredInterests(): never { return access(); },
+      get summaryClient(): never { return access(); },
+      get storyRelationVerifier(): never { return access(); },
+      clock,
+      attestationSink: { record: forbidden("attestation sink") },
+    })).toThrow(unsupported);
+    expect(access).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-capture.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-capture.ts
@@ -1,3 +1,4 @@
+import type { ConfiguredInterestReaderPort } from "@social-monitor/relevance/ports";
 import type { FeedItemReadRepositoryPort, PromotionFeedItemSnapshotRepositoryPort } from "@social-monitor/feed/ports";
 import { InMemoryUserRelevanceProfileRepository } from "@social-monitor/relevance/adapters/persistence/in-memory-user-relevance-profile.repository";
 import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
@@ -46,10 +47,12 @@ export async function captureRefreshDatabaseAuthority(input: {
 // This uses the current selector on the complete repository. No paid relation
 // verifier is composed for preparation. Apply uses the normal agent verifier.
 export async function preflightRefreshSelection(input: {
+  configuredInterests: ConfiguredInterestReaderPort;
   feed: FeedItemReadRepositoryPort; date: string; observedThrough: Date; clock: Clock;
 }): Promise<number> {
   const selector = new RelevanceReaderSummaryEvidenceSelector(new RankFeedItemsUseCase(
     input.feed, new InMemoryUserRelevanceProfileRepository(), input.clock,
+    undefined, undefined, undefined, undefined, undefined, input.configuredInterests,
   ), input.feed, input.clock);
   const selection = await selector.select({
     tenantId: tenantId(refreshScope.tenantId), workspaceId: workspaceId(refreshScope.workspaceId),

--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -1,3 +1,4 @@
+import type { ConfiguredInterestReaderPort } from "@social-monitor/relevance/ports";
 import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
 import { InMemoryMetricsRecorder } from "@social-monitor/platform-metrics";
 import type { PrismaSummaryConnection } from "@social-monitor/summary/adapters/persistence/prisma/prisma-summary-connection";
@@ -23,6 +24,7 @@ import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary
 import { withRefreshSelectionAudit } from "./reader-summary-new-input-refresh-selection-audit";
 
 export async function executeNewInputRefresh(input: {
+  configuredInterests: ConfiguredInterestReaderPort;
   manifest: RefreshManifest; summary: PrismaSummaryConnection;
   feed: FeedItemReadRepositoryPort & PromotionFeedItemSnapshotRepositoryPort;
   clock: Clock; env: NodeJS.ProcessEnv;
@@ -65,7 +67,7 @@ export async function executeNewInputRefresh(input: {
   await assertCurrent();
   await assertRefreshHasNewInput(summary, m.date, m.prior.observedThrough, m.observedThrough);
   await input.assertRuntime();
-  const selectedCount = await preflightRefreshSelection({ feed, date: m.date,
+  const selectedCount = await preflightRefreshSelection({ configuredInterests: input.configuredInterests, feed, date: m.date,
     observedThrough: new Date(m.observedThrough), clock });
   input.record({ status: "preflight", operation: m.operation, selectedCount,
     plannedSummaryGenerations: selectedCount === 0 ? 0 : 1 });
@@ -117,7 +119,7 @@ export async function executeNewInputRefresh(input: {
     catch (error) { guard.invalidate(); throw error; }
   } };
   const canonical = createReaderSummaryDailyCapturePublicationWiring({
-    replay: null, feedItems: feed, summaryClient: summary, clock, attestationSink: sink,
+    replay: null, configuredInterests: input.configuredInterests, feedItems: feed, summaryClient: summary, clock, attestationSink: sink,
     summaryModelMode: "agent-runtime", env: input.env, agentRuntimeClient: runtime,
     storyRelationVerifierGuard: runtime,
   });

--- a/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec-support.ts
@@ -46,6 +46,7 @@ export async function selectorWiring(input: {
     await input.onAttestation?.(value);
   }) };
   const canonical = createReaderSummaryDailyCapturePublicationWiring({
+    configuredInterests: { readCurrent: async (scope) => ({ kind: "available" as const, interest: { ...scope, query: "AI developer tools" } }) },
     replay: null, feedItems: selectorFeed(input.sameStory), summaryClient: {} as never,
     clock: new FixedClock(refreshNow), attestationSink: sink,
     summaryModelMode: "agent-runtime", env: {}, agentRuntimeClient: runtime,

--- a/scripts/lib/reader-summary-new-input-refresh-selector.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selector.spec.ts
@@ -1,3 +1,4 @@
+import type { ConfiguredInterestScope } from "@social-monitor/relevance/ports";
 import { FeedItem } from "@social-monitor/feed/domain";
 import { InMemoryFeedItemReadRepository } from "@social-monitor/feed/adapters/persistence/in-memory-feed-item-read.repository";
 import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
@@ -24,7 +25,7 @@ describe("complete canonical current selector for historical inputs", () => {
         metricAuthority: { observedAt: new Date("2026-09-05T21:55:00Z"), regressionState: "stable" as const },
       })) };
     });
-    const common = { feed, date: m.date, clock: new FixedClock(refreshNow) };
+    const common = { configuredInterests: { readCurrent: async (scope: ConfiguredInterestScope) => ({ kind: "available" as const, interest: { ...scope, query: "AI developer tools" } }) }, feed, date: m.date, clock: new FixedClock(refreshNow) };
     expect(await preflightRefreshSelection({ ...common, observedThrough: new Date(m.prior.observedThrough) })).toBe(0);
     expect(await preflightRefreshSelection({ ...common, observedThrough: new Date(m.observedThrough) })).toBeGreaterThan(0);
     expect(snapshot).toHaveBeenLastCalledWith(expect.objectContaining({ observedThrough: new Date(m.observedThrough) }));

--- a/scripts/lib/support/reader-summary-unsupported-replay.ts
+++ b/scripts/lib/support/reader-summary-unsupported-replay.ts
@@ -1,0 +1,70 @@
+import { readerSummaryDailyModelJobIdentity } from "@social-monitor/summary/domain/value-objects/reader-summary-daily-model-job";
+
+import { canonicalJsonBytes, sha256 } from "../reader-summary-daily-canonical-recovery-v4";
+import { buildReaderSummaryDailyModelJobReceipt } from "../reader-summary-daily-model-job-receipt";
+import type { ReaderSummaryDailyReplayInput } from "../reader-summary-daily-publication-finalizer";
+import { verifyReaderSummaryDailySourceAuthority } from "../reader-summary-daily-source-authority-snapshot";
+
+/** Real verified v1 authority and builder-validated structured receipt, offline. */
+export const verifiedUnsupportedDailyReplay = (): ReaderSummaryDailyReplayInput => {
+  const scope = {
+    tenantId: "10000000-0000-4000-8000-000000000001",
+    workspaceId: "20000000-0000-4000-8000-000000000002",
+    requestedUtcDate: "2026-07-31",
+  };
+  const ingestionCutoff = "2026-08-01T01:00:00.000Z";
+  const canonicalBytes = canonicalJsonBytes({
+    schemaVersion: 1, ...scope, ingestionCutoff, items: [],
+  });
+  const authority = verifyReaderSummaryDailySourceAuthority({
+    ...scope,
+    authority: {
+      requestedUtcDate: scope.requestedUtcDate,
+      ingestionCutoff,
+      canonicalBytes,
+      canonicalSha256: sha256(canonicalBytes),
+    },
+  });
+  const modelJob = readerSummaryDailyModelJobIdentity({
+    ...scope, sourceAuthoritySha256: authority.canonicalSha256,
+  });
+  const responseBytes = canonicalJsonBytes({ headline: "Synthetic stored summary" });
+  const receipt = buildReaderSummaryDailyModelJobReceipt({
+    modelJob,
+    responseBytes,
+    attestation: {
+      schemaVersion: 1,
+      requestId: "unsupported-replay-fixture",
+      purpose: "social_monitor.reader_summary.generate.v2",
+      canonicalRequestSha256: sha256(Buffer.from("synthetic-request")),
+      provider: modelJob.provider,
+      model: modelJob.model,
+      reasoningEffort: modelJob.reasoningEffort,
+      runtimeEngine: modelJob.runtimeEngine,
+      runtimePackageVersion: "1.2.3",
+      launcherSha256: sha256(Buffer.from("synthetic-launcher")),
+      selectedOutputKind: "structured_output",
+      selectedOutputSha256: sha256(responseBytes),
+    },
+    modelTelemetry: {
+      provider: modelJob.provider,
+      model: modelJob.model,
+      reasoningEffort: modelJob.reasoningEffort,
+      inputTokens: 120,
+      outputTokens: 30,
+      totalTokens: 150,
+      usageSource: "PROVIDER_REPORTED",
+      durationMs: 250,
+    },
+  });
+  return {
+    responseBytes,
+    receiptBytes: receipt.receiptBytes,
+    authoritySha256: authority.canonicalSha256,
+    ingestionCutoff,
+    modelJobIdentity: modelJob.value,
+    authority,
+    outputKind: "structured_output",
+    modelTelemetry: receipt.modelTelemetry,
+  };
+};

--- a/scripts/run-reader-summary-new-input-refresh.ts
+++ b/scripts/run-reader-summary-new-input-refresh.ts
@@ -1,3 +1,6 @@
+import { PrismaMonitoringConnection } from "@social-monitor/monitoring/adapters/persistence/prisma/prisma-monitoring-connection";
+import { PrismaInterestRepository } from "@social-monitor/monitoring/adapters/persistence/prisma/prisma-interest.repository";
+import { MonitoringConfiguredInterestReader } from "@social-monitor/relevance/adapters/monitoring/monitoring-configured-interest.reader";
 import { credentials } from "@grpc/grpc-js";
 import { AgentRuntimeServiceClient } from "@social-monitor/contracts/generated/grpc/agent_runtime/v1/agent_runtime";
 import { mkdirSync, constants, realpathSync, openSync, writeSync, fsyncSync, closeSync, writeFileSync } from "node:fs";
@@ -53,10 +56,13 @@ async function main(): Promise<void> {
   const summary = await PrismaSummaryConnection.create(config);
   const feedConnection = await PrismaFeedConnection.create(config);
   const feed = new PrismaFeedItemReadRepository(feedConnection);
+  let monitoring: PrismaMonitoringConnection | undefined;
   const output = resolve(".cache/reader-summary-new-input-refresh");
   mkdirSync(output, { recursive: true, mode: 0o700 });
   if (realpathSync(output) !== output) throw new Error("Refresh evidence directory must not contain symlinks");
   try {
+    monitoring = await PrismaMonitoringConnection.create(config);
+    const configuredInterests = new MonitoringConfiguredInterestReader(new PrismaInterestRepository(monitoring));
     await runWithTenantDatabaseAccess(refreshScope, async () => {
       await assertHistoricalPromotionSystemRole(summary);
       if (command.mode === "prepare") {
@@ -70,7 +76,7 @@ async function main(): Promise<void> {
           const prior = await readRefreshPrior(summary, date);
           const authority = await captureRefreshAuthority({ client: summary, feed, date, observedThrough, clock });
           await assertRefreshHasNewInput(summary, date, prior.observedThrough, observedThrough.toISOString());
-          const eligible = await preflightRefreshSelection({ feed, date, observedThrough, clock });
+          const eligible = await preflightRefreshSelection({ configuredInterests, feed, date, observedThrough, clock });
           assertRefreshEqual(await captureRefreshAuthority({ client: summary, feed, date, observedThrough, clock }), authority, "preparation input");
           assertRefreshEqual(await readRefreshPrior(summary, date), prior, "preparation prior");
           const period = refreshPeriod(date);
@@ -120,7 +126,7 @@ async function main(): Promise<void> {
         finally { closeSync(fd); }
       };
       try {
-        const receipt = await executeNewInputRefresh({ manifest, summary, feed, clock, env: process.env,
+        const receipt = await executeNewInputRefresh({ configuredInterests, manifest, summary, feed, clock, env: process.env,
           runtime, assertFences, assertSource, record,
           assertRuntime: async () => {
             const serving = await resolveReaderSummaryServingAuthority({ summaryModelMode: "agent-runtime",
@@ -137,7 +143,7 @@ async function main(): Promise<void> {
         throw new Error("Refresh stopped; reconcile original operation");
       } finally { channel.close(); }
     });
-  } finally { await feedConnection.close(); await summary.close(); }
+  } finally { await Promise.all([monitoring?.close(), feedConnection.close(), summary.close()]); }
 }
 function required(name: string): string {
   const value = process.env[name]?.trim();

--- a/test/configured-interest-promotion.integration.spec.ts
+++ b/test/configured-interest-promotion.integration.spec.ts
@@ -1,0 +1,118 @@
+import { buildReaderSummaryPeriod } from "@social-monitor/summary/domain";
+import { classifyFeedPromotionEligibility, evaluateReaderPromotionV2, type FeedItem } from "@social-monitor/feed/domain";
+import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import { FixedClock, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { RelevanceReaderSummaryEvidenceSelector } from "@social-monitor/summary/adapters/evidence/relevance-reader-summary-evidence.selector";
+import { InMemoryUserRelevanceProfileRepository } from "@social-monitor/relevance/adapters/persistence/in-memory-user-relevance-profile.repository";
+import type { ConfiguredInterestReaderPort, ConfiguredInterestScope } from "@social-monitor/relevance/ports";
+import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
+import { context, feedItem, nativeMetadata, now, scope, v2Candidate } from "@social-monitor/relevance/features/rank-feed-items/rank-promotion-topic-context.spec-support";
+
+const bread = feedItem({ title: "Local bakers share their best bread recipes with neighbors",
+  providerMetadata: { ...nativeMetadata, ...context,
+    query: "best", searchQuery: "best", topic: "best", topics: ["best"],
+    interestQuerySnapshot: { ...context.interestQuerySnapshot, query: "best" },
+    sourceBindingSnapshot: { ...context.sourceBindingSnapshot, sourceQuery: { mode: "listing", query: "best" } } } });
+const command = { ...scope, limit: 200, rankingProfile: "reader_post_promotion" as const,
+  publishedAtOrAfter: new Date("2026-09-08T00:00:00Z"), publishedBefore: new Date("2026-09-09T00:00:00Z") };
+const clock = new FixedClock(now);
+const repository = (items: readonly FeedItem[], supplemental: readonly FeedItem[] = []): FeedItemReadRepositoryPort => ({
+  list: async () => ({ items: [] }), findById: async () => null,
+  readPromotionSnapshot: async () => ({ ok: true, exhausted: true, physicalRowsRead: items.length + supplemental.length,
+    candidates: items.map((item) => {
+      const canonical = classifyFeedPromotionEligibility(item.toSnapshot());
+      if (!canonical.eligible) throw new Error("Invalid fixture");
+      return { item, canonical, metricAuthority: { observedAt: now, regressionState: "stable" as const } };
+    }), supplementalItems: supplemental,
+    sourceContent: [...items, ...supplemental].map((item) => ({ feedItemId: item.toSnapshot().id,
+      sourceItemId: item.toSnapshot().sourceItemId, body: item.toSnapshot().bodyPreview })),
+  }),
+});
+const ranker = (feed: FeedItemReadRepositoryPort, reader?: ConfiguredInterestReaderPort) => new RankFeedItemsUseCase(
+  feed, new InMemoryUserRelevanceProfileRepository(), clock,
+  undefined, undefined, undefined, undefined, undefined, reader,
+);
+const configured = (query: string): ConfiguredInterestReaderPort => ({
+  readCurrent: async (requested) => ({ kind: "available", interest: { ...requested, query } }),
+});
+
+describe("configured authority through the actual ranking and Summary caller", () => {
+  it.each(["best", "bread recipes"])("rejects copied metadata for unrelated intent and accepts independently configured %s", async (query) => {
+    const feed = repository([bread]);
+    const unrelated = await ranker(feed, configured("Mistral financing")).execute(command);
+    const matching = await ranker(feed, configured(query)).execute(command);
+    if (!unrelated.ok || !matching.ok) throw new Error("Expected resolved authority");
+    expect(evaluateReaderPromotionV2(v2Candidate(unrelated.value.items[0]!)).admitted).toBe(false);
+    expect(evaluateReaderPromotionV2(v2Candidate(matching.value.items[0]!))).toMatchObject({ admitted: true, topQualified: true });
+    const select = (intent: string) => new RelevanceReaderSummaryEvidenceSelector(ranker(feed, configured(intent)), feed, clock).select({
+      ...scope, scope: { type: "interest", interestId: scope.interestId },
+      period: buildReaderSummaryPeriod({ cadence: "daily", startedAt: command.publishedAtOrAfter, endedAt: command.publishedBefore, timezone: "UTC" }),
+      observedThrough: now, maxItems: 120,
+    });
+    expect((await select("Mistral financing")).selectedEvidence).toHaveLength(0);
+    expect((await select(query)).selectedEvidence.map((item) => item.feedItemId)).toContain(bread.toSnapshot().id);
+  });
+
+  it("reads repeated interests once per invocation and fresh configuration next generation, even for an old window", async () => {
+    const reader = { readCurrent: jest.fn().mockResolvedValueOnce({ kind: "available", interest: { ...scope, query: "best" } })
+      .mockResolvedValueOnce({ kind: "available", interest: { ...scope, query: "Mistral financing" } }) };
+    const sameInterest = feedItem({ ...bread.toSnapshot(), id: "second", sourceItemId: "second-source" });
+    const useCase = ranker(repository([bread, sameInterest]), reader);
+    const first = await useCase.execute(command);
+    expect(reader.readCurrent).toHaveBeenCalledTimes(1);
+    const second = await useCase.execute(command);
+    expect(reader.readCurrent).toHaveBeenCalledTimes(2);
+    if (!first.ok || !second.ok) throw new Error("Expected resolved authority");
+    expect(first.value.items.every((item) => item.providerMetadata?.query === "best")).toBe(true);
+    expect(second.value.items.every((item) => item.providerMetadata?.query === "Mistral financing")).toBe(true);
+    expect(first.value.items.every((item) => item.providerMetadata?.query === "best")).toBe(true);
+  });
+
+  it("resolves each independent interest in a workspace without sharing query state", async () => {
+    const other = feedItem({ ...bread.toSnapshot(), id: "other", sourceItemId: "other-source", interestId: "other-interest" });
+    const readCurrent = jest.fn(async (requested: ConfiguredInterestScope) => ({
+      kind: "available" as const, interest: { ...requested,
+        query: requested.interestId === scope.interestId ? "best" : "Mistral financing" },
+    }));
+    const result = await ranker(repository([bread, other]), { readCurrent }).execute({ ...command, interestId: undefined });
+    if (!result.ok) throw result.error;
+    expect(readCurrent).toHaveBeenCalledTimes(2);
+    expect(result.value.items.find((item) => item.feedItemId === "other")!.contentQuality.flags).toContain("weak_topic_match");
+    expect(result.value.items.find((item) => item.feedItemId === bread.toSnapshot().id)!.contentQuality.eligibleForTopRead).toBe(true);
+  });
+
+  it.each(["missing", "unavailable", "throw", "tenant", "workspace", "interest", "blank", "absent"])(
+    "returns a typed operation conflict for %s authority", async (kind) => {
+      const reader: ConfiguredInterestReaderPort = { readCurrent: async () => {
+        if (kind === "throw") throw new Error("Unavailable");
+        if (kind === "missing" || kind === "unavailable") return { kind };
+        return { kind: "available", interest: { ...scope, query: kind === "blank" ? " " : "best",
+          ...(kind === "tenant" ? { tenantId: tenantId("other") } : {}),
+          ...(kind === "workspace" ? { workspaceId: workspaceId("other") } : {}),
+          ...(kind === "interest" ? { interestId: "other" } : {}) } };
+      } };
+      expect(await ranker(repository([bread]), kind === "absent" ? undefined : reader).execute(command))
+        .toMatchObject({ ok: false, error: { code: "operation.conflict" } });
+    },
+  );
+
+  it("sanitizes supplemental contexts and retains legitimate native GitHub topics and fields", async () => {
+    const supplemental = feedItem({ ...bread.toSnapshot(), id: "supplemental", sourceItemId: "supplemental-source",
+      providerKey: "github-trending-page", providerMetadata: { ...bread.toSnapshot().providerMetadata,
+        kind: "github_trending_page", topics: ["bread"], rank: 3, repositoryFullName: "fixture/bread" } });
+    const reader = { readCurrent: jest.fn(configured("Mistral financing").readCurrent) };
+    const result = await ranker(repository([bread], [supplemental]), reader).execute(command);
+    if (!result.ok) throw result.error;
+    expect(reader.readCurrent).toHaveBeenCalledTimes(1);
+    const item = result.value.items.find((item) => item.feedItemId === "supplemental")!;
+    expect(item.providerMetadata).toMatchObject({ query: "Mistral financing", topics: ["bread"], rank: 3, repositoryFullName: "fixture/bread" });
+    expect(item.providerMetadata).not.toHaveProperty("interestQuerySnapshot");
+    expect(item.providerMetadata).not.toHaveProperty("sourceBindingSnapshot");
+    expect(item.providerMetadata).not.toHaveProperty("searchQuery");
+    const noNativeTopics = feedItem({ ...supplemental.toSnapshot(), providerMetadata: {
+      ...supplemental.toSnapshot().providerMetadata, topics: [] } });
+    const without = await ranker(repository([], [noNativeTopics]), configured("Mistral financing")).execute(command);
+    if (!without.ok) throw without.error;
+    expect(without.value.items[0]!.contentQuality.flags).toContain("weak_topic_match");
+  });
+});


### PR DESCRIPTION
Refs #294. Fix Reader Promotion V2 topic authority: independently read scoped configured interests once per invocation instead of trusting copied acquisition metadata; preserve native metrics, safety rules and quality thresholds. New generations including explicit historical replacements use current configured intent, while immutable output_text recovery remains sealed. Unsupported replay rejects before any live reader. Independent review APPROVE on exact29fbcb31a566158faa2b0926b54b46b8b1a185f9; 50 focused recovery/fresh tests independently passed, integrated implementation checks recorded on OLD. Production full-slate comparison, migrated PostgreSQL CI and publication proof remain pending. This does not claim popularity alone determines relevance or that historical summaries are already restored.