### PR TITLE
feat(ingestion): renew retained metrics once per historical day

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -117,7 +117,7 @@ jobs:
         run: npm run prisma:generate
 
       - name: Run backend unit tests
-        run: npm test -- --shard=${{ matrix.shard }}/4
+        run: node scripts/run-with-timeout.mjs --timeout-ms 900000 --node-options --max-old-space-size=2048 -- ./node_modules/.bin/jest --config jest.config.ts --runInBand --shard=${{ matrix.shard }}/4
 
   backend_unit:
     name: Backend build and unit tests

--- a/docs/operations/retained-source-metric-daily-renewal.md
+++ b/docs/operations/retained-source-metric-daily-renewal.md
@@ -1,0 +1,61 @@
+# Finite daily retained HN/Reddit renewal
+
+This incident adds seven independent single-use metric authorities for August 30
+through September 5, 2026, at review base
+`823aa9eb673bfa88b60ed6f3db5e50bc34059833`. Literal IDs and journal paths are in
+`libs/ingestion/domain/policies/retained-metric-daily-grant.ts`. The original
+3,329-row authority and spent September 8 v1 authority remain unchanged. Every day
+requires the same complete original and spent-v1 lineage; no day succeeds another.
+
+Use `scripts/run-retained-metric-daily-maintenance.sh BACKEND_SHA CONTROL_SHA`
+inside the reviewed image with the existing inherited maintenance controls.
+The wrapper preserves lock order 7/9/8 and the existing four-hour ceiling.
+Journal order is original, spent September 8, selected day. Flags are:
+
+- `--date YYYY-MM-DD`, required and restricted to the seven literal records;
+- exactly one of `--prepare`, `--apply`, `--resume`, `--diagnostic`;
+- `--manifest-sha SHA256` required only for apply/resume;
+- existing `--source-sha`, `--executable-sha`, `--legacy-retirement-ref` release controls.
+
+Standalone `--implementation` reports executable identity. There are no path,
+operation-ID, round, reset, expiry-reclaim or automatic date options.
+
+Preparation validates the complete canonical original/amendment/effect chain and
+spent-v1 terminal receipts before any inventory read. Actual operation/final bytes
+and directory-entry digests are pinned from
+`renewal-predecessor-byte-pins-20260909.json`. The supplied `entryListSha256` is
+SHA256 of compact UTF-8 JSON with sorted object keys, of filename-sorted objects
+`{name, sha256}` including `operation.lock`. Existing resolver `entriesSha` remains
+its separate `{name, bytesSha}` canonical contract. Pins supplement canonical
+validation; they cannot replace it. Failed/unavailable terminal rows account for
+spent allowance and do not assert freshness.
+
+Only selected-day predecessor IDs are reread for the current original audit.
+Both exact-ID and complete selected-day HN/Reddit inventories are read twice.
+Identity drift or missing/invalid required originals refuses preparation, returning
+the original audit. Mutable authority changes are recorded separately while the
+first complete inventory supplies the frozen baseline. Current new arrivals are
+included in the bounded frozen manifest, separate from original targets. Later
+arrivals appear only in `--diagnostic`, never expanding the installed allowance.
+Primary-count captures are diagnostic counts, not grants or target manifests.
+
+Review the exact installed manifest SHA. Apply/resume rereads the frozen IDs and
+uses the existing deterministic batch executor, effect validator, provider fetch
+adapters and transaction sampleGuard. Limits remain 10,000 targets, Reddit batches
+of 100, HN singles, one attempt, concurrency one, 10-second provider timeout.
+Unknown transport/OAuth outcomes preserve reservations and stop successors;
+resume cannot refetch them. Lost projection acknowledgement resumes preserved
+samples under the same operation. Do not delete or rewrite any journal to retry.
+Repeated preparation and validated terminal apply/resume return before DB/OAuth.
+Terminal reporting separates original and new-arrival results and old-missing
+audit evidence. A terminal metric result does not prove summary eligibility.
+
+Parent alone activates September 2 first after separately owned native proof and
+immediate summary capacity, then the other six one day at a time just before their
+canonical summary flow. This patch adds no readiness system or scheduling service.
+Do not spend a day while waiting for known runtime readiness. Prepare a new summary
+cutoff at or after its observations, retain the existing six-hour metric authority
+and 30-minute summary preparation/cutoff limits, and preserve regression rejection.
+No X renewal, summary budget, publication authority or production readiness is
+conferred by this metric change. On unknown effects or exhausted freshness, stop;
+never mint another allowance or regenerate historical full workflows.

--- a/libs/ingestion/domain/policies/retained-metric-daily-grant.ts
+++ b/libs/ingestion/domain/policies/retained-metric-daily-grant.ts
@@ -1,0 +1,72 @@
+// Seven reviewed single-use incident authorities. No caller-selected IDs or paths.
+// Original and spent September 8 authorities retain their independent policies.
+import { retainedMetricRenewalGrant } from "./retained-metric-renewal-grant";
+
+export const retainedMetricDailyAuthorities = [
+  {
+    "date": "2026-08-30",
+    "operationId": "86770141-d9f3-51fb-bf59-aa4abeb17382",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260909-2026-08-30"
+  },
+  {
+    "date": "2026-08-31",
+    "operationId": "8fb5d83e-8c23-5247-8504-c33c0f8f3dc5",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260909-2026-08-31"
+  },
+  {
+    "date": "2026-09-01",
+    "operationId": "0b7667b2-6beb-5792-b40f-de555cea66d9",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260909-2026-09-01"
+  },
+  {
+    "date": "2026-09-02",
+    "operationId": "fc9502a0-1ea0-549e-9ec7-5636bcd4504e",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260909-2026-09-02"
+  },
+  {
+    "date": "2026-09-03",
+    "operationId": "615132b4-7a50-58c6-a442-11b356aadc7e",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260909-2026-09-03"
+  },
+  {
+    "date": "2026-09-04",
+    "operationId": "a3ebd553-5563-5d97-af26-5c0d3c3c9cd1",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260909-2026-09-04"
+  },
+  {
+    "date": "2026-09-05",
+    "operationId": "83c3311c-a3c2-50bc-877d-0a5b1cf76cf9",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260909-2026-09-05"
+  }
+] as const;
+export type MetricDailyDate = typeof retainedMetricDailyAuthorities[number]["date"];
+export function retainedMetricDailyGrant(date: string) {
+  const authority = retainedMetricDailyAuthorities.find((item) => item.date === date);
+  if (!authority) return null;
+  return {
+    ...authority, version: "retained-metrics-daily.v1" as const,
+    sourceBase: "823aa9eb673bfa88b60ed6f3db5e50bc34059833",
+    tenantId: retainedMetricRenewalGrant.tenantId, workspaceId: retainedMetricRenewalGrant.workspaceId,
+    dates: [authority.date],
+    endAt: new Date(Date.parse(`${authority.date}T00:00:00.000Z`) + 86_400_000).toISOString(),
+    bounds: { ...retainedMetricRenewalGrant.bounds },
+  };
+}
+
+// Supplied actual predecessor byte pins; canonical resolvers remain mandatory.
+// entryListSha hashes compact JSON with sorted keys of [{name, sha256}], sorted
+// by filename (ASCII). It is not the existing [{name, bytesSha}] entries digest.
+export const retainedMetricDailyPredecessorPins = {
+  "retained-metrics-v1": {
+    "operationBytesSha256": "f7482a69589bf776baa5e2be8234989296937a87e48c1b8e9b26e969c0d051a0",
+    "operationEnvelopeDigest": "0f9fa678de1921b4847ab8f0224f96e4c367308bd56604d999cd670c16b8949a",
+    "finalBytesSha256": "84406e32d6d6848a6f4aea02cbc1d115a0e9bf9752b81e212c9a289c17831681",
+    "entryListSha256": "74ecc6ba55c35fd0ece1fb66c4690c0930badc079b5e8277de58dbfa358bedf1"
+  },
+  "retained-metrics-renewal-20260908": {
+    "operationBytesSha256": "8ab96be0172c0ab56499a5203ca6f2f93692e2101cc94144b0a7702de8d15c70",
+    "operationEnvelopeDigest": "8ef6430e0fa0bb5855f5df899e751ddf274b1dd0404c056e6a0080b101a0abdc",
+    "finalBytesSha256": "815c5c184f2c99d584efe423cf94291e8680f0096a035b2c853b2bb4809db958",
+    "entryListSha256": "6b7aa74454186688350cac27d10f969c0edfcac71ce5075ad578171232353345"
+  }
+} as const;

--- a/libs/ingestion/features/refresh-retained-metrics/metric-daily-admission.spec.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-daily-admission.spec.ts
@@ -1,0 +1,73 @@
+import { retainedMetricDailyAuthorities, retainedMetricDailyGrant } from "../../domain/policies/retained-metric-daily-grant";
+import { dailyFixture, dailyDate, dailyGrant } from "../../../../scripts/lib/retained-metric-daily.spec-support";
+import { implementation } from "../../../../scripts/lib/retained-metric-renewal.spec-support";
+import { assertMetricDailyManifest } from "./metric-daily-manifest";
+import { assertMetricRenewalManifest } from "./metric-renewal-evidence";
+import { assertMetricManifest } from "./metric-refresh-evidence-validation";
+import { target } from "../../../../scripts/lib/retained-metric-refresh.spec-support";
+
+jest.setTimeout(120_000);
+it("admits only seven reviewed dates with distinct paths and operations and unchanged bounds", () => {
+  expect(retainedMetricDailyAuthorities).toHaveLength(7);
+  expect(new Set(retainedMetricDailyAuthorities.map((a) => a.operationId)).size).toBe(7);
+  expect(new Set(retainedMetricDailyAuthorities.map((a) => a.evidencePath)).size).toBe(7);
+  for (const a of retainedMetricDailyAuthorities) {
+    const grant = retainedMetricDailyGrant(a.date)!;
+    expect(grant.dates).toEqual([a.date]);
+    expect(Date.parse(grant.endAt) - Date.parse(`${a.date}T00:00:00Z`)).toBe(86_400_000);
+    expect(grant.bounds).toEqual({ targets: 10000, redditBatch: 100, hnBatch: 1, attempts: 1, concurrency: 1, timeoutMs: 10000 });
+  }
+  for (const date of ["2026-09-06", "2026-09-02T00:00:00Z", "../2026-09-02", ""]) expect(retainedMetricDailyGrant(date)).toBeNull();
+});
+it("validates the full predecessor chain, audits only exact selected-day IDs, freezes arrivals and rejects schema/scope/bounds tampering", async () => {
+  const f = await dailyFixture();
+  const arrival = target({ sourceItemId: "00000000-0000-7000-8000-000000099999", externalId: "reddit:t3_arrival",
+    canonicalUrl: "https://www.reddit.com/comments/arrival/", publishedAt: `${dailyDate}T12:00:00.000Z` });
+  f.setCurrent([...f.targets, arrival]);
+  const result = await f.usecase().prepare(implementation);
+  expect(result.ok).toBe(true); if (!result.ok) throw new Error(result.error.detail);
+  const manifest = result.value;
+  expect(manifest.predecessor.originalSourceItemIds).toHaveLength(3329);
+  const ids = f.targets.filter((t) => t.publishedAt.startsWith(dailyDate)).map((t) => t.sourceItemId);
+  expect(f.inventory.list.mock.calls.map((c) => c[1])).toEqual([ids, undefined, ids, undefined]);
+  expect(manifest.capture.originalAudit.map((a) => a.sourceItemId)).toEqual(ids);
+  expect(manifest.capture.lateArrivalSourceItemIds).toEqual([arrival.sourceItemId]);
+  expect(manifest.targets.every((t) => t.publishedAt.startsWith(dailyDate))).toBe(true);
+  expect(() => assertMetricRenewalManifest(manifest, f.hash, f.clock.now())).toThrow();
+  expect(() => assertMetricManifest(manifest, f.clock.now())).toThrow();
+  const variants = [
+    { ...manifest, operationId: "arbitrary" }, { ...manifest, evidencePath: "elsewhere" },
+    { ...manifest, version: "retained-metrics-renewal.v1" }, { ...manifest, sourceBase: "f".repeat(40) },
+    { ...manifest, bounds: { ...manifest.bounds, attempts: 2 } },
+    { ...manifest, scope: { ...manifest.scope, dates: ["2026-09-01", dailyDate] } },
+    { ...manifest, scope: { ...manifest.scope, tenantId: arrival.sourceItemId } },
+    ...["2026-09-01T23:59:59.999Z", dailyGrant.endAt].map((publishedAt) => ({ ...manifest, targets: [{ ...manifest.targets[0], publishedAt }] })),
+    { ...manifest, targets: [{ ...manifest.targets[0], providerKey: "x" }] },
+    { ...manifest, targets: [manifest.targets[0], manifest.targets[0]] },
+    { ...manifest, targets: [...manifest.targets, { ...manifest.targets[0], sourceItemId: "00000000-0000-7000-8000-000000099998",
+      externalId: manifest.targets[0]!.externalId.replace("reddit:t3_", "reddit:") }] },
+    { ...manifest, targets: Array.from({ length: 10001 }, () => manifest.targets[0]) },
+    { ...manifest, capture: { ...manifest.capture, implementation: { ...implementation, sourceSha: "invalid" } } },
+    { ...manifest, spentRenewal: { ...manifest.spentRenewal, finalBytesSha: "f".repeat(64) } },
+  ];
+  for (const value of variants) expect(() => assertMetricDailyManifest(value, f.hash, f.clock.now())).toThrow();
+  f.inventory.list.mockClear(); f.setCurrent([...f.targets, arrival, { ...arrival, sourceItemId: "post-freeze" }]);
+  expect(await f.usecase().prepare(implementation)).toEqual(result);
+  expect(f.inventory.list).not.toHaveBeenCalled(); expect(f.fetcher.fetch).not.toHaveBeenCalled();
+});
+it.each(["missing", "double-read", "predecessor"])("refuses %s drift without spending or installing a day", async (kind) => {
+  const f = await dailyFixture();
+  if (kind === "missing") f.setCurrent(f.targets.filter((t) => t.sourceItemId !== f.targets[3]!.sourceItemId));
+  if (kind === "double-read") {
+    const list = f.inventory.list.getMockImplementation()!;
+    f.inventory.list.mockImplementation(async (scope, ids) => {
+      const rows = await list(scope, ids);
+      return f.inventory.list.mock.calls.length === 4 ? rows.slice(1) : rows;
+    });
+  }
+  if (kind === "predecessor") f.renewal.values.delete(`${f.renewal.root}/final.json`);
+  const result = await f.usecase().prepare(implementation);
+  expect(result.ok).toBe(false);
+  if (!result.ok && kind === "missing") expect(result.error.originalAudit?.some((a) => a.missingReason === "original_missing")).toBe(true);
+  expect(f.daily.values.size).toBe(0); expect(f.fetcher.fetch).not.toHaveBeenCalled();
+});

--- a/libs/ingestion/features/refresh-retained-metrics/metric-daily-evidence.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-daily-evidence.ts
@@ -1,0 +1,70 @@
+import { retainedMetricDailyPredecessorPins as pins, retainedMetricDailyGrant } from "../../domain/policies/retained-metric-daily-grant";
+import { retainedMetricRenewalGrant as spentGrant } from "../../domain/policies/retained-metric-renewal-grant";
+import type { MetricRefreshOperation, MetricEvidenceEntry } from "./metric-refresh-operation.contracts";
+import type { RefreshDigest } from "./refresh-retained-metrics.contracts";
+import type { MetricDailyManifest } from "./metric-daily.contracts";
+import type { MetricRenewalFinal } from "./renew-retained-metrics.use-case";
+import { resolveMetricRenewal } from "./metric-renewal-evidence";
+import { assertMetricDailyManifest } from "./metric-daily-manifest";
+import { evidenceAssert } from "./metric-refresh-evidence-validation";
+import { validateExecutedMetricEffects } from "./metric-refresh-effect-evidence";
+import { metricRenewalCells } from "./metric-renewal-report";
+
+// Match the supplied entryListSha encoding, including the empty operation.lock.
+export function dailyPredecessorEntryList(entries: readonly MetricEvidenceEntry[]) {
+  return [...entries].sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0)
+    .map((entry) => ({ name: entry.name, sha256: entry.bytesSha }));
+}
+function assertPins(entries: readonly MetricEvidenceEntry[], pin: typeof pins[keyof typeof pins], hash: RefreshDigest) {
+  evidenceAssert(entries.find((e) => e.name === "operation.json")?.bytesSha === pin.operationBytesSha256 &&
+    entries.find((e) => e.name === "final.json")?.bytesSha === pin.finalBytesSha256 &&
+    hash(dailyPredecessorEntryList(entries)) === pin.entryListSha256, "daily_predecessor_bytes_changed");
+}
+export async function readDailyPredecessors(prior: MetricRefreshOperation, spent: MetricRefreshOperation, hash: RefreshDigest, now: Date) {
+  // The fixed resolver validates the complete original chain and binds every
+  // priorEffectiveTarget. Reuse that admitted lineage rather than re-resolving it.
+  const renewal = await resolveMetricRenewal(spent, prior, hash, now);
+  evidenceAssert(renewal && hash(renewal) === pins["retained-metrics-renewal-20260908"].operationEnvelopeDigest,
+    "daily_spent_manifest_invalid");
+  const originalEntries = await prior.entries(), spentEntries = await spent.entries();
+  assertPins(originalEntries, pins["retained-metrics-v1"], hash);
+  assertPins(spentEntries, pins["retained-metrics-renewal-20260908"], hash);
+  evidenceAssert(await spent.read(`${spentGrant.evidencePath}/final.json`), "daily_spent_not_terminal");
+  const spentRenewal = { manifestSha: hash(renewal), operationBytesSha: pins["retained-metrics-renewal-20260908"].operationBytesSha256,
+    finalBytesSha: pins["retained-metrics-renewal-20260908"].finalBytesSha256,
+    entryListSha: hash(dailyPredecessorEntryList(spentEntries)) };
+  return { predecessor: renewal.predecessor, targets: renewal.capture.originalAudit.map((a) => a.priorEffectiveTarget), spentRenewal };
+}
+export async function resolveMetricDaily(date: string, operation: MetricRefreshOperation, prior: MetricRefreshOperation,
+  spent: MetricRefreshOperation, hash: RefreshDigest, now: Date) {
+  const grant = retainedMetricDailyGrant(date);
+  evidenceAssert(grant, "daily_date_not_reviewed");
+  operation.assertHeld(); prior.assertHeld(); spent.assertHeld();
+  // Validate the complete immutable lineage even before installing a new day.
+  const lineage = await readDailyPredecessors(prior, spent, hash, now);
+  const entries = await operation.entries();
+  const value = await operation.read<MetricDailyManifest>(`${grant.evidencePath}/operation.json`);
+  if (!value) { evidenceAssert(entries.every((e) => e.name === "operation.lock"), "daily_missing_manifest"); return null; }
+  assertMetricDailyManifest(value, hash, now);
+  evidenceAssert(value.evidencePath === grant.evidencePath && hash(value.predecessor) === hash(lineage.predecessor) &&
+    hash(value.spentRenewal) === hash(lineage.spentRenewal), "daily_lineage_changed");
+  const originals = lineage.targets.filter((t) => t.publishedAt.slice(0, 10) === date).sort((a, b) => a.sourceItemId.localeCompare(b.sourceItemId));
+  evidenceAssert(hash(originals) === hash(value.capture.originalAudit.map((a) => a.priorEffectiveTarget)), "daily_original_membership_changed");
+  await validateExecutedMetricEffects(operation, value, hash(value), entries.filter((e) => !["operation.json", "operation.lock", "final.json"].includes(e.name)), hash);
+  for (const entry of entries.filter((e) => e.name.endsWith(".observed.json"))) {
+    const observed = await operation.read<{ observations: readonly { observedAt: string }[] }>(`${grant.evidencePath}/${entry.name}`);
+    evidenceAssert(observed && observed.observations.every((o) => o.observedAt >= value.plannedAt && o.observedAt <= now.toISOString()), "daily_observation_time_invalid");
+  }
+  const final = await operation.read<MetricRenewalFinal>(`${grant.evidencePath}/final.json`);
+  if (final) {
+    evidenceAssert(Array.isArray(final.results) && final.results.length === value.targets.length, "daily_final_incomplete");
+    const hashes = new Set(final.results.map((r) => hash(r)));
+    for (const target of value.targets) {
+      const result = await operation.read(`${grant.evidencePath}/result-${target.sourceItemId}.json`);
+      evidenceAssert(result && hashes.has(hash(result)), "daily_final_membership_invalid");
+    }
+    evidenceAssert(hash(final) === hash({ manifestSha: hash(value), results: final.results,
+      cells: metricRenewalCells(final.results, value.scope.dates) }), "daily_final_invalid");
+  }
+  return value;
+}

--- a/libs/ingestion/features/refresh-retained-metrics/metric-daily-manifest.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-daily-manifest.ts
@@ -1,0 +1,71 @@
+import { retainedMetricDailyGrant, retainedMetricDailyPredecessorPins as pins } from "../../domain/policies/retained-metric-daily-grant";
+import { retainedMetricRenewalGrant as originalGrant } from "../../domain/policies/retained-metric-renewal-grant";
+import type { MetricDailyManifest } from "./metric-daily.contracts";
+import type { RefreshDigest } from "./refresh-retained-metrics.contracts";
+import { assertMetricTargets, evidenceAssert, metricSha, metricUuid } from "./metric-refresh-evidence-validation";
+import { metricIdentityInventory, orderedMetricTargets } from "./metric-refresh-amendment";
+import { targetProblem, normalizedRefreshId } from "./metric-refresh-admission";
+import { renewalOriginalAudit } from "./metric-renewal-evidence";
+
+function exact(value: unknown, keys: string): asserts value is Record<string, unknown> {
+  evidenceAssert(value !== null && typeof value === "object" && !Array.isArray(value) &&
+    Object.keys(value).sort().join() === keys.split(" ").sort().join(), "renewal_schema_invalid");
+}
+const time = (value: unknown): value is string => typeof value === "string" && Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value;
+export function assertMetricDailyManifest(value: unknown, hash: RefreshDigest, now: Date): asserts value is MetricDailyManifest {
+  exact(value, "version sourceBase bounds operationId evidencePath scope plannedAt targets predecessor capture spentRenewal");
+  exact(value.spentRenewal, "manifestSha operationBytesSha finalBytesSha entryListSha");
+  evidenceAssert(Object.values(value.spentRenewal).every(metricSha));
+  exact(value.scope, "tenantId workspaceId dates endAt");
+  evidenceAssert(Array.isArray(value.scope.dates) && value.scope.dates.length === 1);
+  const grant = retainedMetricDailyGrant(String(value.scope.dates[0]));
+  evidenceAssert(grant, "daily_date_not_reviewed");
+  exact(value.bounds, "targets redditBatch hnBatch attempts concurrency timeoutMs");
+  exact(value.predecessor, "evidencePath operationId originalManifestSha originalOperationBytesSha effectiveManifestSha finalBytesSha entriesSha originalSourceItemIds");
+  exact(value.capture, "startedAt completedAt inventorySha identityInventorySha originalAudit lateArrivalSourceItemIds implementation");
+  exact(value.capture.implementation, "sourceSha executableSha legacyRetirementRef holderProof");
+  const impl = value.capture.implementation;
+  evidenceAssert([impl.sourceSha, impl.executableSha, impl.holderProof].every(metricSha) && typeof impl.legacyRetirementRef === "string" &&
+    /^[A-Za-z0-9][A-Za-z0-9:/_.-]{0,255}$/u.test(impl.legacyRetirementRef));
+  evidenceAssert(Array.isArray(value.scope.dates) && value.scope.dates.every((d) => typeof d === "string") &&
+    Array.isArray(value.predecessor.originalSourceItemIds) && value.predecessor.originalSourceItemIds.every(metricUuid));
+  evidenceAssert([value.predecessor.originalManifestSha, value.predecessor.originalOperationBytesSha, value.predecessor.effectiveManifestSha,
+    value.predecessor.finalBytesSha, value.predecessor.entriesSha, value.capture.inventorySha, value.capture.identityInventorySha].every(metricSha));
+  evidenceAssert(time(value.plannedAt) && time(value.capture.startedAt) && time(value.capture.completedAt) &&
+    value.capture.startedAt >= grant.endAt && value.capture.completedAt >= value.capture.startedAt &&
+    value.plannedAt === value.capture.completedAt && value.plannedAt <= now.toISOString(), "renewal_capture_time_invalid");
+  assertMetricTargets(value.targets);
+  const manifest = value as MetricDailyManifest;
+  evidenceAssert(manifest.predecessor.evidencePath === originalGrant.predecessorPath &&
+    manifest.predecessor.operationId === originalGrant.predecessorOperationId &&
+    manifest.predecessor.originalManifestSha === originalGrant.predecessorManifestSha &&
+    manifest.predecessor.originalSourceItemIds.length === originalGrant.originalCount &&
+    new Set(manifest.predecessor.originalSourceItemIds).size === originalGrant.originalCount, "daily_original_lineage_invalid");
+  const spent = pins["retained-metrics-renewal-20260908"];
+  evidenceAssert(hash(manifest.spentRenewal) === hash({ manifestSha: spent.operationEnvelopeDigest,
+    operationBytesSha: spent.operationBytesSha256, finalBytesSha: spent.finalBytesSha256,
+    entryListSha: spent.entryListSha256 }), "daily_spent_lineage_invalid");
+  evidenceAssert(hash({ version: manifest.version, evidencePath: manifest.evidencePath, operationId: manifest.operationId,
+    sourceBase: manifest.sourceBase, bounds: manifest.bounds, scope: manifest.scope }) === hash({ version: grant.version,
+    evidencePath: grant.evidencePath, operationId: grant.operationId, sourceBase: grant.sourceBase, bounds: grant.bounds,
+    scope: { tenantId: grant.tenantId, workspaceId: grant.workspaceId, dates: grant.dates, endAt: grant.endAt } }), "renewal_fixed_admission_invalid");
+  evidenceAssert(manifest.targets.every((t) => targetProblem(t, manifest.scope) === null), "renewal_target_invalid");
+  evidenceAssert(new Set(manifest.targets.map((t) => t.sourceItemId)).size === manifest.targets.length &&
+    new Set(manifest.targets.map((t) => `${t.providerKey}:${normalizedRefreshId(t.providerKey, t.externalId)}`)).size === manifest.targets.length, "renewal_duplicate_target");
+  evidenceAssert(hash(orderedMetricTargets(manifest.targets)) === manifest.capture.inventorySha &&
+    hash(metricIdentityInventory(manifest.targets)) === manifest.capture.identityInventorySha, "renewal_inventory_sha_invalid");
+  evidenceAssert(Array.isArray(value.capture.originalAudit) && value.capture.originalAudit.length <= originalGrant.originalCount);
+  for (const audit of value.capture.originalAudit) {
+    exact(audit, "sourceItemId priorEffectiveTarget currentTarget missingReason differences");
+    assertMetricTargets([audit.priorEffectiveTarget]); assertMetricTargets([audit.currentTarget]);
+    evidenceAssert(audit.missingReason === null && Array.isArray(audit.differences), "renewal_original_missing_or_invalid");
+    for (const diff of audit.differences) exact(diff, "field before after");
+  }
+  const originals = manifest.capture.originalAudit;
+  evidenceAssert(hash(originals.map((a) => a.sourceItemId)) === hash(originals.map((a) => a.priorEffectiveTarget.sourceItemId).sort()) &&
+    originals.every((a) => manifest.predecessor.originalSourceItemIds.includes(a.sourceItemId) && targetProblem(a.priorEffectiveTarget, manifest.scope) === null && a.sourceItemId === a.priorEffectiveTarget.sourceItemId &&
+      a.currentTarget !== null && hash(metricIdentityInventory([a.currentTarget])) === hash(metricIdentityInventory(manifest.targets.filter((t) => t.sourceItemId === a.sourceItemId)))), "renewal_original_audit_invalid");
+  evidenceAssert(hash(originals) === hash(renewalOriginalAudit(originals.map((a) => a.priorEffectiveTarget), originals.map((a) => a.currentTarget!), hash)), "renewal_original_diff_invalid");
+  const ids = new Set(manifest.predecessor.originalSourceItemIds);
+  evidenceAssert(hash(manifest.capture.lateArrivalSourceItemIds) === hash(manifest.targets.filter((t) => !ids.has(t.sourceItemId)).map((t) => t.sourceItemId).sort()), "renewal_late_arrivals_invalid");
+}

--- a/libs/ingestion/features/refresh-retained-metrics/metric-daily-replay.spec.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-daily-replay.spec.ts
@@ -1,0 +1,70 @@
+import { err, ok } from "@social-monitor/shared-kernel";
+import { dailyFixture, dailyGrant } from "../../../../scripts/lib/retained-metric-daily.spec-support";
+import { implementation } from "../../../../scripts/lib/retained-metric-renewal.spec-support";
+import type { RetainedMetricFetchCapability } from "./refresh-retained-metrics.contracts";
+import { refreshBatches } from "./metric-refresh-admission";
+
+jest.setTimeout(180_000);
+it("spends deterministic batches once, binds exact final results, and terminal replay reads no inventory", async () => {
+  const f = await dailyFixture();
+  const prepared = await f.usecase().prepare(implementation);
+  if (!prepared.ok) throw new Error(prepared.error.detail);
+  const sha = f.hash(prepared.value), old = f.hash([...f.prior.values]), spent = f.hash([...f.renewal.values]);
+  expect(await f.usecase().execute("f".repeat(64))).toMatchObject({ ok: false });
+  expect(f.fetcher.fetch).not.toHaveBeenCalled();
+  f.fetcher.fetch.mockImplementationOnce(async () => err("known_provider_refusal"));
+  const done = await f.usecase().execute(sha);
+  expect(done).toMatchObject({ ok: true, value: { results: expect.any(Array) } });
+  expect(done).toMatchObject({ ok: true, value: { results: expect.arrayContaining([expect.objectContaining({ status: "failed" }), expect.objectContaining({ status: "unavailable" })]) } });
+  const batches = refreshBatches(prepared.value.targets);
+  expect(f.fetcher.fetch.mock.calls.map((c) => c[0].map((t) => t.sourceItemId))).toEqual(batches.map((b) => b.map((t) => t.sourceItemId)));
+  expect([...f.daily.values.keys()].filter((p) => p.endsWith('.reserved.json'))).toHaveLength(batches.length);
+  const frozen = f.hash([...f.daily.values]);
+  f.inventory.list.mockClear(); f.inventory.read.mockClear(); f.fetcher.fetch.mockClear(); f.setCurrent([]);
+  expect(await f.usecase().execute(sha)).toEqual(done);
+  expect(f.inventory.list).not.toHaveBeenCalled(); expect(f.inventory.read).not.toHaveBeenCalled(); expect(f.fetcher.fetch).not.toHaveBeenCalled();
+  expect(f.hash([...f.daily.values])).toBe(frozen); expect(f.hash([...f.prior.values])).toBe(old); expect(f.hash([...f.renewal.values])).toBe(spent);
+  const finalPath = `${dailyGrant.evidencePath}/final.json`;
+  const final = f.daily.values.get(finalPath) as { results: unknown[] };
+  f.daily.values.set(finalPath, { ...final, results: final.results.slice(1) });
+  expect(await f.usecase().execute(sha)).toMatchObject({ ok: false });
+  expect(f.fetcher.fetch).not.toHaveBeenCalled();
+});
+it("preserves an unknown reservation through resume without refetch or successor", async () => {
+  const f = await dailyFixture();
+  const prepared = await f.usecase().prepare(implementation);
+  if (!prepared.ok) throw new Error(prepared.error.detail);
+  f.fetcher.fetch.mockRejectedValue(new Error("unknown OAuth/transport outcome"));
+  expect(await f.usecase().execute(f.hash(prepared.value))).toMatchObject({ ok: false });
+  const frozen = f.hash([...f.daily.values]);
+  expect(await f.usecase().execute(f.hash(prepared.value))).toMatchObject({ ok: true, value: expect.arrayContaining([expect.objectContaining({ status: "uncertain" })]) });
+  expect(f.hash([...f.daily.values])).toBe(frozen);
+  expect([...f.daily.values.keys()].map((p) => p.split('/').at(-1)).sort()).toEqual(["batch-0.reserved.json", "operation.json"]);
+  expect(f.fetcher.fetch).toHaveBeenCalledTimes(1); expect(f.projection.project).not.toHaveBeenCalled();
+});
+it("resumes preserved projection samples after lost acknowledgement without another fetch or duplicate effect", async () => {
+  const f = await dailyFixture();
+  const prepared = await f.usecase().prepare(implementation);
+  if (!prepared.ok) throw new Error(prepared.error.detail);
+  const first = refreshBatches(prepared.value.targets)[0]![0]!;
+  const fetch: RetainedMetricFetchCapability["fetch"] = async (batch) => ok(batch.map((t) => ({ externalId: t.externalId,
+    returned: t.sourceItemId === first.sourceItemId, reason: t.sourceItemId === first.sourceItemId ? null : "omitted",
+    metadata: t.sourceItemId === first.sourceItemId ? { kind: "reddit_post", score: 42, numComments: 9 } : null })));
+  f.fetcher.fetch.mockImplementation(fetch);
+  const effects = new Set<string>(); let acknowledgementLost = false;
+  f.projection.project.mockImplementation(async (...args: unknown[]) => {
+    const command = args[0] as { samples: { metricsFingerprint: string }[]; observedAt: Date };
+    effects.add(`${first.sourceItemId}:${command.observedAt.toISOString()}`);
+    f.setCurrent(f.targets.map((t) => t.sourceItemId === first.sourceItemId ? { ...t, authority: { ...t.authority,
+      metricsHash: command.samples[0]!.metricsFingerprint, observationAt: command.observedAt.toISOString(), observedAt: command.observedAt.toISOString() } } : t));
+    if (!acknowledgementLost) { acknowledgementLost = true; throw new Error("lost commit acknowledgement"); }
+    return { currentSnapshotsUpdated: 0, observationsAppended: 0, metricChanges: 0, regressionsObserved: 0 };
+  });
+  const sha = f.hash(prepared.value);
+  expect(await f.usecase().execute(sha)).toMatchObject({ ok: true, value: expect.any(Array) });
+  const observation = f.hash(f.daily.values.get(`${dailyGrant.evidencePath}/batch-0.observed.json`));
+  const calls = f.fetcher.fetch.mock.calls.length;
+  expect(await f.usecase().execute(sha)).toMatchObject({ ok: true, value: { results: expect.arrayContaining([expect.objectContaining({ status: "refreshed" })]) } });
+  expect(f.hash(f.daily.values.get(`${dailyGrant.evidencePath}/batch-0.observed.json`))).toBe(observation);
+  expect(f.fetcher.fetch).toHaveBeenCalledTimes(calls); expect(effects.size).toBe(1); expect(f.projection.project).toHaveBeenCalledTimes(2);
+});

--- a/libs/ingestion/features/refresh-retained-metrics/metric-daily.contracts.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/metric-daily.contracts.ts
@@ -1,0 +1,15 @@
+import type { MetricImplementation } from "./metric-refresh-operation.contracts";
+import type { MetricRefreshManifest } from "./refresh-retained-metrics.contracts";
+
+
+import type { MetricRenewalPredecessor, MetricRenewalOriginalAudit } from "./metric-renewal.contracts";
+export type MetricDailyManifest = Omit<MetricRefreshManifest, "version"> & {
+  version: "retained-metrics-daily.v1";
+  predecessor: MetricRenewalPredecessor;
+  spentRenewal: { manifestSha: string; operationBytesSha: string; finalBytesSha: string; entryListSha: string };
+  capture: {
+    startedAt: string; completedAt: string; inventorySha: string; identityInventorySha: string;
+    originalAudit: readonly MetricRenewalOriginalAudit[];
+    lateArrivalSourceItemIds: readonly string[]; implementation: MetricImplementation;
+  };
+};

--- a/libs/ingestion/features/refresh-retained-metrics/renew-daily-retained-metrics.use-case.spec.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/renew-daily-retained-metrics.use-case.spec.ts
@@ -1,0 +1,23 @@
+import { FixedClock, ok } from "@social-monitor/shared-kernel";
+import { RenewDailyRetainedMetricsUseCase } from "./renew-daily-retained-metrics.use-case";
+import { RenewalMemoryJournal, implementation } from "../../../../scripts/lib/retained-metric-renewal.spec-support";
+import { metricRefreshDigest } from "../../../../scripts/lib/retained-metric-refresh-receipts";
+import { retainedMetricRenewalGrant as spentGrant } from "../../domain/policies/retained-metric-renewal-grant";
+import { retainedMetricDailyGrant } from "../../domain/policies/retained-metric-daily-grant";
+
+it("never purchases inventory or metrics without canonical predecessor admission", async () => {
+  for (const date of ["2026-09-02", "2026-09-06"]) {
+  const original = new RenewalMemoryJournal(spentGrant.predecessorPath), spent = new RenewalMemoryJournal(spentGrant.evidencePath);
+  const daily = new RenewalMemoryJournal(retainedMetricDailyGrant("2026-09-02")!.evidencePath);
+  const inventory = { list: jest.fn(async () => []), read: jest.fn(async () => null) };
+  const fetcher = { fetch: jest.fn(async () => ok([])) };
+  const projection = { project: jest.fn(async () => ({ currentSnapshotsUpdated: 0, observationsAppended: 0, metricChanges: 0, regressionsObserved: 0 })) };
+  const usecase = new RenewDailyRetainedMetricsUseCase(date, inventory, fetcher, projection, original, spent, daily,
+    new FixedClock(new Date("2026-09-09T12:00:00.000Z")), metricRefreshDigest);
+  expect(await usecase.prepare(implementation)).toMatchObject({ ok: false });
+  expect(await usecase.execute("f".repeat(64))).toMatchObject({ ok: false });
+  expect(inventory.list).not.toHaveBeenCalled(); expect(fetcher.fetch).not.toHaveBeenCalled(); expect(projection.project).not.toHaveBeenCalled();
+  expect(original.values.size + spent.values.size + daily.values.size).toBe(0);
+  expect(original.held || spent.held || daily.held).toBe(false);
+  }
+});

--- a/libs/ingestion/features/refresh-retained-metrics/renew-daily-retained-metrics.use-case.ts
+++ b/libs/ingestion/features/refresh-retained-metrics/renew-daily-retained-metrics.use-case.ts
@@ -1,0 +1,102 @@
+import { err, ok, type Clock, type Result } from "@social-monitor/shared-kernel";
+import { retainedMetricDailyGrant } from "../../domain/policies/retained-metric-daily-grant";
+import type { SourceEngagementProjectionPort } from "../../ports/source-engagement-projection.port";
+import type { MetricImplementation, MetricRefreshOperation, MetricRefreshOperationAuthority } from "./metric-refresh-operation.contracts";
+import type { MetricRenewalFailure, MetricRenewalOriginalAudit } from "./metric-renewal.contracts";
+import type { MetricRefreshOutcome, RefreshDigest, RetainedMetricFetchCapability, RetainedMetricInventory } from "./refresh-retained-metrics.contracts";
+import { renewalOriginalAudit } from "./metric-renewal-evidence";
+import { readDailyPredecessors, resolveMetricDaily } from "./metric-daily-evidence";
+import { assertMetricDailyManifest } from "./metric-daily-manifest";
+import type { MetricDailyManifest } from "./metric-daily.contracts";
+import { metricIdentityInventory, orderedMetricTargets } from "./metric-refresh-amendment";
+import { ExecuteRetainedMetricBatches } from "./execute-retained-metric-batches";
+import { metricRenewalCells } from "./metric-renewal-report";
+import { evidenceAssert } from "./metric-refresh-evidence-validation";
+
+export type MetricRenewalFinal = { manifestSha: string; results: readonly MetricRefreshOutcome[]; cells: ReturnType<typeof metricRenewalCells> };
+export class RenewDailyRetainedMetricsUseCase {
+  constructor(
+    private readonly date: string,
+    private readonly inventory: RetainedMetricInventory,
+    private readonly fetcher: RetainedMetricFetchCapability,
+    private readonly projection: SourceEngagementProjectionPort,
+    private readonly predecessor: MetricRefreshOperationAuthority,
+    private readonly spent: MetricRefreshOperationAuthority,
+    private readonly renewal: MetricRefreshOperationAuthority,
+    private readonly clock: Clock,
+    private readonly digest: RefreshDigest,
+  ) {}
+
+  // The caller already holds maintenance locks; the order here cannot vary.
+  private async locked<T>(work: (prior: MetricRefreshOperation, spent: MetricRefreshOperation, operation: MetricRefreshOperation) => Promise<T>): Promise<Result<T, MetricRenewalFailure>> {
+    try { return ok(await this.predecessor.withOperation((prior) => this.spent.withOperation((spent) => this.renewal.withOperation((operation) => work(prior, spent, operation))))); }
+    catch (failure) { return err({ code: "renewal_evidence_invalid", detail: failure instanceof Error ? failure.message : "unknown_failure" }); }
+  }
+
+  async prepare(implementation: MetricImplementation): Promise<Result<MetricDailyManifest, MetricRenewalFailure>> {
+    let audit: readonly MetricRenewalOriginalAudit[] | undefined;
+    const result = await this.locked(async (prior, spent, operation) => {
+      const grant = retainedMetricDailyGrant(this.date);
+      evidenceAssert(grant, "daily_date_not_reviewed");
+      const installed = await resolveMetricDaily(this.date, operation, prior, spent, this.digest, this.clock.now());
+      if (installed) {
+        evidenceAssert(installed.capture.implementation.sourceSha === implementation.sourceSha &&
+          installed.capture.implementation.executableSha === implementation.executableSha, "daily_release_changed");
+        return installed;
+      }
+      const predecessor = await readDailyPredecessors(prior, spent, this.digest, this.clock.now());
+      const startedAt = this.clock.now().toISOString();
+      const scope = { tenantId: grant.tenantId, workspaceId: grant.workspaceId, dates: grant.dates, endAt: grant.endAt };
+      const selectedOriginals = predecessor.targets.filter((t) => t.publishedAt.slice(0, 10) === this.date);
+      const selectedIds = selectedOriginals.map((t) => t.sourceItemId);
+      const originals = await this.inventory.list(scope, selectedIds);
+      const targets = orderedMetricTargets(await this.inventory.list(scope));
+      // Exact original rereads cannot disappear through the full-window filter.
+      const originalAudit = renewalOriginalAudit(selectedOriginals, originals, this.digest);
+      audit = originalAudit;
+      evidenceAssert(originals.length === selectedIds.length && originalAudit.every((a) => a.currentTarget !== null &&
+        this.digest(metricIdentityInventory([a.currentTarget])) === this.digest(metricIdentityInventory(targets.filter((t) => t.sourceItemId === a.sourceItemId)))), "renewal_original_missing_or_invalid");
+      const secondOriginals = await this.inventory.list(scope, selectedIds);
+      const secondWindow = await this.inventory.list(scope);
+      evidenceAssert(this.digest(metricIdentityInventory(originals)) === this.digest(metricIdentityInventory(secondOriginals)) &&
+        this.digest(metricIdentityInventory(targets)) === this.digest(metricIdentityInventory(secondWindow)), "renewal_inventory_drift");
+      const completedAt = this.clock.now().toISOString();
+      const ids = new Set(predecessor.predecessor.originalSourceItemIds);
+      const manifest: MetricDailyManifest = {
+        version: grant.version, sourceBase: grant.sourceBase, bounds: grant.bounds, operationId: grant.operationId,
+        evidencePath: grant.evidencePath, scope, plannedAt: completedAt, targets, predecessor: predecessor.predecessor, spentRenewal: predecessor.spentRenewal,
+        capture: { startedAt, completedAt, inventorySha: this.digest(targets), identityInventorySha: this.digest(metricIdentityInventory(targets)),
+          originalAudit: renewalOriginalAudit(selectedOriginals, secondOriginals, this.digest), lateArrivalSourceItemIds: targets.filter((t) => !ids.has(t.sourceItemId)).map((t) => t.sourceItemId).sort(), implementation },
+      };
+      assertMetricDailyManifest(manifest, this.digest, this.clock.now());
+      prior.assertHeld(); spent.assertHeld(); operation.assertHeld();
+      await operation.install(`${grant.evidencePath}/operation.json`, manifest);
+      return manifest;
+    });
+    return !result.ok && audit ? err({ ...result.error, originalAudit: audit }) : result;
+  }
+
+  async execute(expectedSha: string): Promise<Result<MetricRenewalFinal | readonly MetricRefreshOutcome[], MetricRenewalFailure>> {
+    return this.locked(async (prior, spent, operation) => {
+      const grant = retainedMetricDailyGrant(this.date);
+      evidenceAssert(grant, "daily_date_not_reviewed");
+      const manifest = await resolveMetricDaily(this.date, operation, prior, spent, this.digest, this.clock.now());
+      evidenceAssert(manifest && this.digest(manifest) === expectedSha, "reviewed_manifest_sha_mismatch");
+      const final = await operation.read<MetricRenewalFinal>(`${grant.evidencePath}/final.json`);
+      if (final !== null) return final;
+      const current = await this.inventory.list(manifest.scope, manifest.targets.map((t) => t.sourceItemId));
+      evidenceAssert(this.digest(metricIdentityInventory(current)) === manifest.capture.identityInventorySha, "renewal_inventory_drift");
+      const executed = await new ExecuteRetainedMetricBatches(this.inventory, this.fetcher, this.projection, this.clock, this.digest)
+        .execute(operation, manifest, expectedSha);
+      evidenceAssert(executed.ok, executed.ok ? undefined : executed.error);
+      const result = { manifestSha: expectedSha, results: executed.value, cells: metricRenewalCells(executed.value, manifest.scope.dates) };
+      for (const target of manifest.targets) {
+        if (await operation.read(`${grant.evidencePath}/result-${target.sourceItemId}.json`) === null) return executed.value;
+      }
+      // Validate every observation/result binding before granting terminal replay.
+      await resolveMetricDaily(this.date, operation, prior, spent, this.digest, this.clock.now());
+      await operation.install(`${grant.evidencePath}/final.json`, result);
+      return result;
+    });
+  }
+}

--- a/scripts/check-review-ci.mjs
+++ b/scripts/check-review-ci.mjs
@@ -376,7 +376,7 @@ const backendUnitShardingViolations = (source) => {
     "        run: npm run prisma:generate",
     "",
     "      - name: Run backend unit tests",
-    "        run: npm test -- --shard=${{ matrix.shard }}/4",
+    "        run: node scripts/run-with-timeout.mjs --timeout-ms 900000 --node-options --max-old-space-size=2048 -- ./node_modules/.bin/jest --config jest.config.ts --runInBand --shard=${{ matrix.shard }}/4",
     "",
     "  backend_unit:",
     "    name: Backend build and unit tests",

--- a/scripts/check-review-ci.spec.ts
+++ b/scripts/check-review-ci.spec.ts
@@ -32,6 +32,17 @@ describe("backend unit whole-corpus CI sharding", () => {
     },
   );
   it.each([
+    ["node scripts/run-with-timeout.mjs --timeout-ms 900000 --node-options --max-old-space-size=2048 -- ", ""],
+    ["--timeout-ms 900000", "--timeout-ms 600000"],
+    ["--timeout-ms 900000", "--timeout-ms 900001"],
+    ["--timeout-ms 900000", "--timeout-ms 0"],
+    ["node scripts/run-with-timeout.mjs --timeout-ms 900000 --node-options --max-old-space-size=2048 -- ./node_modules/.bin/jest --config jest.config.ts --runInBand --shard=${{ matrix.shard }}/4", "npm test -- --shard=${{ matrix.shard }}/4"],
+    ["node scripts/run-with-timeout.mjs --timeout-ms 900000 --node-options --max-old-space-size=2048 -- ./node_modules/.bin/jest --config jest.config.ts --runInBand --shard=${{ matrix.shard }}/4", "true"],
+    ["--shard=${{ matrix.shard }}/4", "--shard=${{ matrix.shard }}/4 --testPathIgnorePatterns=retained-metric"],
+    ["--shard=${{ matrix.shard }}/4", "--shard=${{ matrix.shard }}/4 --testNamePattern=small"],
+    ["      - name: Run backend unit tests", "      - name: Run backend unit tests\n        if: false"],
+    ["--max-old-space-size=2048", "--max-old-space-size=1536"],
+    ["--runInBand ", ""],
     ["[1, 2, 3, 4]", "[1, 2, 3]"],
     ["[1, 2, 3, 4]", "[1, 2, 3, 3]"],
     ["fail-fast: false", "fail-fast: true"],

--- a/scripts/lib/retained-metric-daily-durability.spec.ts
+++ b/scripts/lib/retained-metric-daily-durability.spec.ts
@@ -1,0 +1,64 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { retainedMetricDailyAuthorities } from "@social-monitor/ingestion/domain/policies/retained-metric-daily-grant";
+import { dailyPredecessorEntryList } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-daily-evidence";
+import { SecureMetricRefreshReceipts, metricRefreshDigest as hash } from "./retained-metric-refresh-receipts";
+import { metricJournalPath, type MetricJournalNamespace } from "./retained-metric-journal";
+
+jest.setTimeout(120_000);
+const date = "2026-09-02", path = `${metricJournalPath(date)}/operation.json`;
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "metric-daily-durable-")); });
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+function child(mode: string) {
+  return spawnSync(process.execPath, ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register", "-e", `
+    const { SecureMetricRefreshReceipts } = require('./scripts/lib/retained-metric-refresh-receipts');
+    const receipts = SecureMetricRefreshReceipts.forTest(process.argv[1], (point, name) => {
+      if (name === 'operation.json' && point === process.argv[2]) process.kill(process.pid, 'SIGKILL');
+    }, '2026-09-02');
+    receipts.install(${JSON.stringify(path)}, {fixture: 'daily'}).then(() => process.exit(0)).catch(() => process.exit(2));
+  `, root, mode], { env: { ...process.env, NODE_ENV: "test", NODE_OPTIONS: "--max-old-space-size=1536", TS_NODE_PROJECT: "tsconfig.build.json" }, timeout: 60000 });
+}
+it("keeps seven closed daily namespaces separate from original and fixed-v1 and fences a competing process", async () => {
+  const original = SecureMetricRefreshReceipts.forTest(root), spent = SecureMetricRefreshReceipts.forTest(root, undefined, "renewal");
+  await original.install(`${metricJournalPath()}/operation.json`, { fixture: "original" });
+  await spent.install(`${metricJournalPath("renewal")}/operation.json`, { fixture: "spent" });
+  const oldBytes = readFileSync(join(root, metricJournalPath(), "operation.json"));
+  const spentBytes = readFileSync(join(root, metricJournalPath("renewal"), "operation.json"));
+  for (const a of retainedMetricDailyAuthorities) {
+    const daily = SecureMetricRefreshReceipts.forTest(root, undefined, a.date);
+    await daily.withOperation(async (o) => {
+      await o.install(`${a.evidencePath}/operation.json`, { fixture: a.date });
+      await expect(o.read(`${metricJournalPath()}/operation.json`)).rejects.toThrow();
+      await expect(o.install(`${metricJournalPath("renewal")}/operation.json`, {})).rejects.toThrow();
+      const other = retainedMetricDailyAuthorities.find((b) => b.date !== a.date)!;
+      await expect(o.install(`${other.evidencePath}/operation.json`, {})).rejects.toThrow();
+      if (a.date === date) expect(child("none").status).toBe(2);
+    });
+  }
+  expect(() => metricJournalPath("2026-09-06" as MetricJournalNamespace)).toThrow();
+  expect(readFileSync(join(root, metricJournalPath(), "operation.json"))).toEqual(oldBytes);
+  expect(readFileSync(join(root, metricJournalPath("renewal"), "operation.json"))).toEqual(spentBytes);
+});
+it.each(["file_partial", "directory_synced"])("retains SIGKILL at %s and only adopts complete bytes", async (point) => {
+  expect(child(point).signal).toBe("SIGKILL");
+  const bytes = readFileSync(join(root, path));
+  const daily = SecureMetricRefreshReceipts.forTest(root, undefined, date);
+  if (point === "file_partial") await expect(daily.read(path)).rejects.toThrow();
+  else expect(await daily.install(path, { fixture: "daily" })).toBe("replayed");
+  expect(readFileSync(join(root, path))).toEqual(bytes);
+});
+it("rejects deep and oversized daily manifests before installing the authority name", async () => {
+  const daily = SecureMetricRefreshReceipts.forTest(root, undefined, date);
+  await expect(daily.install(path, "x".repeat(16 * 1024 * 1024))).rejects.toThrow();
+  let deep: unknown = null; for (let i = 0; i < 33; i++) deep = { child: deep };
+  await expect(daily.install(path, deep)).rejects.toThrow();
+  expect(readdirSync(join(root, metricJournalPath(date)))).toEqual(["operation.lock"]);
+});
+it("encodes predecessor entries with explicit sha256 keys and ASCII filename ordering", () => {
+  const entries = [{ name: "batch-2.reserved.json", bytesSha: "b".repeat(64) }, { name: "batch-10.reserved.json", bytesSha: "a".repeat(64) }];
+  expect(dailyPredecessorEntryList(entries)).toEqual([{ name: "batch-10.reserved.json", sha256: "a".repeat(64) }, { name: "batch-2.reserved.json", sha256: "b".repeat(64) }]);
+  expect(hash(dailyPredecessorEntryList(entries))).not.toBe(hash(entries));
+});

--- a/scripts/lib/retained-metric-daily-receipts.ts
+++ b/scripts/lib/retained-metric-daily-receipts.ts
@@ -1,0 +1,9 @@
+import { SecureMetricRefreshReceipts } from "./retained-metric-refresh-receipts";
+import type { MetricDailyDate } from "@social-monitor/ingestion/domain/policies/retained-metric-daily-grant";
+export function retainedMetricDailyReceipts(date: MetricDailyDate, assertMaintenanceHeld: () => void) {
+  return {
+    predecessor: new SecureMetricRefreshReceipts(assertMaintenanceHeld),
+    spent: new SecureMetricRefreshReceipts(assertMaintenanceHeld, undefined, undefined, "renewal"),
+    renewal: new SecureMetricRefreshReceipts(assertMaintenanceHeld, undefined, undefined, date),
+  };
+}

--- a/scripts/lib/retained-metric-daily.spec-support.ts
+++ b/scripts/lib/retained-metric-daily.spec-support.ts
@@ -37,7 +37,7 @@ export async function dailyFixture() {
   }
   f.renewal.values.set(`${f.renewal.root}/final.json`, { manifestSha, results, cells: metricRenewalCells(results, spentGrant.dates) });
   pinBytes(f.renewal, pins["retained-metrics-renewal-20260908"]);
-  const aliases = new Map([[metricRefreshDigest(manifest), manifestSha]]);
+  const aliases = new Map<string, string>([[metricRefreshDigest(manifest), manifestSha]]);
   for (const [journal, pin] of [[f.prior, pins["retained-metrics-v1"]], [f.renewal, pins["retained-metrics-renewal-20260908"]]] as const) {
     await journal.withOperation(async () => aliases.set(metricRefreshDigest(dailyPredecessorEntryList(await journal.entries())), pin.entryListSha256));
   }

--- a/scripts/lib/retained-metric-daily.spec-support.ts
+++ b/scripts/lib/retained-metric-daily.spec-support.ts
@@ -1,0 +1,57 @@
+import { FixedClock, ok } from "@social-monitor/shared-kernel";
+import { retainedMetricDailyGrant, retainedMetricDailyPredecessorPins as pins } from "@social-monitor/ingestion/domain/policies/retained-metric-daily-grant";
+import { retainedMetricRenewalGrant as spentGrant } from "@social-monitor/ingestion/domain/policies/retained-metric-renewal-grant";
+import { RenewDailyRetainedMetricsUseCase } from "@social-monitor/ingestion/features/refresh-retained-metrics/renew-daily-retained-metrics.use-case";
+import { dailyPredecessorEntryList } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-daily-evidence";
+import { refreshBatches } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-admission";
+import { metricRenewalCells } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-renewal-report";
+import type { MetricRefreshOutcome, RefreshScope, RetainedMetricTarget, RetainedMetricFetchCapability } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
+import { implementation, renewalFixture, RenewalMemoryJournal } from "./retained-metric-renewal.spec-support";
+import { metricRefreshDigest } from "./retained-metric-refresh-receipts";
+
+export const dailyDate = "2026-09-02";
+export const dailyGrant = retainedMetricDailyGrant(dailyDate)!;
+// Synthetic receipts exercise real original, fixed-v1, daily and effect resolvers.
+// Only exact synthetic payload/byte digests substitute the supplied incident pins.
+function pinBytes(journal: RenewalMemoryJournal, pin: typeof pins[keyof typeof pins]) {
+  const entries = journal.entries.bind(journal);
+  journal.entries = async () => (await entries()).map((e) => ({ ...e, bytesSha: e.name === "operation.json" ? pin.operationBytesSha256 :
+    e.name === "final.json" ? pin.finalBytesSha256 : e.bytesSha }));
+}
+export async function dailyFixture() {
+  const f = renewalFixture();
+  pinBytes(f.prior, pins["retained-metrics-v1"]);
+  const prepared = await f.usecase().prepare(implementation);
+  if (!prepared.ok) throw new Error(prepared.error.detail);
+  const manifest = prepared.value, manifestSha = pins["retained-metrics-renewal-20260908"].operationEnvelopeDigest;
+  const results: MetricRefreshOutcome[] = [];
+  for (const [index, batch] of refreshBatches(manifest.targets).entries()) {
+    f.renewal.values.set(`${f.renewal.root}/batch-${index}.reserved.json`, { operationId: manifest.operationId, manifestDigest: manifestSha, targets: batch.map((t) => t.sourceItemId) });
+    f.renewal.values.set(`${f.renewal.root}/batch-${index}.observed.json`, { failure: null, observations: batch.map((t) => ({ externalId: t.externalId,
+      returned: false, observedAt: manifest.plannedAt, metadata: null, sample: null, reason: "omitted" })) });
+    for (const t of batch) {
+      const result: MetricRefreshOutcome = { manifestSha, sourceItemId: t.sourceItemId, externalId: t.externalId, providerKey: t.providerKey,
+        date: t.publishedAt.slice(0, 10), status: "unavailable", returned: false, reason: "omitted", observedAt: manifest.plannedAt, before: t.authority, after: t.authority };
+      f.renewal.values.set(`${f.renewal.root}/result-${t.sourceItemId}.json`, result); results.push(result);
+    }
+  }
+  f.renewal.values.set(`${f.renewal.root}/final.json`, { manifestSha, results, cells: metricRenewalCells(results, spentGrant.dates) });
+  pinBytes(f.renewal, pins["retained-metrics-renewal-20260908"]);
+  const aliases = new Map([[metricRefreshDigest(manifest), manifestSha]]);
+  for (const [journal, pin] of [[f.prior, pins["retained-metrics-v1"]], [f.renewal, pins["retained-metrics-renewal-20260908"]]] as const) {
+    await journal.withOperation(async () => aliases.set(metricRefreshDigest(dailyPredecessorEntryList(await journal.entries())), pin.entryListSha256));
+  }
+  const hash = (value: unknown) => aliases.get(metricRefreshDigest(value)) ?? f.hash(value);
+  const daily = new RenewalMemoryJournal(dailyGrant.evidencePath);
+  let current = structuredClone(f.targets);
+  const inventory = {
+    list: jest.fn(async (scope: RefreshScope, ids?: readonly string[]) => structuredClone(current.filter((t) => ids ? ids.includes(t.sourceItemId) : scope.dates.includes(t.publishedAt.slice(0, 10))))),
+    read: jest.fn(async (_scope: RefreshScope, id: string) => structuredClone(current.find((t) => t.sourceItemId === id) ?? null)),
+  };
+  const fetcher = { fetch: jest.fn(async (batch: readonly RetainedMetricTarget[]): ReturnType<RetainedMetricFetchCapability["fetch"]> => ok(batch.map((t) => ({ externalId: t.externalId, returned: false, metadata: null, reason: "omitted" })))) };
+  const projection = f.projection;
+  const clock = new FixedClock(new Date("2026-09-09T12:00:00.000Z"));
+  const usecase = () => new RenewDailyRetainedMetricsUseCase(dailyDate, inventory, fetcher, projection, f.prior, f.renewal, daily, clock, hash);
+  return { ...f, hash, daily, inventory, fetcher, projection, clock, usecase,
+    setCurrent: (rows: RetainedMetricTarget[]) => { current = rows; } };
+}

--- a/scripts/lib/retained-metric-journal.ts
+++ b/scripts/lib/retained-metric-journal.ts
@@ -6,10 +6,13 @@ import { metricRefreshEvidencePath } from "@social-monitor/ingestion/features/re
 
 import { retainedMetricRenewalGrant } from "@social-monitor/ingestion/domain/policies/retained-metric-renewal-grant";
 
-export type MetricJournalNamespace = "original" | "renewal";
+import { retainedMetricDailyGrant, type MetricDailyDate } from "@social-monitor/ingestion/domain/policies/retained-metric-daily-grant";
+export type MetricJournalNamespace = "original" | "renewal" | MetricDailyDate;
 export function metricJournalPath(namespace: MetricJournalNamespace = "original"): string {
   if (namespace === "original") return metricRefreshEvidencePath;
   if (namespace === "renewal") return retainedMetricRenewalGrant.evidencePath;
+  const daily = retainedMetricDailyGrant(namespace);
+  if (daily) return daily.evidencePath;
   throw new Error("Unknown metric journal namespace");
 }
 

--- a/scripts/lib/retained-metric-refresh-receipts.ts
+++ b/scripts/lib/retained-metric-refresh-receipts.ts
@@ -42,7 +42,7 @@ export class SecureMetricRefreshReceipts implements MetricRefreshOperationAuthor
       install: async (path, value) => {
         const bytes = Buffer.from(canonicalMetricRefreshJson({ digest: metricRefreshDigest(value), value }));
         // Renewal admission must fail size/depth before creating an authority name.
-        if (this.namespace === "renewal") {
+        if (this.namespace !== "original") {
           if (bytes.length > 16 * 1024 * 1024) throw new Error("Metric evidence size limit");
           decodeMetricEnvelope(bytes);
         }

--- a/scripts/lib/retained-metric-renewal-composition.spec.ts
+++ b/scripts/lib/retained-metric-renewal-composition.spec.ts
@@ -1,0 +1,31 @@
+import { FixedClock } from "@social-monitor/shared-kernel";
+import { PrismaSourceEngagementProjectionAdapter } from "@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-projection.adapter";
+import { PrismaRetainedMetricInventory } from "@social-monitor/ingestion/adapters/persistence/prisma-retained-metric-inventory";
+import { RedditAppOnlyTokenProvider } from "@social-monitor/ingestion/adapters/source/reddit/app-only-reddit-token-provider";
+import { retainedMetricRenewalEffects } from "./retained-metric-renewal-composition";
+import { target } from "./retained-metric-refresh.spec-support";
+import { retainedMetricDailyGrant } from "@social-monitor/ingestion/domain/policies/retained-metric-daily-grant";
+
+jest.mock("@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-projection.adapter", () => ({ PrismaSourceEngagementProjectionAdapter: jest.fn() }));
+jest.mock("@social-monitor/ingestion/adapters/persistence/prisma-retained-metric-inventory", () => ({ PrismaRetainedMetricInventory: jest.fn() }));
+jest.mock("@social-monitor/ingestion/adapters/source/reddit/app-only-reddit-token-provider", () => ({ RedditAppOnlyTokenProvider: jest.fn() }));
+it("shares retention skip and exact transactional sampleGuard without acquiring OAuth during construction", async () => {
+  const grant = retainedMetricDailyGrant("2026-09-02")!;
+  const expected = target({ publishedAt: "2026-09-02T12:00:00.000Z" });
+  const scope = { tenantId: grant.tenantId, workspaceId: grant.workspaceId, dates: grant.dates, endAt: grant.endAt };
+  const read = jest.fn().mockResolvedValue(expected);
+  jest.mocked(PrismaRetainedMetricInventory).mockImplementation(() => ({ read }) as unknown as PrismaRetainedMetricInventory);
+  retainedMetricRenewalEffects({} as never, { targets: [expected], scope }, new FixedClock(new Date("2026-09-09T12:00:00.000Z")), {});
+  expect(RedditAppOnlyTokenProvider).not.toHaveBeenCalled();
+  const options = jest.mocked(PrismaSourceEngagementProjectionAdapter).mock.calls[0]![2]!;
+  expect(options.retention).toBe("skip");
+  const transaction = {};
+  await options.sampleGuard!(transaction as never, {} as never, { sourceItemId: expected.sourceItemId } as never);
+  expect(PrismaRetainedMetricInventory).toHaveBeenCalledWith(transaction, expect.any(Function));
+  expect(read).toHaveBeenCalledWith(scope, expected.sourceItemId);
+  read.mockResolvedValue({ ...expected, identityDigest: "f".repeat(64) });
+  await expect(options.sampleGuard!(transaction as never, {} as never, { sourceItemId: expected.sourceItemId } as never)).rejects.toThrow("Transactional renewal target drift");
+  read.mockResolvedValue(null);
+  await expect(options.sampleGuard!(transaction as never, {} as never, { sourceItemId: expected.sourceItemId } as never)).rejects.toThrow();
+  expect(RedditAppOnlyTokenProvider).not.toHaveBeenCalled();
+});

--- a/scripts/lib/retained-metric-renewal-composition.ts
+++ b/scripts/lib/retained-metric-renewal-composition.ts
@@ -1,0 +1,31 @@
+import { CryptoIdGenerator, type Clock } from "@social-monitor/shared-kernel";
+import { PrismaSourceEngagementProjectionAdapter } from "@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-projection.adapter";
+import type { PrismaSourceEngagementClient } from "@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-client";
+import { PrismaRetainedMetricInventory, type PrismaMetricInventoryClient } from "@social-monitor/ingestion/adapters/persistence/prisma-retained-metric-inventory";
+import { HttpHackerNewsClient } from "@social-monitor/ingestion/adapters/source/hacker-news/http-hacker-news-client";
+import { HttpRedditClient } from "@social-monitor/ingestion/adapters/source/reddit/http-reddit-client";
+import { RedditAppOnlyTokenProvider } from "@social-monitor/ingestion/adapters/source/reddit/app-only-reddit-token-provider";
+import { RetainedMetricFetchAdapter } from "@social-monitor/ingestion/adapters/source/retained-metric-fetch.capability";
+import { sameTarget } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-admission";
+import type { MetricRefreshManifest } from "@social-monitor/ingestion/features/refresh-retained-metrics/refresh-retained-metrics.contracts";
+import { metricRefreshDigest as hash } from "./retained-metric-refresh-receipts";
+
+export function retainedMetricRenewalEffects(client: PrismaMetricInventoryClient & PrismaSourceEngagementClient,
+  manifest: Pick<MetricRefreshManifest, "targets" | "scope"> | null, clock: Clock, env: NodeJS.ProcessEnv) {
+  const projection = new PrismaSourceEngagementProjectionAdapter(client, new CryptoIdGenerator(), {
+    retention: "skip", sampleGuard: async (transaction, _command, sample) => {
+      const expected = manifest?.targets.find((t) => t.sourceItemId === sample.sourceItemId);
+      const guarded = new PrismaRetainedMetricInventory(transaction as unknown as PrismaMetricInventoryClient, hash);
+      if (!expected || !sameTarget(expected, await guarded.read(manifest!.scope, expected.sourceItemId), hash)) throw new Error("Transactional renewal target drift");
+    },
+  });
+  let tokenProvider: RedditAppOnlyTokenProvider | undefined;
+  const token = { getAccessToken: async () => {
+    tokenProvider ??= new RedditAppOnlyTokenProvider({ clientId: env.REDDIT_APP_CLIENT_ID ?? "", clientSecret: env.REDDIT_APP_CLIENT_SECRET ?? "",
+      userAgent: env.REDDIT_APP_USER_AGENT, timeoutMs: 10_000, now: () => clock.now().getTime() });
+    return tokenProvider.getAccessToken();
+  } };
+  const fetcher = new RetainedMetricFetchAdapter(new HttpHackerNewsClient(10_000), new HttpRedditClient("https://oauth.reddit.com", 10_000), token,
+    env.REDDIT_APP_USER_AGENT ?? "social-monitor-retained-metrics/1");
+  return { projection, fetcher };
+}

--- a/scripts/run-retained-metric-daily-maintenance.sh
+++ b/scripts/run-retained-metric-daily-maintenance.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Run INSIDE the reviewed read-only daily image, as uid 1000. The parent mounts
+# existing host lock inodes at these exact paths and retires all legacy writers.
+set -euo pipefail
+PATH=/usr/local/bin:/usr/bin:/bin
+export TS_NODE_PROJECT=tsconfig.build.json
+[[ $# -ge 3 && $1 =~ ^[a-f0-9]{40}$ && $2 =~ ^[a-f0-9]{40}$ ]] || exit 64
+metric_backend=$1
+metric_control=$2
+shift 2
+metric_lock_root=/var/data/social-monitor/control
+# Read-only opens cannot create, truncate, or replace the canonical root:0644 locks.
+exec 7<"$metric_lock_root/production-deploy.lock"
+/usr/bin/flock --exclusive --nonblock 7
+exec 9<"$metric_lock_root/daily-run-singleton.lock"
+/usr/bin/flock --exclusive --nonblock 9
+exec 8<"$metric_lock_root/daily-run.lock"
+/usr/bin/flock --exclusive --nonblock 8
+# Parent pins the Docker image ID; deployed marker checks happen after all locks.
+[[ $(cat "$metric_lock_root/deploy-state/backend.sha") == "$metric_backend" &&
+   $(cat "$metric_lock_root/deploy-state/control.sha") == "$metric_control" &&
+   $(cat "$metric_lock_root/postgres-runtime-current/READY") == "$metric_backend" ]] || exit 65
+# Direct exec preserves descriptors 7/9/8. npm and Node spawn wrappers ordinarily
+# close non-stdio descriptors, so they are not supported for this invocation.
+exec /usr/bin/timeout --signal=TERM --kill-after=30s 4h node --max-old-space-size=1024 \
+  -r ts-node/register -r tsconfig-paths/register scripts/run-retained-metric-daily.ts "$@"

--- a/scripts/run-retained-metric-daily.spec.ts
+++ b/scripts/run-retained-metric-daily.spec.ts
@@ -1,0 +1,90 @@
+import { runRetainedMetricDaily } from "./run-retained-metric-daily";
+import { acquirePrismaPgRuntimeConnection, defaultPostgresRuntimePoolConfig, runWithTenantDatabaseAccess } from "@social-monitor/platform-persistence";
+import { loadPrismaRuntimeClient } from "@social-monitor/platform-persistence/prisma-runtime-client";
+import { metricMaintenanceAdmission } from "./lib/retained-metric-maintenance";
+import { retainedMetricDailyReceipts } from "./lib/retained-metric-daily-receipts";
+import { resolveMetricDaily } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-daily-evidence";
+import { metricRefreshDigest as hash } from "./lib/retained-metric-refresh-receipts";
+import { metricRenewalCells } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-renewal-report";
+import type { MetricDailyManifest } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-daily.contracts";
+import { implementation } from "./lib/retained-metric-renewal.spec-support";
+import type { MetricRefreshOperation } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-operation.contracts";
+import { PrismaRetainedMetricInventory } from "@social-monitor/ingestion/adapters/persistence/prisma-retained-metric-inventory";
+import { target } from "./lib/retained-metric-refresh.spec-support";
+
+jest.mock("@social-monitor/platform-persistence", () => ({ acquirePrismaPgRuntimeConnection: jest.fn(), defaultPostgresRuntimePoolConfig: jest.fn(), runWithTenantDatabaseAccess: jest.fn() }));
+jest.mock("@social-monitor/platform-persistence/prisma-runtime-client", () => ({ loadPrismaRuntimeClient: jest.fn() }));
+jest.mock("./lib/retained-metric-maintenance", () => ({ metricMaintenanceAdmission: jest.fn() }));
+jest.mock("./lib/retained-metric-daily-receipts", () => ({ retainedMetricDailyReceipts: jest.fn() }));
+jest.mock("@social-monitor/ingestion/features/refresh-retained-metrics/metric-daily-evidence", () => ({ resolveMetricDaily: jest.fn() }));
+jest.mock("@social-monitor/ingestion/adapters/persistence/prisma-retained-metric-inventory", () => ({ PrismaRetainedMetricInventory: jest.fn() }));
+const order: string[] = [];
+const operation = { assertHeld: jest.fn(), read: jest.fn(), install: jest.fn(), entries: jest.fn() };
+const manifest = { capture: { implementation, originalAudit: [{ sourceItemId: target().sourceItemId, currentTarget: target() }], lateArrivalSourceItemIds: [] }, predecessor: { originalSourceItemIds: [target().sourceItemId] },
+  scope: { dates: ["2026-09-04"] }, targets: [target()] } as unknown as MetricDailyManifest;
+beforeEach(() => {
+  jest.clearAllMocks(); order.length = 0;
+  jest.mocked(metricMaintenanceAdmission).mockReturnValue({ implementation, holder: { pid: 1, startTicks: "1", locks: [] }, assertHeld: jest.fn() } as ReturnType<typeof metricMaintenanceAdmission>);
+  const authority = (name: string) => ({ withOperation: async <T>(work: (o: MetricRefreshOperation) => Promise<T>) => { order.push(name); return work(operation); } });
+  jest.mocked(retainedMetricDailyReceipts).mockReturnValue({ predecessor: authority("predecessor"), spent: authority("spent"), renewal: authority("daily") } as ReturnType<typeof retainedMetricDailyReceipts>);
+  jest.mocked(resolveMetricDaily).mockResolvedValue(manifest);
+  operation.read.mockResolvedValue({ manifestSha: hash(manifest), results: [], cells: metricRenewalCells([], manifest.scope.dates) });
+});
+afterEach(() => jest.restoreAllMocks());
+it.each([["--apply", "--resume"], ["--apply"], ["--prepare", "--date", "2026-09-04"], ["--prepare", "--path", "/tmp/alternate"],
+  ["--prepare", "--operation-id", "arbitrary"], ["--repeat"], ["--resume", "--manifest-sha", "invalid"]])("rejects closed CLI options %j before DB construction", async (...args) => {
+  await expect(runRetainedMetricDaily(["--date", "2026-09-02", ...args], {})).rejects.toThrow();
+  expect(metricMaintenanceAdmission).not.toHaveBeenCalled(); expect(loadPrismaRuntimeClient).not.toHaveBeenCalled();
+});
+it.each(["sha", "release"])("refuses changed installed %s before DB construction", async (kind) => {
+  if (kind === "release") jest.mocked(resolveMetricDaily).mockResolvedValue({ ...manifest, capture: { ...manifest.capture,
+    implementation: { ...implementation, sourceSha: "f".repeat(64) } } });
+  const installed = kind === "release"
+    ? { ...manifest, capture: { ...manifest.capture, implementation: { ...implementation, sourceSha: "f".repeat(64) } } } : manifest;
+  await expect(runRetainedMetricDaily(["--date", "2026-09-02", "--apply", "--manifest-sha", kind === "sha" ? "f".repeat(64) : hash(installed)], {})).rejects.toThrow(kind === "sha" ? /SHA mismatch/ : /release changed/);
+  expect(loadPrismaRuntimeClient).not.toHaveBeenCalled(); expect(acquirePrismaPgRuntimeConnection).not.toHaveBeenCalled();
+});
+it.each(["--apply", "--resume", "--prepare"])("replays terminal %s under predecessor then renewal locks with no DB or installs", async (mode) => {
+  const output = jest.spyOn(process.stdout, "write").mockReturnValue(true);
+  await runRetainedMetricDaily(["--date", "2026-09-02", mode, ...(mode === "--prepare" ? [] : ["--manifest-sha", hash(manifest)])], {});
+  expect(order).toEqual(["predecessor", "spent", "daily"]);
+  expect(output).toHaveBeenCalledTimes(1); expect(operation.install).not.toHaveBeenCalled();
+  expect(defaultPostgresRuntimePoolConfig).not.toHaveBeenCalled(); expect(loadPrismaRuntimeClient).not.toHaveBeenCalled();
+});
+it("captures a separately timed diagnostic late-arrival audit without installing or altering the frozen grant", async () => {
+  const late = target({ sourceItemId: "outside-grant" });
+  jest.mocked(PrismaRetainedMetricInventory).mockImplementation(() => ({ list: jest.fn().mockResolvedValueOnce([target(), late]).mockResolvedValueOnce([target()]) }) as unknown as PrismaRetainedMetricInventory);
+  const close = jest.fn();
+  jest.mocked(acquirePrismaPgRuntimeConnection).mockResolvedValue({ client: {}, close } as never);
+  jest.mocked(runWithTenantDatabaseAccess).mockImplementation(async (_scope, work) => work());
+  const output = jest.spyOn(process.stdout, "write").mockReturnValue(true);
+  await runRetainedMetricDaily(["--date", "2026-09-02", "--diagnostic"], {});
+  expect(JSON.parse(String(output.mock.calls[0]![0]))).toMatchObject({ diagnostic: true, manifestSha: hash(manifest),
+    captureStartedAt: expect.any(String), captureCompletedAt: expect.any(String), outsideGrantSourceItemIds: [late.sourceItemId] });
+  expect(operation.install).not.toHaveBeenCalled(); expect(close).toHaveBeenCalledTimes(1);
+});
+it("keeps original and late-arrival authority references separate in terminal CLI reporting", async () => {
+  const before = { ...target().authority, metricsHash: "a".repeat(64), observedAt: "2026-09-08T11:00:00.000Z",
+    observationAt: "2026-09-08T10:00:00.000Z", observationCount: 1 };
+  const results = [target().sourceItemId, "late-source"].map((sourceItemId, i) => ({ sourceItemId, externalId: `reddit:t3_fixture${i}`,
+    providerKey: "reddit" as const, date: "2026-09-04", status: i ? "superseded" as const : "refreshed" as const,
+    returned: true, reason: null, observedAt: "2026-09-08T12:00:00.000Z", before,
+    after: { ...before, metricsHash: i ? "b".repeat(64) : before.metricsHash, observedAt: i ? "2026-09-08T12:01:00.000Z" : "2026-09-08T12:00:00.000Z" } }));
+  const installed = { ...manifest, capture: { ...manifest.capture, lateArrivalSourceItemIds: ["late-source"] } };
+  jest.mocked(resolveMetricDaily).mockResolvedValue(installed);
+  operation.read.mockResolvedValue({ manifestSha: hash(installed), results, cells: metricRenewalCells(results, manifest.scope.dates) });
+  const output = jest.spyOn(process.stdout, "write").mockReturnValue(true);
+  await runRetainedMetricDaily(["--date", "2026-09-02", "--resume", "--manifest-sha", hash(installed)], {});
+  const report = JSON.parse(String(output.mock.calls[0]![0]));
+  for (const [i, cohort] of ["originals", "lateArrivals"].entries()) {
+    expect(report.cohorts[cohort].count).toBe(1);
+    expect(report.cohorts[cohort].cells[1].authorities).toEqual([{ sourceItemId: results[i]!.sourceItemId,
+      externalId: results[i]!.externalId, observedAt: results[i]!.observedAt, before, after: results[i]!.after }]);
+  }
+  expect(acquirePrismaPgRuntimeConnection).not.toHaveBeenCalled();
+});
+
+it.each([[], ["--date", "2026-09-06"], ["--date", "2026-09-02", "--round", "2"]])("refuses missing or unreviewed daily selector %j", async (...args) => {
+  await expect(runRetainedMetricDaily(["--prepare", ...args], {})).rejects.toThrow();
+  expect(metricMaintenanceAdmission).not.toHaveBeenCalled(); expect(loadPrismaRuntimeClient).not.toHaveBeenCalled();
+});

--- a/scripts/run-retained-metric-daily.ts
+++ b/scripts/run-retained-metric-daily.ts
@@ -5,28 +5,29 @@ import { acquirePrismaPgRuntimeConnection, defaultPostgresRuntimePoolConfig, run
 import { loadPrismaRuntimeClient } from "@social-monitor/platform-persistence/prisma-runtime-client";
 import type { PrismaSourceEngagementClient } from "@social-monitor/feed/adapters/persistence/prisma/prisma-source-engagement-client";
 import { PrismaRetainedMetricInventory, type PrismaMetricInventoryClient } from "@social-monitor/ingestion/adapters/persistence/prisma-retained-metric-inventory";
-import { RenewRetainedMetricsUseCase, type MetricRenewalFinal } from "@social-monitor/ingestion/features/refresh-retained-metrics/renew-retained-metrics.use-case";
-import type { MetricRenewalManifest } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-renewal.contracts";
+import { RenewDailyRetainedMetricsUseCase, type MetricRenewalFinal } from "@social-monitor/ingestion/features/refresh-retained-metrics/renew-daily-retained-metrics.use-case";
+import type { MetricDailyManifest } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-daily.contracts";
 import { metricRenewalCells } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-renewal-report";
-import { resolveMetricRenewal } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-renewal-evidence";
-import { retainedMetricRenewalGrant as grant } from "@social-monitor/ingestion/domain/policies/retained-metric-renewal-grant";
+import { resolveMetricDaily } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-daily-evidence";
+import { retainedMetricDailyGrant } from "@social-monitor/ingestion/domain/policies/retained-metric-daily-grant";
 import type { MetricRefreshOperation } from "@social-monitor/ingestion/features/refresh-retained-metrics/metric-refresh-operation.contracts";
 import { metricRefreshDigest as hash } from "./lib/retained-metric-refresh-receipts";
-import { retainedMetricRenewalReceipts } from "./lib/retained-metric-renewal-receipts";
+import { retainedMetricDailyReceipts } from "./lib/retained-metric-daily-receipts";
 import { metricExecutableIdentity, metricMaintenanceAdmission } from "./lib/retained-metric-maintenance";
 
 type RuntimeClient = PrismaMetricInventoryClient & PrismaSourceEngagementClient & { $disconnect(): Promise<void> };
 const scoped = (operation: MetricRefreshOperation) => ({ ...operation,
   withOperation: async <T>(work: (held: MetricRefreshOperation) => Promise<T>) => { operation.assertHeld(); return work(operation); } });
-function renewalReport(final: MetricRenewalFinal, manifest: MetricRenewalManifest) {
-  const originals = new Set(manifest.predecessor.originalSourceItemIds);
+function renewalReport(final: MetricRenewalFinal, manifest: MetricDailyManifest) {
+  const originals = new Set(manifest.capture.originalAudit.map((a) => a.sourceItemId));
   return { ...final, cohorts: {
+    oldMissing: manifest.capture.originalAudit.filter((a) => a.currentTarget === null),
     originals: { count: originals.size, cells: metricRenewalCells(final.results.filter((r) => originals.has(r.sourceItemId)), manifest.scope.dates) },
     lateArrivals: { count: manifest.capture.lateArrivalSourceItemIds.length,
       cells: metricRenewalCells(final.results.filter((r) => !originals.has(r.sourceItemId)), manifest.scope.dates) },
   } };
 }
-export async function runRetainedMetricRenewal(args: readonly string[], env: NodeJS.ProcessEnv): Promise<void> {
+export async function runRetainedMetricDaily(args: readonly string[], env: NodeJS.ProcessEnv): Promise<void> {
   if (args.length === 1 && args[0] === "--implementation") {
     process.stdout.write(`${JSON.stringify(metricExecutableIdentity())}\n`); return;
   }
@@ -34,7 +35,7 @@ export async function runRetainedMetricRenewal(args: readonly string[], env: Nod
   const modes = ["--prepare", "--apply", "--resume", "--diagnostic"];
   for (let i = 0; i < args.length; i++) {
     const key = args[i]!;
-    if (![...modes, "--manifest-sha", "--source-sha", "--executable-sha", "--legacy-retirement-ref"].includes(key) || options.has(key)) throw new Error("Invalid renewal flag");
+    if (![...modes, "--date", "--manifest-sha", "--source-sha", "--executable-sha", "--legacy-retirement-ref"].includes(key) || options.has(key)) throw new Error("Invalid renewal flag");
     const value = modes.includes(key) ? "true" : args[++i];
     if (!value || value.startsWith("--")) throw new Error("Missing renewal value");
     options.set(key, value);
@@ -42,10 +43,12 @@ export async function runRetainedMetricRenewal(args: readonly string[], env: Nod
   const apply = options.has("--apply") || options.has("--resume");
   if (modes.filter((m) => options.has(m)).length !== 1 || options.has("--manifest-sha") !== apply ||
       (apply && !/^[a-f0-9]{64}$/u.test(options.get("--manifest-sha")!))) throw new Error("Invalid renewal mode/SHA");
+  const grant = retainedMetricDailyGrant(options.get("--date") ?? "");
+  if (!grant) throw new Error("Daily date not reviewed");
   const maintenance = metricMaintenanceAdmission(options.get("--source-sha"), options.get("--executable-sha"), options.get("--legacy-retirement-ref"));
-  const clock = new SystemClock(), authorities = retainedMetricRenewalReceipts(maintenance.assertHeld);
-  await authorities.predecessor.withOperation((prior) => authorities.renewal.withOperation(async (operation) => {
-    const existing = await resolveMetricRenewal(operation, prior, hash, clock.now());
+  const clock = new SystemClock(), authorities = retainedMetricDailyReceipts(grant.date, maintenance.assertHeld);
+  await authorities.predecessor.withOperation((prior) => authorities.spent.withOperation((spent) => authorities.renewal.withOperation(async (operation) => {
+    const existing = await resolveMetricDaily(grant.date, operation, prior, spent, hash, clock.now());
     if (apply && (!existing || hash(existing) !== options.get("--manifest-sha"))) throw new Error("Reviewed renewal SHA mismatch");
     if (existing && (existing.capture.implementation.sourceSha !== maintenance.implementation.sourceSha ||
         existing.capture.implementation.executableSha !== maintenance.implementation.executableSha)) throw new Error("Renewal release changed");
@@ -65,12 +68,12 @@ export async function runRetainedMetricRenewal(args: readonly string[], env: Nod
           if (!existing) throw new Error("Prepare renewal first");
           const captureStartedAt = clock.now().toISOString();
           const currentWindow = await inventory.list(existing.scope);
-          const originals = await inventory.list(existing.scope, existing.predecessor.originalSourceItemIds);
+          const originals = await inventory.list(existing.scope, existing.capture.originalAudit.map((a) => a.sourceItemId));
           process.stdout.write(`${JSON.stringify({ diagnostic: true, manifestSha: hash(existing), captureStartedAt, captureCompletedAt: clock.now().toISOString(), currentWindow, originals,
             outsideGrantSourceItemIds: currentWindow.filter((t) => !existing.targets.some((f) => f.sourceItemId === t.sourceItemId)).map((t) => t.sourceItemId) })}\n`); return;
         }
         const { projection, fetcher } = retainedMetricRenewalEffects(connection.client, existing, clock, env);
-        const usecase = new RenewRetainedMetricsUseCase(inventory, fetcher, projection, scoped(prior), scoped(operation), clock, hash);
+        const usecase = new RenewDailyRetainedMetricsUseCase(grant.date, inventory, fetcher, projection, scoped(prior), scoped(spent), scoped(operation), clock, hash);
         const result = apply ? await usecase.execute(options.get("--manifest-sha")!) : await usecase.prepare(maintenance.implementation);
         const output = apply && result.ok && "results" in result.value && existing ? renewalReport(result.value, existing) :
           { result, ...(!apply && result.ok ? { manifestSha: hash(result.value) } : {}) };
@@ -82,8 +85,8 @@ export async function runRetainedMetricRenewal(args: readonly string[], env: Nod
         }
       });
     } finally { await connection.close(); }
-  }));
+  })));
 }
-if (require.main === module) void runRetainedMetricRenewal(process.argv.slice(2), process.env).catch(() => {
+if (require.main === module) void runRetainedMetricDaily(process.argv.slice(2), process.env).catch(() => {
   process.stderr.write("Metric renewal failed closed; preserve both canonical journals and reconcile.\n"); process.exitCode = 1;
 });


### PR DESCRIPTION
Retained posts in the fixed August 30 to September 5 window have stale metrics, while the previous renewal allowance is already spent. Add seven finite, single-use HN/Reddit daily renewals that preserve original and spent journals, freeze each day's actual inventory, and reuse reservation, projection-resume and duplicate-effect protections.

Independent review approved the original daily implementation da99c167b81bec412568d938071eb5cd55735647 and the final head 2f66abc1a5d60a7b5d09af8a87f65f76b619ba99. Final delta review verified the current main rebase, one blank-line removal and erased Map<string, string> test typing; no correctness findings. CI run34357683685 verifies the final head, including generated Prisma, spec-inclusive TypeScript, PostgreSQL and unit suites. All final CI jobs passed. The complete 16-suite focused set is also evidenced; the strict CI command contract retains every shard and assertion with a measured 15-minute total execution bound.

Production activation remains separate: September 2 first, then each remaining day immediately before its canonical summary, after model runtime readiness. Final deployed source/executable hashes must be measured again. Thresholds, old publications, X collection allowances and summary budgets remain unchanged. This PR does not claim seven-day production completion.

Refs #293, Refs #294
