### PR TITLE
feat(summary): expose immutable preparation observations

### DIFF
--- a/libs/relevance/features/rank-feed-items/promotion-snapshot-preparation.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-snapshot-preparation.spec.ts
@@ -1,0 +1,88 @@
+import { classifyFeedPromotionEligibility } from "@social-monitor/feed/domain";
+import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import { FixedClock } from "@social-monitor/shared-kernel";
+import { fixture, review, cutoff, scope, query } from "../../../../test/support/promotion-content-assessment";
+import { SourceContentQualityPolicy, SourceContentSafetyPolicy } from "../../domain";
+import type { SourceContentQualityReviewRequest } from "../../ports";
+import { rankPromotionSnapshot } from "./rank-promotion-snapshot";
+import type { PromotionSnapshotPreparationObserver } from "./promotion-snapshot-preparation";
+
+const setup = () => {
+  const primary = [fixture("a", "reddit"), fixture("z", "hacker-news"),
+    fixture("hard", "reddit", { providerMetadata: { kind: "reddit_post", score: 1 } })];
+  const supplemental = [fixture("supp-b", "github-trending-page"), fixture("supp-a", "rss")];
+  const sourceContent = [...primary, ...supplemental].map((item) => ({
+    feedItemId: item.toSnapshot().id, sourceItemId: item.toSnapshot().sourceItemId,
+    body: `${item.toSnapshot().bodyPreview} token=fixture-secret`,
+  }));
+  const candidates = primary.map((item) => {
+    const canonical = classifyFeedPromotionEligibility(item.toSnapshot());
+    if (!canonical.eligible) throw new Error("Invalid synthetic metrics");
+    return { item, canonical,
+      metricAuthority: { observedAt: cutoff, regressionState: "stable" as const } };
+  });
+  const feedItems: FeedItemReadRepositoryPort = {
+    list: jest.fn(async () => { throw new Error("Unexpected list"); }),
+    findById: jest.fn(async () => { throw new Error("Unexpected lookup"); }),
+    readPromotionSnapshot: jest.fn(async () => ({ ok: true, candidates, supplementalItems: supplemental,
+      sourceContent, physicalRowsRead: 5, exhausted: true })),
+  };
+  const reviewBatch = jest.fn(async (requests: readonly SourceContentQualityReviewRequest[]) =>
+    requests.map((request) => review(request)));
+  const run = (observePromotionPreparation?: PromotionSnapshotPreparationObserver) => rankPromotionSnapshot({
+    command: { ...scope, limit: 1, observedAtOrBefore: cutoff,
+      publishedAtOrAfter: new Date("2026-09-08T00:00:00Z"),
+      publishedBefore: new Date("2026-09-09T00:00:00Z"), observePromotionPreparation },
+    feedItems, clock: new FixedClock(cutoff), qualityReviewer: { reviewBatch },
+    qualityPolicy: new SourceContentQualityPolicy(), safetyPolicy: new SourceContentSafetyPolicy(),
+    configuredInterests: { readCurrent: async (requested) => ({ kind: "available", interest: { ...requested, query } }) },
+  });
+  return { run, reviewBatch, feedItems };
+};
+
+describe("promotion preparation observation", () => {
+  it("captures every raw partition before sort without a second review or rank pass", async () => {
+    const baseline = setup();
+    const observed = setup();
+    const callback = jest.fn<ReturnType<PromotionSnapshotPreparationObserver>, Parameters<PromotionSnapshotPreparationObserver>>();
+    const expected = await baseline.run();
+    const actual = await observed.run(callback);
+    expect(actual).toEqual(expected);
+    expect(callback).toHaveBeenCalledTimes(1);
+    const preparation = callback.mock.calls[0]![0];
+    expect(preparation.primary.map((item) => item.feedItemId)).toEqual(["a", "z", "hard"]);
+    expect(preparation.supplemental.map((item) => item.feedItemId)).toEqual(["supp-b", "supp-a"]);
+    expect(preparation.primary.every((item) => item.rank === 0)).toBe(true);
+    expect(preparation.requestedCandidateIds).toEqual(["a", "z"]);
+    expect(preparation.primary[2]!.contentQuality.reason).toBe("promotion_assessment_not_requested:hard_gate");
+    expect(preparation.primary[0]!.contentQuality.qualityScore).toBe(0.8);
+    expect(preparation.primary[0]!.sourceText).toContain("workspace boundary");
+    expect(JSON.stringify(preparation)).not.toContain("fixture-secret");
+    if (!actual.ok) throw actual.error;
+    expect(preparation.primary[0]!.contentQuality).not.toBe(
+      actual.value.items.find((item) => item.feedItemId === "a")!.contentQuality);
+    expect(preparation.primary[0]!.providerMetadata).not.toBe(
+      actual.value.items.find((item) => item.feedItemId === "a")!.providerMetadata);
+    expect(actual.value.items[0]!.feedItemId).toBe("z");
+    expect(actual.value.items.map((item) => item.rank)).toEqual([1, 2, 3, 4, 5]);
+    expect(observed.reviewBatch).toHaveBeenCalledTimes(1);
+    expect(observed.reviewBatch.mock.calls[0]![0].map((request) => request.candidateId)).toEqual(["a", "z"]);
+    expect(observed.feedItems.readPromotionSnapshot).toHaveBeenCalledTimes(1);
+    expect(observed.feedItems.list).not.toHaveBeenCalled();
+  });
+
+  it("detaches and freezes nested values, and mutation exceptions cannot alter ranking", async () => {
+    const expected = await setup().run();
+    const attempts: boolean[] = [];
+    const actual = await setup().run((preparation) => {
+      attempts.push(Object.isFrozen(preparation.primary),
+        Object.isFrozen(preparation.primary[0]!.contentQuality.flags),
+        !Reflect.set(preparation.primary[0]!, "score", 999),
+        !Reflect.set(preparation.primary[0]!.contentQuality, "qualityScore", 0),
+        !Reflect.set(preparation.primary[0]!.providerMetadata!, "kind", "forged"));
+      throw new Error("Synthetic observer failure");
+    });
+    expect(attempts).toEqual([true, true, true, true, true]);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/libs/relevance/features/rank-feed-items/promotion-snapshot-preparation.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-snapshot-preparation.spec.ts
@@ -1,5 +1,5 @@
 import { classifyFeedPromotionEligibility } from "@social-monitor/feed/domain";
-import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import type { FeedItemReadRepositoryPort, PromotionFeedItemSnapshotResult } from "@social-monitor/feed/ports";
 import { FixedClock } from "@social-monitor/shared-kernel";
 import { fixture, review, cutoff, scope, query } from "../../../../test/support/promotion-content-assessment";
 import { SourceContentQualityPolicy, SourceContentSafetyPolicy } from "../../domain";
@@ -24,7 +24,7 @@ const setup = () => {
   const feedItems: FeedItemReadRepositoryPort = {
     list: jest.fn(async () => { throw new Error("Unexpected list"); }),
     findById: jest.fn(async () => { throw new Error("Unexpected lookup"); }),
-    readPromotionSnapshot: jest.fn(async () => ({ ok: true, candidates, supplementalItems: supplemental,
+    readPromotionSnapshot: jest.fn(async (): Promise<PromotionFeedItemSnapshotResult> => ({ ok: true, candidates, supplementalItems: supplemental,
       sourceContent, physicalRowsRead: 5, exhausted: true })),
   };
   const reviewBatch = jest.fn(async (requests: readonly SourceContentQualityReviewRequest[]) =>

--- a/libs/relevance/features/rank-feed-items/promotion-snapshot-preparation.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-snapshot-preparation.ts
@@ -1,0 +1,47 @@
+import type { RankedFeedItemView } from "./rank-feed-items.result";
+
+/** Dates become ISO values: freezing a Date does not prevent setTime(). */
+export type PreparationValue<T> = T extends Date ? string
+  : T extends readonly (infer Item)[] ? readonly PreparationValue<Item>[]
+  : T extends object ? { readonly [Key in keyof T]: PreparationValue<T[Key]> }
+  : T;
+
+export type PromotionSnapshotPreparation = {
+  /** Complete mapped partitions in repository order; rank is still zero here. */
+  readonly primary: readonly RankedFeedItemView[];
+  readonly supplemental: readonly RankedFeedItemView[];
+  /** Eligibility requests, not a claim that all requests were attempted/resolved. */
+  readonly requestedCandidateIds: readonly string[];
+};
+
+export type PromotionSnapshotPreparationObserver = (
+  preparation: PreparationValue<PromotionSnapshotPreparation>,
+) => void;
+
+/** Only detached, frozen value projections cross the preparation boundary. */
+export const preparationValue = <T>(value: T): PreparationValue<T> => {
+  const project = (entry: unknown): unknown => {
+    if (entry instanceof Date) return entry.toISOString();
+    if (Array.isArray(entry)) return Object.freeze(entry.map(project));
+    if (entry !== null && typeof entry === "object") {
+      return Object.freeze(Object.fromEntries(
+        Object.entries(entry).map(([key, child]) => [key, project(child)]),
+      ));
+    }
+    return entry;
+  };
+  return project(value) as PreparationValue<T>;
+};
+
+/** Synchronous observation only. Capture owners must retain their own failures;
+ * absence of a callback result is never evidence of successful capture. */
+export const observePromotionSnapshotPreparation = (
+  observer: PromotionSnapshotPreparationObserver,
+  preparation: PromotionSnapshotPreparation,
+): void => {
+  try {
+    observer(preparationValue(preparation));
+  } catch {
+    // Observation must not change ranking, retry assessment, or select evidence.
+  }
+};

--- a/libs/relevance/features/rank-feed-items/rank-feed-items.command.ts
+++ b/libs/relevance/features/rank-feed-items/rank-feed-items.command.ts
@@ -1,5 +1,7 @@
 import type { TenantId, WorkspaceId } from "@social-monitor/shared-kernel";
 
+import type { PromotionSnapshotPreparationObserver } from "./promotion-snapshot-preparation";
+
 export type RankFeedItemsCommand = {
   readonly tenantId: TenantId;
   readonly workspaceId: WorkspaceId;
@@ -13,5 +15,6 @@ export type RankFeedItemsCommand = {
   readonly publishedAtOrAfter?: Date;
   readonly publishedBefore?: Date;
   readonly promotionAssessmentExecution?: { readonly deadlineAtMs: number; readonly signal?: AbortSignal };
+  readonly observePromotionPreparation?: PromotionSnapshotPreparationObserver;
   readonly rankingProfile?: "reader_post_promotion";
 };

--- a/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
@@ -33,6 +33,8 @@ import { assessPromotionContent } from "./promotion-content-assessment";
 import { canCompeteForPromotionAssessment } from "./promotion-assessment-eligibility";
 import { unavailablePromotionHeadline, type PromotionReaderHeadline } from "../../domain/promotion-reader-headline";
 
+import { observePromotionSnapshotPreparation } from "./promotion-snapshot-preparation";
+
 const PROMOTION_SOURCE_TEXT_SAFETY_CAP = 256_000;
 
 export const rankPromotionSnapshot = async (params: {
@@ -263,6 +265,13 @@ export const rankPromotionSnapshot = async (params: {
       contentQuality: presentSourceContentQuality(quality),
     } satisfies RankedFeedItemView;
   });
+  if (command.observePromotionPreparation !== undefined) {
+    observePromotionSnapshotPreparation(command.observePromotionPreparation, {
+      primary: projected,
+      supplemental,
+      requestedCandidateIds: reviewRequests.map((request) => request.candidateId),
+    });
+  }
   const items = [...projected, ...supplemental]
     .sort((left, right) => right.score - left.score ||
       right.publishedAt.localeCompare(left.publishedAt) ||

--- a/libs/summary/adapters/evidence/reader-summary-preparation-observer.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-preparation-observer.spec.ts
@@ -1,0 +1,191 @@
+import { classifyFeedPromotionEligibility } from "@social-monitor/feed/domain";
+import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
+import { preparationValue } from "@social-monitor/relevance/features/rank-feed-items/promotion-snapshot-preparation";
+import type { SourceContentQualityReviewRequest } from "@social-monitor/relevance/ports";
+import { FixedClock, ok } from "@social-monitor/shared-kernel";
+import { fixture, review, cutoff, scope, query } from "../../../../test/support/promotion-content-assessment";
+import { StoryClusteringService } from "../../domain";
+import type { ReaderSummaryEvidenceSelectorPort, ReaderSummaryStoryRelationVerifierInput } from "../../ports";
+import { RelevanceReaderSummaryEvidenceSelector } from "./relevance-reader-summary-evidence.selector";
+import type { ReaderSummaryPreparationObserver } from "./reader-summary-preparation-observer";
+import { readerSummaryRankedItemFixture } from "./relevance-reader-summary-evidence-test-fixtures";
+import * as policy from "./relevance-reader-summary-promotion-candidates";
+
+const selectParams: Parameters<ReaderSummaryEvidenceSelectorPort["select"]>[0] = {
+  ...scope, scope: { type: "workspace" }, maxItems: 5, observedThrough: cutoff,
+  period: { cadence: "daily", timezone: "UTC", periodKey: "synthetic-preparation",
+    startedAt: new Date("2026-09-08T00:00:00Z"), endedAt: new Date("2026-09-09T00:00:00Z") },
+};
+
+const setup = () => {
+  const primary = [fixture("a"), fixture("z", "hacker-news", {
+    canonicalUrl: "https://example.test/a" }),
+  fixture("distinct", "hacker-news", { title: "Compiler memory allocator measurements" }),
+  fixture("outside", "reddit", { publishedAt: new Date("2026-09-07T12:00:00Z") })];
+  const supplemental = [...Array.from({ length: 12 }, (_, index) => {
+    const rank = index + 1;
+    return fixture(`github-${rank}`, "github-trending-page", {
+      canonicalUrl: `https://github.com/fixture/repository-${rank}`,
+      title: `fixture/repository-${rank} is #${rank} on GitHub Trending`,
+      providerMetadata: { kind: "github_trending_page_repository",
+        repository: { fullName: `fixture/repository-${rank}`, totalStars: 20_000, forksCount: 500 },
+        trending: { rank, starsGained: 100 + rank, window: "daily" } },
+    });
+  }), fixture("rss", "rss", { title: "Independent editor tooling notes" }),
+  fixture("unsupported", "github-issues", { title: "Video tooling notes" })];
+  const feedItems: FeedItemReadRepositoryPort = {
+    list: jest.fn(async () => { throw new Error("Unexpected list"); }),
+    findById: jest.fn(async () => { throw new Error("Unexpected lookup"); }),
+    readPromotionSnapshot: jest.fn(async () => ({ ok: true, exhausted: true, physicalRowsRead: 18,
+      candidates: primary.map((item) => {
+        const canonical = classifyFeedPromotionEligibility(item.toSnapshot());
+        if (!canonical.eligible) throw new Error("Invalid synthetic metrics");
+        return { item, canonical, metricAuthority: { observedAt: cutoff, regressionState: "stable" as const } };
+      }), supplementalItems: supplemental,
+      sourceContent: [...primary, ...supplemental].map((item) => ({
+        feedItemId: item.toSnapshot().id, sourceItemId: item.toSnapshot().sourceItemId,
+        body: item.toSnapshot().bodyPreview,
+      })),
+    })),
+  };
+  const reviewBatch = jest.fn(async (requests: readonly SourceContentQualityReviewRequest[]) =>
+    requests.map((request) => review(request)));
+  const ranker = new RankFeedItemsUseCase(feedItems, { findByUser: async () => {
+    throw new Error("Unexpected profile");
+  } } as never, new FixedClock(cutoff), undefined, undefined, undefined, { reviewBatch }, undefined,
+  { readCurrent: async (requested) => ({ kind: "available", interest: { ...requested, query } }) });
+  const execute = jest.spyOn(ranker, "execute");
+  const verify = jest.fn(async (input: ReaderSummaryStoryRelationVerifierInput) => input.candidates.map((candidate) => ({
+    leftFeedItemId: candidate.leftFeedItemId, rightFeedItemId: candidate.rightFeedItemId,
+    sameStory: [candidate.leftFeedItemId, candidate.rightFeedItemId].sort().join(":") === "a:z",
+    confidenceScore: 0.99,
+  })));
+  const run = async (observer?: ReaderSummaryPreparationObserver) => {
+    const result = await new RelevanceReaderSummaryEvidenceSelector(ranker, feedItems,
+      new FixedClock(cutoff), undefined, { verify }, undefined, observer).select(selectParams);
+    // Drain the existing synthetic shadow task; this is not a replay scheduler.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    return result;
+  };
+  return { run, execute, reviewBatch, verify, feedItems };
+};
+
+const ids = (items: readonly { readonly feedItemId: string }[]) => items.map((item) => item.feedItemId);
+
+describe("reader summary preparation observation", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("observes full raw mapping, actual filtered stages and both real groupings before reduction", async () => {
+    const baseline = setup();
+    const expected = await baseline.run();
+    const clustering = jest.spyOn(StoryClusteringService.prototype, "cluster");
+    const reduction = jest.spyOn(policy, "promotionPolicySelection");
+    const promotionSnapshot = jest.fn<ReturnType<ReaderSummaryPreparationObserver["promotionSnapshot"]>,
+      Parameters<ReaderSummaryPreparationObserver["promotionSnapshot"]>>();
+    const beforePolicy = jest.fn<ReturnType<ReaderSummaryPreparationObserver["beforePolicy"]>,
+      Parameters<ReaderSummaryPreparationObserver["beforePolicy"]>>();
+    const boundaryCalls: number[][] = [];
+    const observed = setup();
+    const actual = await observed.run({ promotionSnapshot, beforePolicy: (preparation) => {
+      boundaryCalls.push([clustering.mock.calls.length, reduction.mock.calls.length]);
+      beforePolicy(preparation);
+    } });
+    expect(actual).toEqual(expected);
+    expect(boundaryCalls).toEqual([[2, 0]]);
+    expect(promotionSnapshot).toHaveBeenCalledTimes(1);
+    expect(beforePolicy).toHaveBeenCalledTimes(1);
+    const raw = promotionSnapshot.mock.calls[0]![0];
+    const prepared = beforePolicy.mock.calls[0]![0];
+    expect(ids(raw.primary)).toEqual(["a", "z", "distinct", "outside"]);
+    expect(ids(raw.supplemental)).toEqual([...Array.from({ length: 12 }, (_, i) => `github-${i + 1}`), "rss", "unsupported"]);
+    expect(ids(raw.primary)).toEqual(ids(raw.ranked.primary));
+    expect(ids(raw.supplemental)).toEqual(ids(raw.ranked.supplemental));
+    const ranked = await observed.execute.mock.results[0]!.value;
+    if (!ranked.ok) throw ranked.error;
+    expect(ids(prepared.rankedInventory)).toEqual(ids(ranked.value.items));
+    expect(prepared.rankingOrder).toEqual(ranked.value.items.map(({ feedItemId, rank }) => ({ feedItemId, rank })));
+    expect(ids(prepared.rankedInventory)).not.toEqual([...ids(raw.primary), ...ids(raw.supplemental)]);
+    expect(prepared.rankedInventory).toHaveLength(18);
+    expect(prepared.periodFiltered).toHaveLength(17);
+    expect(prepared.periodExcludedIds).toEqual(["outside"]);
+    expect(prepared.defaultProviderExcludedIds).toContain("unsupported");
+    expect(ids(prepared.periodFiltered)).not.toContain("outside");
+    expect(ids(prepared.defaultProviderFiltered)).not.toContain("unsupported");
+    // Promotion candidates are intentionally reintroduced after the default provider filter.
+    expect(ids(prepared.candidateItems)).toContain("unsupported");
+    expect(ids(prepared.groupingInput).sort()).toEqual(["a", "distinct", "rss", "unsupported", "z"]);
+    expect(ids(prepared.policyItems).sort()).toEqual(["a", "distinct", "rss", "unsupported", "z"]);
+    expect(ids(prepared.admittedSupplemental)).toEqual(Array.from({ length: 10 }, (_, i) => `github-${i + 1}`));
+    expect(prepared.initialGrouping).toEqual(preparationValue(clustering.mock.results[0]!.value));
+    expect(prepared.authoritativeGrouping).toEqual(preparationValue(clustering.mock.results[1]!.value));
+    expect(prepared.groupingInput).toEqual(preparationValue(clustering.mock.calls[0]![0].items));
+    expect(clustering.mock.calls[1]![0].items).toBe(clustering.mock.calls[0]![0].items);
+    expect(prepared.initialGrouping.clusters.length).toBeGreaterThan(1);
+    expect(prepared.initialGrouping.clusters.some((cluster) => cluster.duplicateFeedItemIds.length > 0)).toBe(true);
+    expect(prepared.verifiedPairs).toContain("a\u0000z");
+    expect(prepared.graduatedRelations).toContainEqual({
+      leftFeedItemId: "z", rightFeedItemId: "a", confidence: 0.99,
+    });
+    expect(prepared.verifiedPairs).toEqual([...clustering.mock.calls[1]![0].verifiedStoryRelationPairs!]);
+    expect(prepared.strictTitlePairs).toEqual([...clustering.mock.calls[1]![0].verifiedStrictTitleRelationPairs!]);
+    expect(prepared.initialUnclusteredIds).toEqual([]);
+    expect(prepared.authoritativeUnclusteredIds).toEqual([]);
+    expect(prepared.prePolicySelection).toEqual(preparationValue(reduction.mock.calls[0]![0]));
+    expect(prepared.prePolicySelection.sourceWindow).toMatchObject({
+      periodStartedAt: selectParams.period.startedAt.toISOString(),
+      periodEndedAt: selectParams.period.endedAt.toISOString(), ingestionCutoff: cutoff.toISOString(),
+    });
+    expect(observed.execute).toHaveBeenCalledTimes(1);
+    expect(observed.reviewBatch).toHaveBeenCalledTimes(1);
+    expect(observed.feedItems.readPromotionSnapshot).toHaveBeenCalledTimes(1);
+    expect(observed.verify.mock.calls.map(([input]) => preparationValue({ ...input, signal: undefined })))
+      .toEqual(baseline.verify.mock.calls.map(([input]) => preparationValue({ ...input, signal: undefined })));
+    expect(reduction).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the real cluster-cap omissions before policy fills unclustered candidates", async () => {
+    const items = Array.from({ length: 202 }, (_, index) => readerSummaryRankedItemFixture({
+      feedItemId: `capacity-${index}`, providerKey: "rss", rank: index + 1, score: 1,
+      canonicalUrl: `https://capacity-${index}.test/independent`,
+      title: `Independent source ${index}`, publishedAt: cutoff.toISOString(), observedAt: cutoff.toISOString(),
+    }));
+    const execute = jest.fn(async () => ok({ items, profileApplied: false, generatedAt: cutoff.toISOString() }));
+    const beforePolicy = jest.fn<ReturnType<ReaderSummaryPreparationObserver["beforePolicy"]>,
+      Parameters<ReaderSummaryPreparationObserver["beforePolicy"]>>();
+    await new RelevanceReaderSummaryEvidenceSelector({ execute } as unknown as RankFeedItemsUseCase,
+      setup().feedItems, new FixedClock(cutoff), undefined, undefined, undefined,
+      { promotionSnapshot: jest.fn(), beforePolicy }).select(selectParams);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(beforePolicy).toHaveBeenCalledTimes(1);
+    const value = beforePolicy.mock.calls[0]![0];
+    expect(value.groupingInput).toHaveLength(202);
+    expect(value.authoritativeGrouping.clusters).toHaveLength(200);
+    expect(value.authoritativeUnclusteredIds).toHaveLength(2);
+    expect(value.initialUnclusteredIds).toEqual(value.authoritativeUnclusteredIds);
+    const members = value.authoritativeGrouping.clusters.flatMap((cluster) =>
+      [cluster.representativeFeedItemId, ...cluster.duplicateFeedItemIds]);
+    expect([...members, ...value.authoritativeUnclusteredIds].sort()).toEqual(ids(items).sort());
+    expect(value.policyItems).toHaveLength(202);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents nested callback mutation including dates from changing selection", async () => {
+    const expected = await setup().run();
+    const attempts: boolean[] = [];
+    const observed = setup();
+    const actual = await observed.run({ promotionSnapshot: (value) => {
+      attempts.push(!Reflect.set(value.primary[0]!, "title", "forged"),
+        !Reflect.set(value.ranked.primary[0]!.contentQuality, "qualityScore", 0));
+    }, beforePolicy: (value) => {
+      attempts.push(typeof value.prePolicySelection.sourceWindow.ingestionCutoff === "string",
+        !Reflect.set(value.prePolicySelection.sourceWindow, "ingestionCutoff", "invalid"),
+        !Reflect.set(value.authoritativeGrouping.clusters[0]!, "score", 999),
+        Object.isFrozen(value.policyItems[0]!.contentQuality!.flags));
+      throw new Error("Synthetic observer failure");
+    } });
+    expect(attempts).toEqual([true, true, true, true, true, true]);
+    expect(actual).toEqual(expected);
+    expect(observed.reviewBatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/summary/adapters/evidence/reader-summary-preparation-observer.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-preparation-observer.spec.ts
@@ -1,5 +1,5 @@
 import { classifyFeedPromotionEligibility } from "@social-monitor/feed/domain";
-import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import type { FeedItemReadRepositoryPort, PromotionFeedItemSnapshotResult } from "@social-monitor/feed/ports";
 import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
 import { preparationValue } from "@social-monitor/relevance/features/rank-feed-items/promotion-snapshot-preparation";
 import type { SourceContentQualityReviewRequest } from "@social-monitor/relevance/ports";
@@ -37,7 +37,7 @@ const setup = () => {
   const feedItems: FeedItemReadRepositoryPort = {
     list: jest.fn(async () => { throw new Error("Unexpected list"); }),
     findById: jest.fn(async () => { throw new Error("Unexpected lookup"); }),
-    readPromotionSnapshot: jest.fn(async () => ({ ok: true, exhausted: true, physicalRowsRead: 18,
+    readPromotionSnapshot: jest.fn(async (): Promise<PromotionFeedItemSnapshotResult> => ({ ok: true, exhausted: true, physicalRowsRead: 18,
       candidates: primary.map((item) => {
         const canonical = classifyFeedPromotionEligibility(item.toSnapshot());
         if (!canonical.eligible) throw new Error("Invalid synthetic metrics");
@@ -101,7 +101,7 @@ describe("reader summary preparation observation", () => {
     expect(ids(raw.supplemental)).toEqual([...Array.from({ length: 12 }, (_, i) => `github-${i + 1}`), "rss", "unsupported"]);
     expect(ids(raw.primary)).toEqual(ids(raw.ranked.primary));
     expect(ids(raw.supplemental)).toEqual(ids(raw.ranked.supplemental));
-    const ranked = await observed.execute.mock.results[0]!.value;
+    const ranked: Awaited<ReturnType<RankFeedItemsUseCase["execute"]>> = await observed.execute.mock.results[0]!.value;
     if (!ranked.ok) throw ranked.error;
     expect(ids(prepared.rankedInventory)).toEqual(ids(ranked.value.items));
     expect(prepared.rankingOrder).toEqual(ranked.value.items.map(({ feedItemId, rank }) => ({ feedItemId, rank })));

--- a/libs/summary/adapters/evidence/reader-summary-preparation-observer.ts
+++ b/libs/summary/adapters/evidence/reader-summary-preparation-observer.ts
@@ -1,0 +1,91 @@
+import {
+  preparationValue,
+  type PreparationValue,
+  type PromotionSnapshotPreparation,
+} from "@social-monitor/relevance/features/rank-feed-items/promotion-snapshot-preparation";
+import type {
+  SummaryEvidenceItem,
+  SummaryEvidenceSelection,
+  ApprovedSameStoryRelation,
+  StoryRelationCandidate,
+} from "../../domain";
+import { mapRankedItem } from "./relevance-reader-summary-evidence-support";
+
+export type ReaderSummaryPreparation = {
+  /** Execution order, independently of the raw partitions observed before sort. */
+  readonly rankingOrder: readonly { readonly feedItemId: string; readonly rank: number }[];
+  readonly rankedInventory: readonly SummaryEvidenceItem[];
+  readonly periodExcludedIds: readonly string[];
+  readonly defaultProviderExcludedIds: readonly string[];
+  readonly periodFiltered: readonly SummaryEvidenceItem[];
+  readonly defaultProviderFiltered: readonly SummaryEvidenceItem[];
+  readonly candidateItems: readonly SummaryEvidenceItem[];
+  readonly groupingInput: readonly SummaryEvidenceItem[];
+  readonly initialGrouping: SummaryEvidenceSelection;
+  readonly authoritativeGrouping: SummaryEvidenceSelection;
+  readonly initialUnclusteredIds: readonly string[];
+  readonly authoritativeUnclusteredIds: readonly string[];
+  readonly relationCandidates: readonly StoryRelationCandidate[];
+  readonly verifiedPairs: readonly string[];
+  readonly strictTitlePairs: readonly string[];
+  readonly approvedRelations: readonly ApprovedSameStoryRelation[];
+  readonly graduatedRelations: readonly ApprovedSameStoryRelation[];
+  readonly policyItems: readonly SummaryEvidenceItem[];
+  readonly prePolicySelection: SummaryEvidenceSelection;
+  /** Already admitted by the supplemental policy; never the full inventory. */
+  readonly admittedSupplemental: readonly SummaryEvidenceItem[];
+};
+
+export type ReaderSummaryPreparationObserver = {
+  readonly promotionSnapshot: (preparation: PreparationValue<{
+    readonly ranked: PromotionSnapshotPreparation;
+    readonly primary: readonly SummaryEvidenceItem[];
+    readonly supplemental: readonly SummaryEvidenceItem[];
+  }>) => void;
+  readonly beforePolicy: (preparation: PreparationValue<ReaderSummaryPreparation>) => void;
+};
+
+export const observeReaderPromotionSnapshot = (
+  observer: ReaderSummaryPreparationObserver,
+  ranked: PreparationValue<PromotionSnapshotPreparation>,
+  cutoff: Date,
+  scope: Readonly<{ tenantId: string; workspaceId: string }>,
+): void => {
+  // Called inside the rank observation boundary, before its combined sort.
+  observer.promotionSnapshot(preparationValue({
+    ranked,
+    primary: ranked.primary.map((item) => mapRankedItem(item, cutoff, scope)),
+    supplemental: ranked.supplemental.map((item) => mapRankedItem(item, cutoff, scope)),
+  }));
+};
+
+export const unclusteredPreparationIds = (
+  items: readonly SummaryEvidenceItem[],
+  selection: SummaryEvidenceSelection,
+): readonly string[] => {
+  const clustered = new Set(selection.clusters.flatMap((cluster) =>
+    [cluster.representativeFeedItemId, ...cluster.duplicateFeedItemIds]));
+  return items.filter((item) => !clustered.has(item.feedItemId))
+    .map((item) => item.feedItemId);
+};
+
+export const observeReaderSummaryPreparation = (
+  observer: ReaderSummaryPreparationObserver,
+  preparation: ReaderSummaryPreparation,
+): void => {
+  try {
+    observer.beforePolicy(preparationValue(preparation));
+  } catch {
+    // Capture owns failure accounting. Selection must remain observationally pure.
+  }
+};
+
+/** Stage-local exclusions: a later union can deliberately reintroduce an item. */
+export const excludedPreparationIds = (
+  input: readonly SummaryEvidenceItem[],
+  output: readonly SummaryEvidenceItem[],
+): readonly string[] => {
+  const included = new Set(output.map((item) => item.feedItemId));
+  return input.filter((item) => !included.has(item.feedItemId))
+    .map((item) => item.feedItemId);
+};

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
@@ -40,6 +40,14 @@ import {
   materializeReaderSummaryEditorialSlate,
 } from "./reader-summary-editorial-slate";
 
+import {
+  excludedPreparationIds,
+  observeReaderPromotionSnapshot,
+  observeReaderSummaryPreparation,
+  unclusteredPreparationIds,
+  type ReaderSummaryPreparationObserver,
+} from "./reader-summary-preparation-observer";
+
 /**
  * Original source text is considered through 256k UTF-16 code units. The cap
  * is applied before safety-policy sanitization to bound transient regex/string
@@ -56,6 +64,7 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
     private readonly storyRankingMetrics: StoryRankingMetricsPort = NOOP_STORY_RANKING_METRICS,
     private readonly storyRelationVerifier?: ReaderSummaryStoryRelationVerifierPort,
     private readonly relatedTopicVerifierTimeoutMs = RELATED_TOPIC_VERIFIER_TIMEOUT_MS,
+    private readonly preparationObserver?: ReaderSummaryPreparationObserver,
   ) {
     this.clusterer = new StoryClusteringService(clock);
   }
@@ -78,13 +87,20 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
       observedAtOrBefore: ingestionCutoff,
       rankingProfile: "reader_post_promotion",
       limit: expandedCandidateLimit(params.maxItems),
+      ...(this.preparationObserver === undefined ? {} : {
+        observePromotionPreparation: (preparation) => observeReaderPromotionSnapshot(
+          this.preparationObserver!, preparation, ingestionCutoff, params,
+        ),
+      }),
     });
 
     if (!ranked.ok) {
       throw ranked.error;
     }
+    const rankedInventory = ranked.value.items.map((item) =>
+      mapRankedItem(item, query.observedThrough, params));
     const expandedRankedItems = filterItemsByReaderSummaryPeriod(
-      ranked.value.items.map((item) => mapRankedItem(item, query.observedThrough, params)),
+      rankedInventory,
       params.period,
       params.timestampPolicy,
     );
@@ -165,7 +181,7 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
         authoritativeClusterByEvidenceId.get(relation.leftFeedItemId) ===
           authoritativeClusterByEvidenceId.get(relation.rightFeedItemId),
     );
-    const deterministicPromotionSelection = promotionPolicySelection({
+    const prePolicySelection = {
       ...authoritativeCandidateSelection,
       approvedSameStoryRelations: graduatedRelations,
       sourceWindow: {
@@ -174,7 +190,34 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
         periodEndedAt: params.period.endedAt,
         ingestionCutoff,
       },
-    }, promotionPolicyItems);
+    };
+    if (this.preparationObserver !== undefined) {
+      observeReaderSummaryPreparation(this.preparationObserver, {
+        rankingOrder: ranked.value.items.map(({ feedItemId, rank }) => ({ feedItemId, rank })),
+        rankedInventory,
+        periodExcludedIds: excludedPreparationIds(rankedInventory, expandedRankedItems),
+        defaultProviderExcludedIds: excludedPreparationIds(expandedRankedItems, rankedItems),
+        periodFiltered: expandedRankedItems,
+        defaultProviderFiltered: rankedItems,
+        candidateItems,
+        groupingInput: primaryCandidateItems,
+        initialGrouping: candidateSelection,
+        authoritativeGrouping: authoritativeCandidateSelection,
+        initialUnclusteredIds: unclusteredPreparationIds(primaryCandidateItems, candidateSelection),
+        authoritativeUnclusteredIds: unclusteredPreparationIds(primaryCandidateItems, authoritativeCandidateSelection),
+        relationCandidates: approvedRelations.candidates,
+        verifiedPairs: [...approvedRelations.pairs],
+        strictTitlePairs: [...approvedRelations.strictTitlePairs],
+        approvedRelations: approvedRelations.relations,
+        graduatedRelations,
+        policyItems: promotionPolicyItems,
+        prePolicySelection,
+        admittedSupplemental: githubTrendingEvidence,
+      });
+    }
+    const deterministicPromotionSelection = promotionPolicySelection(
+      prePolicySelection, promotionPolicyItems,
+    );
     const editorialSlate = composeReaderSummaryEditorialSlate({
       selection: deterministicPromotionSelection,
       candidates: promotionPolicyItems,


### PR DESCRIPTION
Reader Summary discards candidates and intermediate grouping while producing the final slate, so later comparisons cannot reconstruct why posts were included or excluded. This adds optional, immutable observations of the complete primary/supplemental partitions and actual grouping immediately before policy reduction, using the existing selection invocation.

Selection, model calls, thresholds and publication behavior remain unchanged. Capture persistence and the real paired experiment follow separately.

Validation: 49 focused tests, final observer tests (5), helper dependency typecheck, and architecture/code-quality/source-line-cap checks. Independent review approves exact head 6618f23737a7aebc8ffec7758e312293fc940441; unchanged test evidence is bound to identical patch, 326 repository dependency files, manifests and runner configuration. Final-head CI: run 34324783650.

Refs #293
Refs #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional preparation snapshots for feed ranking and reader-summary evidence selection.
  - Snapshots include ranking, filtering, grouping, relationship, policy, and supplemental-item stages.
  - Snapshot data is detached, immutable, and protects sensitive values from unintended exposure.
  - Observer callbacks can monitor preparation without changing ranking or selection results.

- **Tests**
  - Added coverage for snapshot contents, processing order, immutability, privacy safeguards, and observer failure isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->