### PR TITLE
fix(summary): separate reader card titles from source bodies

### DIFF
--- a/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
+++ b/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
@@ -114,20 +114,25 @@ describe("DeterministicReaderSummaryModelAdapter", () => {
     {
       sourceTitle: "Developers compare runtime isolation tradeoffs",
       headline: "Reports discuss Developers compare runtime isolation tradeoffs",
-      published: true,
     },
     {
       sourceTitle: "hacker-news story 10",
-      headline: "hacker-news story 10",
-      published: false,
+      headline: "Reports discuss hacker-news story 10",
     },
     {
       sourceTitle: "Developers compare runtime isolation tradeoffs.\n\nPreview deployments remain limited to test workspaces.",
       headline: "Discussion from monitored sources",
-      published: true,
     },
-  ])("binds single-story coverage and enforces copy rejection: $sourceTitle", async ({
-    sourceTitle, headline, published,
+    ...[
+      "Post explores runtime isolation tradeoffs",
+      "Discussion of runtime isolation tradeoffs",
+      "Thread compares runtime isolation tradeoffs",
+      "Reports explore runtime isolation tradeoffs",
+    ].map((sourceTitle) => ({
+      sourceTitle, headline: `Reports discuss ${sourceTitle}`,
+    })),
+  ])("publishes cluster-bound single-story coverage: $sourceTitle", async ({
+    sourceTitle, headline,
   }) => {
     const adapter = new DeterministicReaderSummaryModelAdapter();
     const dailyInput = readerSummaryInput(sourceTitle);
@@ -190,17 +195,8 @@ describe("DeterministicReaderSummaryModelAdapter", () => {
     );
     expect(attempt.draft.headline).toBe(headline);
     expect(attempt.draft.content?.headline).toBe(attempt.draft.headline);
-    if (published) {
-      expect(attempt.draft.headline).not.toBe(sourceTitle);
-      expectPublished(input, attempt);
-    } else {
-      expect(publicationDecision(input, attempt)).toMatchObject({
-        status: "rejected",
-        qualityPassed: false,
-        reasonCodes: ["editorial_quality"],
-        reasons: [expect.stringContaining("Headline copies a top-post title")],
-      });
-    }
+    expect(attempt.draft.headline).not.toBe(sourceTitle);
+    expectPublished(input, attempt);
   });
 });
 

--- a/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
+++ b/libs/summary/adapters/model/deterministic-reader-summary-model.adapter.spec.ts
@@ -110,9 +110,27 @@ describe("DeterministicReaderSummaryModelAdapter", () => {
     expectPublished(input, attempt);
   });
 
-  it("creates a cluster-bound lead for single-story coverage", async () => {
+  it.each([
+    {
+      sourceTitle: "Developers compare runtime isolation tradeoffs",
+      headline: "Reports discuss Developers compare runtime isolation tradeoffs",
+      published: true,
+    },
+    {
+      sourceTitle: "hacker-news story 10",
+      headline: "hacker-news story 10",
+      published: false,
+    },
+    {
+      sourceTitle: "Developers compare runtime isolation tradeoffs.\n\nPreview deployments remain limited to test workspaces.",
+      headline: "Discussion from monitored sources",
+      published: true,
+    },
+  ])("binds single-story coverage and enforces copy rejection: $sourceTitle", async ({
+    sourceTitle, headline, published,
+  }) => {
     const adapter = new DeterministicReaderSummaryModelAdapter();
-    const dailyInput = readerSummaryInput();
+    const dailyInput = readerSummaryInput(sourceTitle);
     const plannedLead = dailyInput.coveragePlan.lead;
     expect(plannedLead).toBeDefined();
     if (plannedLead === undefined) {
@@ -156,8 +174,33 @@ describe("DeterministicReaderSummaryModelAdapter", () => {
     expect(citedClusterIds(input, attempt, lead?.citationIds ?? [])).toEqual(
       new Set([plannedLead.clusterId]),
     );
-    expect(attempt.draft.headline).toBe("Discussion from monitored sources");
-    expectPublished(input, attempt);
+    expect(attempt.draft.content?.topReads[0]).toMatchObject({
+      title: sourceTitle,
+      promotionCandidateId: "feed-10",
+    });
+    expect(input.evidence.selectedEvidence).toContainEqual(
+      expect.objectContaining({
+        feedItemId: "feed-10",
+        sourceItemId: "source-10",
+        providerKey: "hacker-news",
+        canonicalUrl: "https://example.test/hacker-news/10",
+        title: sourceTitle,
+        bodyPreview: "Useful source evidence for a workspace summary.",
+      }),
+    );
+    expect(attempt.draft.headline).toBe(headline);
+    expect(attempt.draft.content?.headline).toBe(attempt.draft.headline);
+    if (published) {
+      expect(attempt.draft.headline).not.toBe(sourceTitle);
+      expectPublished(input, attempt);
+    } else {
+      expect(publicationDecision(input, attempt)).toMatchObject({
+        status: "rejected",
+        qualityPassed: false,
+        reasonCodes: ["editorial_quality"],
+        reasons: [expect.stringContaining("Headline copies a top-post title")],
+      });
+    }
   });
 });
 
@@ -165,6 +208,20 @@ const expectPublished = (
   input: ReaderSummaryModelInput,
   attempt: ProviderReaderSummaryAttempt,
 ): void => {
+  const decision = publicationDecision(input, attempt);
+  if (decision.status === "rejected") {
+    throw new Error(decision.reasons.join("; "));
+  }
+  expect(decision).toMatchObject({
+    status: "published",
+    qualityPassed: true,
+  });
+};
+
+const publicationDecision = (
+  input: ReaderSummaryModelInput,
+  attempt: ProviderReaderSummaryAttempt,
+) => {
   const readerSummaryId = "reader-summary-deterministic-test";
   const promotion = buildReaderPostPromotionProjection({
     evidence: input.evidence.selectedEvidence,
@@ -193,18 +250,9 @@ const expectPublished = (
     promotionAttestations: promotion.attestations,
     promotionEvidenceFacts: promotion.attestedEvidenceFacts,
   });
-  const decision = new ReaderSummaryPublicationPolicy().evaluate({
+  return new ReaderSummaryPublicationPolicy().evaluate({
     artifact,
     evidence: input.evidence,
-  });
-
-  if (decision.status === "rejected") {
-    throw new Error(decision.reasons.join("; "));
-  }
-
-  expect(decision).toMatchObject({
-    status: "published",
-    qualityPassed: true,
   });
 };
 
@@ -236,7 +284,7 @@ const citedClusterIds = (
   );
 };
 
-const readerSummaryInput = (): ReaderSummaryModelInput => {
+const readerSummaryInput = (sourceTitle: string): ReaderSummaryModelInput => {
   const selectedEvidence = [
     evidenceItem("rss", 1, 1.5),
     evidenceItem("rss", 2, 1.5),
@@ -247,7 +295,7 @@ const readerSummaryInput = (): ReaderSummaryModelInput => {
     evidenceItem("rss", 7, 1.495),
     evidenceItem("hacker-news", 8, 1.488),
     evidenceItem("reddit", 9, 1.437),
-    evidenceItem("hacker-news", 10, 1.238),
+    { ...evidenceItem("hacker-news", 10, 1.238), title: sourceTitle },
     evidenceItem("reddit", 11, 1),
     evidenceItem("github-issues", 12, 1),
   ];

--- a/libs/summary/adapters/model/openai-responses-reader-summary-model.adapter.spec.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-model.adapter.spec.ts
@@ -165,7 +165,7 @@ describe("OpenAiResponsesReaderSummaryModelAdapter", () => {
     expect(route.promptVersion).toBe(currentReaderSummaryPromptRelease.id);
     expect(adapter.estimate(input, route).outputTokens).toBe(3_200);
     expect(attempt.draft).toMatchObject({
-      headline: "Discussion from monitored sources",
+      headline: "Reports discuss AI tooling library is trending",
       usage: {
         inputTokens: 111,
         outputTokens: 222,

--- a/libs/summary/domain/aggregates/reader-summary-headline-publication.spec.ts
+++ b/libs/summary/domain/aggregates/reader-summary-headline-publication.spec.ts
@@ -52,11 +52,18 @@ describe("reader summary headline through aggregate and publication", () => {
     expect(decision).toMatchObject({ status: "published", qualityPassed: true });
   });
 
-  it("keeps the neutral fallback available for a noncopy", () => {
+  it("source-frames the neutral fallback for a noncopy with a short source title", () => {
     const { content, decision } = throughPublication(
       "Developers weigh AI runtime quality",
     );
-    expect(content.headline).toBe("Discussion from monitored sources");
+    // The canonical title stays separate from the body; it is safe to reuse
+    // the complete short heading with neutral source framing.
+    expect(content.topReads.map((read) => read.title)).toEqual([
+      "AI runtime quality discussion",
+    ]);
+    expect(content.headline).toBe(
+      "Reports discuss AI runtime quality discussion",
+    );
     expect(decision).toMatchObject({ status: "published", qualityPassed: true });
   });
 });

--- a/libs/summary/domain/services/reader-post-promotion-evidence-admission.spec.ts
+++ b/libs/summary/domain/services/reader-post-promotion-evidence-admission.spec.ts
@@ -61,32 +61,47 @@ describe("admitReaderPostPromotionEvidence supplemental appendix", () => {
     ]);
   });
 
-  it("publishes a reader-facing title instead of provider boilerplate", () => {
-    const fixture = fixtureSelection();
-    const evidence = fixture.selectedEvidence.map((item) =>
-      item.feedItemId === "hn:top"
-        ? { ...item, title: "X post by @builder: Agent release reaches developers" }
-        : item,
-    );
-    const projection = buildReaderPostPromotionProjection({
-      evidence,
-      clusters: fixture.clusters,
-      sourceWindow: fixture.sourceWindow,
-      citations: evidence.map((item) => ({
-        citationId: `citation:${item.feedItemId}`,
-        feedItemId: item.feedItemId,
-        sourceItemId: item.sourceItemId,
-        providerKey: item.providerKey,
-        field: "canonicalUrl" as const,
-        canonicalUrl: item.canonicalUrl,
-      })),
-    });
+  it.each([undefined, "The release remains limited to a developer preview."])(
+    "normalizes provider boilerplate without changing HN identity (body: %s)",
+    (bodyPreview) => {
+      const fixture = fixtureSelection();
+      const evidence = fixture.selectedEvidence.map((item) =>
+        item.feedItemId === "hn:top"
+          ? {
+              ...item,
+              title: "X post by @builder: Agent release reaches developers",
+              bodyPreview,
+            }
+          : item,
+      );
+      const projection = buildReaderPostPromotionProjection({
+        evidence,
+        clusters: fixture.clusters,
+        sourceWindow: fixture.sourceWindow,
+        citations: evidence.map((item) => ({
+          citationId: `citation:${item.feedItemId}`,
+          feedItemId: item.feedItemId,
+          sourceItemId: item.sourceItemId,
+          providerKey: item.providerKey,
+          field: "canonicalUrl" as const,
+          canonicalUrl: item.canonicalUrl,
+        })),
+      });
 
-    expect(projection.topReads[0]?.title)
-      .toBe("Agent release reaches developers");
-  });
+      expect(projection.topReads[0]?.title)
+        .toBe("Agent release reaches developers");
+      expect(projection.topReads[0]).toMatchObject({
+        providerKey: "hacker-news",
+        canonicalUrl: "https://news.ycombinator.com/item?id=50",
+        promotionCandidateId: "hn:top",
+        citationIds: ["citation:hn:top"],
+      });
+      expect(projection.admittedEvidence).toContainEqual(evidence[0]);
+      expect(projection.admittedEvidence[0]?.bodyPreview).toBe(bodyPreview);
+    },
+  );
 
-  it("derives a reader-facing promotion title from the source body", () => {
+  it("keeps the separate source title and retains body evidence", () => {
     const fixture = fixtureSelection();
     const evidence = fixture.selectedEvidence.map((item) =>
       item.feedItemId === "hn:top"
@@ -112,8 +127,25 @@ describe("admitReaderPostPromotionEvidence supplemental appendix", () => {
       })),
     });
 
-    expect(projection.topReads[0]?.title).toBe(
-      "Nice Work OpenAI\n\nOpenAI introduced a lower-cost business plan for teams with a two-seat minimum.",
+    expect(projection.topReads[0]?.title).toBe("Nice Work OpenAI");
+    expect(projection.admittedEvidence).toContainEqual(evidence[0]);
+    expect(projection.admittedEvidence[0]).toMatchObject({
+      feedItemId: "hn:top",
+      sourceItemId: "hn:top",
+      providerKey: "hacker-news",
+      canonicalUrl: "https://news.ycombinator.com/item?id=50",
+      title: "Nice Work OpenAI",
+      bodyPreview:
+        "OpenAI introduced a lower-cost business plan for teams with a two-seat minimum.",
+    });
+    expect(projection.admittedCitations).toContainEqual(
+      expect.objectContaining({
+        citationId: "citation:hn:top",
+        feedItemId: "hn:top",
+        sourceItemId: "hn:top",
+        providerKey: "hacker-news",
+        canonicalUrl: "https://news.ycombinator.com/item?id=50",
+      }),
     );
   });
 

--- a/libs/summary/domain/services/reader-post-promotion-evidence-input.ts
+++ b/libs/summary/domain/services/reader-post-promotion-evidence-input.ts
@@ -1,6 +1,6 @@
 import type { SummaryEvidenceItem, SummarySourceWindow } from "../value-objects/summary-evidence-item";
 import type { ReaderPostPromotionInput } from "../policies/reader-post-promotion-policy";
-import { buildReaderPostPromotionTitle, hasReaderFacingPromotionSource } from "./reader-post-promotion-title";
+import { readerPostAvailableSourceText, hasReaderFacingPromotionSource } from "./reader-post-promotion-title";
 import { readerPostPromotionBoundary, readerPostPromotionFreshnessIsValid } from "./reader-post-promotion-freshness";
 
 /** Maps the same evidence facts at producer admission and writer validation. */
@@ -65,7 +65,7 @@ export const readerPostPromotionEvidenceInput = (
       (facts?.metrics === undefined ? "missing" : "observed"),
     ...(facts?.metrics === undefined ? {} : { metrics: facts.metrics }),
     whyImportant: item.whyImportant.find((reason) => reason.trim().length > 0) ??
-      buildReaderPostPromotionTitle({ lead: item }),
+      (readerPostAvailableSourceText(item) ?? ""),
     clusterId,
   };
 };

--- a/libs/summary/domain/services/reader-post-promotion-title.ts
+++ b/libs/summary/domain/services/reader-post-promotion-title.ts
@@ -1,4 +1,7 @@
-import { readerSummaryProviderIdentity } from "../value-objects/reader-summary-provider-identity";
+import {
+  readerSummaryIndependentProviderFamily,
+  readerSummaryProviderIdentity,
+} from "../value-objects/reader-summary-provider-identity";
 import type { SummaryEvidenceItem } from
   "../value-objects/summary-evidence-item";
 import {
@@ -46,7 +49,17 @@ export const buildReaderPostPromotionTitle = (params: {
   readonly lead: SummaryEvidenceItem;
   readonly admitted?: readonly SummaryEvidenceItem[];
   readonly promotionReasons?: readonly string[];
-}): string => readerPostAvailableSourceText(params.lead) ?? "";
+}): string => {
+  const source = readerPostAvailableSourceText(params.lead);
+  if (source === undefined) return "";
+  // Titled sources already carry their headline separately from body evidence.
+  // X titles are body previews, so retain the available post and its qualifiers.
+  // Missing headlines also use available source text, never a generated claim.
+  return readerSummaryIndependentProviderFamily(params.lead) !== "x" &&
+    params.lead.title.trim().length > 0
+    ? params.lead.title.trim()
+    : source;
+};
 
 export const hasReaderFacingPromotionSource = (
   item: SummaryEvidenceItem,
@@ -59,7 +72,7 @@ export const hasReaderFacingPromotionTitle = hasReaderFacingPromotionSource;
 export const isFaithfulReaderSourcePresentation = (
   read: { readonly title: string; readonly canonicalUrl?: string; readonly providerKey: string },
   evidence: readonly SummaryEvidenceItem[],
-): boolean => evidence.some((item) =>
+): boolean => read.title.trim().length > 0 && evidence.some((item) =>
   item.canonicalUrl === read.canonicalUrl && readerSummaryProviderIdentity(item).providerKey === read.providerKey &&
-  readerPostAvailableSourceText(item) === read.title,
+  buildReaderPostPromotionTitle({ lead: item }) === read.title,
 );

--- a/libs/summary/domain/services/reader-post-promotion-title.ts
+++ b/libs/summary/domain/services/reader-post-promotion-title.ts
@@ -9,9 +9,12 @@ import {
   isTechnicalReaderTitle,
 } from "../policies/reader-summary-reader-facing-text-policy";
 
+const sourceTitleWithoutProviderBoilerplate = (title: string): string =>
+  title.trim().replace(/^X post by @[^:]+:\s*/iu, "");
+
 /** Presentation availability, not content admission or concise-title styling. */
 export const isUsableReaderSourceText = (value: string): boolean => {
-  const text = value.trim().replace(/^X post by @[^:]+:\s*/iu, "");
+  const text = sourceTitleWithoutProviderBoilerplate(value);
   return text.replace(/https?:\/\/\S+/giu, "").trim().length > 0 &&
     !isLowInformationReaderTitle(text) && !isTechnicalReaderTitle(text) &&
     text.toLowerCase() !== "cited story" &&
@@ -30,7 +33,7 @@ export const readerPostAvailableSourceText = (
   const body = lead.sourceText?.trim()
     ? lead.sourceText
     : lead.bodyPreview?.trim() ? lead.bodyPreview : undefined;
-  const title = lead.title.trim().replace(/^X post by @[^:]+:\s*/iu, "");
+  const title = sourceTitleWithoutProviderBoilerplate(lead.title);
   if (body === undefined || body.length === 0) {
     return isUsableReaderSourceText(title) ? title : undefined;
   }
@@ -52,12 +55,13 @@ export const buildReaderPostPromotionTitle = (params: {
 }): string => {
   const source = readerPostAvailableSourceText(params.lead);
   if (source === undefined) return "";
+  const title = sourceTitleWithoutProviderBoilerplate(params.lead.title);
   // Titled sources already carry their headline separately from body evidence.
   // X titles are body previews, so retain the available post and its qualifiers.
   // Missing headlines also use available source text, never a generated claim.
   return readerSummaryIndependentProviderFamily(params.lead) !== "x" &&
-    params.lead.title.trim().length > 0
-    ? params.lead.title.trim()
+    title.length > 0
+    ? title
     : source;
 };
 

--- a/libs/summary/domain/services/reader-summary-headline-policy.ts
+++ b/libs/summary/domain/services/reader-summary-headline-policy.ts
@@ -148,12 +148,9 @@ const buildHumanReaderHeadline = (
       isUnverifiedLegalTopRead(lead)) {
     return "Discussion from monitored sources";
   }
-  if (lead.confirmedProviderKeys.length > 1 || lead.confidence.level === "high") {
-    return lead.title;
-  }
-  return isExplicitlySourceFramedText(lead.title, lead)
-    ? lead.title
-    : `Reports discuss ${lead.title}`;
+  // Source framing or corroboration does not make a copied heading synthesis.
+  // Keep the complete short title in the report frame, just as for other leads.
+  return `Reports discuss ${lead.title}`;
 };
 
 export const isUnverifiedLegalTopRead = (lead: {

--- a/libs/summary/domain/services/reader-summary-headline-source-context.spec.ts
+++ b/libs/summary/domain/services/reader-summary-headline-source-context.spec.ts
@@ -47,6 +47,25 @@ describe("headline source context", () => {
     },
   );
 
+  it.each([
+    { title: "Discussion of runtime isolation", confidence: "low", providers: ["reddit"] },
+    { title: "Runtime isolation improves", confidence: "high", providers: ["reddit"] },
+    { title: "Runtime isolation improves", confidence: "low", providers: ["reddit", "rss"] },
+  ] as const)("never generates a bare source heading: $title / $confidence / $providers", ({
+    title, confidence, providers,
+  }) => {
+    expect(groundedReaderHeadline({
+      headline: "Summary: current discussion",
+      sourceTitles: [title],
+      sourceMix: [],
+      topReads: [{
+        ...lead(title),
+        confidence: { level: confidence, score: 0.9, rationale: "Synthetic support" },
+        confirmedProviderKeys: [...providers],
+      }],
+    })).toBe(`Reports discuss ${title}`);
+  });
+
   it("does not hide a copied model headline behind the neutral fallback", () => {
     const sourceTitle = "Atlas bypasses approval";
     expect(groundedReaderHeadline({

--- a/libs/summary/domain/services/reader-summary-support.spec.ts
+++ b/libs/summary/domain/services/reader-summary-support.spec.ts
@@ -169,7 +169,7 @@ describe("groundedReaderHeadline", () => {
     );
   });
 
-  it("replaces a vague daily wrap headline with the concrete lead title", () => {
+  it("replaces a vague daily wrap headline with the complete lead title in a Reports discuss frame", () => {
     const lead = {
       ...topRead(),
       title: "Acme launches a lower-cost coding model",
@@ -181,7 +181,7 @@ describe("groundedReaderHeadline", () => {
         topReads: [lead],
         sourceMix: [],
       }),
-    ).toBe("Acme launches a lower-cost coding model");
+    ).toBe("Reports discuss Acme launches a lower-cost coding model");
   });
 
   it("does not trust a thematic headline when its citations come from one provider group", () => {
@@ -355,7 +355,7 @@ describe("groundedReaderHeadline", () => {
         topReads: [lead],
         sourceMix: [],
       }),
-    ).toBe("Acme sues Example Labs over alleged model theft");
+    ).toBe("Reports discuss Acme sues Example Labs over alleged model theft");
   });
 
   it("does not let unrelated cross-source coverage validate a single-source lead", () => {

--- a/libs/summary/domain/services/reader-summary-top-read-builder.spec.ts
+++ b/libs/summary/domain/services/reader-summary-top-read-builder.spec.ts
@@ -97,7 +97,7 @@ describe("reader summary top read builder", () => {
     );
 
     expect(topRead.title).toBe(
-      "Claude Code tracker raises telemetry questions\n\nDevelopers are debating what Claude Code usage tracking means.",
+      "Claude Code tracker raises telemetry questions",
     );
     expect(topRead.reason).toBe(
       "The post explains why Claude Code tracking concerns matter for developer teams.",
@@ -611,7 +611,7 @@ describe("reader summary top read builder", () => {
     expect(topRead.reason).toBe(
       "The report states: RSS explains an AI agent security update\n\nThe update records how connected MCP servers access files, networks and local tools. Teams can use the audit data before granting production permissions.",
     );
-    expect(topRead.title).toBe("RSS explains an AI agent security update\n\nThe update records how connected MCP servers access files, networks and local tools. Teams can use the audit data before granting production permissions.");
+    expect(topRead.title).toBe("RSS explains an AI agent security update");
     expect(topRead.reason).toContain(topRead.title);
     expect(topRead.reason).not.toContain("source-reported");
   });

--- a/libs/summary/domain/services/reader-summary-top-read-title.ts
+++ b/libs/summary/domain/services/reader-summary-top-read-title.ts
@@ -1,7 +1,7 @@
 import type { SummaryEvidenceItem } from "../value-objects/summary-evidence-item";
 import { isUnpolishedReaderTitle } from
   "../policies/reader-summary-reader-facing-text-policy";
-import { readerPostAvailableSourceText } from "./reader-post-promotion-title";
+import { buildReaderPostPromotionTitle } from "./reader-post-promotion-title";
 
 export const buildTopReadTitle = (params: {
   readonly storyTitle: string;
@@ -12,13 +12,13 @@ export const buildTopReadTitle = (params: {
   // The shared/legacy builder must preserve the same lead context as promotion.
   // A generated title or a support item's text cannot replace that context.
   if (params.primaryEvidence !== undefined) {
-    return readerPostAvailableSourceText(params.primaryEvidence) ?? "";
+    return buildReaderPostPromotionTitle({ lead: params.primaryEvidence });
   }
   return "";
 };
 
 export const evidenceReaderTitle = (evidence: SummaryEvidenceItem): string =>
-  readerPostAvailableSourceText(evidence) ?? "";
+  buildReaderPostPromotionTitle({ lead: evidence });
 
 export const isUnverifiedBreakingSourceTitle = (value: string): boolean =>
   /^(?:X post by @[^:]+:\s*)?(?:breaking|just\s+in)\s*:/iu.test(value.trim());

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job-promotion-control.spec.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job-promotion-control.spec.ts
@@ -158,7 +158,7 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
     expect(result.ok).toBe(true);
     const snapshot = scenario.artifacts.all()[0]?.toSnapshot();
     expect(snapshot?.content?.topReads[0]).toMatchObject({
-      title: "Runtime regression discussion\n\nUsers are discussing a runtime regression.",
+      title: "Runtime regression discussion",
       providerKey: "reddit",
       citationIds: ["c1"],
       providerMetrics: [{ label: "Score", value: "50" }],
@@ -169,6 +169,15 @@ describe("ExecuteReaderSummaryJobUseCase promotion controls", () => {
     );
     expect(scenario.model.generatedEvidenceIds()).toEqual([["feed-1"]]);
     const modelEvidence = scenario.model.generatedEvidencePayloads()[0];
+    expect(JSON.parse(modelEvidence!).selectedEvidence).toEqual([
+      expect.objectContaining({
+        feedItemId: "feed-1",
+        sourceItemId: "reddit-post-1",
+        canonicalUrl: "https://reddit.example.test/post-1",
+        title: "Runtime regression discussion",
+        bodyPreview: "Users are discussing a runtime regression.",
+      }),
+    ]);
     expect(modelEvidence).not.toContain("feed-related");
     expect(modelEvidence).not.toContain("relation:related-topic");
     expect(modelEvidence).not.toContain("must-not-reach-model");

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.spec.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.spec.ts
@@ -376,6 +376,22 @@ describe("ExecuteReaderSummaryJobUseCase", () => {
       }),
     );
 
+    const model = new CapturingReaderSummaryModel({
+      topReads: [{ title: "Untrusted model top read" }],
+      narrativeSections: [
+        {
+          id: "lead",
+          kind: "lead",
+          title: "Overview",
+          text: "Runtime regression discussion is the main signal.",
+          citationIds: ["c1"],
+          storyClusterId: "cluster-1",
+        },
+      ],
+    } as unknown as ProviderReaderSummaryAttempt["draft"]["content"], [
+      "provider_failed",
+    ]);
+
     const result = await new ExecuteReaderSummaryJobUseCase(
       jobs,
       artifacts,
@@ -385,21 +401,7 @@ describe("ExecuteReaderSummaryJobUseCase", () => {
           return primaryReaderSummaryEvidence(makeReaderEvidenceSelection());
         },
       },
-      new CapturingReaderSummaryModel({
-        topReads: [{ title: "Untrusted model top read" }],
-        narrativeSections: [
-          {
-            id: "lead",
-            kind: "lead",
-            title: "Overview",
-            text: "Runtime regression discussion is the main signal.",
-            citationIds: ["c1"],
-            storyClusterId: "cluster-1",
-          },
-        ],
-      } as unknown as ProviderReaderSummaryAttempt["draft"]["content"], [
-        "provider_failed",
-      ]),
+      model,
       new CapturingReaderSummaryPublication(jobs, artifacts, events),
       new StaticIdGenerator(),
       new FixedClock(new Date("2026-06-28T08:05:00.000Z")),
@@ -445,8 +447,18 @@ describe("ExecuteReaderSummaryJobUseCase", () => {
       },
     });
     expect(artifacts.all()[0]?.toSnapshot().content?.topReads[0]?.title).toBe(
-      "Runtime regression discussion\n\nUsers are discussing a runtime regression.",
+      "Runtime regression discussion",
     );
+    expect(JSON.parse(model.generatedEvidencePayloads()[0]!).selectedEvidence).toEqual([
+      expect.objectContaining({
+        feedItemId: "feed-1",
+        sourceItemId: "reddit-post-1",
+        providerKey: "reddit",
+        canonicalUrl: "https://reddit.example.test/post-1",
+        title: "Runtime regression discussion",
+        bodyPreview: "Users are discussing a runtime regression.",
+      }),
+    ]);
     expect(artifacts.all()[0]?.toSnapshot().content?.narrativeSections).toEqual(
       [
         {

--- a/libs/summary/interfaces/rest/reader-summary-title-projection.spec-support.ts
+++ b/libs/summary/interfaces/rest/reader-summary-title-projection.spec-support.ts
@@ -1,0 +1,47 @@
+import { buildReaderPostPromotionProjection } from "../../domain/services/reader-post-promotion-projection";
+import { readerPostPromotionEvidenceInput } from "../../domain/services/reader-post-promotion-evidence-input";
+import { selectReaderPostPromotions } from "../../domain/policies/reader-post-promotion-selection";
+import { bindReaderPromotionV2TestSelection } from "../../domain/services/reader-post-promotion-attestation.spec-support";
+import {
+  dailyEvidenceSelection,
+  dailySynthesisArtifact,
+} from "../../domain/policies/reader-summary-publication-policy-test-fixtures";
+import { withPublicationCards } from "../../domain/policies/reader-summary-promotion-publication-test-fixtures";
+import { presentReaderSummaryArtifact } from "../../features/shared/reader-summary-artifact-presenter";
+import { readerSummaryArtifactViewFromReaderSummaryView } from "./reader-summary-rest.mapper";
+
+/** Deterministic V2 Top/Additional envelope; never invokes a model or provider. */
+export const projectPublicTitles = (title: string, sourceText: string) => {
+  const selection = dailyEvidenceSelection(25);
+  const evidence = selection.selectedEvidence.map((item) => ({
+    ...item, title, sourceText, bodyPreview: sourceText.slice(0, 280),
+  }));
+  const base = dailySynthesisArtifact();
+  const snapshot = base.toSnapshot();
+  const binding = { artifactId: snapshot.readerSummaryId, sourceWindow: selection.sourceWindow };
+  const { editorialSlate } = bindReaderPromotionV2TestSelection(
+    selectReaderPostPromotions(evidence.map((item, index) =>
+      readerPostPromotionEvidenceInput(item, selection.sourceWindow,
+        snapshot.citationMap[index]!.citationId, true, selection.clusters[index]!.id))),
+    binding,
+  );
+  const projection = buildReaderPostPromotionProjection({
+    evidence,
+    clusters: selection.clusters,
+    citations: snapshot.citationMap,
+    sourceWindow: selection.sourceWindow,
+    editorialSlate,
+    attestationBinding: binding,
+  });
+  const artifact = withPublicationCards(base, {
+    topReads: projection.topReads,
+    selectedPosts: projection.additionalPosts,
+  }, projection.attestations, projection.attestedEvidenceFacts);
+  const view = presentReaderSummaryArtifact(artifact, {
+    status: "fresh", checkedAt: new Date("2026-07-05T09:00:00Z"),
+  });
+  return {
+    evidence, projection, view,
+    response: readerSummaryArtifactViewFromReaderSummaryView(view),
+  };
+};

--- a/libs/summary/interfaces/rest/reader-summary-title-projection.spec.ts
+++ b/libs/summary/interfaces/rest/reader-summary-title-projection.spec.ts
@@ -1,0 +1,104 @@
+import { projectPublicTitles } from "./reader-summary-title-projection.spec-support";
+import { readerSummaryArtifactViewFromReaderSummaryView } from "./reader-summary-rest.mapper";
+import {
+  buildReaderPostPromotionTitle,
+  hasReaderFacingPromotionSource,
+  isFaithfulReaderSourcePresentation,
+  readerPostAvailableSourceText,
+} from "../../domain/services/reader-post-promotion-title";
+import { readerPostPromotionEvidenceInput } from "../../domain/services/reader-post-promotion-evidence-input";
+import { buildTopReadTitle, evidenceReaderTitle } from "../../domain/services/reader-summary-top-read-title";
+
+describe("Reader Promotion V2 title projection to public Top and posts", () => {
+  it.each([[119, 5268], [73, 4642], [91, 3254]])(
+    "keeps a %i-character headline separate from %i characters of body evidence",
+    (titleLength, bodyLength) => {
+      // Same dimensions as the protected Sept 8 examples, with synthetic text.
+      const title = "Source headline ".padEnd(titleLength, "t");
+      const body = "Context and qualifications. ".repeat(250).slice(0, bodyLength);
+      const { response, projection, evidence } = projectPublicTitles(title, body);
+      expect(response.readerBrief.topReads).toHaveLength(1);
+      expect(response.readerBrief.selectedPosts).toHaveLength(1);
+      const cards = [...response.readerBrief.topReads, ...response.readerBrief.selectedPosts];
+      cards.forEach((card, index) => {
+        const item = evidence[index]!;
+        expect(card.title).toBe(title);
+        expect(card.title).not.toContain(body);
+        expect(card.canonicalUrl).toBe(item.canonicalUrl);
+        expect(card.providerKey).toBe(item.providerKey);
+        expect(card.promotionAttestation?.candidateId).toBe(item.feedItemId);
+        expect(card.promotionAttestation?.canonicalIdentity)
+          .toBe(item.promotionFacts!.canonicalIdentity);
+        expect(projection.admittedEvidence[index]).toBe(item);
+        expect(item.sourceText).toBe(body);
+        expect(item.bodyPreview).toBe(body.slice(0, 280));
+        expect(isFaithfulReaderSourcePresentation(card, [item])).toBe(true);
+        expect(isFaithfulReaderSourcePresentation({ ...card, title: `${title}\n\n${body}` }, [item]))
+          .toBe(false);
+        expect(response.citations.find((citation) => citation.feedItemId === item.feedItemId)?.sourceItemId)
+          .toBe(item.sourceItemId);
+      });
+    },
+  );
+
+  it.each([
+    ["Ordinary source headline", "Separate body with a qualification."],
+    ["Ordinary source headline", ""],
+    ["Headline with\n\nintentional paragraph break", "Separate body."],
+    ["A legitimate long headline ".repeat(300), "Separate body."],
+    ["A title mentioning body words", "body words"],
+  ])("preserves legitimate source title structure", (title, body) => {
+    const { response, evidence } = projectPublicTitles(title, body);
+    const expected = title.trim();
+    expect(response.readerBrief.topReads[0]?.title).toBe(expected);
+    expect(response.readerBrief.selectedPosts[0]?.title).toBe(expected);
+    expect(evidenceReaderTitle(evidence[0]!)).toBe(expected);
+    expect(buildTopReadTitle({ primaryEvidence: evidence[0], evidence,
+      storyTitle: "Generated claim", storySummary: "Generated prose" })).toBe(expected);
+  });
+
+  it("uses available body for a missing title without borrowing generated prose", () => {
+    const body = "The source has no headline. Its qualification must remain intact.";
+    const { response } = projectPublicTitles("  ", body);
+    expect(response.readerBrief.topReads[0]?.title).toBe(body);
+    expect(response.readerBrief.selectedPosts[0]?.title).toBe(body);
+  });
+
+  it("keeps content availability and promotion input facts independent of title projection", () => {
+    const { evidence } = projectPublicTitles("Source headline", "Separate body evidence.");
+    const item = { ...evidence[0]!, whyImportant: [] };
+    const { sourceWindow } = projectPublicTitles(item.title, item.sourceText!).view;
+    const window = {
+      windowId: sourceWindow.windowId,
+      startedAt: new Date(sourceWindow.startedAt), endedAt: new Date(sourceWindow.endedAt),
+      selectedFeedItemIds: [item.feedItemId], storyClusterIds: [],
+    };
+    expect(readerPostPromotionEvidenceInput(item, window, "citation", true).whyImportant)
+      .toBe(readerPostAvailableSourceText(item));
+    expect(hasReaderFacingPromotionSource(item)).toBe(true);
+    const missing = { ...item, title: "", bodyPreview: "", sourceText: "" };
+    expect(buildReaderPostPromotionTitle({ lead: missing })).toBe("");
+    expect(hasReaderFacingPromotionSource(missing)).toBe(false);
+    expect(isFaithfulReaderSourcePresentation(missing, [missing])).toBe(false);
+    expect(hasReaderFacingPromotionSource({ ...item, sourceText: "Check this out!" })).toBe(false);
+  });
+
+  it.each(["x", "x-twitter", "twitter"])("retains %s full post semantics without repeating its preview", (providerKey) => {
+    const body = "A source post begins here. ".repeat(30) + "The preceding claim is retracted.";
+    const { evidence } = projectPublicTitles("Source headline", body);
+    const item = { ...evidence[0]!, providerKey,
+      title: `X post by @fixture: ${body.slice(0, 100)}...` };
+    expect(buildReaderPostPromotionTitle({ lead: item })).toBe(body);
+    expect(buildReaderPostPromotionTitle({ lead: { ...item, title: "Simulation only." } }))
+      .toBe(`Simulation only.\n\n${body}`);
+  });
+
+  it("still rejects forged source identity at the public mapper", () => {
+    const { view } = projectPublicTitles("Source headline", "Separate body evidence.");
+    expect(() => readerSummaryArtifactViewFromReaderSummaryView({
+      ...view,
+      content: { ...view.content, topReads: [{ ...view.content.topReads[0]!,
+        canonicalUrl: "https://example.test/unrelated" }] },
+    })).toThrow("promotion board is invalid");
+  });
+});


### PR DESCRIPTION
Refs #294. Fix canonical title assembly: titled sources retain their separate headline instead of concatenating the complete body into public Top/Additional title fields. Preserve body evidence, identity, whyImportant fallback and X full-post semantics. No arbitrary truncation or historical artifact rewrites. Three real protected-row examples reproduce old lengths5389/4717/3347 and corrected source titles119/73/91 while retaining body content. Focused608tests, architecture, quality and linecap checks pass; isolated full typecheck lacks generated Prisma client, focused source typecheck passes. Independent exact-head review running. Production regeneration/API/UI proof remains pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reader summaries now use clean source titles without appending body previews.
  * Headlines consistently use the “Reports discuss …” format for grounded stories.
  * Source-title formatting and fallback behavior are improved when titles are missing or include provider boilerplate.
  * Evidence and citation details are preserved more accurately across published summaries.

* **Tests**
  * Expanded coverage for title projection, evidence identity, provider-specific formatting, and headline normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->