### PR TITLE
fix(runtime): preserve and validate classified failure diagnostics

### DIFF
--- a/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
+++ b/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
@@ -10,6 +10,7 @@ import {
 } from "node:fs/promises";
 import { join } from "node:path";
 import { withTrustedCodexWorkerUsage } from "./codex-worker-cli-usage.mjs";
+import { subscriptionRuntimeFailureDetails } from "./subscription-runtime-failure-details.mjs";
 
 import {
   admitSubscriptionRuntimeWrapperRequest,
@@ -345,10 +346,7 @@ function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
             accountCount: authPool.accounts.length,
           }),
           {
-            details: {
-              reason: result.reason,
-              ...(result.failureDetails ?? {}),
-            },
+            details: subscriptionRuntimeFailureDetails(result),
           },
         );
       } finally {

--- a/apps/agent-runtime/bin/subscription-runtime-failure-details.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-failure-details.mjs
@@ -1,0 +1,31 @@
+// This boundary exports diagnostic codes, never arbitrary executor/provider data.
+const classifiedReasons = new Set([
+  "quota_limited", "capacity_unavailable", "account_unavailable",
+  "reconnect_required", "permission_required", "task_timeout",
+  "provider_output_invalid", "runtime_interrupted", "goal_slice_exhausted",
+  "budget_exceeded", "model_unavailable", "user_abort", "unknown_error",
+]);
+const capacityReasons = new Set([
+  "quota_recheck_identity_changed", "quota_recheck_inconclusive",
+  "quota_recheck_failed",
+  "rate_limit_threshold", "quota_limited", "account_exhausted",
+]);
+const failureStatuses = new Set(["waiting_capacity", "partial", "failed", "aborted"]);
+const availabilities = new Set([
+  "available", "busy", "warming", "cooldown", "quota_exhausted", "degraded", "disabled",
+]);
+
+export const subscriptionRuntimeFailureDetails = (result) => {
+  const details = {};
+  if (classifiedReasons.has(result.reason)) details.reason = result.reason;
+  if (failureStatuses.has(result.status)) details.safeExecutorStatus = result.status;
+  const failure = result.failureDetails ?? {};
+  if (capacityReasons.has(failure.reason)) details.capacityReason = failure.reason;
+  if (availabilities.has(failure.availability)) details.availability = failure.availability;
+  if (typeof failure.cooldownUntil === "string"
+    && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(failure.cooldownUntil)
+    && Number.isFinite(Date.parse(failure.cooldownUntil))) {
+    details.cooldownUntil = failure.cooldownUntil;
+  }
+  return details;
+};

--- a/apps/agent-runtime/bin/subscription-runtime-failure-details.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-failure-details.test.mjs
@@ -63,7 +63,7 @@ async function finalAssessment(t, serialized) {
     const child = new EventEmitter();
     child.stdout = new EventEmitter();
     child.stderr = new EventEmitter();
-    queueMicrotask(() => {
+    globalThis.queueMicrotask(() => {
       child.stdout.emit("data", Buffer.from(serialized.stdout));
       child.emit("close", serialized.exitCode, null);
     });
@@ -153,3 +153,43 @@ test("unrecognized code values are not exported as diagnostic data", async (t) =
   assert.equal(serialized.stdout.includes("synthetic-private-value"), false);
   assert.deepEqual(result.failure.details, { subscriptionWorkerCode: "subscription_worker_run_failed" });
 });
+
+for (const key of ["capacityReason", "safeExecutorStatus"]) {
+  test(`backend rejects malformed ${key} in direct CLI envelopes and final logs`, async (t) => {
+    const marker = "synthetic-private-provider-auth-marker";
+    for (const value of [marker, "", null, 17, true, [marker], { value: marker },
+      "account_unavailable", "constructor", "toString"]) {
+      // Bypass the wrapper helper: this JSON is the untrusted CLI boundary.
+      const details = {
+        reason: "account_unavailable", capacityReason: "quota_recheck_identity_changed",
+        safeExecutorStatus: "waiting_capacity", availability: "cooldown",
+        cooldownUntil: "2026-09-08T12:00:00.000Z",
+        subscriptionWorkerCode: "subscription_worker_run_failed", [key]: value,
+      };
+      const expected = { ...details };
+      delete expected[key];
+      const serialized = {
+        stdout: JSON.stringify({
+          status: "failed", warnings: [], failure: {
+            code: "unknown_runtime_failure", safeMessage: "Synthetic failure",
+            retryable: false, details,
+          },
+        }),
+        exitCode: 1, request: { ...assessmentRequest(), timeoutMs: 5_000 },
+      };
+      const parsed = parseSubscriptionRuntimeCliResult(serialized.stdout);
+      assert.deepEqual(parsed.failure.details, expected);
+      assert.equal(parsed.failure.code, "provider_session_invalid");
+      const { result, logs } = await finalAssessment(t, serialized);
+      assert.deepEqual(result.failure.details, expected);
+      assert.equal(result.failure.code, "provider_session_invalid");
+      assert.equal(result.failure.reconnectRequired, false);
+      const finalLog = logs.find(([message]) => message === "agent runtime task did not complete");
+      assert.ok(finalLog, "the final failure log must actually be emitted");
+      assert.deepEqual(JSON.parse(finalLog[1].failureDetails), expected);
+      for (const surface of [parsed, result, logs]) {
+        assert.equal(JSON.stringify(surface).includes(marker), false);
+      }
+    }
+  });
+}

--- a/apps/agent-runtime/bin/subscription-runtime-failure-details.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-failure-details.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import { EventEmitter } from "node:events";
+import { createRequire } from "node:module";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { SubscriptionWorkerError } from "@vioxen/subscription-runtime/worker-core";
+import { runSubscriptionAgentTaskCli } from "../../../node_modules/@vioxen/subscription-runtime/dist/worker-local/agent-task-runner/cli.js";
+import { subscriptionRuntimeFailureDetails } from "./subscription-runtime-failure-details.mjs";
+
+const require = createRequire(import.meta.url);
+require("ts-node").register({ transpileOnly: true, compilerOptions: { rootDir: process.cwd() } });
+require("tsconfig-paths/register");
+const { parseSubscriptionRuntimeCliResult } = require("../src/subscription-runtime-cli-support.ts");
+const { SubscriptionRuntimeCliExecutor } = require("../src/subscription-runtime-cli-executor.ts");
+const { admitSubscriptionRuntimeRequest } = require("../src/subscription-runtime-purpose-model-policy.ts");
+const { assessmentRequest } = require("../src/source-content-assessment-runtime.spec-support.ts");
+
+// Exercise the installed CLI's actual catch/factory/serialization with an inert
+// worker. No pool, auth, provider process or runtime service is created.
+async function serializeFailure(result) {
+  const sandbox = await mkdtemp(join(tmpdir(), "classification-boundary-"));
+  const request = { ...assessmentRequest(), timeoutMs: 5_000 };
+  const canonical = admitSubscriptionRuntimeRequest(request).canonicalRequest;
+  const output = [];
+  let calls = 0;
+  let disposals = 0;
+  try {
+    const exitCode = await runSubscriptionAgentTaskCli(
+      ["--provider", "codex", "--format", "result-json", "--ephemeral", "--state-root", sandbox],
+      {
+        cwd: () => sandbox, env: () => ({}),
+        readStdin: async () => JSON.stringify(canonical),
+        writeStdout: (chunk) => output.push(chunk), writeStderr: () => {},
+      },
+      () => ({
+        start: async () => {},
+        run: async () => {
+          calls++;
+          throw new SubscriptionWorkerError("subscription_worker_run_failed", "Synthetic capacity failure", {
+            details: subscriptionRuntimeFailureDetails(result),
+          });
+        },
+        dispose: async () => { disposals++; },
+      }),
+    );
+    assert.equal(exitCode, 1);
+    assert.equal(calls, 1);
+    assert.equal(disposals, 1);
+    return { stdout: output.join(""), exitCode, request };
+  } finally {
+    await rm(sandbox, { recursive: true, force: true });
+  }
+}
+
+async function finalAssessment(t, serialized) {
+  const logs = [];
+  // Only the OS transport is replaced: the executor consumes the real CLI bytes
+  // through runCli and cliExecutionResult, then applies its assessment policy.
+  const spawn = t.mock.method(childProcess, "spawn", () => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from(serialized.stdout));
+      child.emit("close", serialized.exitCode, null);
+    });
+    return child;
+  });
+  const installation = {
+    executablePath: "/synthetic/classification-cli", packageRootRealpath: "/synthetic",
+    runtimePackageVersion: "0.1.0-main.41", launcherSha256: "a".repeat(64),
+  };
+  const executor = new SubscriptionRuntimeCliExecutor({
+    command: installation.executablePath, ephemeral: false,
+    installationInspector: { inspect: async () => installation },
+    logger: Object.fromEntries(["info", "warn", "error", "debug"].map((level) =>
+      [level, (...args) => logs.push(args)])),
+  });
+  try {
+    const result = await executor.execute(serialized.request);
+    assert.equal(spawn.mock.callCount(), 1, "assessment must never replay the request");
+    assert.equal(result.failure.retryable, false);
+    assert.equal(result.executionAttestation, undefined);
+    return { result, logs };
+  } finally {
+    spawn.mock.restore();
+  }
+}
+
+for (const [reason, code] of [
+  ["account_unavailable", "provider_session_invalid"],
+  ["capacity_unavailable", "backend_unavailable"],
+  ["quota_limited", "quota_limited"],
+]) {
+  test(`${reason} survives CLI serialization and assessment remains nonretryable`, async (t) => {
+    const serialized = await serializeFailure({
+      status: "waiting_capacity", reason,
+      failureDetails: {
+        reason: "quota_recheck_identity_changed", availability: "cooldown",
+        cooldownUntil: "2026-09-08T12:00:00.000Z",
+        safeExecutorStatus: "failed", capacityReason: "spoofed-detail",
+        accountId: "synthetic-account-omit", auth: "synthetic-auth-omit",
+        providerPayload: { value: "synthetic-provider-omit" }, stderrTail: "synthetic-stderr-omit",
+      },
+    });
+    const envelope = JSON.parse(serialized.stdout);
+    assert.equal(envelope.failure.code, "unknown_runtime_failure");
+    assert.equal(envelope.failure.retryable, false);
+    const parsed = parseSubscriptionRuntimeCliResult(serialized.stdout);
+    assert.equal(parsed.failure.code, code);
+    assert.equal(parsed.failure.retryable, true);
+    const { result, logs } = await finalAssessment(t, serialized);
+    assert.equal(result.failure.code, code);
+    assert.equal(result.failure.reconnectRequired, false);
+    assert.deepEqual(result.failure.details, {
+      reason, capacityReason: "quota_recheck_identity_changed",
+      safeExecutorStatus: "waiting_capacity", availability: "cooldown",
+      cooldownUntil: "2026-09-08T12:00:00.000Z",
+      subscriptionWorkerCode: "subscription_worker_run_failed",
+    });
+    for (const surface of [serialized.stdout, JSON.stringify(result), JSON.stringify(logs)]) {
+      for (const omitted of ["synthetic-account-omit", "synthetic-auth-omit", "synthetic-provider-omit",
+        "synthetic-stderr-omit", "spoofed-detail"]) assert.equal(surface.includes(omitted), false);
+    }
+  });
+}
+
+test("absent or unrecognized details cannot invent a classified account failure", async (t) => {
+  for (const failureDetails of [undefined, null, {
+    reason: "account_unavailable", safeExecutorStatus: "waiting_capacity",
+    availability: "synthetic-private-value", cooldownUntil: "synthetic-private-value",
+  }]) {
+    const serialized = await serializeFailure({ status: "failed", reason: "unknown_error", failureDetails });
+    const { result } = await finalAssessment(t, serialized);
+    assert.equal(result.failure.code, "unknown_runtime_failure");
+    assert.deepEqual(result.failure.details, {
+      reason: "unknown_error", safeExecutorStatus: "failed",
+      subscriptionWorkerCode: "subscription_worker_run_failed",
+    });
+  }
+});
+
+test("unrecognized code values are not exported as diagnostic data", async (t) => {
+  const serialized = await serializeFailure({
+    reason: "synthetic-private-value", status: "synthetic-private-value",
+    failureDetails: { reason: "synthetic-private-value", availability: {}, cooldownUntil: [] },
+  });
+  const { result } = await finalAssessment(t, serialized);
+  assert.equal(result.failure.code, "unknown_runtime_failure");
+  assert.equal(serialized.stdout.includes("synthetic-private-value"), false);
+  assert.deepEqual(result.failure.details, { subscriptionWorkerCode: "subscription_worker_run_failed" });
+});

--- a/apps/agent-runtime/src/subscription-runtime-cli-support.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-support.spec.ts
@@ -65,3 +65,27 @@ describe("subscription CLI terminal process receipt", () => {
     }).status).toBe("completed");
   });
 });
+
+describe("subscription CLI safe failure diagnostic values", () => {
+  it.each([
+    ["capacityReason", "quota_recheck_identity_changed"],
+    ["capacityReason", "quota_recheck_inconclusive"],
+    ["capacityReason", "quota_recheck_failed"],
+    ["capacityReason", "rate_limit_threshold"],
+    ["capacityReason", "quota_limited"],
+    ["capacityReason", "account_exhausted"],
+    ["safeExecutorStatus", "waiting_capacity"],
+    ["safeExecutorStatus", "partial"],
+    ["safeExecutorStatus", "failed"],
+    ["safeExecutorStatus", "aborted"],
+  ])("preserves recognized %s=%s separately from classification", (key, value) => {
+    const details = { reason: "account_unavailable", [key]: value };
+    const result = parseSubscriptionRuntimeCliResult(JSON.stringify({
+      status: "failed", warnings: [], failure: {
+        code: "unknown_runtime_failure", details,
+      },
+    }));
+    expect(result.failure?.details).toEqual(details);
+    expect(result.failure?.code).toBe("provider_session_invalid");
+  });
+});

--- a/apps/agent-runtime/src/subscription-runtime-cli-support.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-support.ts
@@ -292,6 +292,15 @@ const safeRuntimeFailureDetailKeys = new Set([
   "subscriptionWorkerCode",
 ]);
 
+// CLI JSON is untrusted even when the wrapper normally filters these values.
+const safeRuntimeCapacityReasons = new Set([
+  "quota_recheck_identity_changed", "quota_recheck_inconclusive",
+  "quota_recheck_failed", "rate_limit_threshold", "quota_limited", "account_exhausted",
+]);
+const safeRuntimeExecutorStatuses = new Set([
+  "waiting_capacity", "partial", "failed", "aborted",
+]);
+
 const readSafeRuntimeFailureDetails = (
   value: unknown,
 ): Readonly<Record<string, string>> => {
@@ -303,9 +312,16 @@ const readSafeRuntimeFailureDetails = (
   return Object.fromEntries(
     Object.entries(record).flatMap(([key, detail]) => {
       const safeValue = optionalString(detail);
-      return safeRuntimeFailureDetailKeys.has(key) && safeValue !== undefined
-        ? [[key, safeValue]]
-        : [];
+      if (!safeRuntimeFailureDetailKeys.has(key) || safeValue === undefined) {
+        return [];
+      }
+      if (key === "capacityReason" && !safeRuntimeCapacityReasons.has(safeValue)) {
+        return [];
+      }
+      if (key === "safeExecutorStatus" && !safeRuntimeExecutorStatuses.has(safeValue)) {
+        return [];
+      }
+      return [[key, safeValue]];
     }),
   );
 };

--- a/apps/agent-runtime/src/subscription-runtime-cli-support.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-support.ts
@@ -284,6 +284,8 @@ const readFailure = (
 };
 
 const safeRuntimeFailureDetailKeys = new Set([
+  "capacityReason",
+  "safeExecutorStatus",
   "availability",
   "cooldownUntil",
   "reason",

--- a/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
@@ -1,5 +1,7 @@
 import {
+  appendFile,
   chmod,
+  copyFile,
   mkdir,
   mkdtemp,
   realpath,
@@ -17,9 +19,23 @@ import {
   resolveSubscriptionRuntimeExecutable,
 } from "./subscription-runtime-installation";
 
+const launcherName = "run-codex-subscription-runtime-agent-task.mjs";
+const dependencyNames = [
+  "subscription-runtime-failure-details.mjs",
+  "codex-worker-cli-usage.mjs",
+  "codex-auth-pool-manifest.mjs",
+  "codex-auth-pool-routing.mjs",
+  "subscription-runtime-purpose-model-policy.mjs",
+  "reader-promotion-v2-canary-contract.cjs",
+];
+
 describe("subscription runtime installation admission", () => {
   let root: string | undefined;
   let previousPath: string | undefined;
+
+  beforeEach(() => {
+    previousPath = process.env.PATH;
+  });
 
   afterEach(async () => {
     if (previousPath === undefined) {
@@ -50,6 +66,82 @@ describe("subscription runtime installation admission", () => {
       runtimePackageVersion: approvedSubscriptionRuntimePackageVersion,
       launcherSha256: approvedSubscriptionRuntimeLauncherSha256,
     });
+  });
+
+  // Copy bytes without executing the wrapper or accessing provider/auth state.
+  const copyInstallation = async () => {
+    root = await mkdtemp(join(tmpdir(), "runtime-installation-"));
+    const bin = join(root, "bin");
+    await mkdir(bin);
+    for (const name of [launcherName, ...dependencyNames]) {
+      await copyFile(join(process.cwd(), "apps/agent-runtime/bin", name), join(bin, name));
+    }
+    await chmod(join(bin, launcherName), 0o755);
+    await symlink(join(process.cwd(), "node_modules"), join(root, "node_modules"));
+    return bin;
+  };
+
+  it.each([launcherName, ...dependencyNames])(
+    "rejects changed %s bytes on reinspection of an admitted installation",
+    async (name) => {
+      const bin = await copyInstallation();
+      const command = join(bin, launcherName);
+      const inspector = new FileSubscriptionRuntimeInstallationInspector();
+      await expect(inspector.inspect(command)).resolves.toMatchObject({
+        launcherSha256: approvedSubscriptionRuntimeLauncherSha256,
+      });
+
+      await appendFile(join(bin, name), "\n// synthetic tamper\n");
+
+      await expect(inspector.inspect(command)).rejects.toThrow(
+        name === launcherName
+          ? "Agent runtime launcher bytes are not approved"
+          : `Agent runtime launcher dependency bytes are not approved: ${name}`,
+      );
+    },
+  );
+
+  it("rejects a missing classification helper", async () => {
+    const bin = await copyInstallation();
+    await rm(join(bin, "subscription-runtime-failure-details.mjs"));
+
+    await expect(new FileSubscriptionRuntimeInstallationInspector().inspect(
+      join(bin, launcherName),
+    )).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("checks helpers beside the real launcher even through a command symlink", async () => {
+    const bin = await copyInstallation();
+    const command = join(root!, "launcher-link");
+    await symlink(join(bin, launcherName), command);
+    const inspector = new FileSubscriptionRuntimeInstallationInspector();
+    await expect(inspector.inspect(command)).resolves.toMatchObject({
+      executablePath: await realpath(join(bin, launcherName)),
+    });
+    const helper = join(bin, "subscription-runtime-failure-details.mjs");
+    const replacement = join(root!, "replacement.mjs");
+    await writeFile(replacement, "export const subscriptionRuntimeFailureDetails = () => ({});\n");
+    await rm(helper);
+    await symlink(replacement, helper);
+
+    await expect(inspector.inspect(command)).rejects.toThrow(
+      "Agent runtime launcher dependency bytes are not approved: subscription-runtime-failure-details.mjs",
+    );
+  });
+
+  it.each([
+    { name: "@vioxen/subscription-runtime", version: "0.0.0-unapproved" },
+    { name: "unapproved-runtime", version: approvedSubscriptionRuntimePackageVersion },
+  ])("rejects an unapproved package manifest %j", async (manifest) => {
+    const bin = await copyInstallation();
+    await rm(join(root!, "node_modules"));
+    const packageRoot = join(root!, "node_modules/@vioxen/subscription-runtime");
+    await mkdir(packageRoot, { recursive: true });
+    await writeFile(join(packageRoot, "package.json"), JSON.stringify(manifest));
+
+    await expect(new FileSubscriptionRuntimeInstallationInspector().inspect(
+      join(bin, launcherName),
+    )).rejects.toThrow("Installed subscription runtime version is not approved");
   });
 
   it("skips missing and non-executable PATH entries and returns the real path", async () => {

--- a/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
@@ -1,16 +1,25 @@
+import { execFile } from "node:child_process";
 import {
   appendFile,
   chmod,
   copyFile,
   mkdir,
   mkdtemp,
+  readFile,
   realpath,
+  rename,
   rm,
   symlink,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+import { assessmentRequest } from "./source-content-assessment-runtime.spec-support";
+import { attachExecutorOwnedExecutionAttestation } from "./subscription-runtime-execution-attestation";
+import { admitSubscriptionRuntimeRequest } from "./subscription-runtime-purpose-model-policy";
 
 import {
   approvedSubscriptionRuntimeLauncherSha256,
@@ -101,33 +110,97 @@ describe("subscription runtime installation admission", () => {
     },
   );
 
-  it("rejects a missing classification helper", async () => {
+  it.each([launcherName, ...dependencyNames])("rejects missing %s", async (name) => {
     const bin = await copyInstallation();
-    await rm(join(bin, "subscription-runtime-failure-details.mjs"));
+    await rm(join(bin, name));
+
+    const inspection = new FileSubscriptionRuntimeInstallationInspector().inspect(
+      join(bin, launcherName),
+    );
+    if (name === launcherName) {
+      await expect(inspection).rejects.toThrow("Agent runtime launcher command cannot be resolved");
+    } else {
+      await expect(inspection).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("admits a repository directory symlink and a command symlink", async () => {
+    const bin = await copyInstallation();
+    const repositoryLink = join(root!, "repository-link");
+    await symlink(bin, repositoryLink);
+    const command = join(root!, "launcher-link");
+    await symlink(join(repositoryLink, launcherName), command);
+
+    await expect(new FileSubscriptionRuntimeInstallationInspector().inspect(command))
+      .resolves.toMatchObject({ executablePath: await realpath(join(bin, launcherName)) });
+  });
+
+  it.each(dependencyNames)("rejects byte-identical symlinked helper %s", async (name) => {
+    const bin = await copyInstallation();
+    const helper = join(bin, name);
+    const relocated = join(root!, name);
+    await rename(helper, relocated);
+    await symlink(relocated, helper);
 
     await expect(new FileSubscriptionRuntimeInstallationInspector().inspect(
       join(bin, launcherName),
-    )).rejects.toMatchObject({ code: "ENOENT" });
+    )).rejects.toThrow(`Agent runtime launcher dependency is not a regular file: ${name}`);
   });
 
-  it("checks helpers beside the real launcher even through a command symlink", async () => {
-    const bin = await copyInstallation();
-    const command = join(root!, "launcher-link");
-    await symlink(join(bin, launcherName), command);
-    const inspector = new FileSubscriptionRuntimeInstallationInspector();
-    await expect(inspector.inspect(command)).resolves.toMatchObject({
-      executablePath: await realpath(join(bin, launcherName)),
-    });
-    const helper = join(bin, "subscription-runtime-failure-details.mjs");
-    const replacement = join(root!, "replacement.mjs");
-    await writeFile(replacement, "export const subscriptionRuntimeFailureDetails = () => ({});\n");
-    await rm(helper);
-    await symlink(replacement, helper);
+  it.each(["installation", "post-completion attestation"])(
+    "rejects relocated policy with unchecked adjacent CJS during %s",
+    async (phase) => {
+      const bin = await copyInstallation();
+      const command = join(bin, launcherName);
+      const inspector = new FileSubscriptionRuntimeInstallationInspector();
+      const admittedInstallation = await inspector.inspect(command);
+      const request = assessmentRequest();
+      const admission = admitSubscriptionRuntimeRequest(request);
+      const attest = () => attachExecutorOwnedExecutionAttestation({
+        command, request, ...admission, admittedInstallation,
+        installationInspector: inspector,
+        result: { status: "completed", structuredOutput: { synthetic: true }, warnings: [] },
+      });
+      expect((await attest()).executionAttestation).toBeDefined();
 
-    await expect(inspector.inspect(command)).rejects.toThrow(
-      "Agent runtime launcher dependency bytes are not approved: subscription-runtime-failure-details.mjs",
-    );
-  });
+      const policy = "subscription-runtime-purpose-model-policy.mjs";
+      const contract = "reader-promotion-v2-canary-contract.cjs";
+      const relocated = join(root!, "relocated");
+      await mkdir(relocated);
+      const policyBytes = await readFile(join(bin, policy));
+      const contractBytes = await readFile(join(bin, contract));
+      await rename(join(bin, policy), join(relocated, policy));
+      await symlink(join(relocated, policy), join(bin, policy));
+      await writeFile(join(relocated, contract),
+        'module.exports = { readerPromotionV2CanaryPurpose: "synthetic-unapproved-contract", ' +
+        'readerPromotionV2CanaryOutputIsValid: () => true };\n');
+      expect(await readFile(join(bin, policy))).toEqual(policyBytes);
+      expect(await readFile(join(bin, contract))).toEqual(contractBytes);
+
+      // Native Node imports only the pure policy, never the launcher/provider/auth runtime.
+      const loaded = await promisify(execFile)(process.execPath, [
+        "--input-type=module", "-e",
+        'const policy = await import(process.argv[1]); ' +
+        'console.log(JSON.stringify([policy.readerPromotionV2CanaryPurpose, ' +
+        'policy.readerPromotionV2CanaryOutputIsValid({})]));',
+        pathToFileURL(join(bin, policy)).href,
+      ], { timeout: 5_000 });
+      expect(JSON.parse(loaded.stdout)).toEqual(["synthetic-unapproved-contract", true]);
+
+      if (phase === "installation") {
+        await expect(inspector.inspect(command)).rejects.toThrow(
+          `Agent runtime launcher dependency is not a regular file: ${policy}`,
+        );
+      } else {
+        const result = await attest();
+        expect(result).toMatchObject({
+          status: "failed",
+          failure: { code: "agent_runtime.execution_attestation_invalid", retryable: false },
+        });
+        expect(result.executionAttestation).toBeUndefined();
+      }
+    },
+  );
 
   it.each([
     { name: "@vioxen/subscription-runtime", version: "0.0.0-unapproved" },

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -1,5 +1,5 @@
 import { constants } from "node:fs";
-import { access, readFile, realpath, stat } from "node:fs/promises";
+import { access, lstat, readFile, realpath, stat } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import {
@@ -63,7 +63,13 @@ export class FileSubscriptionRuntimeInstallationInspector implements Subscriptio
     for (const [name, approvedSha256] of Object.entries(
       approvedSubscriptionRuntimeDependencies,
     )) {
-      const dependencyBytes = await readFile(join(dirname(executablePath), name));
+      const dependencyPath = join(dirname(executablePath), name);
+      // Node resolves helper symlinks before loading their adjacent imports.
+      // Require local regular files so the pinned closure is the loaded closure.
+      if (!(await lstat(dependencyPath)).isFile()) {
+        throw new Error(`Agent runtime launcher dependency is not a regular file: ${name}`);
+      }
+      const dependencyBytes = await readFile(dependencyPath);
       if (createHash("sha256").update(dependencyBytes).digest("hex") !== approvedSha256) {
         throw new Error(`Agent runtime launcher dependency bytes are not approved: ${name}`);
       }

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -14,7 +14,26 @@ import {
 export const approvedSubscriptionRuntimePackageVersion =
   "0.1.0-main.41";
 export const approvedSubscriptionRuntimeLauncherSha256 =
-  "31be41148fdeca3b2d50a960f8d5a84c2809121dfc981db8f70ea9c261036fc9";
+  "3e0082642f2705c678d3f21d2f083fd2c851aaf62759a12d24eb59be30a1a38e";
+
+// Repository wrapper approval, separate from the vendored package provenance.
+// Pin the local import closure too: launcher bytes alone do not bind helpers.
+// These literal pins track the source at 40c9032bb8e93ae1bd5be3b522f042b661fa5ae8;
+// changes to any member require a coordinated, reviewed admission update.
+const approvedSubscriptionRuntimeDependencies = Object.freeze({
+  "subscription-runtime-failure-details.mjs":
+    "5c7e12660c4500a533cda147be44723019c8b223353f1e2d25c3483ff5a1484a",
+  "codex-worker-cli-usage.mjs":
+    "9a0c7d5f4f38d99eb9c91063c6773edda226884f98f9e611837015ddb2d325f9",
+  "codex-auth-pool-manifest.mjs":
+    "6e856a532a55e893d009e68c08cb7f0e2731bd21ab8f6029bbfc88d5cbbbeb25",
+  "codex-auth-pool-routing.mjs":
+    "5b76a13787a92852282488d5beec8ebb3bfd27f9dfbc059daa8bb521b5524c49",
+  "subscription-runtime-purpose-model-policy.mjs":
+    "0c60d62aa38ed04db9643f708a780e9dc72b337d8e0709f92d89d366f5a8f355",
+  "reader-promotion-v2-canary-contract.cjs":
+    "13432d41d7999d15f22880017e73cbd943c209db62161b2a6a2bec6b0766775c",
+});
 
 export type SubscriptionRuntimeInstallationIdentity = {
   /** Exact real path that was admitted and must be passed to spawn. */
@@ -39,6 +58,15 @@ export class FileSubscriptionRuntimeInstallationInspector implements Subscriptio
       .digest("hex");
     if (launcherSha256 !== approvedSubscriptionRuntimeLauncherSha256) {
       throw new Error("Agent runtime launcher bytes are not approved");
+    }
+
+    for (const [name, approvedSha256] of Object.entries(
+      approvedSubscriptionRuntimeDependencies,
+    )) {
+      const dependencyBytes = await readFile(join(dirname(executablePath), name));
+      if (createHash("sha256").update(dependencyBytes).digest("hex") !== approvedSha256) {
+        throw new Error(`Agent runtime launcher dependency bytes are not approved: ${name}`);
+      }
     }
 
     const manifest = await readInstalledManifest(executablePath);

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "check:retention": "node scripts/check-retention.mjs",
     "check:retention-plan": "ts-node -r tsconfig-paths/register scripts/check-retention-plan.ts",
     "check:runtime-compose": "node scripts/check-runtime-compose.mjs",
-    "check:subscription-runtime-auth-pool-e2e": "node --test apps/agent-runtime/bin/codex-auth-pool-manifest.test.mjs apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.test.mjs",
+    "check:subscription-runtime-auth-pool-e2e": "node --test --test-concurrency=1 apps/agent-runtime/bin/codex-auth-pool-manifest.test.mjs apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.test.mjs apps/agent-runtime/bin/subscription-runtime-failure-details.test.mjs",
     "check:runtime-profile-guards": "node scripts/run-with-timeout.mjs --timeout-ms 60000 --node-options --max-old-space-size=512 -- ts-node -r tsconfig-paths/register scripts/check-runtime-profile-guards.ts",
     "check:security-final-sweep": "node scripts/check-security-final-sweep.mjs",
     "check:staging-reliability-evidence": "node scripts/check-staging-reliability-evidence.mjs && node scripts/check-postgres-restore-evidence.mjs",

--- a/scripts/check-review-ci.mjs
+++ b/scripts/check-review-ci.mjs
@@ -32,7 +32,7 @@ const transitionProtected = readFileSync(transitionProtectedPath, "utf8");
 const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const violations = [];
 const subscriptionRuntimeAuthPoolE2eCommand =
-  "node --test apps/agent-runtime/bin/codex-auth-pool-manifest.test.mjs apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.test.mjs";
+  "node --test --test-concurrency=1 apps/agent-runtime/bin/codex-auth-pool-manifest.test.mjs apps/agent-runtime/bin/codex-auth-pool-routing.test.mjs apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.test.mjs apps/agent-runtime/bin/subscription-runtime-failure-details.test.mjs";
 const dailyCursorPostgres18Command =
   "node scripts/run-with-timeout.mjs --timeout-ms 180000 --node-options --max-old-space-size=1024 -- ts-node -r tsconfig-paths/register scripts/check-reader-summary-daily-execution-cursor-postgres.ts";
 const rollingReceiptTest =


### PR DESCRIPTION
Preserve classified execution failures separately from capacity diagnostics. Validate diagnostic values at the untrusted CLI boundary and cover final result/log sanitization with synthetic regression tests. Include boundary tests in the existing runtime CI gate.

No changes to maxAttempts, retry/capacity flags, model policy or assessment retryability. Focused checks passed: 7 boundary tests, 53 Jest tests, 6 purpose-policy tests, affected strict TypeScript and structural gates. Independent hosted exact-SHA review is running; production E2E is not yet claimed.

Refs #294
Related: https://github.com/777genius/social-monitor/pull/293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subscription-runtime failure reporting with clearer, validated diagnostic details, including capacity and executor status.
  - Normalized failed-session error classification for more consistent handling.
  - Excluded unrecognized, malformed, or unsafe diagnostic data from serialized failures.

- **Security**
  - Added integrity checks for the runtime launcher and required dependencies.
  - Installations now detect tampered or missing runtime files and reject unapproved package manifests.

- **Tests**
  - Expanded coverage for failure reporting, diagnostic sanitization, and installation integrity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->