### PR TITLE
fix(relevance): enforce native assessment output schema

### DIFF
--- a/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
+++ b/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
@@ -53,6 +53,9 @@ const admission = admitSubscriptionRuntimeWrapperRequest({
   : undefined);
 const isSourceContentAssessment = admission.canonicalRequest.context.purpose === "social_monitor.relevance.assess_source_content.v1";
 const isReaderPromotionV2Canary = admission.canonicalRequest.context.purpose === readerPromotionV2CanaryPurpose;
+const assessmentOutputSchemas = isSourceContentAssessment
+  ? sourceContentAssessmentOutputSchemas(admission.canonicalRequest.task)
+  : undefined;
 await writeFile(inputPath, JSON.stringify(admission.canonicalRequest), "utf8");
 
 const { FileBackendCodexWorker, NodeProcessRunner } = await import(
@@ -84,7 +87,7 @@ const createStrictCodexWorker = (input) => {
     if (isReaderPromotionV2Canary) {
       return createReaderPromotionV2CanaryWorker({ input, model, authPool });
     }
-    return createPooledCodexWorker({ input, model, authPool });
+    return createPooledCodexWorker({ input, model, authPool, outputSchemas: assessmentOutputSchemas });
   }
 
   if (isSourceContentAssessment) {
@@ -221,7 +224,18 @@ function readerPromotionV2CanaryWorkerOptions() {
   };
 }
 
-function createPooledCodexWorker({ input, model, authPool }) {
+function sourceContentAssessmentOutputSchemas(task) {
+  const name = "social_monitor_source_content_quality_review";
+  const schema = task.controls.outputSchema;
+  if (task.outputSchemaName !== name ||
+      (task.controls.outputSchemaName !== undefined && task.controls.outputSchemaName !== name) ||
+      schema === null || typeof schema !== "object" || Array.isArray(schema)) {
+    throw new Error("Source content assessment requires its named output schema object");
+  }
+  return { [name]: schema };
+}
+
+function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
   let executor;
   let disposed = false;
 
@@ -284,6 +298,7 @@ function createPooledCodexWorker({ input, model, authPool }) {
                 sourceEnv: subscriptionOnlyCodexEnvironment(input.env),
                 model,
                 reasoningEffort: admission.profile.reasoningEffort,
+                ...(outputSchemas === undefined ? {} : { outputSchemas }),
                 ...(input.timeoutMs ? { taskTimeoutMs: input.timeoutMs } : {}),
               },
             }),

--- a/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
@@ -15,6 +15,36 @@ import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+require("ts-node").register({ transpileOnly: true, compilerOptions: { rootDir: resolve(dirname(fileURLToPath(import.meta.url)), "../../..") } });
+const { promotionResponseSchema, parseReviews } = require(
+  "../../../libs/relevance/adapters/model/source-content-quality-review-wire.ts",
+);
+const { promotionWireCandidate } = require(
+  "../../../libs/relevance/adapters/model/promotion-review-wire.ts",
+);
+// Native runtime canonicalizes unordered required lists; preserve every constraint.
+const nativeAssessmentSchema = JSON.parse(JSON.stringify(promotionResponseSchema,
+  (key, value) => key === "required" ? [...value].sort() : value));
+const assessmentRequest = {
+  candidateId: "sandbox-assessment", providerKey: "reddit",
+  title: "Measured compiler diagnostics", deterministic: { flags: [] },
+  promotion: { tenantId: "sandbox-tenant", workspaceId: "sandbox-workspace",
+    interestId: "sandbox-interest", sourceBindingId: "sandbox-binding",
+    sourceItemId: "sandbox-item", trustedIntent: "compiler diagnostics",
+    availability: "title_only" },
+};
+const assessmentOutput = { reviews: [{
+  candidateId: assessmentRequest.candidateId,
+  bindingId: promotionWireCandidate(assessmentRequest).bindingId,
+  decision: "promote", confidence: 0.9, qualityScore: 0.9,
+  interestRelevanceScore: 0.9, engagementIntegrityScore: 0.9,
+  flags: [], reason: "Captured diagnostic observation",
+  evidence: [{ field: "title", start: 0, end: assessmentRequest.title.length,
+    quote: assessmentRequest.title }], resolvedSoftFlags: [],
+}] };
 
 import { orderCodexAuthAccountsForTask } from "./codex-auth-pool-routing.mjs";
 import "./reader-promotion-v2-canary-lane.e2e.test.mjs";
@@ -190,14 +220,15 @@ test(
   },
 );
 
-for (const firstAccount of ["account-b", "account-a"]) {
-  test(`assessment reuses pool with one attempt starting on ${firstAccount}`, { timeout: 30_000 }, async () => {
-    const fixture = await createFixture();
+for (const [firstAccount, available] of [["account-b", false], ["account-a", false], ["account-a", true]]) {
+  test(`assessment native schema with one attempt starting on ${firstAccount}, available=${available}`, { timeout: 30_000 }, async () => {
+    const fixture = await createFixture(available);
     try {
       const request = agentTaskRequest(taskIdStartingWith(["account-a", "account-b"], firstAccount));
       request.context.purpose = "social_monitor.relevance.assess_source_content.v1";
       request.task.outputSchemaName = "social_monitor_source_content_quality_review";
       request.task.controls.outputSchemaName = "social_monitor_source_content_quality_review";
+      request.task.controls.outputSchema = promotionResponseSchema;
       await writeFile(fixture.requestPath, JSON.stringify(request));
       const execution = await execFileAsync(process.execPath, [runtimeBridgePath,
         "--provider", "codex", "--input", fixture.requestPath, "--format", "result-json",
@@ -212,9 +243,14 @@ for (const firstAccount of ["account-b", "account-a"]) {
       }).then(({ stdout }) => JSON.parse(stdout), (error) => JSON.parse(error.stdout));
       const attempts = (await readFile(fixture.attemptLogPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
       assert.equal(attempts.some(({ command }) => command === "exec"), false);
-      assert.equal(execution.status, firstAccount === "account-b" ? "completed" : "failed");
-      if (firstAccount === "account-b") {
-        assert.deepEqual(execution.structuredOutput, { ok: true, account: "account-b" });
+      assert.equal(execution.status, firstAccount === "account-b" || available ? "completed" : "failed");
+      if (firstAccount === "account-b" || available) {
+        assert.deepEqual(execution.structuredOutput, assessmentOutput);
+        assert.deepEqual(attempts.find(({ command }) => command === "turn").outputSchema, nativeAssessmentSchema);
+        assert.equal(execution.warnings?.some(({ code }) => code === "codex_app_server_output_schema_not_native") ?? false, false);
+        const [review] = parseReviews(JSON.stringify(execution.structuredOutput), [assessmentRequest]);
+        assert.equal(review.assessment.binding, assessmentRequest.promotion);
+        assert.equal(review.qualityScore, 0.9);
         assert.equal(attempts.filter(({ command }) => command === "turn").length, 1);
       } else {
         assert.equal(attempts.some(({ account }) => account === "account-b"), false);
@@ -225,7 +261,35 @@ for (const firstAccount of ["account-b", "account-a"]) {
   });
 }
 
-async function createFixture() {
+for (const invalid of ["missing-name", "wrong-name", "conflicting-name", "missing-schema", "null-schema", "array-schema"]) {
+  test(`assessment rejects ${invalid} before native startup`, async () => {
+    const fixture = await createFixture();
+    try {
+      const request = agentTaskRequest("sandbox-invalid-schema");
+      request.context.purpose = "social_monitor.relevance.assess_source_content.v1";
+      request.task.outputSchemaName = "social_monitor_source_content_quality_review";
+      request.task.controls.outputSchema = promotionResponseSchema;
+      if (invalid === "missing-name") delete request.task.outputSchemaName;
+      if (invalid === "wrong-name") request.task.outputSchemaName = "other";
+      if (invalid === "conflicting-name") request.task.controls.outputSchemaName = "other";
+      if (invalid === "missing-schema") delete request.task.controls.outputSchema;
+      if (invalid === "null-schema") request.task.controls.outputSchema = null;
+      if (invalid === "array-schema") request.task.controls.outputSchema = [];
+      await writeFile(fixture.requestPath, JSON.stringify(request));
+      await assert.rejects(execFileAsync(process.execPath, [runtimeBridgePath,
+        "--provider", "codex", "--input", fixture.requestPath], {
+        cwd: fixture.sandboxProject,
+        env: { PATH: process.env.PATH, LANG: "C.UTF-8" },
+      }), (error) => {
+        assert.match(error.stderr, /schema|outputSchema/);
+        return true;
+      });
+      await assert.rejects(stat(fixture.attemptLogPath), { code: "ENOENT" });
+    } finally { await fixture.cleanup(); }
+  });
+}
+
+async function createFixture(available = false) {
   const root = await mkdtemp(
     join(tmpdir(), "social-monitor-subscription-runtime-e2e-"),
   );
@@ -281,7 +345,7 @@ async function createFixture() {
   const codexBinaryPath = join(root, "fake-codex.mjs");
   await writeFile(
     codexBinaryPath,
-    fakeCodexBinarySource(attemptLogPath, stateRoot),
+    fakeCodexBinarySource(attemptLogPath, stateRoot, available),
     "utf8",
   );
   await chmod(codexBinaryPath, 0o755);
@@ -368,7 +432,7 @@ function fakeCodexAuth(accountId) {
   };
 }
 
-function fakeCodexBinarySource(attemptLogPath, stateRoot) {
+function fakeCodexBinarySource(attemptLogPath, stateRoot, available) {
   return `#!/usr/bin/env node
 import { createHash } from "node:crypto";
 import { appendFile, readFile, writeFile } from "node:fs/promises";
@@ -390,7 +454,7 @@ if (command === "app-server") {
       continue;
     }
     if (request.method === "account/rateLimits/read") {
-      const usedPercent = account === "account-a" ? 100 : 20;
+      const usedPercent = account === "account-a" && !${available} ? 100 : 20;
       await recordAttempt({ account, command: "rate-limits", usedPercent });
       send({
         id: request.id,
@@ -402,7 +466,7 @@ if (command === "app-server") {
               resetsAt: Math.floor(Date.now() / 1000) + 3600,
             },
             rateLimitReachedType:
-              account === "account-a" ? "usage_limit_reached" : null,
+              account === "account-a" && !${available} ? "usage_limit_reached" : null,
           },
         },
       });
@@ -452,7 +516,7 @@ if (command === "app-server") {
         materializedAuthChanged,
       });
       send({ id: request.id, result: { turn: { id: turnId } } });
-      if (account === "account-a") {
+      if (account === "account-a" && !${available}) {
         send({
           method: "turn/completed",
           params: {
@@ -470,7 +534,7 @@ if (command === "app-server") {
             turnId,
             item: {
               type: "agentMessage",
-              text: JSON.stringify({ ok: true, account }),
+              text: JSON.stringify(request.params.outputSchema?.properties?.reviews ? ${JSON.stringify(assessmentOutput)} : { ok: true, account }),
             },
           },
         });

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -14,7 +14,7 @@ import {
 export const approvedSubscriptionRuntimePackageVersion =
   "0.1.0-main.41";
 export const approvedSubscriptionRuntimeLauncherSha256 =
-  "324368e8ea966db7cd30e6e8cb49f44ecb0fe532a39ff59b67aa81421f6a52c2";
+  "31be41148fdeca3b2d50a960f8d5a84c2809121dfc981db8f70ea9c261036fc9";
 
 export type SubscriptionRuntimeInstallationIdentity = {
   /** Exact real path that was admitted and must be passed to spawn. */

--- a/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
+++ b/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
@@ -1,0 +1,99 @@
+import { FixedClock, SystemClock } from "@social-monitor/shared-kernel";
+import { AgentRuntimeSourceContentQualityReviewerAdapter } from "./agent-runtime-source-content-quality-reviewer.adapter";
+import { parseReviews } from "./source-content-quality-review-wire";
+import { cutoff, fixture, run } from "../../../../test/support/promotion-content-assessment";
+import { outputFor } from "../../../../scripts/lib/source-content-assessment-runtime.spec-support";
+import { attestRefreshExecution, refreshTestRuntimeClient } from "../../../../scripts/lib/reader-summary-new-input-refresh-model.spec-support";
+
+type Wire = Record<string, unknown>;
+// Sanitized shapes from both completed journals: qualityScore/confidence existed,
+// relevance/integrity scores and flags did not. No original source text is copied.
+const observed = (review: Wire, second = false): Wire => ({
+  candidateId: review.candidateId, bindingId: review.bindingId,
+  decision: "relevant", confidence: 0.95, qualityScore: 0.8,
+  evidence: review.evidence,
+  ...(second ? { justification: "Synthetic", screeningFlagResolutions: [] }
+    : { reason: "Synthetic", flagResolutions: [] }),
+});
+const mutations: Record<string, (output: { reviews: Wire[] }) => Wire> = {
+  "observed batch one": (o) => ({ results: o.reviews.map((r) => observed(r)) }),
+  "observed batch two": (o) => ({ results: o.reviews.map((r) => observed(r, true)) }),
+  "results alias only": (o) => ({ results: o.reviews }),
+  "relevant decision": (o) => ({ reviews: o.reviews.map((r) => ({ ...r, decision: "relevant" })) }),
+  "not_relevant decision": (o) => ({ reviews: o.reviews.map((r) => ({ ...r, decision: "not_relevant" })) }),
+};
+for (const field of ["confidence", "qualityScore", "interestRelevanceScore", "engagementIntegrityScore", "flags", "reason", "resolvedSoftFlags"]) {
+  mutations[`missing ${field}`] = (o) => ({ reviews: o.reviews.map((r) => {
+    const copy = { ...r }; delete copy[field]; return copy;
+  }) });
+}
+for (const [field, alias] of [["reason", "justification"], ["resolvedSoftFlags", "flagResolutions"],
+  ["resolvedSoftFlags", "screeningFlagResolutions"]] as const) {
+  mutations[alias] = (o) => ({ reviews: o.reviews.map((r) => {
+    const copy = { ...r, [alias]: r[field] }; delete copy[field]; return copy;
+  }) });
+}
+
+describe("assessment schema consumer protocol", () => {
+  it.each([{}, { results: [] }, { reviews: null }, { reviews: {} }])(
+    "explicitly rejects missing/non-array reviews: %j", (output) => {
+      expect(() => parseReviews(JSON.stringify(output))).toThrow("protocol requires a reviews array");
+    });
+
+  it.each(Object.keys(mutations))("rejects %s through attested structured output and keeps candidates pending", async (name) => {
+    const failures: string[] = [];
+    let calls = 0;
+    const adapter = new AgentRuntimeSourceContentQualityReviewerAdapter({
+      clock: new FixedClock(cutoff), ids: { generate: () => `sandbox-wire-${++calls}` },
+      batchTimeoutMs: 300_000, totalTimeoutMs: 600_000,
+      client: refreshTestRuntimeClient(async (request) => {
+        const output = mutations[name]!(outputFor(request));
+        const result = await attestRefreshExecution(request, output);
+        // A valid text summary cannot repair malformed selected structured output.
+        return { ...result, outputText: JSON.stringify(outputFor(request)) };
+      }),
+    });
+    const result = await run([fixture("protocol")], { reviewBatch: async (requests, options) => {
+      try { return await adapter.reviewBatch(requests, options); }
+      catch (error) { failures.push((error as Error).message); throw error; }
+    } });
+    expect(calls).toBe(1);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).not.toContain("runtime completion");
+    if (name.includes("observed") || name === "results alias only") {
+      expect(failures[0]).toBe("Quality review protocol requires a reviews array");
+    }
+    expect(result.ranking.orderedCandidateIds).toHaveLength(0);
+    expect(result.items[0]!.contentQuality).toMatchObject({ qualityScore: 0,
+      needsLlmReview: true, eligibleForTopRead: false });
+  });
+
+  it.each([true, false])("preserves valid siblings=%s when the third batch times out without retry", async (valid) => {
+    jest.useFakeTimers();
+    jest.setSystemTime(cutoff);
+    let calls = 0;
+    try {
+      const adapter = new AgentRuntimeSourceContentQualityReviewerAdapter({
+        clock: new SystemClock(), ids: { generate: () => `sandbox-deadline-${calls}` },
+        batchTimeoutMs: 300_000, totalTimeoutMs: 600_000,
+        client: refreshTestRuntimeClient(async (request) => {
+          calls++;
+          if (calls === 3) return new Promise(() => {});
+          const output = outputFor(request);
+          return attestRefreshExecution(request, valid ? output
+            : mutations[calls === 1 ? "observed batch one" : "observed batch two"]!(output));
+        }),
+      });
+      const pending = run(Array.from({ length: 24 }, (_, i) => fixture(`wire-${String(i).padStart(2, "0")}`)),
+        adapter, { clock: new SystemClock(), execution: { deadlineAtMs: cutoff.getTime() + 300_000 } });
+      await jest.advanceTimersByTimeAsync(300_001);
+      const result = await pending;
+      expect(calls).toBe(3);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 16 : 0);
+      expect(result.items.filter((item) => item.contentQuality.needsLlmReview)).toHaveLength(valid ? 8 : 24);
+      await jest.advanceTimersByTimeAsync(300_000);
+      expect(calls).toBe(3);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 16 : 0);
+    } finally { jest.useRealTimers(); }
+  });
+});

--- a/libs/relevance/adapters/model/source-content-quality-review-wire.ts
+++ b/libs/relevance/adapters/model/source-content-quality-review-wire.ts
@@ -25,7 +25,10 @@ export const parseReviews = (
   }
 
   const parsed = asRecord(JSON.parse(outputText), "quality review output");
-  const reviews = Array.isArray(parsed.reviews) ? parsed.reviews : [];
+  if (!Array.isArray(parsed.reviews)) {
+    throw new Error("Quality review protocol requires a reviews array");
+  }
+  const reviews = parsed.reviews;
 
   return reviews.map((review) => {
     const record = asRecord(review, "quality review item");


### PR DESCRIPTION
## Problem
Production assessment completed with the wrong JSON contract: results instead of reviews, invalid decisions and missing component scores. The canonical schema reached task controls but was never registered on pooled app-server workers. Both actual outputs carried the no-native-schema fallback warning; no candidate from these batches could be admitted.

## Change
- Register the validated assessment schema on every pooled worker using the existing native app-server path.
- Reject missing/non-array reviews explicitly without synthesizing scores or translating aliases.
- Update the reviewed launcher digest and add native wire/protocol regressions.

No publication authority, quality thresholds, timeout, model policy or database changes.

## Evidence
- 26 native fake-app-server tests passed, exact schema at turn/start, no exec fallback.
- 77 focused tests across 7 suites passed, malformed observed shapes rejected, valid siblings survive later timeout.
- Architecture, runtime profile, code-quality, line-cap and focused lint passed.
- Independent exact-head review pending; production positive E2E remains required after deployment.

Refs #294. Follow-up to #331; do not equate this merge with completed ranking E2E.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Source content assessments now use validated structured output schemas for more consistent review results.
  - Assessment requests with missing, mismatched, null, or invalid schemas are rejected before processing.
  - Malformed review responses now produce clear validation errors instead of being treated as empty results.
  - Valid review results remain available when an unrelated assessment batch times out.
- **Reliability**
  - Improved handling of account availability and assessment execution across subscription runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->