### PR TITLE
refactor(x): share canonical invocation with hermetic parity evidence

### DIFF
--- a/apps/x-collector/src/x_collector/canonical_search_invocation.py
+++ b/apps/x-collector/src/x_collector/canonical_search_invocation.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime
+from typing import Callable
+
+from . import __version__
+from .candidate_rejection_cache import (
+    CandidateRejectionCacheError, CandidateRejectionScope, candidate_rejection_scope,
+)
+from .domain import (
+    DailySearchRequest, DailySearchResult, XCollectedPost, XCollectorRun,
+    XCollectorWarning, XCollectorRateLimitError, XCollectorUnavailableError,
+)
+from .scoring import CandidateSignal, aggregate_candidates, rank_candidates
+from .search_budget import retry_after_ms_until, warnings_for_budget_decision
+from .search_plan import plan_scweet_search_passes
+from .canonical_search_services import (
+    CanonicalSearchServices, CanonicalSearchObserver, PassRecord, ChosenOrigin,
+    CacheObservation, CanonicalObservationError,
+)
+
+
+class CanonicalInvocation:
+    """One ordinary invocation; external execution and storage remain injected."""
+
+    def __init__(self, services: CanonicalSearchServices,
+                 observer: CanonicalSearchObserver | None = None) -> None:
+        self.services = services
+        self.observer = observer
+
+    def _observe_cache(self, observation: CacheObservation) -> None:
+        if self.observer is not None:
+            self._notify(self.observer.on_cache_observation, observation)
+
+    def _notify(self, callback: Callable[..., None], *facts: object) -> None:
+        try:
+            callback(*(deepcopy(fact) for fact in facts))
+        except Exception as exc:
+            raise CanonicalObservationError("Canonical observation failed") from exc
+
+    @staticmethod
+    def _observed_rejections(rejections):
+        try:
+            return tuple(rejections.items())
+        except Exception as exc:
+            raise CanonicalObservationError("Cache observation snapshot failed") from exc
+
+    def run(
+        self,
+        request: DailySearchRequest,
+    ) -> DailySearchResult:
+        started_at = self.services.clock.now()
+        scweet = self.services.start_execution()
+        self.services.prepare_account_pool()
+        since, until = self.services.date_window(request)
+        fetched_posts: list[tuple[XCollectedPost, CandidateSignal]] = []
+        warnings: list[XCollectorWarning] = []
+        if request.cursor:
+            warnings.append(
+                XCollectorWarning(
+                    code="x_collector.cursor_ignored",
+                    message=(
+                        "Daily multi-pass search ignores external cursor; "
+                        "dedupe is handled by the Social Monitor store."
+                    ),
+                ),
+            )
+
+        planned_passes = plan_scweet_search_passes(request)
+        budget = self.services.budget_search_passes(planned_passes)
+        self.services.account_usage_observer.record_budget_decision(request, budget)
+        warnings.extend(warnings_for_budget_decision(budget))
+        if not budget.passes and budget.remaining_request_budget is not None:
+            raise XCollectorRateLimitError(
+                "Scweet account pool budget exhausted",
+                retry_after_ms=retry_after_ms_until(
+                    self.services.clock.now(),
+                    budget.reset_at,
+                ),
+                reset_at=budget.reset_at,
+            )
+
+        for search_pass in budget.passes:
+            self.services.prepare_account_pool()
+            try:
+                records, scweet, usage, failover_count = (
+                    self.services.execute_pass(
+                        scweet,
+                        request=request,
+                        search_pass=search_pass,
+                        since=since,
+                        until=until,
+                    )
+                )
+            except Exception as classified:
+                warning = partial_warning_for_late_failure(
+                    classified,
+                    search_pass.label,
+                    len(fetched_posts),
+                )
+                if warning is not None:
+                    warnings.append(warning)
+                    break
+
+                raise classified
+
+            if failover_count > 0:
+                warnings.append(
+                    XCollectorWarning(
+                        code="x_collector.account_failover",
+                        message=(
+                            f"{search_pass.label} resumed with another account "
+                            f"after {failover_count} account-scoped failure(s)"
+                        ),
+                    ),
+                )
+
+            observed_records: list[PassRecord] = []
+            accepted_count = 0
+            for rank, record in enumerate(records, start=1):
+                post = self.services.normalize_record(record, search_pass.product)
+                in_window = post is not None and self.services.in_window(post, request)
+                if self.observer is not None:
+                    observed_records.append(PassRecord(rank, post, in_window))
+                if post is not None and in_window:
+                    fetched_posts.append((
+                        post,
+                        CandidateSignal(
+                            pass_label=search_pass.label,
+                            product=search_pass.product,
+                            rank=rank,
+                        ),
+                    ))
+                    accepted_count += 1
+
+            if self.observer is not None:
+                self._notify(self.observer.on_pass_records,
+                    search_pass, tuple(observed_records),
+                )
+
+            self.services.account_usage_observer.complete_pass_success(
+                request,
+                usage,
+                fetched_count=len(records),
+                accepted_count=accepted_count,
+            )
+            if len(records) < search_pass.limit:
+                warnings.append(
+                    XCollectorWarning(
+                        code="x_collector.partial_pass",
+                        message=(
+                            f"{search_pass.label} returned fewer records "
+                            "than requested"
+                        ),
+                    ),
+                )
+            if records and accepted_count == 0:
+                warnings.append(
+                    XCollectorWarning(
+                        code="x_collector.pass_filtered",
+                        message=(
+                            f"{search_pass.label} returned records, but all "
+                            "were outside the requested window or invalid"
+                        ),
+                    ),
+                )
+            if self.services.account_budget_is_depleted():
+                warnings.append(
+                    XCollectorWarning(
+                        code="x_collector.account_budget_depleted",
+                        message=(
+                            "Scweet account pool budget was depleted after "
+                            f"{search_pass.label}; returning partial daily "
+                            "search results"
+                        ),
+                    ),
+                )
+                break
+
+        ranking_posts, rejection_scope, rejection_cache_ready = (
+            self._filter_cached_rank_rejections(
+                request,
+                fetched_posts,
+                started_at,
+                warnings,
+            )
+        )
+        selected_posts = rank_candidates(
+            ranking_posts,
+            query=request.query,
+            window_end=request.window_end,
+            max_items=request.max_items,
+        )
+        completed_at = self.services.clock.now()
+        if rejection_cache_ready and rejection_scope is not None:
+            self._record_ranking_outcomes(
+                rejection_scope,
+                ranking_posts,
+                selected_posts,
+                completed_at,
+                warnings,
+            )
+
+        result = DailySearchResult(
+            posts=tuple(selected_posts),
+            next_cursor=None,
+            warnings=tuple(warnings),
+            run=XCollectorRun(
+                collector_engine="scweet",
+                collector_version=f"scweet-5.3 service-{__version__}",
+                started_at=started_at,
+                completed_at=completed_at,
+                requested_limit=request.max_items,
+                fetched_count=len(fetched_posts),
+                returned_count=len(selected_posts),
+                partial=len(selected_posts) < request.max_items,
+            ),
+        )
+
+        if self.observer is not None:
+            origins = []
+            by_id = {c.post.tweet_id: c for c in aggregate_candidates(ranking_posts)}
+            for selected in selected_posts:
+                candidate = by_id[selected.tweet_id]
+                origin = next(signal for post, signal in ranking_posts
+                              if post is candidate.post)
+                origins.append(ChosenOrigin(selected.tweet_id, origin, candidate.signals))
+            self._notify(self.observer.on_invocation_return, result, tuple(origins))
+        return result
+
+    def _filter_cached_rank_rejections(
+        self,
+        request: DailySearchRequest,
+        fetched_posts: list[tuple[XCollectedPost, CandidateSignal]],
+        now: datetime,
+        warnings: list[XCollectorWarning],
+    ) -> tuple[
+        list[tuple[XCollectedPost, CandidateSignal]],
+        CandidateRejectionScope | None,
+        bool,
+    ]:
+        repository = self.services.rejection_repository
+        if repository is None or not fetched_posts:
+            self._observe_cache(CacheObservation(
+                "bypass", "not_configured" if repository is None else "empty_pool",
+            ))
+            return fetched_posts, None, False
+
+        scope = candidate_rejection_scope(request)
+        unique_candidates = aggregate_candidates(fetched_posts)
+        operation = "load"
+        observed_ids = tuple(candidate.post.tweet_id for candidate in unique_candidates)
+        try:
+            rejections = repository.load_rejections(
+                scope,
+                tuple(candidate.post.tweet_id for candidate in unique_candidates),
+            )
+            if self.observer is not None:
+                self._observe_cache(CacheObservation(
+                    "load", "success", scope, observed_ids,
+                    rejections=self._observed_rejections(rejections),
+                ))
+            suppressed_ids = tuple(
+                candidate.post.tweet_id
+                for candidate in unique_candidates
+                if (
+                    (rejection := rejections.get(candidate.post.tweet_id))
+                    is not None
+                    and self.services.rejection_policy.should_suppress(
+                        rejection,
+                        candidate.post,
+                        request,
+                        now,
+                    )
+                )
+            )
+            maximum_suppressed_count = max(
+                0,
+                len(unique_candidates) - request.max_items,
+            )
+            suppressed_ids = suppressed_ids[:maximum_suppressed_count]
+            operation = "mark_seen"
+            observed_ids = suppressed_ids
+            repository.mark_seen(scope, suppressed_ids, now)
+        except CandidateRejectionCacheError:
+            append_rejection_cache_warning(warnings)
+            self._observe_cache(CacheObservation(
+                operation, "unavailable", scope, observed_ids,
+                at=now if operation == "mark_seen" else None,
+            ))
+            return fetched_posts, scope, False
+
+        self._observe_cache(CacheObservation(
+            "mark_seen", "success", scope, suppressed_ids, at=now,
+        ))
+        suppressed = set(suppressed_ids)
+        return (
+            [item for item in fetched_posts if item[0].tweet_id not in suppressed],
+            scope,
+            True,
+        )
+
+    def _record_ranking_outcomes(
+        self,
+        scope: CandidateRejectionScope,
+        ranking_posts: list[tuple[XCollectedPost, CandidateSignal]],
+        selected_posts: list[XCollectedPost],
+        now: datetime,
+        warnings: list[XCollectorWarning],
+    ) -> None:
+        repository = self.services.rejection_repository
+        if repository is None:
+            return
+
+        selected_ids = tuple(post.tweet_id for post in selected_posts)
+        selected_id_set = set(selected_ids)
+        rejected_posts = tuple(
+            candidate.post
+            for candidate in aggregate_candidates(ranking_posts)
+            if candidate.post.tweet_id not in selected_id_set
+        )
+        rejections = ()
+        try:
+            rejections = tuple(
+                self.services.rejection_policy.new_rejection(post, now)
+                for post in rejected_posts
+            )
+            repository.record_outcomes(
+                scope,
+                selected_ids,
+                rejections,
+                now,
+            )
+        except CandidateRejectionCacheError:
+            append_rejection_cache_warning(warnings)
+            self._observe_cache(CacheObservation("record_outcomes", "unavailable", scope,
+                                                 selected_ids, at=now, outcomes=rejections))
+            return
+        self._observe_cache(CacheObservation("record_outcomes", "success", scope,
+                                             selected_ids, at=now, outcomes=rejections))
+
+
+def append_rejection_cache_warning(
+    warnings: list[XCollectorWarning],
+) -> None:
+    if any(
+        warning.code == "x_collector.rejection_cache_unavailable"
+        for warning in warnings
+    ):
+        return
+    warnings.append(
+        XCollectorWarning(
+            code="x_collector.rejection_cache_unavailable",
+            message=(
+                "The derived candidate rejection cache was unavailable; "
+                "collection continued without cached suppression"
+            ),
+        ),
+    )
+
+
+def partial_warning_for_late_failure(
+    failure: Exception,
+    pass_label: str,
+    fetched_count: int,
+) -> XCollectorWarning | None:
+    if fetched_count <= 0:
+        return None
+
+    if isinstance(failure, XCollectorRateLimitError):
+        return XCollectorWarning(
+            code="x_collector.partial_rate_limit",
+            message=(
+                f"{pass_label} hit a rate limit after earlier passes returned "
+                "posts; returning partial daily search results"
+            ),
+        )
+
+    if isinstance(failure, XCollectorUnavailableError):
+        return XCollectorWarning(
+            code="x_collector.partial_provider_failure",
+            message=(
+                f"{pass_label} hit a transient provider failure after earlier "
+                "passes returned posts; returning partial daily search results"
+            ),
+        )
+
+    return None

--- a/apps/x-collector/src/x_collector/canonical_search_services.py
+++ b/apps/x-collector/src/x_collector/canonical_search_services.py
@@ -1,0 +1,78 @@
+"""Injected ordinary capabilities and detached observation facts, with no I/O."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Mapping, Protocol
+
+from .account_usage import SearchPassUsage
+from .candidate_rejection_cache import (
+    CandidateRejection, CandidateRejectionPolicy, CandidateRejectionScope,
+)
+from .domain import DailySearchRequest, DailySearchResult, SearchProduct, XCollectedPost
+from .ports import AccountUsageObserverPort, CandidateRejectionRepositoryPort, Clock
+from .scoring import CandidateSignal
+from .search_budget import SearchBudgetDecision
+from .search_plan import ScweetSearchPass
+
+
+class PassExecutor(Protocol):
+    def __call__(self, session: Any, *, request: DailySearchRequest,
+                 search_pass: ScweetSearchPass, since: str, until: str
+                 ) -> tuple[list[Mapping[str, Any]], Any, SearchPassUsage, int]: ...
+
+
+@dataclass(frozen=True)
+class CanonicalSearchServices:
+    clock: Clock
+    start_execution: Callable[[], Any]
+    prepare_account_pool: Callable[[], None]
+    date_window: Callable[[DailySearchRequest], tuple[str, str]]
+    budget_search_passes: Callable[[tuple[ScweetSearchPass, ...]], SearchBudgetDecision]
+    account_usage_observer: AccountUsageObserverPort
+    execute_pass: PassExecutor
+    normalize_record: Callable[[Mapping[str, Any], SearchProduct], XCollectedPost | None]
+    in_window: Callable[[XCollectedPost, DailySearchRequest], bool]
+    account_budget_is_depleted: Callable[[], bool]
+    rejection_repository: CandidateRejectionRepositoryPort | None
+    rejection_policy: CandidateRejectionPolicy
+
+
+@dataclass(frozen=True)
+class PassRecord:
+    """Rank is after the existing Mapping boundary, before validity/window filtering."""
+    rank: int
+    post: XCollectedPost | None
+    in_window: bool
+
+
+@dataclass(frozen=True)
+class ChosenOrigin:
+    tweet_id: str
+    chosen_signal: CandidateSignal
+    all_candidate_signals: tuple[CandidateSignal, ...]
+
+
+@dataclass(frozen=True)
+class CacheObservation:
+    operation: str
+    outcome: str
+    scope: CandidateRejectionScope | None = None
+    ids: tuple[str, ...] = ()
+    at: datetime | None = None
+    rejections: tuple[tuple[str, CandidateRejection], ...] = ()
+    outcomes: tuple[CandidateRejection, ...] = ()
+
+
+class CanonicalSearchObserver(Protocol):
+    def on_pass_records(self, search_pass: ScweetSearchPass,
+                        records_with_original_rank: tuple[PassRecord, ...]) -> None: ...
+
+    def on_cache_observation(self, observation: CacheObservation) -> None: ...
+
+    def on_invocation_return(self, actual_result: DailySearchResult,
+                             chosen_origins: tuple[ChosenOrigin, ...]) -> None: ...
+
+
+class CanonicalObservationError(Exception):
+    """Capture failed. No complete invocation evidence may be published or replayed."""

--- a/apps/x-collector/tests/fixtures/canonical_search/README.md
+++ b/apps/x-collector/tests/fixtures/canonical_search/README.md
@@ -1,0 +1,18 @@
+# Immutable canonical-search oracle
+
+`baseline_scweet_adapter.py` preserves the exact original repository bytes from
+commit `2690a1a0e55b6c4100481f8b7cafbb9f0bc24685`, path
+`apps/x-collector/src/x_collector/scweet_adapter.py` (before E1 extraction).
+
+SHA-256: `539d6ee1ac7e17b0ff1e7e9bb9a261a4f36aa4906d2905f989e30361f75241e1`.
+
+Captured once with `git show <commit>:<path>` and byte/hash verified during
+fixture creation. This is trusted repository source used only as a test oracle;
+do not regenerate it from current implementation or update it with production edits.
+The loader verifies these bytes before executing them in a separate test module.
+Normal tests need no Git, network, bootstrap, or `.cache` directory.
+
+The raw frozen fixture costs 969 lines, counted separately from E1 implementation
+changes, and remains subject to the unchanged 1000-line source cap.
+Parity evidence is written only when `CANONICAL_SEARCH_PARITY_OUTPUT` explicitly
+names an absolute output file path in an existing directory; normal tests create no evidence files.

--- a/apps/x-collector/tests/fixtures/canonical_search/baseline_scweet_adapter.py
+++ b/apps/x-collector/tests/fixtures/canonical_search/baseline_scweet_adapter.py
@@ -6,8 +6,7 @@ from datetime import UTC, datetime, timedelta
 from email.utils import parsedate_to_datetime
 from typing import Any, Callable, Mapping
 
-from .canonical_search_invocation import CanonicalInvocation
-from .canonical_search_services import CanonicalSearchServices, CanonicalSearchObserver
+from . import __version__
 from .account_pool import AccountLimitOverride, AccountPoolLimits
 from .account_limit_profiles import AccountLimitProfile, load_account_limit_profiles
 from .adaptive_account_limits import (
@@ -21,7 +20,10 @@ from .account_usage_observer import (
 )
 from .account_usage import SearchPassUsage
 from .candidate_rejection_cache import (
+    CandidateRejectionCacheError,
     CandidateRejectionPolicy,
+    CandidateRejectionScope,
+    candidate_rejection_scope,
 )
 from .config import XCollectorSettings
 from .domain import (
@@ -32,7 +34,9 @@ from .domain import (
     XCollectorAuthError,
     XCollectorInvalidRequestError,
     XCollectorRateLimitError,
+    XCollectorRun,
     XCollectorUnavailableError,
+    XCollectorWarning,
     XPostMetrics,
     XPostContentKind,
     XEligibilityMetricsState,
@@ -44,10 +48,13 @@ from .ports import (
     Clock,
     DailySearchCollectorPort,
 )
+from .scoring import CandidateSignal, aggregate_candidates, rank_candidates
 from .search_budget import (
     SearchBudgetDecision,
     budget_search_passes,
     estimate_pass_request_cost,
+    retry_after_ms_until,
+    warnings_for_budget_decision,
 )
 from .scweet_account_pool_ledger import (
     SCWEET_REUSABLE_ACCOUNT_STATUSES,
@@ -56,7 +63,7 @@ from .scweet_account_pool_ledger import (
 from .scweet_errors import classify_scweet_error
 from .scweet_run_maintenance import reconcile_stale_scweet_runs
 from .scweet_run_identity import ScweetRunIdentityTracker
-from .search_plan import ScweetSearchPass
+from .search_plan import ScweetSearchPass, plan_scweet_search_passes
 from .sqlite_account_usage_event_repository import (
     SqliteAccountUsageEventRepository,
 )
@@ -271,22 +278,165 @@ class ScweetDailySearchCollector(DailySearchCollectorPort):
     def collect_daily_search(
         self,
         request: DailySearchRequest,
-        observer: CanonicalSearchObserver | None = None,
     ) -> DailySearchResult:
-        return CanonicalInvocation(CanonicalSearchServices(
-            clock=self._clock,
-            start_execution=self._scweet_factory,
-            prepare_account_pool=self._prepare_account_pool,
-            date_window=scweet_date_window,
-            budget_search_passes=self._budget_search_passes,
-            account_usage_observer=self._account_usage_observer,
-            execute_pass=self._run_pass_with_failover,
-            normalize_record=post_from_scweet_record,
-            in_window=post_is_in_window,
-            account_budget_is_depleted=self._account_budget_is_depleted,
-            rejection_repository=self._candidate_rejection_repository,
-            rejection_policy=self._candidate_rejection_policy,
-        ), observer).run(request)
+        started_at = self._clock.now()
+        scweet = self._scweet_factory()
+        self._prepare_account_pool()
+        since, until = scweet_date_window(request)
+        fetched_posts: list[tuple[XCollectedPost, CandidateSignal]] = []
+        warnings: list[XCollectorWarning] = []
+        if request.cursor:
+            warnings.append(
+                XCollectorWarning(
+                    code="x_collector.cursor_ignored",
+                    message=(
+                        "Daily multi-pass search ignores external cursor; "
+                        "dedupe is handled by the Social Monitor store."
+                    ),
+                ),
+            )
+
+        planned_passes = plan_scweet_search_passes(request)
+        budget = self._budget_search_passes(planned_passes)
+        self._account_usage_observer.record_budget_decision(request, budget)
+        warnings.extend(warnings_for_budget_decision(budget))
+        if not budget.passes and budget.remaining_request_budget is not None:
+            raise XCollectorRateLimitError(
+                "Scweet account pool budget exhausted",
+                retry_after_ms=retry_after_ms_until(
+                    self._clock.now(),
+                    budget.reset_at,
+                ),
+                reset_at=budget.reset_at,
+            )
+
+        for search_pass in budget.passes:
+            self._prepare_account_pool()
+            try:
+                records, scweet, usage, failover_count = (
+                    self._run_pass_with_failover(
+                        scweet,
+                        request=request,
+                        search_pass=search_pass,
+                        since=since,
+                        until=until,
+                    )
+                )
+            except Exception as classified:
+                warning = partial_warning_for_late_failure(
+                    classified,
+                    search_pass.label,
+                    len(fetched_posts),
+                )
+                if warning is not None:
+                    warnings.append(warning)
+                    break
+
+                raise classified
+
+            if failover_count > 0:
+                warnings.append(
+                    XCollectorWarning(
+                        code="x_collector.account_failover",
+                        message=(
+                            f"{search_pass.label} resumed with another account "
+                            f"after {failover_count} account-scoped failure(s)"
+                        ),
+                    ),
+                )
+
+            accepted_count = 0
+            for rank, record in enumerate(records, start=1):
+                post = post_from_scweet_record(record, search_pass.product)
+                if post is not None and post_is_in_window(post, request):
+                    fetched_posts.append((
+                        post,
+                        CandidateSignal(
+                            pass_label=search_pass.label,
+                            product=search_pass.product,
+                            rank=rank,
+                        ),
+                    ))
+                    accepted_count += 1
+
+            self._account_usage_observer.complete_pass_success(
+                request,
+                usage,
+                fetched_count=len(records),
+                accepted_count=accepted_count,
+            )
+            if len(records) < search_pass.limit:
+                warnings.append(
+                    XCollectorWarning(
+                        code="x_collector.partial_pass",
+                        message=(
+                            f"{search_pass.label} returned fewer records "
+                            "than requested"
+                        ),
+                    ),
+                )
+            if records and accepted_count == 0:
+                warnings.append(
+                    XCollectorWarning(
+                        code="x_collector.pass_filtered",
+                        message=(
+                            f"{search_pass.label} returned records, but all "
+                            "were outside the requested window or invalid"
+                        ),
+                    ),
+                )
+            if self._account_budget_is_depleted():
+                warnings.append(
+                    XCollectorWarning(
+                        code="x_collector.account_budget_depleted",
+                        message=(
+                            "Scweet account pool budget was depleted after "
+                            f"{search_pass.label}; returning partial daily "
+                            "search results"
+                        ),
+                    ),
+                )
+                break
+
+        ranking_posts, rejection_scope, rejection_cache_ready = (
+            self._filter_cached_rank_rejections(
+                request,
+                fetched_posts,
+                started_at,
+                warnings,
+            )
+        )
+        selected_posts = rank_candidates(
+            ranking_posts,
+            query=request.query,
+            window_end=request.window_end,
+            max_items=request.max_items,
+        )
+        completed_at = self._clock.now()
+        if rejection_cache_ready and rejection_scope is not None:
+            self._record_ranking_outcomes(
+                rejection_scope,
+                ranking_posts,
+                selected_posts,
+                completed_at,
+                warnings,
+            )
+
+        return DailySearchResult(
+            posts=tuple(selected_posts),
+            next_cursor=None,
+            warnings=tuple(warnings),
+            run=XCollectorRun(
+                collector_engine="scweet",
+                collector_version=f"scweet-5.3 service-{__version__}",
+                started_at=started_at,
+                completed_at=completed_at,
+                requested_limit=request.max_items,
+                fetched_count=len(fetched_posts),
+                returned_count=len(selected_posts),
+                partial=len(selected_posts) < request.max_items,
+            ),
+        )
 
     def _run_pass_with_failover(
         self,
@@ -373,6 +523,91 @@ class ScweetDailySearchCollector(DailySearchCollectorPort):
             and snapshot.total_remaining_requests >= estimated_cost
         )
 
+    def _filter_cached_rank_rejections(
+        self,
+        request: DailySearchRequest,
+        fetched_posts: list[tuple[XCollectedPost, CandidateSignal]],
+        now: datetime,
+        warnings: list[XCollectorWarning],
+    ) -> tuple[
+        list[tuple[XCollectedPost, CandidateSignal]],
+        CandidateRejectionScope | None,
+        bool,
+    ]:
+        repository = self._candidate_rejection_repository
+        if repository is None or not fetched_posts:
+            return fetched_posts, None, False
+
+        scope = candidate_rejection_scope(request)
+        unique_candidates = aggregate_candidates(fetched_posts)
+        try:
+            rejections = repository.load_rejections(
+                scope,
+                tuple(candidate.post.tweet_id for candidate in unique_candidates),
+            )
+            suppressed_ids = tuple(
+                candidate.post.tweet_id
+                for candidate in unique_candidates
+                if (
+                    (rejection := rejections.get(candidate.post.tweet_id))
+                    is not None
+                    and self._candidate_rejection_policy.should_suppress(
+                        rejection,
+                        candidate.post,
+                        request,
+                        now,
+                    )
+                )
+            )
+            maximum_suppressed_count = max(
+                0,
+                len(unique_candidates) - request.max_items,
+            )
+            suppressed_ids = suppressed_ids[:maximum_suppressed_count]
+            repository.mark_seen(scope, suppressed_ids, now)
+        except CandidateRejectionCacheError:
+            append_rejection_cache_warning(warnings)
+            return fetched_posts, scope, False
+
+        suppressed = set(suppressed_ids)
+        return (
+            [item for item in fetched_posts if item[0].tweet_id not in suppressed],
+            scope,
+            True,
+        )
+
+    def _record_ranking_outcomes(
+        self,
+        scope: CandidateRejectionScope,
+        ranking_posts: list[tuple[XCollectedPost, CandidateSignal]],
+        selected_posts: list[XCollectedPost],
+        now: datetime,
+        warnings: list[XCollectorWarning],
+    ) -> None:
+        repository = self._candidate_rejection_repository
+        if repository is None:
+            return
+
+        selected_ids = tuple(post.tweet_id for post in selected_posts)
+        selected_id_set = set(selected_ids)
+        rejected_posts = tuple(
+            candidate.post
+            for candidate in aggregate_candidates(ranking_posts)
+            if candidate.post.tweet_id not in selected_id_set
+        )
+        try:
+            repository.record_outcomes(
+                scope,
+                selected_ids,
+                tuple(
+                    self._candidate_rejection_policy.new_rejection(post, now)
+                    for post in rejected_posts
+                ),
+                now,
+            )
+        except CandidateRejectionCacheError:
+            append_rejection_cache_warning(warnings)
+
     def _budget_search_passes(
         self,
         planned_passes: tuple[ScweetSearchPass, ...],
@@ -404,6 +639,54 @@ class ScweetDailySearchCollector(DailySearchCollectorPort):
         now = self._clock.now()
         self._account_pool_ledger.apply_profile_cooldowns(now)
         self._account_pool_ledger.apply_collection_priorities(now)
+
+
+def append_rejection_cache_warning(
+    warnings: list[XCollectorWarning],
+) -> None:
+    if any(
+        warning.code == "x_collector.rejection_cache_unavailable"
+        for warning in warnings
+    ):
+        return
+    warnings.append(
+        XCollectorWarning(
+            code="x_collector.rejection_cache_unavailable",
+            message=(
+                "The derived candidate rejection cache was unavailable; "
+                "collection continued without cached suppression"
+            ),
+        ),
+    )
+
+
+def partial_warning_for_late_failure(
+    failure: Exception,
+    pass_label: str,
+    fetched_count: int,
+) -> XCollectorWarning | None:
+    if fetched_count <= 0:
+        return None
+
+    if isinstance(failure, XCollectorRateLimitError):
+        return XCollectorWarning(
+            code="x_collector.partial_rate_limit",
+            message=(
+                f"{pass_label} hit a rate limit after earlier passes returned "
+                "posts; returning partial daily search results"
+            ),
+        )
+
+    if isinstance(failure, XCollectorUnavailableError):
+        return XCollectorWarning(
+            code="x_collector.partial_provider_failure",
+            message=(
+                f"{pass_label} hit a transient provider failure after earlier "
+                "passes returned posts; returning partial daily search results"
+            ),
+        )
+
+    return None
 
 
 def collector_failure_kind(failure: Exception) -> str:

--- a/apps/x-collector/tests/support/canonical_search_invocation_support.py
+++ b/apps/x-collector/tests/support/canonical_search_invocation_support.py
@@ -1,0 +1,218 @@
+"""Synthetic-only differential harness; oracle bytes are pinned, never extracted code."""
+from __future__ import annotations
+
+import builtins
+from contextlib import ExitStack
+from copy import deepcopy
+from dataclasses import asdict, replace
+from datetime import UTC, datetime, timedelta
+import hashlib
+import types
+import os
+import json
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+from x_collector import scweet_adapter as current
+from x_collector.account_usage_observer import NoopAccountUsageObserver
+from x_collector.candidate_rejection_cache import CandidateRejectionCacheError
+from x_collector.domain import DailySearchRequest, SearchProduct
+
+BASELINE = Path(__file__).resolve().parents[1] / 'fixtures/canonical_search/baseline_scweet_adapter.py'
+NOW = datetime(2026, 9, 6, tzinfo=UTC)
+
+
+def load_oracle():
+    expected = '539d6ee1ac7e17b0ff1e7e9bb9a261a4f36aa4906d2905f989e30361f75241e1'
+    source = BASELINE.read_bytes()
+    if hashlib.sha256(source).hexdigest() != expected:
+        raise ValueError('Canonical search baseline SHA-256 mismatch')
+    name = 'x_collector.e1_pinned_baseline'
+    module = types.ModuleType(name)
+    module.__file__ = str(BASELINE)
+    module.__package__ = 'x_collector'
+    sys.modules[name] = module
+    exec(compile(source, str(BASELINE), 'exec'), module.__dict__)
+    return module
+
+
+def request(**changes):
+    return replace(DailySearchRequest(
+        'synthetic-request', 'synthetic-tenant', 'synthetic-workspace',
+        'synthetic-binding', 'synthetic-scan', 'synthetic-correlation',
+        'synthetic research', 'en', 24, NOW,
+        (SearchProduct.TOP, SearchProduct.LATEST), 50, 3, 30, 0, 0, None,
+    ), **changes)
+
+
+def record(identity, likes=40, author=None, **changes):
+    return dict(tweet_id=identity, text='synthetic research fixture ' + identity,
+                timestamp='2026-09-05T12:00:00Z', likes=likes,
+                retweets=0, comments=0, is_original=True,
+                tweet_url='https://example.invalid/post/' + identity,
+                user={'screen_name': author or 'synthetic_' + identity, 'name': 'Fixture'},
+                media={'image_links': ['https://example.invalid/media/' + identity]},
+                **changes)
+
+
+class Clock:
+    def __init__(self, events):
+        self.events = events
+        self.count = 0
+
+    def now(self):
+        value = NOW + timedelta(seconds=self.count)
+        self.count += 1
+        self.events.append(('clock', value))
+        return value
+
+
+class Repository:
+    def __init__(self, rows=None, failure=None):
+        self.rows = deepcopy(rows or {})
+        self.failure = failure
+        self.calls = []
+
+    def call(self, operation, *args):
+        self.calls.append((operation, deepcopy(args)))
+        if self.failure == operation:
+            raise CandidateRejectionCacheError('synthetic unavailable')
+
+    def load_rejections(self, scope, ids):
+        self.call('load', scope, ids)
+        return self.rows
+
+    def mark_seen(self, scope, ids, now):
+        self.call('mark_seen', scope, ids, now)
+
+    def record_outcomes(self, scope, ids, rejections, now):
+        self.call('record_outcomes', scope, ids, rejections, now)
+
+
+class Observer:
+    def __init__(self):
+        self.passes = []
+        self.cache = []
+        self.returned = None
+
+    def on_pass_records(self, search_pass, records):
+        self.passes.append((search_pass, records))
+
+    def on_cache_observation(self, fact):
+        self.cache.append(fact)
+
+    def on_invocation_return(self, result, origins):
+        self.returned = result, origins
+
+
+class ParityCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.oracle = load_oracle()
+
+    def setUp(self):
+        self.stack = ExitStack()
+        self.addCleanup(self.stack.close)
+        original_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name == 'Scweet' or name.startswith('Scweet.'):
+                raise AssertionError('Real Scweet import prohibited')
+            return original_import(name, *args, **kwargs)
+
+        self.stack.enter_context(patch('builtins.__import__', guarded_import))
+        self.stack.enter_context(patch('sqlite3.connect', side_effect=AssertionError('No SQLite')))
+        for module in (current, self.oracle):
+            for name in ('ScweetAccountPoolLedger', 'SqliteAccountUsageEventRepository',
+                         'SqliteCandidateRejectionRepository'):
+                self.stack.enter_context(patch.object(module, name,
+                    side_effect=AssertionError('Real repository factory prohibited')))
+            self.stack.enter_context(patch.object(module.ScweetDailySearchCollector,
+                'from_settings', side_effect=AssertionError('Real composition prohibited')))
+
+    def run_collector(self, module, pages, req, repository=None, observer=None,
+                      budget=None, depleted=False, failovers=0, infrastructure=False, capacity=None):
+        events = []
+        clock = Clock(events)
+        usage_observer = NoopAccountUsageObserver()
+        pages = deepcopy(pages)
+
+        class Synthetic:
+            def search(self, query, **kwargs):
+                events.append(('search', query, kwargs))
+                page = pages.pop(0)
+                if isinstance(page, Exception):
+                    raise page
+                return page
+
+        session = Synthetic()
+
+        def start():
+            events.append(('start',))
+            return session
+
+        ledger = None
+        if capacity is not None:
+            from x_collector.account_pool import AccountCapacity, AccountPoolLimits, AccountPoolSnapshot
+            class Ledger:
+                def snapshot(self, now):
+                    events.append(('snapshot', now))
+                    account = AccountCapacity(1, 'synthetic_account', 1, 0, 0,
+                        capacity, 600, 100, capacity, 600, None, None, None, False, None)
+                    return AccountPoolSnapshot(now, AccountPoolLimits(capacity, 600), (account,))
+
+                def apply_profile_cooldowns(self, now):
+                    events.append(('cooldowns', now))
+
+                def apply_collection_priorities(self, now):
+                    events.append(('priorities', now))
+            ledger = Ledger()
+        collector = module.ScweetDailySearchCollector(start, clock,
+            account_pool_ledger=ledger, candidate_rejection_repository=repository)
+
+        def execute(session, *, request, search_pass, since, until):
+            events.append(('execute', search_pass))
+            records = module.run_scweet_search_pass(session, request=request,
+                search_pass=search_pass, since=since, until=until)
+            usage = usage_observer.begin_pass(request, search_pass, 8)
+            return records, session, usage, failovers
+
+        if not infrastructure:
+            collector._run_pass_with_failover = execute
+        if capacity is None:
+            collector._prepare_account_pool = lambda: events.append(('prepare',))
+            collector._account_budget_is_depleted = lambda: depleted
+        if budget is not None:
+            collector._budget_search_passes = lambda passes: budget(passes)
+        try:
+            if observer is None:
+                result = collector.collect_daily_search(req)
+            else:
+                result = collector.collect_daily_search(req, observer)
+            outcome = ('result', asdict(result))
+        except Exception as exc:
+            result = exc
+            outcome = ('error', type(exc).__name__, str(exc), vars(exc))
+        return outcome, events, repository.calls if repository else [], result
+
+    def parity(self, pages, req=None, rows=None, failure=None, configured=False, **kwargs):
+        req = req or request()
+        old_repo = Repository(rows, failure) if configured else None
+        new_repo = Repository(rows, failure) if configured else None
+        old = self.run_collector(self.oracle, pages, req, old_repo, **kwargs)
+        observer = Observer()
+        new = self.run_collector(current, pages, req, new_repo, observer, **kwargs)
+        off = self.run_collector(current, pages, req,
+            Repository(rows, failure) if configured else None, **kwargs)
+        self.assertEqual(old[:3], new[:3])
+        self.assertEqual(old[:3], off[:3])
+        if output_name := os.environ.get('CANONICAL_SEARCH_PARITY_OUTPUT'):
+            output = Path(output_name)
+            if not output.is_absolute():
+                raise ValueError('Parity output must be an explicit absolute path')
+            with output.open('a') as stream:
+                stream.write(json.dumps({'test': self.id(), 'baseline': old[:3],
+                                         'extracted': new[:3]}, default=str) + '\n')
+        return new[3], observer, new[1], new[2]

--- a/apps/x-collector/tests/test_canonical_search_cache_parity.py
+++ b/apps/x-collector/tests/test_canonical_search_cache_parity.py
@@ -1,0 +1,151 @@
+from dataclasses import replace
+from datetime import timedelta
+
+from support.canonical_search_invocation_support import (
+    ParityCase, Observer, Repository, current, request, record, NOW,
+)
+from x_collector.candidate_rejection_cache import CandidateRejectionPolicy, snapshot_candidate
+from x_collector.domain import SearchProduct
+from x_collector.canonical_search_services import CanonicalObservationError
+
+
+class CacheParity(ParityCase):
+    def rows(self):
+        return {identity: CandidateRejectionPolicy().new_rejection(
+            current.post_from_scweet_record(record(identity, likes), SearchProduct.TOP), NOW)
+            for identity, likes in [('a', 100), ('b', 50), ('c', 10)]}
+
+    def pages(self):
+        return [[record('a', 100), record('b', 50), record('c', 10)], [], []]
+
+    def test_absent_empty_suppression_and_clipped_suppression(self):
+        result, obs, _, calls = self.parity(self.pages())
+        self.assertEqual(calls, [])
+        self.assertEqual(obs.cache[0].outcome, 'not_configured')
+        for rows in ({}, self.rows()):
+            for limit in (1, 2, 3, 4):
+                with self.subTest(rows=bool(rows), limit=limit):
+                    result, obs, _, calls = self.parity(self.pages(), request(max_items=limit),
+                        rows=rows, configured=True)
+                    self.assertEqual([c[0] for c in calls], ['load', 'mark_seen', 'record_outcomes'])
+                    self.assertEqual(calls[0][1][1], ('a', 'b', 'c'))
+                    self.assertEqual(calls[1][1][1], tuple(rows)[:max(0, 3-limit)])
+                    self.assertEqual(calls[1][1][2], NOW)
+                    self.assertEqual(calls[2][1][3], NOW + timedelta(seconds=1))
+                    self.assertEqual(len(result.posts), min(limit, 3))
+                    self.assertEqual([o.operation for o in obs.cache],
+                                     ['load', 'mark_seen', 'record_outcomes'])
+                    self.assertEqual(obs.cache[0].rejections, tuple(rows.items()))
+        _, obs, _, calls = self.parity([[], [], []], configured=True)
+        self.assertEqual(calls, [])
+        self.assertEqual(obs.cache[0].outcome, 'empty_pool')
+
+    def test_load_mark_and_write_failures(self):
+        full, _, _, _ = self.parity(self.pages(), request(max_items=1))
+        for failure, operations in [('load', ['load']),
+                ('mark_seen', ['load', 'mark_seen']),
+                ('record_outcomes', ['load', 'mark_seen', 'record_outcomes'])]:
+            result, obs, _, calls = self.parity(self.pages(), request(max_items=1),
+                rows=self.rows(), failure=failure, configured=True)
+            self.assertEqual([c[0] for c in calls], operations)
+            self.assertEqual(sum(w.code == 'x_collector.rejection_cache_unavailable'
+                                 for w in result.warnings), 1)
+            self.assertEqual(obs.cache[-1].outcome, 'unavailable')
+            if failure != 'record_outcomes':
+                self.assertEqual(result.posts, full.posts)
+            else:
+                normal, _, _, _ = self.parity(self.pages(), request(max_items=1),
+                    rows=self.rows(), configured=True)
+                self.assertEqual(result.posts, normal.posts)
+
+    def test_actual_branch_timestamps_preserve_supplied_times_and_clock_order(self):
+        for failure in (None, 'load', 'mark_seen', 'record_outcomes'):
+            with self.subTest(failure=failure):
+                result, obs, events, calls = self.parity(
+                    self.pages(), request(max_items=1), rows=self.rows(),
+                    failure=failure, configured=True)
+                self.assertEqual([e[0] for e in events], [
+                    'clock', 'start', 'prepare', 'prepare', 'execute', 'search',
+                    'prepare', 'execute', 'search', 'prepare', 'execute', 'search', 'clock'])
+                self.assertEqual([e[1] for e in events if e[0] == 'clock'],
+                                 [NOW, NOW + timedelta(seconds=1)])
+                self.assertEqual(result.run.started_at, NOW)
+                self.assertEqual(result.run.completed_at, NOW + timedelta(seconds=1))
+                self.assertEqual([o.operation for o in obs.cache], [c[0] for c in calls])
+                for fact, (operation, args) in zip(obs.cache, calls):
+                    self.assertEqual(fact.outcome,
+                                     'unavailable' if operation == failure else 'success')
+                    self.assertEqual(fact.scope, args[0])
+                    self.assertEqual(fact.ids, args[1])
+                    if operation == 'load':
+                        self.assertEqual(len(args), 2)
+                        self.assertIsNone(fact.at)
+                    else:
+                        self.assertEqual(fact.at, args[-1])
+                        self.assertEqual(fact.at, result.run.started_at
+                                         if operation == 'mark_seen'
+                                         else result.run.completed_at)
+
+    def test_expiry_refresh_growth_threshold_policy_and_media_fingerprint(self):
+        for change in ('expiry', 'refresh', 'growth', 'threshold', 'media', 'policy', 'reason'):
+            with self.subTest(change=change):
+                rows = self.rows()
+                old = rows['a']
+                pages = self.pages()
+                req = request(max_items=2)
+                if change == 'expiry':
+                    rows['a'] = replace(old, expires_at=NOW)
+                elif change == 'refresh':
+                    rows['a'] = replace(old, refresh_after=NOW)
+                elif change == 'growth':
+                    pages[0][0]['likes'] = 150
+                elif change == 'threshold':
+                    rows['a'] = replace(old, snapshot=replace(old.snapshot,
+                        metrics=replace(old.snapshot.metrics, likes=29)))
+                elif change == 'media':
+                    pages[0][0]['media']['image_links'] = ['https://example.invalid/changed']
+                elif change == 'policy':
+                    rows['a'] = replace(old, policy_version='synthetic-old-policy')
+                else:
+                    rows['a'] = replace(old, reason='synthetic-other-reason')
+                result, obs, _, calls = self.parity(pages, req, rows=rows, configured=True)
+                self.assertEqual(calls[1][1][1], ('b',))
+                self.assertIn('a', [p.tweet_id for p in result.posts])
+                if change == 'media':
+                    observed = obs.passes[0][1][0].post
+                    self.assertNotEqual(snapshot_candidate(observed).content_fingerprint,
+                                        rows['a'].snapshot.content_fingerprint)
+
+    def test_recorded_rejections_keep_media_and_completion_time(self):
+        result, obs, _, calls = self.parity(self.pages(), request(max_items=1), configured=True)
+        rejections = calls[-1][1][2]
+        self.assertEqual(len(rejections), 2)
+        for rejection in rejections:
+            post = next(r.post for r in obs.passes[0][1]
+                        if r.post.tweet_id == rejection.snapshot.tweet_id)
+            self.assertEqual(rejection.snapshot, snapshot_candidate(post))
+            self.assertEqual(rejection.refresh_after, NOW + timedelta(hours=30, seconds=1))
+        self.assertEqual(obs.cache[-1].outcomes, rejections)
+
+    def test_cache_observer_detached_and_unknown_write_not_replayed(self):
+        class Mutator(Observer):
+            def on_cache_observation(self, fact):
+                if fact.rejections:
+                    object.__setattr__(fact.rejections[0][1].snapshot,
+                                       'content_fingerprint', 'synthetic-mutation')
+                    object.__setattr__(fact.scope, 'tenant_id', 'synthetic-mutation')
+        old = self.run_collector(self.oracle, self.pages(), request(max_items=1),
+                                 Repository(self.rows()))
+        new = self.run_collector(current, self.pages(), request(max_items=1),
+                                 Repository(self.rows()), Mutator())
+        self.assertEqual(old[:3], new[:3])
+        for operation in ('load', 'mark_seen', 'record_outcomes'):
+            class Failing(Observer):
+                def on_cache_observation(self, fact):
+                    if fact.operation == operation:
+                        raise RuntimeError('synthetic capture failure')
+            repo = Repository(self.rows())
+            result = self.run_collector(current, self.pages(), request(max_items=1),
+                                        repo, Failing())[3]
+            self.assertIsInstance(result, CanonicalObservationError)
+            self.assertEqual(sum(c[0] == operation for c in repo.calls), 1)

--- a/apps/x-collector/tests/test_canonical_search_invocation.py
+++ b/apps/x-collector/tests/test_canonical_search_invocation.py
@@ -1,0 +1,223 @@
+from dataclasses import FrozenInstanceError, replace
+from datetime import timedelta
+from unittest.mock import patch
+
+from support.canonical_search_invocation_support import (
+    ParityCase, Observer, current, request, record, NOW,
+)
+from x_collector.canonical_search_services import CanonicalObservationError
+from x_collector.domain import SearchProduct, XCollectorRateLimitError, XCollectorUnavailableError
+from x_collector.scoring import rank_candidates
+from x_collector.search_budget import SearchBudgetDecision
+
+
+class InvocationParity(ParityCase):
+    def test_three_pass_order_thresholds_and_top_only(self):
+        for products in ((SearchProduct.TOP, SearchProduct.LATEST), (SearchProduct.TOP,)):
+            with self.subTest(products=products):
+                result, observer, events, _ = self.parity(
+                    [[record('a', 100)], [record('b', 90)], [record('c', 5)]],
+                    request(search_products=products, cursor='synthetic-cursor'))
+                passes = [e[1] for e in events if e[0] == 'execute']
+                self.assertEqual([(p.label, p.product.value, p.limit,
+                    p.min_likes, p.min_retweets, p.min_replies) for p in passes], [
+                    ('top_base', 'top', 50, 30, 0, 0),
+                    ('top_strict', 'top', 50, 90, 10, 5),
+                    ('latest_discovery', 'latest', 50, 5, 0, 0)])
+                self.assertIsNone(result.next_cursor)
+                self.assertFalse(result.run.partial)
+                self.assertEqual(result.run.requested_limit, 3)
+                self.assertEqual(result.run.fetched_count, 3)
+                self.assertEqual(observer.returned[0], result)
+                self.assertEqual([e[0] for e in events], [
+                    'clock', 'start', 'prepare', 'prepare', 'execute', 'search',
+                    'prepare', 'execute', 'search', 'prepare', 'execute', 'search', 'clock'])
+
+    def test_rank_gaps_duplicates_and_all_signals(self):
+        invalid = {'tweet_id': 'invalid'}
+        outside = {**record('outside'), 'timestamp': '2026-09-04T23:59:59Z'}
+        result, obs, _, _ = self.parity([
+            [None, invalid, outside, record('a', 100), record('b', 50)],
+            [record('a', 20), record('c', 40)],
+            [record('a', 200), record('b', 1)],
+        ])
+        self.assertEqual([r.rank for r in obs.passes[0][1]], [1, 2, 3, 4])
+        self.assertIsNone(obs.passes[0][1][0].post)
+        self.assertFalse(obs.passes[0][1][1].in_window)
+        origins = {o.tweet_id: o for o in obs.returned[1]}
+        self.assertEqual([(s.pass_label, s.rank) for s in origins['a'].all_candidate_signals],
+                         [('top_base', 3), ('top_strict', 1), ('latest_discovery', 1)])
+        self.assertEqual(origins['a'].chosen_signal.product, SearchProduct.LATEST)
+        self.assertEqual(origins['b'].chosen_signal.product, SearchProduct.TOP)
+        self.assertEqual(next(p for p in result.posts if p.tweet_id == 'a').metrics.likes, 200)
+
+    def test_latest_to_top_preference_uses_actual_aggregator(self):
+        # Ordinary planner orders TOP first. Reorder the injected budget to exercise
+        # the existing aggregator's asymmetric LATEST -> TOP rule without a scorer copy.
+        def reverse_budget(passes):
+            return SearchBudgetDecision(tuple(reversed(passes)), 3, 24, None, None, None, None)
+        result, obs, _, _ = self.parity([
+            [record('a', 900)], [record('a', 2)], [record('a', 1)],
+        ], budget=reverse_budget)
+        self.assertEqual(result.posts[0].metrics.likes, 2)
+        self.assertEqual(obs.returned[1][0].chosen_signal.pass_label, 'top_strict')
+        self.assertEqual(len(obs.returned[1][0].all_candidate_signals), 3)
+
+    def test_whole_pool_scoring_includes_below_predicate(self):
+        pages = [[record('a', 200), record('b', 80), record('c', 40)], [], [record('low', 1)]]
+        result, obs, _, _ = self.parity(pages, request(max_items=3))
+        without, _, _, _ = self.parity([pages[0], [], []], request(max_items=3))
+        scores = {p.tweet_id: p.trend_score for p in result.posts}
+        self.assertTrue(any(scores.get(p.tweet_id) != p.trend_score for p in without.posts))
+        self.assertEqual(obs.passes[2][1][0].post.metrics.likes, 1)
+
+    def test_author_diversity_refill_limits_and_stable_order(self):
+        same_author = [record(str(i), 50, author='same') for i in range(6)]
+        for limit in (0, 1, 2, 4, 8):
+            with self.subTest(limit=limit):
+                result, _, _, _ = self.parity([same_author, [], []], request(max_items=limit))
+                self.assertEqual(len(result.posts), min(limit, 6))
+                self.assertEqual([p.tweet_id for p in result.posts],
+                                 [str(i) for i in range(min(limit, 6))])
+        result, _, _, _ = self.parity([
+            same_author + [record('different', 5, author='other')], [], [],
+        ], request(max_items=4))
+        self.assertIn('different', [p.tweet_id for p in result.posts])
+        # Identical duplicate pass ranks create equal confidence and engagement;
+        # a later publication breaks the score tie only when age z is also tied.
+        pages = [[record('a', 40), record('b', 40)],
+                 [record('b', 40), record('a', 40)], []]
+        tied, _, _, _ = self.parity(pages)
+        self.assertEqual([p.tweet_id for p in tied.posts], ['a', 'b'])
+
+    def test_late_failures_initial_failure_budget_depletion_and_failover_warning(self):
+        for error in (XCollectorRateLimitError('synthetic rate'),
+                      XCollectorUnavailableError('synthetic unavailable')):
+            result, _, events, _ = self.parity([[record('a')], error, []])
+            self.assertEqual(result.run.returned_count, 1)
+            self.assertEqual(len([e for e in events if e[0] == 'execute']), 2)
+            self.assertTrue(any(w.code.startswith('x_collector.partial_') for w in result.warnings))
+            failed, observer, _, _ = self.parity([error, [], []])
+            self.assertIsInstance(failed, type(error))
+            self.assertIsNone(observer.returned)
+        depleted, _, events, _ = self.parity([[record('a')], [], []], depleted=True)
+        self.assertEqual(len([e for e in events if e[0] == 'execute']), 1)
+        self.assertIn('x_collector.account_budget_depleted', [w.code for w in depleted.warnings])
+        result, _, _, _ = self.parity([[record('a')], [], []], failovers=1)
+        self.assertEqual(sum(w.code == 'x_collector.account_failover' for w in result.warnings), 3)
+
+    def test_no_initial_budget_and_empty_filtered_pass(self):
+        def exhausted(passes):
+            return SearchBudgetDecision((), len(passes), 0, 0, 1, 0, NOW + timedelta(hours=1))
+        result, obs, events, _ = self.parity([[], [], []], budget=exhausted)
+        self.assertIsInstance(result, XCollectorRateLimitError)
+        self.assertIsNone(obs.returned)
+        self.assertFalse(any(e[0] == 'execute' for e in events))
+        result, _, _, _ = self.parity([[{'tweet_id': 'invalid'}], {}, []])
+        self.assertEqual(result.run.fetched_count, 0)
+        self.assertIn('x_collector.pass_filtered', [w.code for w in result.warnings])
+
+    def test_date_windows_exclusive_end_inclusive_start(self):
+        for end in (NOW, NOW + timedelta(microseconds=1),
+                    NOW + timedelta(hours=12), NOW - timedelta(hours=24)):
+            req = request(window_end=end)
+            pages = [[{**record('start'), 'timestamp': (end - timedelta(hours=24)).isoformat()},
+                      {**record('end'), 'timestamp': end.isoformat()},
+                      {**record('last'), 'timestamp': (end - timedelta(microseconds=1)).isoformat()}], [], []]
+            result, _, events, _ = self.parity(pages, req)
+            self.assertEqual({p.tweet_id for p in result.posts}, {'start', 'last'})
+            search = next(e for e in events if e[0] == 'search')[2]
+            self.assertEqual((search['since'], search['until']), self.oracle.scweet_date_window(req))
+        self.assertEqual(current.scweet_date_window(request()), ('2026-09-05', '2026-09-05'))
+
+    def test_detachment_and_observer_errors_fail_capture(self):
+        class Mutator(Observer):
+            def on_pass_records(self, search_pass, records):
+                super().on_pass_records(search_pass, records)
+                with self_case.assertRaises(FrozenInstanceError):
+                    records[0].post.text = 'mutated'
+                object.__setattr__(records[0].post.metrics, 'likes', 999999)
+                object.__setattr__(records[0].post, 'text', 'mutated detached value')
+                object.__setattr__(search_pass, 'label', 'mutated')
+
+            def on_invocation_return(self, result, origins):
+                object.__setattr__(result.posts[0], 'text', 'mutated detached result')
+                object.__setattr__(origins[0].chosen_signal, 'rank', 999)
+        self_case = self
+        pages = [[record('a')], [record('b')], [record('c')]]
+        baseline = self.run_collector(self.oracle, pages, request())
+        mutated = self.run_collector(current, pages, request(), observer=Mutator())
+        self.assertEqual(baseline[:3], mutated[:3])
+        for hook in ('on_pass_records', 'on_cache_observation', 'on_invocation_return'):
+            observer = Observer()
+            def fail(*args):
+                from x_collector.candidate_rejection_cache import CandidateRejectionCacheError
+                raise CandidateRejectionCacheError('synthetic observer failure')
+            setattr(observer, hook, fail)
+            result = self.run_collector(current, pages, request(), observer=observer)[3]
+            self.assertIsInstance(result, CanonicalObservationError)
+
+    def test_ordinary_entrypoint_calls_shared_actual_ranker(self):
+        from x_collector import canonical_search_invocation as invocation
+        with patch.object(invocation, 'rank_candidates', wraps=rank_candidates) as ranker:
+            result = self.run_collector(current, [[record('a')], [], []], request())[3]
+            self.assertEqual(result.run.returned_count, 1)
+            ranker.assert_called_once()
+            self.assertEqual(len(ranker.call_args.args[0]), 1)
+
+    def test_existing_infrastructure_executor_and_account_budget_clock_order(self):
+        for capacity, count in ((24, 3), (16, 2), (8, 1), (0, 0)):
+            result, obs, events, _ = self.parity(
+                [[record('a')], [record('b')], [record('c')]],
+                infrastructure=True, capacity=capacity)
+            self.assertEqual(sum(e[0] == 'search' for e in events), count)
+            if count:
+                self.assertEqual(result.run.returned_count, count)
+                self.assertEqual(events[0], ('clock', NOW))
+                self.assertEqual(events[1], ('start',))
+                self.assertEqual(events[2], ('clock', NOW + timedelta(seconds=1)))
+                self.assertEqual(events[3], ('cooldowns', NOW + timedelta(seconds=1)))
+                self.assertEqual(events[4], ('priorities', NOW + timedelta(seconds=1)))
+            else:
+                self.assertIsInstance(result, XCollectorRateLimitError)
+                self.assertIsNone(obs.returned)
+
+    def test_existing_failover_executor_retry_and_late_classification(self):
+        result, _, events, _ = self.parity([
+            RuntimeError('synthetic rate limit'), [record('a')],
+            [record('b')], [record('c')],
+        ], infrastructure=True, capacity=100)
+        self.assertEqual(sum(e[0] == 'start' for e in events), 2)
+        self.assertEqual(sum(e[0] == 'search' for e in events), 4)
+        self.assertEqual(sum(w.code == 'x_collector.account_failover'
+                             for w in result.warnings), 1)
+        result, _, _, _ = self.parity([
+            [record('a')], RuntimeError('synthetic transient failure'), [],
+        ], infrastructure=True)
+        self.assertIn('x_collector.partial_provider_failure', [w.code for w in result.warnings])
+        result, _, events, _ = self.parity([
+            RuntimeError('synthetic rate limit') for _ in range(3)
+        ], infrastructure=True, capacity=100)
+        self.assertIsInstance(result, XCollectorRateLimitError)
+        self.assertEqual(sum(e[0] == 'start' for e in events), 3)
+
+    def test_publication_tiebreak_and_strict_confidence(self):
+        older = record('older', 0)
+        newer = {**record('newer', 0), 'timestamp': '2026-09-05T13:00:00Z'}
+        result, _, _, _ = self.parity([[older, newer], [newer, older], []])
+        self.assertEqual(result.posts[0].trend_score, result.posts[1].trend_score)
+        self.assertEqual([p.tweet_id for p in result.posts], ['newer', 'older'])
+        base, _, _, _ = self.parity([[record('a')], [], []])
+        strict, _, _, _ = self.parity([[record('a')], [record('a')], []])
+        self.assertGreater(strict.posts[0].trend_score, base.posts[0].trend_score)
+
+    def test_missing_malformed_metrics_and_originality_remain_normalizer_facts(self):
+        pages = [[{**record('missing'), 'likes': None, 'retweets': None},
+                  {**record('malformed'), 'likes': 'synthetic-invalid', 'comments': None},
+                  {**record('unknown'), 'is_original': False}], [], []]
+        result, obs, _, _ = self.parity(pages)
+        posts = {p.tweet_id: p for p in result.posts}
+        self.assertEqual(posts['missing'].metrics.likes, 0)
+        self.assertFalse(posts['missing'].metrics.likes_observed)
+        self.assertEqual(posts['malformed'].metrics.eligibility_state.value, 'malformed')
+        self.assertEqual(posts['unknown'].content_kind.value, 'unknown')

--- a/apps/x-collector/tests/test_canonical_search_self_containment.py
+++ b/apps/x-collector/tests/test_canonical_search_self_containment.py
@@ -1,0 +1,45 @@
+"""The differential suite must work from source files alone, without bootstrap."""
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from support import canonical_search_invocation_support as support
+
+
+class OracleSelfContainment(unittest.TestCase):
+    def test_hash_mismatch_fails_before_execution(self):
+        with patch.object(Path, 'read_bytes', return_value=b'raise RuntimeError("untrusted")'):
+            with self.assertRaisesRegex(ValueError, 'SHA-256 mismatch'):
+                support.load_oracle()
+
+    def test_fresh_copy_without_git_cache_or_test_artifacts(self):
+        package = Path(__file__).resolve().parents[1]
+        with TemporaryDirectory(prefix='canonical-search-fresh-') as directory:
+            root = Path(directory)
+            for name in ('src', 'tests'):
+                shutil.copytree(package / name, root / name,
+                                ignore=shutil.ignore_patterns('.cache', '.git', '__pycache__', '*.pyc'))
+            def snapshot():
+                return {str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+                        for p in root.rglob('*') if p.is_file()}
+            before = snapshot()
+            self.assertFalse(any(p.name in ('.cache', '.git') for p in root.rglob('*')))
+            env = dict(os.environ, PYTHONPATH=str(root / 'src') + os.pathsep + str(root / 'tests'),
+                       PYTHONDONTWRITEBYTECODE='1')
+            env.pop('CANONICAL_SEARCH_PARITY_OUTPUT', None)
+            result = subprocess.run([
+                sys.executable, '-B', '-m', 'unittest', '-v',
+                'test_canonical_search_invocation', 'test_canonical_search_cache_parity',
+            ], cwd=root, env=env, capture_output=True, text=True, timeout=60)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn('Ran 20 tests', result.stderr)
+            self.assertNotIn('skipped', result.stderr.lower())
+            self.assertEqual(snapshot(), before, 'Normal tests wrote source-tree artifacts')
+            self.assertFalse(any(p.name in ('.cache', '.git', '__pycache__')
+                                 for p in root.rglob('*')))


### PR DESCRIPTION
The X collector invocation currently owns pass execution, cache observations and whole-pool ranking in one adapter. Extract that existing flow into a shared coordinator so the historical collection path can observe the same canonical decisions without implementing a second ranking algorithm. Ordinary collection keeps its existing results, cache policy and error behavior.

Optional observers receive detached pass/cache/result facts. Failed cache loads have no invented timestamp. A committed, hash-checked pre-extraction implementation provides a hermetic before/after oracle.

Validation on the byte-identical implementation: 22 fixture unittests and 50 focused adapter/scoring/SQLite-cache pytest tests pass with zero skips in the pinned Python 3.13.15 image, without network or production configuration. Independent review also ran 11 adversarial probes with 164 comparisons. Source certification, architecture, code-quality and source-line-cap checks pass. Independent final integration review approved commit 46735e35a88d13ce1ae760daf07a4c61603d6feb with a verified 31-file import/config closure. CI run [34223973471](https://github.com/777genius/social-monitor/actions/runs/34223973471) passed; its tested merge commit has the same tree as the reviewed head.

Review budget: 1441 changed non-fixture lines; the additional 969-line immutable baseline fixture is a documented fixture-only exception. No human-written file exceeds 1000 lines. This checkpoint does not enable the pending X observation protocol or claim the seven-day production E2E is complete.

Refs #294
