### PR TITLE
fix(security): bind vendor syntax exception to file digest

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "check:staging-reliability-evidence": "node scripts/check-staging-reliability-evidence.mjs && node scripts/check-postgres-restore-evidence.mjs",
     "check:reddit-smoke": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-reddit-ingestion-smoke.ts",
     "check:rss-smoke": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-rss-ingestion-smoke.ts",
-    "check:secrets": "node scripts/check-secrets.mjs",
+    "check:secrets": "node scripts/check-secrets.mjs && node --test scripts/check-secrets.test.mjs",
     "check:source-certification": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-source-provider-certification.ts",
     "check:source-ranking-eval": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-source-ranking-eval.ts",
     "check:source-query-planner-eval": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-source-query-planner-eval.ts",

--- a/scripts/check-secrets.mjs
+++ b/scripts/check-secrets.mjs
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 
 const allowlistPath = 'ops/security/secret-scan-allowlist.json';
 const allowlist = JSON.parse(readFileSync(allowlistPath, 'utf8'));
@@ -108,7 +109,17 @@ for (const file of trackedFiles) {
     continue;
   }
 
-  const content = readFileSync(file, 'utf8');
+  const bytes = readFileSync(file);
+  const content = bytes.toString('utf8');
+
+  // The heuristic captures Python syntax, not a credential. Bind this literal
+  // to the reviewed vendor bytes here, independently of materialize_sdk's
+  // manifest/30-file closure/per-file and command SHA provenance checks.
+  if (file === 'test/fixtures/x-canonical/sdk-installed-source/Scweet/account_session.py.txt'
+    && createHash('sha256').update(bytes).digest('hex')
+      === 'bc46ce04e044b1b0db6df24dd82b6c1bbc1b7985da183dd02c8cfc5ae7824bd5') {
+    allowedValuesByPath.set(file, new Set(['(']));
+  }
 
   if (privateKeyPattern.test(content)) {
     report(file, 'private key block is not allowed');

--- a/scripts/check-secrets.test.mjs
+++ b/scripts/check-secrets.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+
+const fixture = 'test/fixtures/x-canonical/sdk-installed-source/Scweet/account_session.py.txt';
+const elsewhere = 'test/fixtures/unrelated.txt';
+const assignment = (value) => `DEFAULT_X_BEARER_TOKEN = ${value}\n`;
+const synthetic = ['prod', 'bearer', 'token'].join('.');
+
+// Execute the whole default scanner, including its policy self-checks and all
+// detectors, in a disposable tracked repository. No SDK bytes are embedded.
+const pinnedSha = 'bc46ce04e044b1b0db6df24dd82b6c1bbc1b7985da183dd02c8cfc5ae7824bd5';
+const syntax = `${assignment('(')}    "token-value"\n)\n`;
+const sha = (content) => createHash('sha256').update(content).digest('hex');
+
+function scan(t, file, content, approvedContent) {
+  const cwd = mkdtempSync(join(tmpdir(), 'check-secrets-regression-'));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  for (const path of ['scripts/check-secrets.mjs', 'ops/security/secret-scan-allowlist.json']) {
+    mkdirSync(dirname(join(cwd, path)), { recursive: true });
+    copyFileSync(new URL(`../${path}`, import.meta.url), join(cwd, path));
+  }
+  if (approvedContent !== undefined) {
+    // Substitute only the digest in the disposable scanner, never the policy
+    // or SDK bytes: standalone CI has no vendor fixture on this base.
+    const script = join(cwd, 'scripts/check-secrets.mjs');
+    const source = readFileSync(script, 'utf8');
+    assert.equal(source.split(pinnedSha).length, 2);
+    writeFileSync(script, source.replace(pinnedSha, sha(approvedContent)));
+  }
+  mkdirSync(dirname(join(cwd, file)), { recursive: true });
+  writeFileSync(join(cwd, file), content);
+  execFileSync('git', ['init', '--quiet'], { cwd });
+  execFileSync('git', ['add', '--', file], { cwd });
+  return spawnSync(process.execPath, ['scripts/check-secrets.mjs'], { cwd, encoding: 'utf8' });
+}
+
+function expectScan(t, file, content, status, reason, approvedContent) {
+  const result = scan(t, file, content, approvedContent);
+  assert.equal(result.status, status);
+  if (reason) assert.ok(result.stderr.includes(reason));
+  else assert.equal(result.stdout.trim(), 'Secret scan contract OK');
+}
+
+test('accepts only the scoped multiline assignment syntax', (t) => {
+  expectScan(t, fixture, syntax, 0, undefined, syntax);
+});
+
+for (const file of [elsewhere, `${fixture}.txt`, fixture.replace('Scweet/', 'Other/')]) {
+  test(`rejects the opening parenthesis outside the exact path: ${file}`, (t) => {
+    expectScan(t, file, syntax, 1, 'documented placeholder', syntax);
+  });
+}
+
+for (const file of [fixture, elsewhere]) {
+  for (const value of [synthetic, `"${synthetic}"`, `(${synthetic})`]) {
+    test(`rejects populated same-line assignment at ${file}: ${value}`, (t) => {
+      expectScan(t, file, assignment(value), 1, 'documented placeholder', assignment(value));
+    });
+  }
+  const negatives = [
+    [['-----BEGIN ', 'PRIVATE KEY-----'].join(''), 'private key block'],
+    [`Bearer ${synthetic}`, 'bearer token literal'],
+    [['smk', 'prod', 'secret'].join('_'), 'generated API/webhook key'],
+    [['whsec', 'prod', 'secret'].join('_'), 'generated API/webhook key'],
+    [['postgresql:', `//user:${synthetic}@example.invalid/db`].join(''), 'credential URL password'],
+  ];
+  for (const [content, reason] of negatives) {
+    test(`preserves ${reason} detection at ${file}`, (t) => {
+      expectScan(t, file, content, 1, reason, content);
+    });
+  }
+  test(`preserves empty, placeholder and token-count handling at ${file}`, (t) => {
+    expectScan(t, file, 'EMPTY_TOKEN=\nNEXT_KEY=\nOPENAI_READER_SUMMARY_MAX_OUTPUT_TOKENS=2500\n'
+      + assignment('"token-value"'), 0);
+  });
+}
+
+test('a scoped parenthesis does not skip later detections in the same file', (t) => {
+  const content = syntax + `Bearer ${synthetic}\n`;
+  expectScan(t, fixture, content, 1, 'bearer token literal', content);
+});
+
+test('the production digest rejects unreviewed syntax and any changed bytes', (t) => {
+  expectScan(t, fixture, syntax, 1, 'documented placeholder');
+  for (const changed of [syntax + '# changed\n', syntax.replace('token-value', synthetic)]) {
+    expectScan(t, fixture, changed, 1, 'documented placeholder', syntax);
+  }
+});


### PR DESCRIPTION
The secrets scanner interprets a multiline Python assignment in the pinned SDK fixture as a populated secret with value `(`, blocking PR #333. Accept that syntax only at its exact path and reviewed whole-file SHA256; all existing detectors continue scanning the file.

Validation: independent review of 8251aaf06aeffd6856c94db79af5276d0e3fcc51, 24 executable regressions, real pinned fixture checks, and four rejected policy mutations. Architecture/code-quality and source-cap checks passed. No dependency or SDK bytes changed.

Refs #294. Unblocks #333; E2 baseline refresh follows separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved secret scanning to more reliably detect private keys, tokens, credential URLs, and other sensitive content.
  - Added stricter validation for approved fixture content, preventing modified or incorrectly placed exceptions from bypassing checks.

- **Tests**
  - Added automated coverage for valid and invalid secret patterns, placeholder values, token handling, and approved fixture verification.
  - The secret-check command now runs both scanning and its automated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->