### PR TITLE
fix(ci): unblock production verification and patch vulnerable parsers

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -299,13 +299,13 @@ jobs:
           npm run check:reader-summary-daily-canonical-recovery-production
           npm run check:reader-summary-publication-signal-regression
   verify_backend_shards:
-    name: Test affected backend shard ${{ matrix.shard }}/4
+    name: Test affected backend shard ${{ matrix.shard }}/5
     needs: plan
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix: {shard: [1, 2, 3, 4]}
+      matrix: {shard: [1, 2, 3, 4, 5]}
     # Keep jobs successful with skipped steps when backend is unchanged.
     # A skipped/cancelled/failed matrix job is never accepted by verify_backend.
     steps:
@@ -337,7 +337,7 @@ jobs:
           if [[ $base == 0000000000000000000000000000000000000000 ]]; then
             base=$(git rev-list --max-parents=0 "$GITHUB_SHA" | tail -n 1)
           fi
-          npm test -- --changedSince="$base" --shard=${{ matrix.shard }}/4
+          npm test -- --changedSince="$base" --shard=${{ matrix.shard }}/5
   verify_backend:
     name: Verify backend, collector and deploy control
     needs: [plan, verify_backend_shards]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7473,9 +7473,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
-      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -8550,9 +8550,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -9101,9 +9101,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
-      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -10102,12 +10102,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -10586,14 +10587,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -401,7 +401,7 @@
   "overrides": {
     "@eslint/eslintrc": "3.3.6",
     "@istanbuljs/load-nyc-config": {
-      "js-yaml": "4.3.1"
+      "js-yaml": "4.3.2"
     },
     "@nestjs/swagger": {
       "js-yaml": "5.2.2"
@@ -411,11 +411,11 @@
     "brace-expansion": "5.0.9",
     "browserslist": "4.28.8",
     "deepmerge-ts": "8.0.2",
-    "hono": "4.13.3",
+    "hono": "4.13.5",
     "fast-uri": "3.1.7",
     "form-data": "4.0.6",
     "ip-address": "10.4.0",
-    "multer": "2.2.0",
+    "multer": "2.3.0",
     "mysql2": "3.24.2",
     "socket.io-parser": "4.2.7",
     "tar": "7.5.22"

--- a/scripts/production-deploy-sharding.spec.ts
+++ b/scripts/production-deploy-sharding.spec.ts
@@ -13,7 +13,7 @@ base=$BACKEND_BASE
 if [[ $base == 0000000000000000000000000000000000000000 ]]; then
   base=$(git rev-list --max-parents=0 "$GITHUB_SHA" | tail -n 1)
 fi
-npm test -- --changedSince="$base" --shard=\${{ matrix.shard }}/4
+npm test -- --changedSince="$base" --shard=\${{ matrix.shard }}/5
 `;
 
 // Like check-review-ci, parse the complete YAML and keep execution keys exact:
@@ -21,9 +21,9 @@ npm test -- --changedSince="$base" --shard=\${{ matrix.shard }}/4
 function check(text: string) {
   const { jobs } = yaml.load(text, { json: false });
   expect(jobs.verify_backend_shards).toEqual({
-    name: 'Test affected backend shard ${{ matrix.shard }}/4',
+    name: 'Test affected backend shard ${{ matrix.shard }}/5',
     needs: 'plan', 'runs-on': 'ubuntu-latest', 'timeout-minutes': 45,
-    strategy: { 'fail-fast': false, matrix: { shard: [1, 2, 3, 4] } },
+    strategy: { 'fail-fast': false, matrix: { shard: [1, 2, 3, 4, 5] } },
     steps: [
       { name: 'Check out the release commit', if: condition, uses: checkout,
         with: { 'fetch-depth': 0, ref: '${{ github.sha }}' } },
@@ -106,17 +106,21 @@ describe('production affected-test shards', () => {
   });
   it.each([
     ['          DATABASE_URL: postgresql://fixture:social_monitor_local_password@127.0.0.1:5432/fixture\n', ''],
-    ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3]'],
+    ['shard: [1, 2, 3, 4, 5]', 'shard: [1, 2, 3, 4]'],
     ['timeout-minutes: 45', 'timeout-minutes: 90'],
     ['test "$(git rev-parse HEAD)" = "$GITHUB_SHA"', 'true'],
     ['npm ci\n          npm run prisma:generate\n          npm run build', 'npm ci\n          npm run build'],
+    ['npm run build', 'true'],
     ['--changedSince="$base"', '--changedSince=HEAD'],
-    ['shard: [1, 2, 3, 4]', 'shard: [1, 2, 3, 3]'],
-    ['matrix: {shard: [1, 2, 3, 4]}', 'matrix: {shard: [1, 2, 3, 4], exclude: [{shard: 4}]}'],
+    ['shard: [1, 2, 3, 4, 5]', 'shard: [1, 2, 3, 4, 4]'],
+    ['matrix: {shard: [1, 2, 3, 4, 5]}', 'matrix: {shard: [1, 2, 3, 4, 5], exclude: [{shard: 4}]}'],
     ['fail-fast: false', 'fail-fast: true'],
-    ['--shard=${{ matrix.shard }}/4', '--shard=${{ matrix.shard }}/5'],
-    ['--shard=${{ matrix.shard }}/4', '--shard=${{ matrix.shard }}/4 --passWithNoTests'],
-    ['--shard=${{ matrix.shard }}/4', '--shard=${{ matrix.shard }}/4 --testPathPatterns=small'],
+    ['--shard=${{ matrix.shard }}/5', '--shard=${{ matrix.shard }}/4'],
+    ['--shard=${{ matrix.shard }}/5', '--shard=${{ matrix.shard }}/6'],
+    ['shard ${{ matrix.shard }}/5', 'shard ${{ matrix.shard }}/4'],
+    ['shard ${{ matrix.shard }}/5', 'shard ${{ matrix.shard }}/6'],
+    ['--shard=${{ matrix.shard }}/5', '--shard=${{ matrix.shard }}/5 --passWithNoTests'],
+    ['--shard=${{ matrix.shard }}/5', '--shard=${{ matrix.shard }}/5 --testPathPatterns=small'],
     ['needs: [plan, verify_backend_shards]', 'needs: plan'],
     ['!cancelled()', 'success()'],
     ['= "success"', '!= "failure"'],
@@ -129,6 +133,16 @@ describe('production affected-test shards', () => {
     expect(source).toContain(before);
     expect(() => check(source.replace(before, after))).toThrow();
   });
+  it.each(['release_a', 'deploy'])('rejects bypassed %s dependencies and failure policy', (id) => {
+    for (const field of ['needs', 'if', 'continue-on-error']) {
+      const workflow = yaml.load(source);
+      workflow.jobs[id][field] = field === 'needs' ? ['plan'] : field === 'if' ? 'always()' : true;
+      expect(() => check(yaml.dump(workflow))).toThrow();
+    }
+  });
+  it.each(['skipped', 'cancelled'])('rejects accepting %s shards', (result) => {
+    expect(() => check(source.replace('= "success"', `= "${result}"`))).toThrow();
+  });
   it.each(['success', 'failure', 'cancelled', 'skipped', ''])('aggregate result %s fails closed', (result) => {
     const gate = yaml.load(source).jobs.verify_backend.steps[0].run;
     const run = spawnSync('bash', ['-e', '-c', gate.replace('${{ needs.verify_backend_shards.result }}', result)]);
@@ -136,7 +150,7 @@ describe('production affected-test shards', () => {
   });
   it.each(['backend', 'control', 'frontend', 'x_collector', 'maintenance'])('preserves %s skip semantics', (mode) => {
     const { jobs } = yaml.load(source);
-    // Successful plan always schedules four jobs. Backend=false skips their
+    // Successful plan always schedules five jobs. Backend=false skips their
     // individual steps, yielding success, not a skipped matrix dependency.
     expect(jobs.verify_backend_shards.if).toBeUndefined();
     expect(jobs.verify_backend_shards.needs).toBe('plan');
@@ -159,13 +173,13 @@ describe('production affected-test shards', () => {
       expect(evaluate(jobs.verify_backend.if, result)).toBe(false);
     }
   });
-  it.each([0, 1, 2, 3, 4, 5, 34, 796])('Jest partitions %s files without loss or overlap', (count) => {
+  it.each([0, 1, 2, 3, 4, 5, 6, 34, 796])('Jest partitions %s files without loss or overlap', (count) => {
     const Sequencer = createRequire(`${process.cwd()}/package.json`)('@jest/test-sequencer').default;
     const sequencer = new Sequencer();
     const tests = Array.from({ length: count }, (_, i) => ({
       path: `/repo/test-${i}.spec.ts`, context: { config: { rootDir: '/repo' } },
     }));
-    const shards = [1, 2, 3, 4].map(shardIndex => sequencer.shard(tests, { shardIndex, shardCount: 4 }));
+    const shards = [1, 2, 3, 4, 5].map(shardIndex => sequencer.shard(tests, { shardIndex, shardCount: 5 }));
     const union = shards.flat().map((test: { path: string }) => test.path);
     expect(union.sort()).toEqual(tests.map(test => test.path).sort());
     expect(new Set(union).size).toBe(count);
@@ -178,7 +192,7 @@ describe('production affected-test shards', () => {
         env: { ...process.env, BACKEND_BASE: base, GITHUB_SHA: 'target-sha' }, encoding: 'utf8',
       });
       expect(run.status).toBe(0);
-      expect(run.stdout).toBe(`<test>\n<-->\n<--changedSince=${base === '0'.repeat(40) ? 'root-sha' : base}>\n<--shard=3/4>\n`);
+      expect(run.stdout).toBe(`<test>\n<-->\n<--changedSince=${base === '0'.repeat(40) ? 'root-sha' : base}>\n<--shard=3/5>\n`);
     },
   );
   it('propagates selector resolution and test-command failures', () => {


### PR DESCRIPTION
Production verification timed out when two expensive renewal suites shared one shard. Use five production shards while retaining the existing timeout, affected-test selection and strict aggregate release gate. Patch vulnerable YAML, multipart, Hono and query-parser dependencies with minimal compatible updates; Nest versions remain unchanged.

Independent exact-commit reviews approve b1f648a sharding and dc1090ae dependency delta. Verification includes 582-suite partition equality, 78 workflow contract tests, multipart abort/size boundaries, YAML/Hono/qs fixtures, and a dependency audit with zero vulnerabilities. Final combined-head CI and production deployment timings remain required.

Refs #294