### PR TITLE
feat(eval): compare real reader inputs under controlled conditions

### DIFF
--- a/scripts/evals/reader-paired-experiment/README.md
+++ b/scripts/evals/reader-paired-experiment/README.md
@@ -323,3 +323,126 @@ Identical commands and envelopes are insufficient when another tape disagrees
 on abort events, completion times, parsed reviews or verdict inventory. This
 ambiguity is sticky and independent of response-pool order; it cannot silently
 select the first tape's outcome.
+
+## Controlled offline experiment
+
+`--mode controlled` reads a separate `paired-controlled-experiment.v1` manifest.
+It preserves the historical/default completion contract. Controlled completion
+requires validated immutable observations, explicit common controls, exact successful
+response coverage through the real parsers, independently anchored local owner
+receipts, all 21 returned arms with complete inventories/stage audits, 14 matched
+comparisons and quiescent detached lanes. Missing obligations stay incomplete.
+
+The manifest requires `mode: "CONTROLLED"`, `pins: {old, final}` with the existing
+exact revisions, `schedule: "successful_immediate_lexicographic_record.v1"`, and
+all seven ordered UTC `days`. `before` supplies `{preflight, receipt, hostReceipt,
+directory}`: each reference is `{path, sha256}` pointing to original capture-core
+bytes. It reads every day and controls hash and receipt join without constructing
+P2 seals. Each day supplies `after` (an original P2 seal reference), optional
+`responsePool` seal references, `evaluationControls`, and `interventions` for
+`before` and `after`.
+
+`evaluationControls` contains `clock`, `locale`, `snapshot` and `selection`
+(each `{query, presentKeys}`), `interests` (scoped `{query, result}` records), and
+`model` (the existing explicit assessment/relation constructor options).
+The clock must equal AFTER observedThrough and follow BEFORE observedThrough.
+Both populations retain original timestamps and raw data. Snapshot filters and
+population windows cannot be changed by this adapter. Common interest controls
+may cover the union of both populations. The original capture-core ranking limit
+is never interpreted as selector maxItems.
+
+Each population intervention has `kind: "common_evaluation_controls"`,
+`observationSha256`, `originalControlsSha256`, and `evaluationControlsSha256`.
+Digests use `controlsDigest` from `controlled-evaluation-view.cjs`. The original
+control digest covers `{observationQuery, observationPresentKeys, controls,
+interests}`. These declarations disclose interventions; they are not independent
+producer authority. P2 observations and capture-core records retain their original
+controls and read-time provenance separately.
+
+Controlled delivery preserves observed durations, lifecycle events, full commands,
+transport IDs and attestations. Only successful completed records can supply
+responses. Equal semantic request/output duplicates select the lexicographically
+smallest record ID (`sealSha256:sequence`) across the frozen union; conflicting
+successful outputs fail closed. Historical failures remain in capture histories.
+Real revision adapters parse the selected responses and verify parser/verdict
+bindings. Missing and invalid requests remain sticky even when caught by selectors.
+Invocation-local clients isolate overlapping requests. Controlled host quiescence
+tracks the entire parser operation, drains FIFO immediates and microtasks, and
+rejects pending work without firing positive timers.
+
+Results keep historical timing/replay and publication claims false. They retain
+all primary/supplemental rows and two separate comparisons; FINAL/AFTER is reused.
+A partial request union is not a complete discovery inventory because later
+requests depend on earlier responses. No future capture, provider call or native
+execution is part of this offline command.
+
+
+### Local execution owner boundary
+
+The parent supplies `--owner-receipt-sha256s SHA1,SHA2,...` separately from the
+manifest. The list contains the independently inspected BEFORE host-receipt hash
+and each independently inspected P2 owner-receipt hash. The program never reads
+an anchor list from the experiment manifest, tape, receipt or environment.
+`executeControlled(manifest, repo, expectedReceiptSha256s)` exposes the same
+explicit boundary to the trusted local caller. Pin the experiment manifest with
+`--sha256` and freeze its response pool and schedule before comparing outcomes.
+
+Each AFTER/response-pool seal reference adds `ownerReceipt: {path, sha256}`.
+Keep this separate receipt outside the immutable P2 capture directory. The P2
+seal and journals remain unchanged. A `paired-p2-local-owner-receipt.v1` contains:
+
+- `authority: "local_execution_owner_attestation"`, `action: "actual_p2_apply"`;
+- `captureSealSha256`, exact `scope` from `started.json`, and `operationId`;
+- `commandManifestSha256`: SHA256 of the canonical JSON of
+  `controls.json.manifest` (`hash` exported by `capture-owner-receipt.cjs`);
+- equal full Git `reviewedSourceCommit` and `deployedSourceCommit`, `sourceSha256`
+  matching both source hashes in the recorded command manifest;
+- immutable `imageId` (`sha256:` plus 64 hex digits), `ownedContainerId`
+  (64 hex digits), and exact manifest `runtime: {engine, packageVersion,
+  launcherSha256}`;
+- UTC `startedAt`, `endedAt`, and `terminal: {status: "exited", exitCode: 0}`.
+
+The parent constructs that receipt only after independently executing and
+inspecting the reviewed P2 container and its sidecar. The receipt pins the actual
+apply, scope, manifest, runtime/container identity and execution interval. All
+sealed callback timestamps must fit that interval. The selected model callbacks
+must join the exact generated request, original transport IDs, canonical request
+hash, runtime, provider/model/reasoning, output attestation and real parser/verdict
+inventory. Native quota receipts cannot substitute for this actual-apply receipt.
+
+This is **local owner attestation**, not cryptographically authenticated remote
+execution. The evaluator can check receipt joins but cannot independently discover
+what the parent executed; supplying the expected SHA is the parent's trust
+assertion. Synthetic fixtures are regression evidence only. Marked synthetic P2
+captures cannot acquire real authority, even with a matching owner-shaped receipt.
+Returned provenance booleans cannot be injected as authority into selector calls;
+only immutable observations/tapes admitted by the readers retain that binding.
+
+Example (all referenced files are already available locally):
+
+```sh
+NODE_OPTIONS=--max-old-space-size=1536 node scripts/evals/reader-paired-experiment/run.cjs \
+  --mode controlled --manifest /tmp/paired/experiment.json --sha256 MANIFEST_SHA \
+  --owner-receipt-sha256s BEFORE_HOST_SHA,AFTER_OWNER_SHA,UNION_OWNER_SHA \
+  --out /tmp/paired/result.json
+```
+
+Reports are create-only, mode 0600; exit 0 requires controlled completion, otherwise
+exit 2 retains the gaps. `complete`, `historicalTimingVerified`,
+`historicalReplayComplete` and publication fields keep their separate meanings;
+publication artifact IDs remain null. An abstention or genuine count/byte-budget
+pending item need not prevent execution completion, but does prevent full quality
+resolution. Missing/failed response validation is always an execution gap.
+The successful-immediate policy explicitly excludes historical model/transport
+latency and deadline frequency. Historical failures are retained and never
+relabelled as successes. Data comparisons cover all observed population/content/
+metric/authority changes; no metrics-only or quality-improvement claim is made.
+
+Original capture-core limitations remain: prospective capture at
+`2026-09-09T11:47:10.523Z`, separate day/config transactions, possible post-cutoff
+engagement writes, and physical residuals without provider exclusion reasons.
+No historical as-of reconstruction or observed zero model-call claim is implied.
+Tests under this directory use only supplied dependencies and synthetic fixtures:
+`NODE_OPTIONS=--max-old-space-size=1536 node --test --test-concurrency=1
+scripts/evals/reader-paired-experiment/*.test.cjs` (set `NODE_PATH` to a supplied
+matching dependency tree if the workspace dependency link is unavailable).

--- a/scripts/evals/reader-paired-experiment/capture-core-fixture.cjs
+++ b/scripts/evals/reader-paired-experiment/capture-core-fixture.cjs
@@ -1,0 +1,54 @@
+'use strict';
+const fs = require('node:fs'), os = require('node:os'), path = require('node:path');
+const { absentFilters } = require('./capture-core-observation.cjs');
+const { DAYS } = require('./frozen-input.cjs');
+const { sha } = require('./revision-source.cjs');
+const { syntheticTape } = require('./full-selector-fixture.cjs');
+const { clone } = require('./recorded-selector-ports.cjs');
+// Synthetic structural compatibility only: none of these owner-shaped receipts
+// establish independent real capture or model-execution authority.
+function captureCoreFixture(mutate = () => {}) {
+  const tape = syntheticTape(), raw = tape.files['inputs.json'].snapshot;
+  const { tenantId, workspaceId } = tape.files['snapshot-query.json'].query;
+  const scope = { tenantId, workspaceId }, cutoff = '2026-09-09T11:47:10.523Z';
+  const identity = { commit: 'a'.repeat(40), imageId: `sha256:${'b'.repeat(64)}`, sourceSha256: 'c'.repeat(64) };
+  const records = DAYS.map(day => {
+    const s = clone(raw);
+    s.candidates.forEach(c => {
+      c.item.publishedAt = `${day}T12:00:00.000Z`;
+      if (c.exactTimestamps) c.exactTimestamps.publishedAt = c.item.publishedAt;
+    });
+    return { day, startedAt: cutoff, endedAt: cutoff, query: { ...scope,
+      windowStartedAt: `${day}T00:00:00.000Z`, windowEndedAt: new Date(Date.parse(`${day}T00:00:00.000Z`) + 86400000).toISOString(),
+      timestampPolicy: 'published_at', observedThrough: cutoff }, snapshot: s };
+  });
+  const ids = [...new Set([...raw.candidates.map(c => c.item), ...raw.supplementalItems].map(i => i.interestId))];
+  const controls = { cutoff, scope, queries: records.map(r => ({ day: r.day, timezone: 'UTC', cadence: 'daily',
+    rankingQuery: { ...scope, rankingProfile: 'reader_post_promotion', limit: 200, publishedAtOrAfter: r.query.windowStartedAt,
+      publishedBefore: r.query.windowEndedAt, observedAtOrBefore: cutoff }, absentFilters })),
+  interests: ids.map(interestId => ({ scope: { ...scope, interestId }, readStartedAt: cutoff, readEndedAt: cutoff,
+    result: { kind: 'available', interest: { ...scope, interestId, query: 'Synthetic configured interest' } } })) };
+  mutate({ records, controls });
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'controlled-capture-core-'));
+  const write = (file, value) => {
+    const bytes = JSON.stringify(value) + '\n';
+    fs.writeFileSync(path.join(directory, file), bytes, { mode: 0o600 });
+    return { file, sha256: sha(bytes) };
+  };
+  const ref = r => ({ path: path.join(directory, r.file), sha256: r.sha256 });
+  const receipt = { format: 'current-freshness-capture.v1', status: 'capture_only_diagnostics_remaining',
+    cutoff, endedAt: cutoff, identity, days: records.map(r => write(`${r.day}.json`, r)), controls: write('controls.json', controls),
+    limitations: ['Synthetic fixture; no real observation'] };
+  const receiptRef = ref(write('capture-receipt.json', receipt));
+  const host = { format: 'current-freshness-host-receipt.v1', status: 'capture_container_completed', identity,
+    captureReceiptSha256: receiptRef.sha256, capturedThrough: cutoff,
+    container: { Image: identity.imageId, State: { Status: 'exited', ExitCode: 0 } } };
+  const hostRef = ref(write('host-receipt.json', host));
+  const preflight = { format: 'current-freshness-preflight.v1', status: 'complete', cutoff, scope, identity,
+    captureReceiptSha256: receiptRef.sha256, hostReceiptSha256: hostRef.sha256,
+    snapshots: receipt.days, controls: receipt.controls };
+  const args = { directory, receipt: receiptRef, hostReceipt: hostRef, preflight: ref(write('preflight.json', preflight)) };
+  return { args, records, controls, cleanup: () => fs.rmSync(directory, { recursive: true, force: true }) };
+}
+
+module.exports = { captureCoreFixture };

--- a/scripts/evals/reader-paired-experiment/capture-core-observation.cjs
+++ b/scripts/evals/reader-paired-experiment/capture-core-observation.cjs
@@ -1,0 +1,101 @@
+'use strict';
+const path = require('node:path');
+const { read, date, DAYS, snapshot } = require('./frozen-input.cjs');
+const { check, digest } = require('./revision-source.cjs');
+const { clone, same } = require('./recorded-selector-ports.cjs');
+const absentFilters = ['interestId', 'searchQuery', 'providerKey', 'repositoryTrendWindow', 'repositoryLanguage', 'repositoryTopic'];
+function freeze(value) {
+  if (value && typeof value === 'object') {
+    Object.values(value).forEach(freeze);
+    Object.freeze(value);
+  }
+  return value;
+}
+function interval(start, end, lower, upper) {
+  check(date(start) >= date(lower) && date(end) >= date(start) && date(end) <= date(upper), 'capture_interval_invalid');
+}
+function validateRaw(record, scope) {
+  const raw = record.snapshot;
+  const rows = [...raw.candidates.map(c => c.item), ...(raw.supplementalItems || [])];
+  check(Number.isSafeInteger(raw.physicalRowsRead) && raw.physicalRowsRead >= rows.length, 'physical_count_invalid');
+  for (const row of rows) check(['interestId', 'sourceBindingId', 'providerKey'].every(k =>
+    typeof row[k] === 'string' && row[k].trim()), 'inventory_identity_invalid');
+  // Reuse the existing full snapshot invariants. The validation-only entity
+  // retains plain properties; the revision ports hydrate real FeedItem objects.
+  snapshot({ format: 'read-only-full-promotion-snapshot.v1', capturedAt: record.endedAt ?? record.query.observedThrough,
+    observedThrough: record.query.observedThrough, snapshot: { ...raw,
+      candidates: raw.candidates.map(c => ({ ...c, item: { props: c.item } })),
+      supplementalItems: (raw.supplementalItems || []).map(props => ({ props })) } }, record.day,
+  { ...scope, clock: record.query.observedThrough, query: record.query }, { rehydrate: props => props });
+  return rows;
+}
+// Reads original capture-core bytes directly. No P2 seal, callback, model log,
+// journal sequence or synthetic zero-call claim is created by this adapter.
+const ownerObservations = new WeakSet();
+const coreOriginVerified = observation => ownerObservations.has(observation);
+function captureCore({ preflight: preflightRef, receipt: receiptRef, hostReceipt: hostRef, directory }, expectedReceiptSha256s = []) {
+  const preflight = read(preflightRef), receipt = read(receiptRef), host = read(hostRef);
+  check(preflight.format === 'current-freshness-preflight.v1' && preflight.status === 'complete', 'preflight_incomplete');
+  check(receipt.format === 'current-freshness-capture.v1' && receipt.status === 'capture_only_diagnostics_remaining', 'capture_receipt_invalid');
+  check(host.format === 'current-freshness-host-receipt.v1' && host.status === 'capture_container_completed' &&
+    host.container?.State?.Status === 'exited' && host.container.State.ExitCode === 0, 'host_receipt_incomplete');
+  check(preflight.captureReceiptSha256 === receiptRef.sha256 && preflight.hostReceiptSha256 === hostRef.sha256 &&
+    host.captureReceiptSha256 === receiptRef.sha256, 'capture_receipt_join_mismatch');
+  check(same(preflight.identity, receipt.identity) && same(host.identity, receipt.identity) &&
+    host.container.Image === receipt.identity.imageId, 'capture_identity_mismatch');
+  check(/^[a-f0-9]{40}$/.test(receipt.identity.commit) && /^[a-f0-9]{64}$/.test(receipt.identity.sourceSha256) &&
+    /^sha256:[a-f0-9]{64}$/.test(receipt.identity.imageId), 'capture_identity_invalid');
+  check(receipt.cutoff === '2026-09-09T11:47:10.523Z' && preflight.cutoff === receipt.cutoff &&
+    host.capturedThrough === receipt.cutoff, 'capture_cutoff_mismatch');
+  check(same(preflight.snapshots, receipt.days) && same(preflight.controls, receipt.controls), 'capture_inventory_receipt_mismatch');
+  check(same(receipt.days.map(d => d.file), DAYS.map(day => `${day}.json`)) && receipt.controls.file === 'controls.json', 'exact_ordered_seven_UTC_days_required');
+  const load = ref => read({ path: path.join(directory, ref.file), sha256: ref.sha256 });
+  const controls = load(receipt.controls), records = receipt.days.map(load), scope = controls.scope;
+  check(same(scope, preflight.scope) && same(Object.keys(scope).sort(), ['tenantId', 'workspaceId']) &&
+    Object.values(scope).every(v => typeof v === 'string' && v.trim()), 'capture_scope_mismatch');
+  check(controls.cutoff === receipt.cutoff && date(receipt.endedAt) >= date(receipt.cutoff), 'control_cutoff_mismatch');
+  check(same(records.map(r => r.day), DAYS) && same(controls.queries.map(q => q.day), DAYS), 'exact_ordered_seven_UTC_days_required');
+  const needed = new Set();
+  let previousEnd = receipt.cutoff;
+  records.forEach((record, i) => {
+    interval(record.startedAt, record.endedAt, previousEnd, receipt.endedAt);
+    previousEnd = record.endedAt;
+    const start = `${record.day}T00:00:00.000Z`, end = new Date(+date(start) + 86400000).toISOString();
+    check(same(record.query, { ...scope, windowStartedAt: start, windowEndedAt: end,
+      timestampPolicy: 'published_at', observedThrough: receipt.cutoff }), 'snapshot_control_query_mismatch');
+    check(same(controls.queries[i], { day: record.day, timezone: 'UTC', cadence: 'daily',
+      rankingQuery: { ...scope, rankingProfile: 'reader_post_promotion', limit: 200,
+        publishedAtOrAfter: start, publishedBefore: end, observedAtOrBefore: receipt.cutoff }, absentFilters }), 'ranking_control_query_mismatch');
+    validateRaw(record, scope).forEach(row => needed.add(row.interestId));
+  });
+  const seen = new Set();
+  for (const control of controls.interests) {
+    const query = control.scope, result = control.result;
+    check(same(Object.keys(query).sort(), ['interestId', 'tenantId', 'workspaceId']) &&
+      query.tenantId === scope.tenantId && query.workspaceId === scope.workspaceId &&
+      needed.has(query.interestId) && !seen.has(query.interestId), 'interest_inventory_mismatch');
+    check(result.kind === 'available' && ['tenantId', 'workspaceId', 'interestId'].every(k => result.interest[k] === query[k]) &&
+      typeof result.interest.query === 'string' && result.interest.query.trim(), 'configured_interest_invalid');
+    interval(control.readStartedAt, control.readEndedAt, receipt.cutoff, receipt.endedAt);
+    seen.add(query.interestId);
+  }
+  check(seen.size === needed.size, 'interest_inventory_incomplete');
+  let originGap;
+  try { require('./capture-owner-receipt.cjs').anchored(hostRef, expectedReceiptSha256s); }
+  catch (error) { originGap = error.message; }
+  const observations = freeze(records.map((record, i) => ({
+    format: 'paired-immutable-observation.v1', kind: 'capture-core', day: record.day, scope: clone(scope),
+    observationRef: { path: path.join(directory, receipt.days[i].file), sha256: receipt.days[i].sha256 },
+    observationQuery: clone(record.query), observationPresentKeys: Object.keys(record.query),
+    startedAt: record.startedAt, endedAt: record.endedAt, snapshot: clone(record.snapshot),
+    interests: clone(controls.interests), originalControls: clone(controls.queries[i]),
+    controlsRef: { path: path.join(directory, receipt.controls.file), sha256: receipt.controls.sha256 },
+    provenance: { preflight: preflightRef, receipt: receiptRef, hostReceipt: hostRef, identity: clone(receipt.identity),
+      limitations: clone(receipt.limitations || []), integrityVerified: true, independentOriginVerified: !originGap, originGap: originGap ?? null,
+      modelInvocationHistory: 'not_recorded' },
+    observationSha256: digest(record),
+  })));
+  if (!originGap) observations.forEach(observation => ownerObservations.add(observation));
+  return observations;
+}
+module.exports = { captureCore, validateRaw, freeze, absentFilters, coreOriginVerified };

--- a/scripts/evals/reader-paired-experiment/capture-core-observation.test.cjs
+++ b/scripts/evals/reader-paired-experiment/capture-core-observation.test.cjs
@@ -1,0 +1,59 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { captureCore } = require('./capture-core-observation.cjs');
+const { DAYS } = require('./frozen-input.cjs');
+const { captureCoreFixture: fixture } = require('./capture-core-fixture.cjs');
+
+test('seven original capture-core days retain every ordered row, timestamp, authority and read interval', () => {
+  const f = fixture();
+  try {
+    const observed = captureCore(f.args);
+    assert.deepEqual(observed.map(o => o.day), DAYS);
+    observed.forEach((o, i) => {
+      assert.deepEqual(o.snapshot, f.records[i].snapshot);
+      assert.deepEqual(o.observationQuery, f.records[i].query);
+      assert.deepEqual(o.interests, f.controls.interests);
+      assert.equal(o.startedAt, f.records[i].startedAt);
+      assert.equal(o.endedAt, f.records[i].endedAt);
+      assert.equal(o.provenance.independentOriginVerified, false);
+      assert.equal(o.provenance.modelInvocationHistory, 'not_recorded');
+      assert.equal(o.snapshot.candidates.length, 4);
+      assert.equal(o.snapshot.supplementalItems.length, 12);
+      assert.equal(o.seal, undefined);
+      assert.throws(() => { o.snapshot.candidates[0].item.observedAt = 'changed'; }, TypeError);
+    });
+  } finally { f.cleanup(); }
+});
+
+test('even rehashed structural receipt fixtures reject scope, source joins, interests, query filters and missing days', () => {
+  const cases = [
+    [v => { v.records.pop(); }, /seven_UTC_days/],
+    [v => { v.records[0].snapshot.candidates[0].item.workspaceId = 'other'; }, /scope mismatch/],
+    [v => { v.records[0].snapshot.sourceContent.pop(); }, /coverage mismatch/],
+    [v => { v.records[0].snapshot.sourceContent[0].sourceItemId = 'other'; }, /source-content join/],
+    [v => { v.records[0].query.interestId = 'extra'; }, /snapshot_control_query/],
+    [v => { v.controls.queries[0].rankingQuery.limit = 201; }, /ranking_control_query/],
+    [v => { v.controls.queries[0].absentFilters = []; }, /ranking_control_query/],
+    [v => { v.controls.interests.pop(); }, /interest_inventory_incomplete/],
+    [v => { v.controls.interests[0].result.interest.workspaceId = 'other'; }, /configured_interest_invalid/],
+    [v => { v.records[0].endedAt = '2026-09-09T11:47:10.524Z'; }, /capture_interval/],
+    [v => { v.records[0].snapshot.exhausted = false; }, /incomplete snapshot/],
+  ];
+  for (const [mutate, error] of cases) {
+    const f = fixture(mutate);
+    try { assert.throws(() => captureCore(f.args), error); } finally { f.cleanup(); }
+  }
+});
+
+test('original file hashes reject silent timestamp edits and changed receipts', () => {
+  for (const name of ['2026-08-30.json', 'capture-receipt.json', 'host-receipt.json', 'controls.json']) {
+    const f = fixture();
+    try {
+      fs.appendFileSync(path.join(f.args.directory, name), ' ');
+      assert.throws(() => captureCore(f.args), /SHA256 mismatch/);
+    } finally { f.cleanup(); }
+  }
+});

--- a/scripts/evals/reader-paired-experiment/capture-owner-receipt.cjs
+++ b/scripts/evals/reader-paired-experiment/capture-owner-receipt.cjs
@@ -1,0 +1,48 @@
+'use strict';
+const { read, date } = require('./frozen-input.cjs');
+const { check, digest } = require('./revision-source.cjs');
+const { canonical, same } = require('./recorded-selector-ports.cjs');
+const hash = value => digest(canonical(value));
+// Trust enters ONLY through the execution owner's separate argument. A hash
+// declared by the manifest/tape itself supplies integrity, never authority.
+function anchored(ref, expectedReceiptSha256s) {
+  check(ref && /^[a-f0-9]{64}$/.test(ref.sha256) &&
+    Array.isArray(expectedReceiptSha256s) && expectedReceiptSha256s.includes(ref.sha256), 'owner_receipt_out_of_band_anchor_missing');
+  return read(ref);
+}
+function p2OwnerReceipt(tape, ref, expectedReceiptSha256s) {
+  const receipt = anchored(ref, expectedReceiptSha256s);
+  const started = tape.files['started.json'], controls = tape.files['controls.json'], manifest = controls.manifest;
+  check(receipt.format === 'paired-p2-local-owner-receipt.v1' &&
+    receipt.authority === 'local_execution_owner_attestation' && receipt.action === 'actual_p2_apply', 'owner_receipt_contract_invalid');
+  check(!tape.seal.synthetic && !controls.synthetic && !receipt.synthetic, 'synthetic_capture_has_no_real_authority');
+  check(receipt.captureSealSha256 === tape.sealSha256 && same(receipt.scope, started.scope) &&
+    receipt.operationId === started.scope.operation && receipt.operationId === manifest.operation &&
+    receipt.commandManifestSha256 === hash(manifest) &&
+    ['tenantId', 'workspaceId', 'observedThrough'].every(key => manifest[key] === started.scope[key]), 'owner_receipt_capture_join_mismatch');
+  check(/^[a-f0-9]{40}$/.test(receipt.reviewedSourceCommit) && receipt.reviewedSourceCommit === receipt.deployedSourceCommit &&
+    /^sha256:[a-f0-9]{64}$/.test(receipt.imageId) && /^[a-f0-9]{64}$/.test(receipt.ownedContainerId) &&
+    /^[a-f0-9]{64}$/.test(receipt.sourceSha256) && receipt.sourceSha256 === manifest.sourceSha256 &&
+    receipt.sourceSha256 === manifest.deployedSourceSha256 && same(receipt.runtime, manifest.runtime), 'owner_receipt_runtime_identity_mismatch');
+  check(receipt.runtime?.engine === 'subscription-runtime-cli' && typeof receipt.runtime.packageVersion === 'string' &&
+    receipt.runtime.packageVersion.trim() && /^[a-f0-9]{64}$/.test(receipt.runtime.launcherSha256), 'owner_receipt_runtime_identity_invalid');
+  const start = +date(receipt.startedAt), end = +date(receipt.endedAt);
+  check(end >= start && receipt.terminal?.status === 'exited' && receipt.terminal.exitCode === 0 &&
+    Number.isSafeInteger(started.atMs) && started.atMs >= start && started.atMs <= end, 'owner_receipt_execution_incomplete');
+  for (const [name, rows] of Object.entries(tape.files)) if (name.endsWith('.jsonl'))
+    check(rows.every(row => row.atMs >= started.atMs && row.atMs <= end), 'owner_receipt_lifecycle_outside_execution');
+  return { receiptSha256: ref.sha256, receipt, model: manifest.model, reasoningEffort: manifest.reasoningEffort, authority: 'local_execution_owner_attestation',
+    remoteExecutionCryptographicallyAuthenticated: false };
+}
+function verifyOwnerInvocation(origin, command, result) {
+  const runtime = origin.receipt.runtime, attestation = result.executionAttestation;
+  check(same({ engine: attestation?.runtimeEngine, packageVersion: attestation?.runtimePackageVersion,
+    launcherSha256: attestation?.launcherSha256 }, runtime), 'owner_invocation_runtime_mismatch');
+  check(command.tenantId === origin.receipt.scope.tenantId && command.workspaceId === origin.receipt.scope.workspaceId,
+    'owner_invocation_scope_mismatch');
+  check(command.provider === 'codex' && command.controls.model === origin.model &&
+    command.controls.reasoningEffort === origin.reasoningEffort, 'owner_invocation_model_mismatch');
+  // Request/output/transport IDs and model controls are checked by the actual
+  // revision admission, envelope validators and parsers, not a second schema.
+}
+module.exports = { anchored, p2OwnerReceipt, verifyOwnerInvocation, hash };

--- a/scripts/evals/reader-paired-experiment/capture-owner-receipt.test.cjs
+++ b/scripts/evals/reader-paired-experiment/capture-owner-receipt.test.cjs
@@ -1,0 +1,115 @@
+'use strict';
+const test = require('node:test'), assert = require('node:assert/strict');
+const fs = require('node:fs'), os = require('node:os'), path = require('node:path');
+const { p2OwnerReceipt, verifyOwnerInvocation } = require('./capture-owner-receipt.cjs');
+const { syntheticTape } = require('./full-selector-fixture.cjs');
+const { sha } = require('./revision-source.cjs');
+const { clone } = require('./recorded-selector-ports.cjs');
+// Tests inject an artificial local owner at the explicit trust boundary. Passing
+// that structural contract is NOT evidence of a production execution. No fixture
+// receipt is distributed as a trusted capture or used in a real experiment.
+function fixture() {
+  const tape = syntheticTape();
+  delete tape.seal.synthetic; delete tape.files['controls.json'].synthetic;
+  const receipt = require('./p2-fixture.cjs').ownerContractReceipt(tape);
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'controlled-owner-contract-'));
+  const write = () => {
+    const bytes = JSON.stringify(receipt), filename = path.join(directory, 'owner.json');
+    fs.writeFileSync(filename, bytes); return { path: filename, sha256: sha(bytes) };
+  };
+  return { tape, receipt, write, cleanup: () => fs.rmSync(directory, { recursive: true, force: true }) };
+}
+test('only the separately supplied owner SHA anchors the receipt; self-declared trust and native quota cannot substitute', () => {
+  const f = fixture();
+  try {
+    f.receipt.trustedAnchor = true;
+    const ref = f.write();
+    assert.throws(() => p2OwnerReceipt(f.tape, ref, []), /out_of_band_anchor_missing/);
+    assert.throws(() => p2OwnerReceipt(f.tape, ref, ['d'.repeat(64)]), /out_of_band_anchor_missing/);
+    const origin = p2OwnerReceipt(f.tape, ref, [ref.sha256]);
+    assert.equal(origin.receiptSha256, ref.sha256);
+    assert.equal(origin.authority, 'local_execution_owner_attestation');
+    assert.equal(origin.remoteExecutionCryptographicallyAuthenticated, false);
+    f.receipt.format = 'native-quota-receipt.v1';
+    const native = f.write();
+    assert.throws(() => p2OwnerReceipt(f.tape, native, [native.sha256]), /contract_invalid/);
+  } finally { f.cleanup(); }
+});
+test('anchored receipt still requires exact capture, command, operation, runtime, image, container and completed lifecycle joins', () => {
+  const mutations = [
+    f => { f.receipt.captureSealSha256 = 'e'.repeat(64); },
+    f => { f.receipt.commandManifestSha256 = 'e'.repeat(64); },
+    f => { f.receipt.operationId += ':other'; },
+    f => { f.receipt.scope.workspaceId = 'other'; },
+    f => { f.receipt.reviewedSourceCommit = 'f'.repeat(40); },
+    f => { f.receipt.sourceSha256 = 'e'.repeat(64); },
+    f => { f.receipt.imageId = 'mutable:latest'; },
+    f => { f.receipt.ownedContainerId = 'name-only'; },
+    f => { f.receipt.runtime.launcherSha256 = 'e'.repeat(64); },
+    f => { f.receipt.terminal.exitCode = 1; },
+    f => { f.receipt.terminal.status = 'running'; },
+    f => { f.receipt.startedAt = f.receipt.endedAt; },
+    f => { f.tape.files['models.jsonl'][0].atMs = Date.parse(f.receipt.endedAt) + 1; },
+    f => { f.tape.seal.synthetic = true; },
+    f => { f.receipt.synthetic = true; },
+  ];
+  for (const mutate of mutations) {
+    const f = fixture();
+    try { mutate(f); const ref = f.write(); assert.throws(() => p2OwnerReceipt(f.tape, ref, [ref.sha256])); }
+    finally { f.cleanup(); }
+  }
+});
+test('receipt bytes and selected model runtime cannot be substituted after independent pinning', () => {
+  const f = fixture();
+  try {
+    const ref = f.write(), origin = p2OwnerReceipt(f.tape, ref, [ref.sha256]);
+    const end = f.tape.files['models.jsonl'].find(r => r.event.kind === 'envelope_verified').event;
+    verifyOwnerInvocation(origin, end.command, end.result);
+    for (const key of ['runtimeEngine', 'runtimePackageVersion', 'launcherSha256']) {
+      const result = clone(end.result); result.executionAttestation[key] = 'wrong';
+      assert.throws(() => verifyOwnerInvocation(origin, end.command, result), /runtime_mismatch/);
+    }
+    const command = clone(end.command); command.controls.model = 'wrong';
+    assert.throws(() => verifyOwnerInvocation(origin, command, end.result), /model_mismatch/);
+    fs.appendFileSync(ref.path, ' ');
+    assert.throws(() => p2OwnerReceipt(f.tape, ref, [ref.sha256]), /SHA256 mismatch/);
+  } finally { f.cleanup(); }
+});
+
+test('reader and actual parsers retain the admitted local receipt binding; copied provenance cannot grant authority', async () => {
+  const { p2Fixture, ownerContractReceipt } = require('./p2-fixture.cjs');
+  const { p2Observation, originFor } = require('./p2-observation.cjs');
+  const { controlledFixture } = require('./controlled-fixture.cjs');
+  const { evaluationView, controlsDigest } = require('./controlled-evaluation-view.cjs');
+  const { fullSelector } = require('./revision-full-selector.cjs');
+  const { FINAL } = require('./revision-source.cjs');
+  // Deliberately inject an artificial trusted owner for contract coverage. The
+  // generated files are deleted; this test does not establish real provenance.
+  const f = p2Fixture(tape => { delete tape.seal.synthetic; delete tape.files['controls.json'].synthetic; });
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'controlled-owner-parser-'));
+  try {
+    const tape = p2Observation(f.ref).tape, receipt = ownerContractReceipt(tape);
+    const bytes = JSON.stringify(receipt), filename = path.join(directory, 'owner.json');
+    fs.writeFileSync(filename, bytes);
+    const ref = { ...f.ref, ownerReceipt: { path: filename, sha256: sha(bytes) } };
+    const admitted = p2Observation(ref, [sha(bytes)]), c = controlledFixture().controls;
+    const observation = admitted.observation;
+    assert.equal(originFor(admitted.tape).receiptSha256, sha(bytes));
+    const declaration = { kind: 'common_evaluation_controls', observationSha256: observation.observationSha256,
+      originalControlsSha256: controlsDigest({ observationQuery: observation.observationQuery,
+        observationPresentKeys: observation.observationPresentKeys, controls: observation.originalControls, interests: observation.interests }),
+      evaluationControlsSha256: controlsDigest(c) };
+    const run = observed => fullSelector({ revision: FINAL, mode: 'CONTROLLED',
+      evaluation: evaluationView(observed, c, declaration), modelControls: c.model, responseTapes: [admitted.tape] });
+    const result = await run(observation);
+    assert.equal(result.replay.consumed.length, 2);
+    assert.ok(result.replay.consumed.every(record => record.ownerReceiptSha256 === sha(bytes)));
+    assert.deepEqual(result.gaps, []);
+    assert.equal(result.quiescence.settled, true);
+    assert.equal(result.historicalTimingVerified, false);
+    assert.equal(result.artifactId, null);
+    const forged = await run(clone(observation));
+    assert.ok(forged.gaps.some(g => g.kind === 'observation_origin_unverified'));
+    assert.equal(forged.controlledExperimentComplete, false);
+  } finally { f.cleanup(); fs.rmSync(directory, { recursive: true, force: true }); }
+});

--- a/scripts/evals/reader-paired-experiment/controlled-budgets.test.cjs
+++ b/scripts/evals/reader-paired-experiment/controlled-budgets.test.cjs
@@ -1,0 +1,97 @@
+'use strict';
+const test = require('node:test'), assert = require('node:assert/strict');
+const { syntheticTape } = require('./full-selector-fixture.cjs');
+const { controlledFixture } = require('./controlled-fixture.cjs');
+const { clone } = require('./recorded-selector-ports.cjs');
+const { revisionSource, FINAL, digest } = require('./revision-source.cjs');
+const { fullSelector } = require('./revision-full-selector.cjs');
+const kinds = result => result.gaps.map(g => g.kind);
+async function run(tape) {
+  const f = controlledFixture();
+  f.controls.interests = clone(tape.files['interests.jsonl'].map(row => row.event));
+  f.observation.interests = clone(f.controls.interests);
+  f.observation.snapshot = clone(tape.files['inputs.json'].snapshot);
+  f.observation.observationSha256 = digest(f.observation.snapshot);
+  return fullSelector({ revision: FINAL, mode: 'CONTROLLED', evaluation: f.view(),
+    modelControls: f.controls.model, responseTapes: [tape] });
+}
+test('actual 200 candidate attempt bound retains the 201st pending raw row', async () => {
+  const tape = syntheticTape(), input = tape.files['inputs.json'];
+  const primary = clone(input.snapshot.candidates.find(c => c.item.id === 'promote'));
+  const body = clone(input.snapshot.sourceContent.find(c => c.feedItemId === 'promote'));
+  input.snapshot.candidates = Array.from({ length: 201 }, (_, i) => {
+    const candidate = clone(primary); candidate.item.id = `bound-${String(i).padStart(3, '0')}`;
+    candidate.item.sourceItemId = `source-${candidate.item.id}`;
+    return candidate;
+  });
+  input.snapshot.sourceContent = input.snapshot.candidates.map(c => ({ ...body, feedItemId: c.item.id, sourceItemId: c.item.sourceItemId }));
+  input.snapshot.supplementalItems = [];
+  input.primaryIds = input.snapshot.candidates.map(c => c.item.id); input.supplementalIds = [];
+  input.snapshot.physicalRowsRead = 201;
+  tape.files['models.jsonl'] = [];
+  const result = await run(tape);
+  assert.equal(result.selectorReturned, true);
+  assert.equal(result.rows.length, 201);
+  assert.equal(result.assessmentCoverage.requestedCount, 201);
+  assert.equal(result.assessmentCoverage.attemptedCount, 200);
+  assert.equal(result.rows.find(r => r.candidateId === 'bound-200').quality.reason, 'promotion_assessment_pending:budget_exhausted');
+  assert.equal(result.assessmentCoverage.unresolvedCandidateCount, 201);
+});
+test('real response parser produces a rejection and detects rehashed binding forgery', async () => {
+  const source = revisionSource(process.cwd(), FINAL, '2026-09-05T21:59:00.000Z');
+  const parse = source.load('libs/relevance/adapters/model/source-content-quality-review-wire.ts').parseReviews;
+  const hash = source.load('libs/contracts/grpc/agent_runtime/v1/execution-attestation.ts').canonicalJsonSha256;
+  const tape = syntheticTape();
+  const envelope = tape.files['models.jsonl'].find(r => r.event.kind === 'envelope_verified').event;
+  const review = envelope.result.structuredOutput.reviews.find(r => r.candidateId === 'reject');
+  review.decision = 'reject'; review.qualityScore = 0.1;
+  envelope.result.executionAttestation.selectedOutputSha256 = source.invoke(hash, [envelope.result.structuredOutput]);
+  const terminal = tape.files['assessments.jsonl'].find(r => r.event.phase === 'completed').event;
+  terminal.reviewsJson = JSON.stringify(source.invoke(parse, [JSON.stringify(envelope.result.structuredOutput), JSON.parse(terminal.requestsJson)]));
+  const result = await run(tape);
+  assert.equal(result.rows.find(r => r.candidateId === 'reject').status, 'model_resolved');
+  assert.equal(result.rows.find(r => r.candidateId === 'reject').quality.decision, 'reject');
+  assert.equal(result.rows.find(r => r.candidateId === 'reject').quality.eligibleForSummary, false);
+  // Retained producer verdicts must agree too; this modified synthetic tape has
+  // deliberately not updated verdictsJson and is therefore explicitly partial.
+  assert.ok(kinds(result).includes('assessment_verdict_replay_mismatch'));
+  assert.equal(result.complete, false);
+  review.bindingId = 'forged-other-source';
+  envelope.result.executionAttestation.selectedOutputSha256 = source.invoke(hash, [envelope.result.structuredOutput]);
+  const forged = await run(tape);
+  assert.ok(kinds(forged).includes('assessment_replay_failed'));
+  assert.equal(forged.rows.find(r => r.candidateId === 'reject').status, 'pending');
+});
+test('actual total-byte exhaustion stops attempts while retaining every eligible source', async () => {
+  const tape = syntheticTape(), input = tape.files['inputs.json'];
+  const primary = clone(input.snapshot.candidates.find(c => c.item.id === 'promote'));
+  const body = clone(input.snapshot.sourceContent.find(c => c.feedItemId === 'promote'));
+  input.snapshot.candidates = Array.from({ length: 30 }, (_, i) => {
+    const candidate = clone(primary);
+    candidate.item.id = `bytes-${String(i).padStart(2, '0')}`;
+    candidate.item.sourceItemId = `source-${candidate.item.id}`;
+    return candidate;
+  });
+  input.snapshot.sourceContent = input.snapshot.candidates.map(c =>
+    ({ ...body, feedItemId: c.item.id, sourceItemId: c.item.sourceItemId }));
+  input.snapshot.supplementalItems = [];
+  input.primaryIds = input.snapshot.candidates.map(c => c.item.id);
+  input.supplementalIds = []; input.snapshot.physicalRowsRead = 30;
+  tape.files['interests.jsonl'][0].event.result.interest.query = 'technical evidence '.repeat(1600);
+  tape.files['models.jsonl'] = [];
+  const result = await run(tape);
+  assert.equal(result.selectorReturned, true);
+  assert.equal(result.rows.length, 30);
+  assert.equal(result.assessmentCoverage.requestedCount, 30);
+  assert.ok(result.assessmentCoverage.attemptedCount > 0 && result.assessmentCoverage.attemptedCount < 30);
+  const batches = result.gaps.filter(g => g.kind === 'missing_assessment_request').map(g => g.request);
+  const bytes = batch => 2 + batch.reduce((sum, r) => sum + Buffer.byteLength(JSON.stringify(r)) + 1, 0);
+  assert.ok(batches.every(batch => bytes(batch) <= 64000));
+  const total = batches.reduce((sum, batch) => sum + bytes(batch), 0);
+  const smallest = Math.min(...result.assessmentRequests.map(r => bytes([r])));
+  assert.ok(total <= 512000 && total + smallest > 512000);
+  assert.equal(batches.flat().length, result.assessmentCoverage.attemptedCount);
+  assert.ok(result.rows.filter(r => !r.attempted).every(r =>
+    r.quality.reason === 'promotion_assessment_pending:budget_exhausted'));
+  assert.equal(result.assessmentCoverage.unresolvedCandidateCount, 30);
+});

--- a/scripts/evals/reader-paired-experiment/controlled-evaluation-view.cjs
+++ b/scripts/evals/reader-paired-experiment/controlled-evaluation-view.cjs
@@ -1,0 +1,53 @@
+'use strict';
+const { check, digest } = require('./revision-source.cjs');
+const { date } = require('./frozen-input.cjs');
+const { clone, canonical, same, withKeys } = require('./recorded-selector-ports.cjs');
+const { freeze, validateRaw } = require('./capture-core-observation.cjs');
+const controlsDigest = value => digest(canonical(value));
+function queryRecord(record) {
+  check(record && record.query && Array.isArray(record.presentKeys), 'explicit_query_and_present_keys_required');
+  withKeys(record.query, record.presentKeys);
+  return record;
+}
+function evaluationView(observation, controls, declaration) {
+  check(observation.format === 'paired-immutable-observation.v1', 'immutable_observation_required');
+  const query = queryRecord(controls.snapshot).query;
+  const selection = queryRecord(controls.selection).query;
+  const cutoff = controls.clock, original = observation.observationQuery;
+  check(date(cutoff) >= date(original.observedThrough), 'evaluation_precedes_observation');
+  check(query.observedThrough === cutoff && selection.observedThrough === cutoff, 'evaluation_clock_query_mismatch');
+  for (const key of ['tenantId', 'workspaceId']) check(query[key] === observation.scope[key] &&
+    selection[key] === observation.scope[key], 'evaluation_scope_mismatch');
+  check(same({ ...query, observedThrough: original.observedThrough }, original), 'evaluation_population_query_changed');
+  check(selection.period?.startedAt === query.windowStartedAt && selection.period.endedAt === query.windowEndedAt &&
+    selection.period.cadence === 'daily' && selection.period.timezone === 'UTC', 'evaluation_period_mismatch');
+  check(selection.scope && ['workspace', 'user'].includes(selection.scope.type) &&
+    Number.isSafeInteger(selection.maxItems) && selection.maxItems > 0 &&
+    typeof controls.locale === 'string' && controls.locale.trim(), 'explicit_selector_controls_required');
+  check(controls.model?.assessment && controls.model.relation && Array.isArray(controls.interests), 'explicit_model_and_interest_controls_required');
+  // The complete original context and complete common target are both bound.
+  // Even an unchanged target requires the declaration, so no caller can
+  // silently reinterpret missing capture-core selector options as observations.
+  const originalControls = { observationQuery: original, observationPresentKeys: observation.observationPresentKeys,
+    controls: observation.originalControls, interests: observation.interests };
+  check(declaration?.kind === 'common_evaluation_controls' && declaration.observationSha256 === observation.observationSha256 &&
+    declaration.originalControlsSha256 === controlsDigest(originalControls) &&
+    declaration.evaluationControlsSha256 === controlsDigest(controls), 'undeclared_evaluation_intervention');
+  const rows = validateRaw({ day: observation.day, snapshot: observation.snapshot, query: original,
+    endedAt: observation.endedAt }, observation.scope);
+  const needed = new Set(rows.map(row => row.interestId)), seen = new Set();
+  for (const interest of controls.interests) {
+    check(interest.query && same(Object.keys(interest.query).sort(), ['interestId', 'tenantId', 'workspaceId']) &&
+      ['tenantId', 'workspaceId'].every(k => interest.query[k] === observation.scope[k]) &&
+      typeof interest.query.interestId === 'string' && interest.query.interestId.trim() && !seen.has(interest.query.interestId), 'evaluation_interest_inventory_mismatch');
+    check(interest.result?.kind === 'available' && ['tenantId', 'workspaceId', 'interestId'].every(k =>
+      interest.result.interest[k] === interest.query[k]) && typeof interest.result.interest.query === 'string' &&
+      interest.result.interest.query.trim(), 'evaluation_interest_unavailable');
+    seen.add(interest.query.interestId);
+  }
+  check([...needed].every(id => seen.has(id)), 'evaluation_interest_inventory_incomplete');
+  return freeze({ format: 'paired-controlled-evaluation-view.v1', observation, controls: clone(controls),
+    declaration: clone(declaration), controlsSha256: controlsDigest(controls),
+    originalControlsSha256: controlsDigest(originalControls), evaluationClock: cutoff });
+}
+module.exports = { evaluationView, controlsDigest, queryRecord };

--- a/scripts/evals/reader-paired-experiment/controlled-fixture.cjs
+++ b/scripts/evals/reader-paired-experiment/controlled-fixture.cjs
@@ -1,0 +1,26 @@
+'use strict';
+// Synthetic compatibility inputs. Never a producer receipt or authority anchor.
+const { syntheticTape, modelControls } = require('./full-selector-fixture.cjs');
+const { clone } = require('./recorded-selector-ports.cjs');
+const { digest } = require('./revision-source.cjs');
+const { evaluationView, controlsDigest } = require('./controlled-evaluation-view.cjs');
+function controlledFixture() {
+  const tape = syntheticTape(), snapshot = tape.files['inputs.json'].snapshot;
+  const q = tape.files['snapshot-query.json'], selection = tape.files['selection-query.json'];
+  const observation = { format: 'paired-immutable-observation.v1', kind: 'synthetic_test_only',
+    day: q.query.windowStartedAt.slice(0, 10), scope: { tenantId: q.query.tenantId, workspaceId: q.query.workspaceId },
+    observationRef: { path: 'synthetic_test_only', sha256: tape.sealSha256 },
+    observationQuery: clone(q.query), observationPresentKeys: clone(q.presentKeys),
+    snapshot: clone(snapshot), startedAt: q.query.observedThrough, endedAt: q.query.observedThrough,
+    interests: tape.files['interests.jsonl'].map(r => clone(r.event)), originalControls: clone(tape.files['controls.json']),
+    provenance: { integrityVerified: false, independentOriginVerified: false, modelInvocationHistory: 'synthetic' },
+    observationSha256: digest(snapshot) };
+  const controls = { clock: q.query.observedThrough, snapshot: clone(q), selection: clone(selection),
+    model: clone(modelControls), locale: 'en', interests: clone(observation.interests) };
+  const declare = () => ({ kind: 'common_evaluation_controls', observationSha256: observation.observationSha256,
+    originalControlsSha256: controlsDigest({ observationQuery: observation.observationQuery,
+      observationPresentKeys: observation.observationPresentKeys, controls: observation.originalControls, interests: observation.interests }),
+    evaluationControlsSha256: controlsDigest(controls) });
+  return { tape, observation, controls, declare, view: () => evaluationView(observation, controls, declare()) };
+}
+module.exports = { controlledFixture };

--- a/scripts/evals/reader-paired-experiment/controlled-host.test.cjs
+++ b/scripts/evals/reader-paired-experiment/controlled-host.test.cjs
@@ -1,0 +1,62 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { replayHost } = require('./replay-host.cjs');
+
+test('controlled detached parser work settles without changing the foreground result', async () => {
+  const host = replayHost(), order = [];
+  try {
+    const selection = { selected: ['foreground'] };
+    host.globals.setImmediate(() => {
+      host.track('shadow:parser', async () => {
+        order.push('shadow response');
+        await Promise.resolve();
+        order.push('shadow parsed');
+      });
+    }).unref();
+    host.globals.AbortSignal.timeout(100);
+    const actual = await host.run(Promise.resolve(selection), { requireQuiescence: true });
+    assert.equal(actual, selection);
+    assert.deepEqual(order, ['shadow response', 'shadow parsed']);
+    assert.equal(host.quiescence().settled, true);
+    assert.equal(host.report().pendingTimers.length, 1);
+  } finally { host.close(); }
+});
+
+test('foreground completion and unused timers cannot hide a pending shadow parser', async () => {
+  const host = replayHost();
+  let finish;
+  try {
+    host.globals.AbortSignal.timeout(100);
+    const shadow = host.track('shadow:relation-parser', () => new Promise(resolve => { finish = resolve; }));
+    await assert.rejects(host.run(Promise.resolve('selected'), { requireQuiescence: true }), /controlled_operation_unfinished/);
+    assert.deepEqual(host.quiescence().outstanding, [{ id: 1, label: 'shadow:relation-parser' }]);
+    assert.equal(host.quiescence().settled, false);
+    assert.ok(host.report().trace.every(entry => entry.action !== 'fired'));
+    finish(); await shadow;
+    assert.equal(host.quiescence().settled, true);
+  } finally { host.close(); }
+});
+
+test('caught detached parser failure stays sticky and concurrent operation bindings remain separate', async () => {
+  const host = replayHost();
+  let finish;
+  try {
+    const foreground = host.track('foreground:assessment', () => new Promise(resolve => { finish = resolve; }));
+    const shadow = host.track('shadow:relation', async () => { throw Error('malformed'); }).catch(() => []);
+    await shadow;
+    assert.deepEqual(host.quiescence().outstanding, [{ id: 1, label: 'foreground:assessment' }]);
+    assert.deepEqual(host.quiescence().failedOperations, [{ id: 2, label: 'shadow:relation' }]);
+    finish('parsed'); assert.equal(await foreground, 'parsed');
+    await assert.rejects(host.run(Promise.resolve('selected'), { requireQuiescence: true }), /controlled_operation_failed/);
+    assert.equal(host.quiescence().settled, false);
+    // Historical/default behavior is unchanged; its completion contract is
+    // separate and does not opt in to controlled operation certification.
+    assert.equal(await host.run(Promise.resolve('selected')), 'selected');
+  } finally { host.close(); }
+});
+
+test('closed hosts reject new operation ownership', () => {
+  const host = replayHost(); host.close();
+  assert.throws(() => host.track('late', () => 1), /replay_host_closed/);
+});

--- a/scripts/evals/reader-paired-experiment/controlled-matrix.cjs
+++ b/scripts/evals/reader-paired-experiment/controlled-matrix.cjs
@@ -1,0 +1,93 @@
+'use strict';
+const { OLD, FINAL, digest, check } = require('./revision-source.cjs');
+const { DAYS, date } = require('./frozen-input.cjs');
+const { captureCore } = require('./capture-core-observation.cjs');
+const { p2Observation } = require('./p2-observation.cjs');
+const { evaluationView } = require('./controlled-evaluation-view.cjs');
+const { fullSelector } = require('./revision-full-selector.cjs');
+const { compare } = require('./revision-selection.cjs');
+const { same } = require('./recorded-selector-ports.cjs');
+const ARM_PLAN = [['oldAfter', OLD, 'after'], ['finalAfter', FINAL, 'after'], ['finalBefore', FINAL, 'before']];
+function inputDifference(before, after) {
+  const rows = observation => [
+    ...observation.snapshot.candidates.map((row, index) => ({ id: row.item.id, partition: 'primary', index, row })),
+    ...(observation.snapshot.supplementalItems || []).map((row, index) => ({ id: row.id, partition: 'supplemental', index, row })),
+  ];
+  const left = new Map(rows(before).map(r => [r.id, r])), right = new Map(rows(after).map(r => [r.id, r]));
+  const source = observation => new Map(observation.snapshot.sourceContent.map(s => [s.feedItemId, s]));
+  const leftSource = source(before), rightSource = source(after);
+  return { estimand: 'all_observed_input_changes', metricsOnlyVerified: false,
+    beforeObservationSha256: before.observationSha256, afterObservationSha256: after.observationSha256,
+    rows: [...new Set([...left.keys(), ...right.keys()])].map(id => ({ candidateId: id,
+      before: left.get(id) ?? null, after: right.get(id) ?? null,
+      beforeSourceContent: leftSource.get(id) ?? null, afterSourceContent: rightSource.get(id) ?? null,
+      changed: !same(left.get(id), right.get(id)) || !same(leftSource.get(id), rightSource.get(id)) })) };
+}
+async function executeControlled(manifest, repo, expectedReceiptSha256s = []) {
+  check(manifest.format === 'paired-controlled-experiment.v1' && manifest.mode === 'CONTROLLED', 'explicit_controlled_manifest_required');
+  check(same(manifest.pins, { old: OLD, final: FINAL }), 'exact_algorithm_pins_required');
+  check(same(manifest.days.map(d => d.day), DAYS), 'exact_ordered_seven_UTC_days_required');
+  check(manifest.schedule === 'successful_immediate_lexicographic_record.v1', 'explicit_frozen_schedule_required');
+  const result = { format: 'paired-controlled-results.v1', mode: 'CONTROLLED', complete: false,
+    controlledExperimentComplete: false, historicalTimingVerified: false, historicalReplayComplete: false,
+    publicationComplete: false, artifactId: null, algorithm: [], data: [], days: [], gaps: [],
+    estimands: ['algorithm_change_on_identical_AFTER', 'all_observed_BEFORE_AFTER_input_changes_under_FINAL'],
+    excludedFromEstimand: ['transport_latency', 'model_latency', 'deadline_frequency', 'historical_ordering'],
+    manifestSha256: digest(manifest), schedule: manifest.schedule, expectedReceiptSha256s: [...expectedReceiptSha256s] };
+  let beforeDays = [];
+  try { beforeDays = captureCore(manifest.before, expectedReceiptSha256s); }
+  catch (error) { result.gaps.push({ kind: 'before_capture_invalid', code: error.message }); }
+  for (const day of manifest.days) {
+    const observations = { before: beforeDays.find(o => o.day === day.day) }, views = {}, arms = {}, pool = [];
+    try {
+      const after = p2Observation(day.after, expectedReceiptSha256s);
+      check(after.observation.day === day.day, 'after_observation_day_mismatch');
+      observations.after = after.observation; pool.push(after.tape);
+      if (!after.observation.provenance.independentOriginVerified) result.gaps.push({ day: day.day, kind: 'after_origin_unverified', code: after.observation.provenance.originGap });
+    } catch (error) { result.gaps.push({ day: day.day, kind: 'after_capture_invalid', code: error.message }); }
+    for (const [index, ref] of (day.responsePool || []).entries()) {
+      try {
+        const response = p2Observation(ref, expectedReceiptSha256s); pool.push(response.tape);
+        if (!response.observation.provenance.independentOriginVerified) result.gaps.push({ day: day.day, responsePoolIndex: index, kind: 'response_origin_unverified', code: response.observation.provenance.originGap });
+      }
+      catch (error) { result.gaps.push({ day: day.day, responsePoolIndex: index, kind: 'response_capture_invalid', code: error.message }); }
+    }
+    try {
+      check(observations.after && day.evaluationControls.clock === observations.after.observationQuery.observedThrough, 'evaluation_clock_must_derive_from_AFTER');
+      if (observations.before) check(date(day.evaluationControls.clock) > date(observations.before.observationQuery.observedThrough), 'AFTER_must_follow_BEFORE');
+      for (const population of ['before', 'after']) if (observations[population])
+        views[population] = evaluationView(observations[population], day.evaluationControls, day.interventions?.[population]);
+    } catch (error) { result.gaps.push({ day: day.day, kind: 'evaluation_controls_invalid', code: error.message }); }
+    for (const [arm, revision, population] of ARM_PLAN) {
+      arms[arm] = null;
+      if (!views[population]) { result.gaps.push({ day: day.day, arm, kind: 'missing_valid_evaluation_view' }); continue; }
+      try {
+        arms[arm] = await fullSelector({ repo, revision, mode: 'CONTROLLED', evaluation: views[population],
+          responseTapes: pool, modelControls: day.evaluationControls.model });
+        result.gaps.push(...arms[arm].gaps.map(g => ({ day: day.day, arm, ...g })));
+      } catch (error) { result.gaps.push({ day: day.day, arm, kind: 'controlled_arm_failed', code: error.message }); }
+    }
+    for (const [experiment, leftKey, rightKey] of [['algorithm', 'oldAfter', 'finalAfter'], ['data', 'finalBefore', 'finalAfter']]) {
+      const left = arms[leftKey], right = arms[rightKey];
+      const matched = left && right && left.evaluationControlsSha256 === right.evaluationControlsSha256;
+      const complete = Boolean(matched && left.controlledExperimentComplete && right.controlledExperimentComplete);
+      let changes = null;
+      if (matched && left.rows && right.rows) {
+        const { missingAssessmentCount, ...difference } = compare(left, right);
+        changes = { ...difference, unresolvedCandidateCount: missingAssessmentCount,
+          replayMissingRequestCount: new Set([...left.gaps, ...right.gaps].filter(g => g.kind.startsWith('missing_')).map(g => g.kind + ':' + g.requestSha256)).size };
+      }
+      result[experiment].push({ day: day.day, beforeArm: leftKey, afterArm: rightKey, controlledExperimentComplete: complete,
+        matchedExogenousControls: Boolean(matched), changes,
+        beforeSha256: left ? digest(left) : null, afterSha256: right ? digest(right) : null });
+    }
+    result.days.push({ day: day.day, arms, inputDifference: observations.before && observations.after
+      ? inputDifference(observations.before, observations.after) : null });
+  }
+  result.executedArmCount = result.days.flatMap(d => Object.values(d.arms)).filter(Boolean).length;
+  result.comparisonCount = result.algorithm.length + result.data.length;
+  result.controlledExperimentComplete = result.executedArmCount === 21 && result.comparisonCount === 14 &&
+    result.gaps.length === 0 && [...result.algorithm, ...result.data].every(c => c.controlledExperimentComplete);
+  return result;
+}
+module.exports = { executeControlled, inputDifference, ARM_PLAN };

--- a/scripts/evals/reader-paired-experiment/controlled-matrix.test.cjs
+++ b/scripts/evals/reader-paired-experiment/controlled-matrix.test.cjs
@@ -1,0 +1,135 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { executeControlled, ARM_PLAN, inputDifference } = require('./controlled-matrix.cjs');
+const { DAYS } = require('./frozen-input.cjs');
+const { OLD, FINAL } = require('./revision-source.cjs');
+const { controlledFixture } = require('./controlled-fixture.cjs');
+const { clone } = require('./recorded-selector-ports.cjs');
+function manifest() {
+  return { format: 'paired-controlled-experiment.v1', mode: 'CONTROLLED', pins: { old: OLD, final: FINAL },
+    schedule: 'successful_immediate_lexicographic_record.v1', days: DAYS.map(day => ({ day })) };
+}
+test('controlled matrix declares exactly 21 unique arms and two distinct seven-day comparisons', async () => {
+  assert.deepEqual(ARM_PLAN, [['oldAfter', OLD, 'after'], ['finalAfter', FINAL, 'after'], ['finalBefore', FINAL, 'before']]);
+  assert.equal(ARM_PLAN.length * DAYS.length, 21);
+  const result = await executeControlled(manifest(), process.cwd());
+  assert.equal(result.algorithm.length, 7);
+  assert.equal(result.data.length, 7);
+  assert.equal(result.comparisonCount, 14);
+  assert.equal(result.executedArmCount, 0);
+  assert.equal(result.controlledExperimentComplete, false);
+  assert.equal(result.historicalTimingVerified, false);
+  assert.equal(result.historicalReplayComplete, false);
+  assert.equal(result.publicationComplete, false);
+  for (const [i, day] of result.days.entries()) {
+    assert.equal(day.day, DAYS[i]);
+    assert.deepEqual(Object.keys(day.arms), ['oldAfter', 'finalAfter', 'finalBefore']);
+    assert.equal(result.algorithm[i].afterArm, 'finalAfter');
+    assert.equal(result.data[i].afterArm, 'finalAfter');
+  }
+  assert.equal(result.gaps.filter(g => g.kind === 'missing_valid_evaluation_view').length, 21);
+});
+test('omitted days, wrong revisions and unspecified scheduling are rejected before execution', async () => {
+  for (const change of [m => m.days.pop(), m => { m.pins.old = FINAL; }, m => { delete m.schedule; }, m => { delete m.mode; }]) {
+    const m = manifest(); change(m);
+    await assert.rejects(executeControlled(m, process.cwd()));
+  }
+});
+test('data contrast retains population, order, source, metric and authority differences without a metrics-only claim', () => {
+  const before = controlledFixture().observation, after = clone(before);
+  after.snapshot.candidates[0].canonical.metrics = { kind: 'hacker_news', points: 321 };
+  after.snapshot.candidates[0].metricAuthority = { regressionState: 'confirmed_correction', observedAt: '2026-09-09T12:00:00.000Z' };
+  after.snapshot.sourceContent[0].body += ' synthetic change';
+  after.snapshot.supplementalItems.reverse();
+  const diff = inputDifference(before, after);
+  assert.equal(diff.metricsOnlyVerified, false);
+  assert.equal(diff.rows.length, 16);
+  assert.ok(diff.rows.some(r => r.changed && r.before.partition === 'primary'));
+  assert.ok(diff.rows.some(r => r.changed && r.before.partition === 'supplemental'));
+  assert.notDeepEqual(diff.rows[0].beforeSourceContent, diff.rows[0].afterSourceContent);
+  assert.deepEqual(diff.rows[0].after.row.metricAuthority, after.snapshot.candidates[0].metricAuthority);
+});
+
+test('controlled CLI writes an incomplete report create-only and never promotes missing inputs', () => {
+  const fs = require('node:fs'), os = require('node:os'), path = require('node:path');
+  const { spawnSync } = require('node:child_process');
+  const { sha } = require('./revision-source.cjs');
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'controlled-cli-'));
+  try {
+    const file = path.join(directory, 'manifest.json'), out = path.join(directory, 'result.json');
+    const bytes = JSON.stringify(manifest()); fs.writeFileSync(file, bytes);
+    const args = [path.join(__dirname, 'run.cjs'), '--mode', 'controlled', '--manifest', file,
+      '--sha256', sha(bytes), '--out', out];
+    const first = spawnSync(process.execPath, args, { encoding: 'utf8' });
+    assert.equal(first.status, 2, first.stderr);
+    const original = fs.readFileSync(out), report = JSON.parse(original);
+    assert.equal(report.mode, 'CONTROLLED');
+    assert.equal(report.controlledExperimentComplete, false);
+    assert.equal(report.comparisonCount, 14);
+    assert.equal(fs.statSync(out).mode & 0o777, 0o600);
+    const second = spawnSync(process.execPath, args, { encoding: 'utf8' });
+    assert.equal(second.status, 2);
+    assert.match(second.stderr, /EEXIST/);
+    assert.deepEqual(fs.readFileSync(out), original);
+  } finally { fs.rmSync(directory, { recursive: true, force: true }); }
+});
+
+test('all 21 real pinned selectors run offline on seven synthetic observation pairs with common controls; missing authority stays incomplete', async () => {
+  const { captureCoreFixture } = require('./capture-core-fixture.cjs');
+  const { p2Fixture } = require('./p2-fixture.cjs');
+  const { captureCore } = require('./capture-core-observation.cjs');
+  const { p2Observation } = require('./p2-observation.cjs');
+  const { controlsDigest } = require('./controlled-evaluation-view.cjs');
+  const { modelControls } = require('./full-selector-fixture.cjs');
+  const before = captureCoreFixture(), afterFixtures = [];
+  try {
+    const observations = captureCore(before.args), m = manifest(); m.before = before.args;
+    for (const [i, day] of m.days.entries()) {
+      const after = p2Fixture(tape => {
+        const record = clone(before.records[i]), input = tape.files['inputs.json'];
+        record.query.observedThrough = '2026-09-09T12:00:00.000Z';
+        input.query = record.query; input.queryKeys = Object.keys(record.query); input.snapshot = record.snapshot;
+        tape.files['snapshot-query.json'] = { query: clone(record.query), presentKeys: input.queryKeys };
+        tape.seal.scope.observedThrough = record.query.observedThrough;
+        tape.files['started.json'].scope = clone(tape.seal.scope);
+        const selection = tape.files['selection-query.json'].query;
+        selection.observedThrough = record.query.observedThrough;
+        selection.period.startedAt = record.query.windowStartedAt; selection.period.endedAt = record.query.windowEndedAt;
+      });
+      afterFixtures.push(after);
+      const observedAfter = p2Observation(after.ref).observation;
+      day.after = after.ref;
+      day.evaluationControls = { clock: observedAfter.observationQuery.observedThrough, locale: 'en',
+        snapshot: clone(after.tape.files['snapshot-query.json']), selection: clone(after.tape.files['selection-query.json']),
+        interests: clone(after.tape.files['interests.jsonl'].map(r => r.event)), model: clone(modelControls) };
+      day.evaluationControls.snapshot.presentKeys.push('interestId');
+      const declare = observation => ({ kind: 'common_evaluation_controls', observationSha256: observation.observationSha256,
+        originalControlsSha256: controlsDigest({ observationQuery: observation.observationQuery,
+          observationPresentKeys: observation.observationPresentKeys, controls: observation.originalControls, interests: observation.interests }),
+        evaluationControlsSha256: controlsDigest(day.evaluationControls) });
+      day.interventions = { before: declare(observations[i]), after: declare(observedAfter) };
+    }
+    const result = await executeControlled(m, process.cwd());
+    assert.equal(result.executedArmCount, 21, JSON.stringify(result.gaps));
+    assert.equal(result.comparisonCount, 14);
+    assert.ok([...result.algorithm, ...result.data].every(c => c.matchedExogenousControls));
+    for (const [i, day] of result.days.entries()) {
+      for (const arm of Object.values(day.arms)) {
+        assert.equal(arm.selectorReturned, true, JSON.stringify(arm.gaps));
+        assert.equal(arm.rows.length, 16);
+        assert.equal(arm.inventory.primary.length, 4);
+        assert.equal(arm.inventory.supplemental.length, 12);
+        assert.equal(arm.controlledExperimentComplete, false);
+        assert.equal(arm.actualProducerVerified, false);
+        assert.deepEqual(arm.observation.snapshot, before.records[i].snapshot);
+      }
+      assert.ok(day.arms.oldAfter.rows.every(r => r.status === 'deterministic_legacy'));
+      assert.equal(result.algorithm[i].afterSha256, result.data[i].afterSha256);
+    }
+    assert.ok(result.gaps.some(g => g.kind === 'observation_origin_unverified'));
+    assert.equal(result.controlledExperimentComplete, false);
+    assert.equal(result.historicalTimingVerified, false);
+    assert.equal(result.publicationComplete, false);
+  } finally { before.cleanup(); afterFixtures.forEach(f => f.cleanup()); }
+});

--- a/scripts/evals/reader-paired-experiment/controlled-responses.test.cjs
+++ b/scripts/evals/reader-paired-experiment/controlled-responses.test.cjs
@@ -1,0 +1,127 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { recordedResponses } = require('./recorded-model-responses.cjs');
+const { syntheticTape, modelControls } = require('./full-selector-fixture.cjs');
+const { revisionSource, FINAL } = require('./revision-source.cjs');
+const { replayHost } = require('./replay-host.cjs');
+const { ledger, clone } = require('./recorded-selector-ports.cjs');
+function setup(tapes) {
+  const host = replayHost(), clock = { now: () => new Date('2026-09-05T21:59:00.000Z') };
+  const source = revisionSource(process.cwd(), FINAL, clock.now().toISOString(), host), gaps = ledger();
+  const replay = recordedResponses(source, tapes, gaps, clock, modelControls, { mode: 'CONTROLLED', host });
+  const requests = JSON.parse(tapes[0].files['assessments.jsonl'].find(r => r.event.phase === 'attempt').event.requestsJson);
+  const raw = clone(tapes[0].files['relations.jsonl'].find(r => r.event.phase === 'attempt').event.query);
+  // Only the typed date fields consumed by the actual relation request builder
+  // are hydrated. The original tape remains byte-for-byte unchanged.
+  const query = { ...raw, evidence: raw.evidence.map(item => ({ ...item,
+    publishedAt: new Date(item.publishedAt), observedAt: new Date(item.observedAt) })), requestedAt: new Date(raw.requestedAt),
+    period: { ...raw.period, startedAt: new Date(raw.period.startedAt), endedAt: new Date(raw.period.endedAt) },
+    clusters: raw.clusters.map(c => ({ ...c, observedAtRange: {
+      startedAt: new Date(c.observedAtRange.startedAt), endedAt: new Date(c.observedAtRange.endedAt) } })) };
+  delete query.aborted;
+  return { host, source, replay, gaps, requests, query };
+}
+test('overlapping actual assessment and relation parsers keep separate record and transport identities', async () => {
+  const tape = syntheticTape(), s = setup([tape]);
+  try {
+    const [reviews, decisions] = await s.host.run(Promise.all([
+      s.replay.reviewer().reviewBatch(s.requests), s.replay.relation().verify(s.query),
+    ]), { requireQuiescence: true });
+    assert.equal(reviews.length, 3);
+    assert.ok(Array.isArray(decisions));
+    const report = s.replay.report();
+    assert.equal(report.consumed.length, 2);
+    assert.equal(new Set(report.consumed.map(c => c.requestId)).size, 2);
+    assert.equal(report.delivery.length, 2);
+    assert.equal(s.host.quiescence().settled, true);
+    assert.ok(s.gaps.entries().every(g => g.kind === 'producer_origin_unverified'));
+  } finally { s.host.close(); }
+});
+test('pre-aborted relation request never becomes recorded success', async () => {
+  const s = setup([syntheticTape()]);
+  try {
+    await assert.rejects(s.replay.relation().verify({ ...s.query, signal: AbortSignal.abort() }), /relation_request_expired/);
+    assert.equal(s.replay.report().consumed.length, 0);
+    assert.equal(s.host.quiescence().settled, false);
+  } finally { s.host.close(); }
+});
+test('stable selection allows differing observed durations but retains all original histories', async () => {
+  const a = syntheticTape(), b = syntheticTape();
+  a.sealSha256 = 'b'.repeat(64); b.sealSha256 = 'a'.repeat(64);
+  for (const row of b.files['models.jsonl']) if (row.event.kind === 'envelope_verified') row.atMs += 75;
+  const s = setup([a, b]);
+  try {
+    await s.host.run(s.replay.reviewer().reviewBatch(s.requests), { requireQuiescence: true });
+    assert.ok(s.replay.report().consumed[0].recordId.startsWith('a'.repeat(64)));
+    assert.equal(s.replay.report().captureHistories.length, 2);
+    assert.equal(s.replay.report().delivery[0].originalTerminalAtMs - s.replay.report().delivery[0].originalStartAtMs, 75);
+  } finally { s.host.close(); }
+});
+
+test('concurrent foreground and safe-recall shadow run actual parsers with isolated original IDs; missing shadow is sticky', async () => {
+  const base = syntheticTape(), builder = setup([base]), shadow = syntheticTape();
+  try {
+    const shadowQuery = { ...builder.query, verificationLane: 'safe_recall_shadow' };
+    const Adapter = builder.source.load('libs/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter.ts').AgentRuntimeReaderSummaryStoryRelationVerifier;
+    const admit = builder.source.load('apps/agent-runtime/src/subscription-runtime-purpose-model-policy.ts').admitSubscriptionRuntimeRequest;
+    const hash = builder.source.load('libs/contracts/grpc/agent_runtime/v1/execution-attestation.ts').canonicalJsonSha256;
+    let shadowCommand, shadowResult;
+    // Synthetic contract fixture generated through the actual command builder.
+    // No capture owner is attached and no provider or runtime client is invoked.
+    const adapter = new Adapter({ client: { async runTask(command) {
+      shadowCommand = clone(command);
+      shadowResult = clone(base.files['models.jsonl'].filter(r => r.event.kind === 'envelope_verified').at(-1).event.result);
+      shadowResult.executionAttestation.requestId = command.requestId;
+      const admitted = builder.source.invoke(admit, [{ ...command, providerInstanceId: undefined, cwd: undefined,
+        outputSchemaJson: JSON.stringify(command.outputSchema), controlsJson: JSON.stringify(command.controls), metadata: command.metadata ?? {} }]);
+      shadowResult.executionAttestation.canonicalRequestSha256 = builder.source.invoke(hash, [admitted.canonicalRequest]);
+      return shadowResult;
+    } } });
+    const decisions = await adapter.verify(shadowQuery);
+    const oldId = base.files['models.jsonl'].filter(r => r.event.kind === 'invocation_started').at(-1).event.command.requestId;
+    shadow.files['models.jsonl'] = shadow.files['models.jsonl'].filter(r => r.event.command?.requestId === oldId);
+    shadow.files['models.jsonl'].forEach(row => {
+      row.event.command = clone(shadowCommand);
+      if (row.event.kind === 'envelope_verified') row.event.result = clone(shadowResult);
+    });
+    shadow.files['relations.jsonl'].forEach(row => {
+      if (row.event.phase === 'attempt') row.event.query = clone({ ...shadowQuery, aborted: false });
+      else row.event.outcome.decisions = clone(decisions);
+    });
+    shadow.files['assessments.jsonl'] = [];
+    shadow.sealSha256 = 'd'.repeat(64);
+    const s = setup([base, shadow]);
+    try {
+      const verifier = s.replay.relation();
+      await s.host.run(Promise.all([verifier.verify(s.query), verifier.verify({ ...s.query, verificationLane: 'safe_recall_shadow' })]), { requireQuiescence: true });
+      assert.deepEqual(new Set(s.replay.report().consumed.map(record => record.requestId)), new Set([oldId, shadowCommand.requestId]));
+      assert.ok(s.gaps.entries().every(gap => gap.kind === 'producer_origin_unverified'));
+      assert.equal(s.host.quiescence().settled, true);
+    } finally { s.host.close(); }
+    await assert.rejects(builder.replay.relation().verify(shadowQuery), /missing_relation_request/);
+    assert.ok(builder.gaps.entries().some(gap => gap.kind === 'missing_relation_request'));
+    assert.equal(builder.host.quiescence().settled, false);
+  } finally { builder.host.close(); }
+});
+
+test('controlled response conflicts fail closed and a separate success never rewrites a failed historical attempt', async () => {
+  const a = syntheticTape(), b = syntheticTape(); b.sealSha256 = 'e'.repeat(64);
+  const end = b.files['models.jsonl'].find(row => row.event.kind === 'envelope_verified');
+  end.event.result.structuredOutput.reviews[0].confidence = 0.81;
+  const conflict = setup([a, b]);
+  try {
+    await assert.rejects(conflict.replay.reviewer().reviewBatch(conflict.requests), /ambiguous_recorded_request/);
+    assert.ok(conflict.gaps.entries().some(gap => gap.kind === 'ambiguous_recorded_request'));
+  } finally { conflict.host.close(); }
+  end.event.kind = 'invocation_failed';
+  const success = setup([a, b]);
+  try {
+    await success.host.run(success.replay.reviewer().reviewBatch(success.requests), { requireQuiescence: true });
+    const report = success.replay.report();
+    assert.ok(report.consumed[0].recordId.startsWith(a.sealSha256));
+    assert.ok(report.captureHistories[1].models.some(row => row.event.kind === 'invocation_failed'));
+    assert.equal(end.event.kind, 'invocation_failed');
+    assert.ok(success.gaps.entries().some(gap => gap.kind === 'producer_origin_unverified'));
+  } finally { success.host.close(); }
+});

--- a/scripts/evals/reader-paired-experiment/controlled-selector.test.cjs
+++ b/scripts/evals/reader-paired-experiment/controlled-selector.test.cjs
@@ -1,0 +1,94 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { controlledFixture } = require('./controlled-fixture.cjs');
+const { evaluationView } = require('./controlled-evaluation-view.cjs');
+const { fullSelector } = require('./revision-full-selector.cjs');
+const { FINAL, OLD, digest } = require('./revision-source.cjs');
+const { clone } = require('./recorded-selector-ports.cjs');
+const run = (f, extra = {}) => fullSelector({ revision: FINAL, mode: 'CONTROLLED', evaluation: f.view(),
+  modelControls: f.controls.model, responseTapes: [f.tape], ...extra });
+
+test('evaluation clock changes without rewriting any original observation timestamp', () => {
+  const f = controlledFixture(), original = clone(f.observation);
+  f.controls.clock = '2026-09-09T12:00:00.000Z';
+  f.controls.snapshot.query.observedThrough = f.controls.clock;
+  f.controls.selection.query.observedThrough = f.controls.clock;
+  const view = f.view();
+  assert.equal(view.evaluationClock, f.controls.clock);
+  assert.deepEqual(view.observation, original);
+  assert.notEqual(view.observation.observationQuery.observedThrough, view.evaluationClock);
+  assert.throws(() => evaluationView(f.observation, { ...f.controls, locale: 'fr' }, f.declare()), /undeclared_evaluation_intervention/);
+});
+
+test('query present keys, clock, scoped interests and original-control bindings fail closed', () => {
+  for (const mutate of [
+    f => { f.controls.snapshot.presentKeys.pop(); },
+    f => { f.controls.selection.query.observedThrough = '2026-09-04T00:00:00.000Z'; },
+    f => { f.controls.snapshot.query.interestId = 'different'; },
+    f => { f.controls.interests = []; },
+    f => { f.controls.interests[0].result.interest.workspaceId = 'different'; },
+  ]) {
+    const f = controlledFixture(); mutate(f);
+    assert.throws(() => f.view());
+  }
+  const f = controlledFixture(), declaration = f.declare();
+  f.observation.interests[0].result.interest.query += ' changed';
+  assert.throws(() => evaluationView(f.observation, f.controls, declaration), /undeclared_evaluation_intervention/);
+});
+
+test('nonzero observed successes pass real controlled parsers while retaining duration and unverified synthetic origin', async () => {
+  const f = controlledFixture();
+  for (const row of f.tape.files['models.jsonl']) if (row.event.kind === 'envelope_verified') row.atMs += 50;
+  const result = await run(f);
+  assert.equal(result.selectorReturned, true);
+  assert.equal(result.rows.length, 16);
+  assert.equal(result.inventory.supplemental.length, 12);
+  assert.equal(result.replay.consumed.length, 2);
+  assert.equal(result.replay.delivery.length, 2);
+  assert.ok(result.replay.delivery.every(d => d.controlledElapsedMs === 0 && d.originalTerminalAtMs - d.originalStartAtMs === 50));
+  assert.equal(result.quiescence.settled, true);
+  assert.equal(result.preparationAudit.status, 'controlled_actual_stage_inventory');
+  assert.equal(result.preparationAudit.historicalCallbackEqualityVerified, false);
+  assert.ok(result.gaps.some(g => g.kind === 'producer_origin_unverified'));
+  assert.equal(result.controlledExperimentComplete, false);
+  assert.equal(result.historicalTimingVerified, false);
+  assert.equal(result.historicalReplayComplete, false);
+  assert.equal(result.actualProducerVerified, false);
+  assert.equal(result.rows.find(r => r.candidateId === 'abstain').status, 'model_abstained');
+  assert.equal(result.rows.find(r => r.candidateId === 'hard-gate').status, 'deterministic_hard_gate');
+  const repeated = await run(f);
+  assert.equal(digest(repeated), digest(result));
+  const unobserved = await run(f, { observe: false });
+  assert.deepEqual(unobserved.selection, result.selection);
+  assert.deepEqual(unobserved.replay.consumed, result.replay.consumed);
+  const historical = await fullSelector({ revision: FINAL, tape: f.tape, modelControls: f.controls.model });
+  assert.ok(historical.gaps.some(g => g.kind === 'precise_timing_replay_required'));
+});
+
+test('controlled OLD retains its deterministic quality and missing union stays sticky', async () => {
+  const f = controlledFixture(), result = await run(f, { revision: OLD });
+  assert.ok(result.rows.every(r => r.status === 'deterministic_legacy'));
+  assert.equal(result.assessmentRequests.length, 0);
+  assert.ok(result.gaps.some(g => g.kind === 'missing_relation_request'));
+  assert.equal(result.controlledExperimentComplete, false);
+});
+
+test('failed, pending, aborted, malformed and mismatched exact commands cannot certify controlled success', async () => {
+  for (const mutate of [
+    f => { f.tape.files['models.jsonl'] = f.tape.files['models.jsonl'].filter(r => r.event.kind !== 'envelope_verified'); },
+    f => { f.tape.files['models.jsonl'].find(r => r.event.kind === 'envelope_verified').event.kind = 'invocation_failed'; },
+    f => { f.tape.files['assessments.jsonl'].find(r => r.event.phase === 'completed').event.consumed = false; },
+    f => { f.tape.files['models.jsonl'].find(r => r.event.kind === 'envelope_verified').event.result.structuredOutput = {}; },
+    f => { f.tape.files['models.jsonl'].find(r => r.event.kind === 'invocation_started').event.command.timeoutMs--; },
+    f => { f.tape.files['models.jsonl'].find(r => r.event.kind === 'invocation_started').event.command.prompt += 'wrong'; },
+    f => { f.tape.files['models.jsonl'].find(r => r.event.kind === 'invocation_started').event.command.outputSchema = {}; },
+    f => { f.tape.files['models.jsonl'].find(r => r.event.kind === 'envelope_verified').event.result.executionAttestation.selectedOutputSha256 = '0'.repeat(64); },
+    f => { f.tape.files['models.jsonl'].find(r => r.event.kind === 'envelope_verified').event.result.executionAttestation.canonicalRequestSha256 = '0'.repeat(64); },
+  ]) {
+    const f = controlledFixture(); mutate(f); const result = await run(f);
+    assert.equal(result.controlledExperimentComplete, false);
+    assert.ok(result.gaps.some(g => /missing_|replay_failed|command_mismatch/.test(g.kind)), JSON.stringify(result.gaps));
+    assert.equal(result.rows.length, 16);
+  }
+});

--- a/scripts/evals/reader-paired-experiment/p2-fixture.cjs
+++ b/scripts/evals/reader-paired-experiment/p2-fixture.cjs
@@ -1,0 +1,41 @@
+'use strict';
+const fs = require('node:fs'), os = require('node:os'), path = require('node:path');
+const { syntheticTape } = require('./full-selector-fixture.cjs');
+const { clone } = require('./recorded-selector-ports.cjs');
+const { hash } = require('./capture-owner-receipt.cjs');
+const { sha } = require('./revision-source.cjs');
+// A seal-shaped synthetic fixture tests integrity checks only. The reader
+// must keep independentOriginVerified false, including its nominal case.
+function p2Fixture(mutate = () => {}) {
+  const tape = syntheticTape(), input = tape.files['inputs.json'];
+  Object.assign(tape.files, { 'rank-command.json': { command: {}, presentKeys: [] },
+    'canonical-bindings.json': {}, 'promotion.json': {}, 'preparation.json': {}, 'selection.json': {},
+    'candidate-status.json': [...input.primaryIds, ...input.supplementalIds].map(feedItemId => ({ feedItemId, status: 'pending' })) });
+  tape.seal.complete = true; tape.seal.failures = [];
+  tape.seal.observationCounts = { snapshots: 1, promotion: 1, preparation: 1, selections: 1,
+    relationAttempts: tape.files['relations.jsonl'].filter(r => r.event.phase === 'attempt').length,
+    modelRequests: tape.files['models.jsonl'].filter(r => r.event.kind === 'invocation_started').length };
+  mutate(tape);
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'controlled-p2-'));
+  const files = Object.entries(tape.files).map(([name, value]) => {
+    const bytes = name.endsWith('.jsonl') ? value.map(v => JSON.stringify(v)).join('\n') + '\n' : JSON.stringify(value) + '\n';
+    fs.writeFileSync(path.join(directory, name), bytes);
+    return { name, bytes: Buffer.byteLength(bytes), sha256: sha(bytes) };
+  });
+  const bytes = JSON.stringify({ ...tape.seal, files }), filename = path.join(directory, 'seal.json');
+  fs.writeFileSync(filename, bytes);
+  return { ref: { path: filename, sha256: sha(bytes) }, directory, tape,
+    cleanup: () => fs.rmSync(directory, { recursive: true, force: true }) };
+}
+// Artificial trust-boundary input for unit tests only, never production evidence.
+function ownerContractReceipt(tape) {
+  const manifest = tape.files['controls.json'].manifest, started = tape.files['started.json'];
+  return { format: 'paired-p2-local-owner-receipt.v1', authority: 'local_execution_owner_attestation',
+    action: 'actual_p2_apply', captureSealSha256: tape.sealSha256, scope: clone(started.scope),
+    operationId: manifest.operation, commandManifestSha256: hash(manifest),
+    reviewedSourceCommit: 'a'.repeat(40), deployedSourceCommit: 'a'.repeat(40),
+    sourceSha256: manifest.sourceSha256, imageId: `sha256:${'b'.repeat(64)}`, ownedContainerId: 'c'.repeat(64),
+    runtime: clone(manifest.runtime), startedAt: new Date(started.atMs - 100).toISOString(),
+    endedAt: new Date(started.atMs + 60000).toISOString(), terminal: { status: 'exited', exitCode: 0 } };
+}
+module.exports = { p2Fixture, ownerContractReceipt };

--- a/scripts/evals/reader-paired-experiment/p2-observation.cjs
+++ b/scripts/evals/reader-paired-experiment/p2-observation.cjs
@@ -1,0 +1,75 @@
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const { capture, clone, same } = require('./recorded-selector-ports.cjs');
+const { check, digest } = require('./revision-source.cjs');
+const { validateRaw, freeze } = require('./capture-core-observation.cjs');
+const origins = new WeakMap();
+const originFor = value => origins.get(value);
+function p2Observation(ref, expectedReceiptSha256s = []) {
+  const tape = capture(ref), { seal, files } = tape;
+  check(seal.complete === true && Array.isArray(seal.failures) && seal.failures.length === 0, 'p2_capture_incomplete');
+  const names = new Set(seal.files.map(f => f.name));
+  for (const name of fs.readdirSync(path.dirname(ref.path))) {
+    if (/\.(json|jsonl)$/.test(name) && name !== path.basename(ref.path)) check(names.has(name), 'p2_unsealed_capture_file');
+  }
+  for (const name of ['rank-command.json', 'canonical-bindings.json', 'promotion.json', 'preparation.json', 'selection.json', 'candidate-status.json'])
+    check(files[name] !== undefined, `p2_missing_original_callback:${name}`);
+  check(same(files['started.json'].scope, seal.scope), 'p2_started_scope_mismatch');
+  const query = files['snapshot-query.json'].query, input = files['inputs.json'];
+  check(query.observedThrough === seal.scope.observedThrough && query.tenantId === seal.scope.tenantId &&
+    query.workspaceId === seal.scope.workspaceId && same(input.query, query) &&
+    same(input.queryKeys, files['snapshot-query.json'].presentKeys), 'p2_input_query_mismatch');
+  const scope = { tenantId: query.tenantId, workspaceId: query.workspaceId }, day = query.windowStartedAt.slice(0, 10);
+  validateRaw({ day, query, snapshot: input.snapshot, endedAt: query.observedThrough }, scope);
+  const primary = input.snapshot.candidates.map(c => c.item.id), supplemental = (input.snapshot.supplementalItems || []).map(i => i.id);
+  check(same(primary, input.primaryIds) && same(supplemental, input.supplementalIds) &&
+    same(files['candidate-status.json'].map(r => r.feedItemId), [...primary, ...supplemental]), 'p2_ordered_inventory_mismatch');
+  const counts = seal.observationCounts;
+  check(counts && ['snapshots', 'promotion', 'preparation', 'selections'].every(k => counts[k] === 1), 'p2_callback_counts_incomplete');
+  const interestIds = new Set();
+  for (const { event } of files['interests.jsonl'] || []) {
+    check(event.query?.tenantId === scope.tenantId && event.query?.workspaceId === scope.workspaceId &&
+      typeof event.query.interestId === 'string' && !interestIds.has(event.query.interestId), 'p2_interest_scope_or_duplicate');
+    interestIds.add(event.query.interestId);
+    if (event.result?.kind === 'available') check(['tenantId', 'workspaceId', 'interestId'].every(key =>
+      event.result.interest[key] === event.query[key]) && event.result.interest.query?.trim(), 'p2_interest_result_mismatch');
+  }
+  const events = (files['models.jsonl'] || []).map(r => r.event);
+  const starts = events.filter(e => e.kind === 'invocation_started');
+  check(new Set(starts.map(e => e.command.requestId)).size === starts.length && counts.modelRequests === starts.length, 'p2_model_inventory_mismatch');
+  check(events.every(event => starts.some(start => start.command.requestId ===
+    (event.command?.requestId ?? event.requestId))), 'p2_orphan_model_callback');
+  for (const start of starts) {
+    const ends = events.filter(e => ['envelope_verified', 'envelope_not_consumed', 'invocation_failed'].includes(e.kind) &&
+      (e.command?.requestId ?? e.requestId) === start.command.requestId);
+    check(ends.length === 1, 'p2_model_unfinished_or_duplicate');
+    if (ends[0].command) check(same(ends[0].command, start.command), 'p2_terminal_command_mismatch');
+  }
+  for (const [file, id, phase] of [['relations.jsonl', 'id', 'terminal'], ['assessments.jsonl', 'batch', 'completed']]) {
+    const rows = (files[file] || []).map(r => r.event), attempts = rows.filter(e => e.phase === 'attempt');
+    check(rows.every(row => attempts.some(attempt => attempt[id] === row[id])), 'p2_orphan_lane_callback');
+    if (file === 'relations.jsonl') check(counts.relationAttempts === attempts.length, 'p2_relation_inventory_mismatch');
+    check(new Set(attempts.map(e => e[id])).size === attempts.length, 'p2_duplicate_lane_attempt');
+    for (const attempt of attempts) {
+      const ends = rows.filter(e => e.phase !== 'attempt' && e[id] === attempt[id]);
+      check(ends.length === 1 && (file === 'assessments.jsonl' || ends[0].phase === phase), 'p2_lane_unfinished_or_duplicate');
+    }
+  }
+  let origin, originGap;
+  try { origin = require('./capture-owner-receipt.cjs').p2OwnerReceipt(tape, ref.ownerReceipt, expectedReceiptSha256s); }
+  catch (error) { originGap = error.message; }
+  const observation = freeze({ format: 'paired-immutable-observation.v1', kind: 'P2', day, scope,
+    observationRef: clone(ref), observationQuery: clone(query), observationPresentKeys: clone(input.queryKeys),
+    // P2 does not provide snapshot read intervals. Retain that gap explicitly.
+    startedAt: null, endedAt: null, captureStartedAtMs: files['started.json'].atMs,
+    snapshot: clone(input.snapshot), interests: clone((files['interests.jsonl'] || []).map(r => r.event)),
+    originalControls: { selection: clone(files['selection-query.json']), controls: clone(files['controls.json']) },
+    provenance: { integrityVerified: true, independentOriginVerified: Boolean(origin), origin: origin ?? null, originGap: originGap ?? null, seal: clone(seal), hashes: clone(tape.hashes),
+      modelInvocationHistory: 'original_P2_journal', historicalReadInterval: 'not_recorded' },
+    observationSha256: digest({ query, snapshot: input.snapshot, sealSha256: tape.sealSha256 }) });
+  freeze(tape);
+  if (origin) { origins.set(tape, origin); origins.set(observation, origin); }
+  return { tape, observation };
+}
+module.exports = { p2Observation, originFor };

--- a/scripts/evals/reader-paired-experiment/p2-observation.test.cjs
+++ b/scripts/evals/reader-paired-experiment/p2-observation.test.cjs
@@ -1,0 +1,58 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs'), path = require('node:path');
+const { p2Observation } = require('./p2-observation.cjs');
+const { p2Fixture: fixture } = require('./p2-fixture.cjs');
+
+test('P2 integrity reader preserves full original journals and never treats a synthetic seal as origin authority', () => {
+  const f = fixture();
+  try {
+    const result = p2Observation(f.ref);
+    assert.deepEqual(result.tape.files, f.tape.files);
+    assert.deepEqual(result.observation.snapshot, f.tape.files['inputs.json'].snapshot);
+    assert.equal(result.observation.provenance.independentOriginVerified, false);
+    assert.equal(result.observation.startedAt, null);
+    assert.equal(result.observation.endedAt, null);
+    assert.equal(result.observation.provenance.historicalReadInterval, 'not_recorded');
+  } finally { f.cleanup(); }
+});
+test('incomplete seals, unfinished models/lanes, omitted rows and mismatched scopes fail closed', () => {
+  const cases = [
+    [t => { t.seal.complete = false; }, /p2_capture_incomplete/],
+    [t => { t.seal.failures.push('late_callback'); }, /p2_capture_incomplete/],
+    [t => { t.files['models.jsonl'] = t.files['models.jsonl'].filter(r => r.event.kind !== 'envelope_verified'); }, /p2_model_unfinished/],
+    [t => { t.files['relations.jsonl'] = t.files['relations.jsonl'].filter(r => r.event.phase === 'attempt'); }, /p2_lane_unfinished/],
+    [t => { t.files['candidate-status.json'].pop(); }, /p2_ordered_inventory/],
+    [t => { t.files['started.json'].scope.tenantId = 'different'; }, /p2_started_scope/],
+    [t => { delete t.files['preparation.json']; }, /p2_missing_original_callback/],
+    [t => { t.seal.observationCounts.relationAttempts++; }, /p2_relation_inventory/],
+    [t => { t.files['interests.jsonl'][0].event.query.workspaceId = 'other'; }, /p2_interest_scope/],
+    [t => { t.files['relations.jsonl'].find(r => r.event.phase === 'terminal').event.id = 900; }, /p2_orphan_lane/],
+  ];
+  for (const [mutate, code] of cases) {
+    const f = fixture(mutate);
+    try { assert.throws(() => p2Observation(f.ref), code); } finally { f.cleanup(); }
+  }
+});
+test('unsealed late journals cannot be silently omitted', () => {
+  const f = fixture();
+  try {
+    fs.writeFileSync(path.join(f.directory, 'failures.jsonl'), '{"late":true}\n');
+    assert.throws(() => p2Observation(f.ref), /p2_unsealed_capture_file/);
+  } finally { f.cleanup(); }
+});
+
+test('provenance flags and receipt hashes inside an untrusted reference cannot register owner authority', () => {
+  const { originFor } = require('./p2-observation.cjs');
+  const f = fixture();
+  try {
+    const result = p2Observation({ ...f.ref, actualProducer: true, trustedAnchor: f.ref.sha256,
+      ownerReceipt: { path: f.ref.path, sha256: f.ref.sha256 } });
+    assert.equal(result.observation.provenance.independentOriginVerified, false);
+    assert.match(result.observation.provenance.originGap, /out_of_band_anchor_missing/);
+    assert.equal(originFor(result.tape), undefined);
+    assert.equal(originFor({ ...result.observation, provenance: { independentOriginVerified: true } }), undefined);
+    assert.throws(() => { result.tape.files['models.jsonl'].pop(); }, TypeError);
+  } finally { f.cleanup(); }
+});

--- a/scripts/evals/reader-paired-experiment/recorded-model-responses.cjs
+++ b/scripts/evals/reader-paired-experiment/recorded-model-responses.cjs
@@ -9,7 +9,9 @@ const semantic = command => {
   void correlationId;
   return clone(rest);
 };
-function recordedResponses(source, tapes, gaps, clock, controls) {
+function recordedResponses(source, tapes, gaps, clock, controls, experiment = {}) {
+  const controlled = experiment.mode === 'CONTROLLED';
+  const delivery = [];
   const records = [], consumed = [], assessedRecords = [], attemptedIds = new Set(), observations = [];
   for (const tape of tapes) {
     const models = tape.files['models.jsonl'] || [];
@@ -30,15 +32,30 @@ function recordedResponses(source, tapes, gaps, clock, controls) {
       const assessmentEnd = unique('assessments.jsonl', r => r.event.phase !== 'attempt' && r.event.batch === start.event.assessmentBatch, 'duplicate_assessment_terminal');
       const relation = unique('relations.jsonl', r => r.event.phase === 'attempt' && r.event.id === start.event.relationId, 'duplicate_relation_attempt');
       const relationEnd = unique('relations.jsonl', r => r.event.phase === 'terminal' && r.event.id === start.event.relationId, 'duplicate_relation_terminal');
-      records.push({ id: `${tape.sealSha256}:${start.sequence}`, start, modelEvents, terminal: terminal[0], assessment, assessmentEnd, relation, relationEnd });
+      records.push({ origin: controlled ? require('./p2-observation.cjs').originFor(tape) : undefined, id: `${tape.sealSha256}:${start.sequence}`, start, modelEvents, terminal: terminal[0], assessment, assessmentEnd, relation, relationEnd });
     }
   }
   let active, generated = 0;
   const exactRecord = (kind, request) => {
-    const matches = records.filter(record => kind === 'assessment'
+    let matches = records.filter(record => kind === 'assessment'
       ? record.assessment && same(JSON.parse(record.assessment.event.requestsJson), clone(request))
       : record.relation && same(record.relation.event.query, clone({ ...request, signal: undefined, aborted: request.signal?.aborted ?? false })));
     if (!matches.length) return gaps.fail(`missing_${kind}_request`, request);
+    if (controlled) {
+      matches = matches.filter(record => record.terminal?.event.kind === 'envelope_verified' &&
+        !record.modelEvents.some(row => ['invocation_aborted', 'envelope_not_consumed', 'invocation_failed', 'invocation_rejected'].includes(row.event.kind)) &&
+        (kind === 'assessment' ? record.assessmentEnd?.event.phase === 'completed' && record.assessmentEnd.event.consumed === true
+          : record.relationEnd?.event.outcome.status === 'validated' && !record.relationEnd.event.outcome.aborted));
+      if (!matches.length) return gaps.fail(`missing_successful_${kind}_request`, request);
+      const output = record => ({ command: semantic(record.start.event.command),
+        structuredOutput: record.terminal.event.result.structuredOutput, outputText: record.terminal.event.result.outputText,
+        reviews: record.assessmentEnd?.event.reviewsJson, verdicts: record.assessmentEnd?.event.verdictsJson,
+        decisions: record.relationEnd?.event.outcome.decisions });
+      if (!matches.every(r => same(output(r), output(matches[0])))) return gaps.fail('ambiguous_recorded_request', { kind, request });
+      // Outcome-independent stable policy, shared by every arm. Full histories
+      // remain in the report; only transport identity and timing may differ.
+      return matches.sort((a, b) => a.id < b.id ? -1 : a.id > b.id ? 1 : 0)[0];
+    }
     // Duplicate captures must agree on the complete consumed call and observed
     // outcome. Choosing the first envelope must not hide a conflicting abort,
     // parser result, verdict inventory or completion time in another tape.
@@ -51,13 +68,13 @@ function recordedResponses(source, tapes, gaps, clock, controls) {
       return gaps.fail('ambiguous_recorded_request', { kind, request });
     return matches[0];
   };
-  const client = { runTask: async (command, options) => {
-    const record = active;
+  const clientFor = record => ({ runTask: async (command, options) => {
     if (!record || !same(semantic(command), semantic(record.start.event.command))) gaps.fail('missing_model_command', command);
     // Original transport identity is supplied before the actual adapter builds
     // its command. Attestations are never rewritten for a new request ID.
     if (command.requestId !== record.start.event.command.requestId || command.correlationId !== record.start.event.command.correlationId) gaps.fail('transport_identity_mismatch', command);
-    consumed.push({ recordId: record.id, requestId: command.requestId, semanticSha256: digest(semantic(command)) });
+    const consumption = { recordId: record.id, requestId: command.requestId, semanticSha256: digest(semantic(command)) };
+    consumed.push(consumption);
     const end = record.terminal;
     observations.push({ recordId: record.id, startAtMs: record.start.atMs, terminalAtMs: end?.atMs ?? null,
       modelOutcome: end?.event.kind ?? 'pending', assessmentOutcome: clone(record.assessmentEnd?.event ?? null),
@@ -68,63 +85,81 @@ function recordedResponses(source, tapes, gaps, clock, controls) {
       record.relationEnd?.event.outcome.aborted || record.relationEnd?.event.outcome.status === 'aborted';
     if (timingSensitive) return gaps.fail('precise_timing_replay_required', { recordId: record.id });
     if (!end) return gaps.fail('recorded_model_still_pending', { recordId: record.id });
-    if (end.atMs !== record.start.atMs || record.assessmentEnd?.event.failure === 'deadline' ||
+    if ((!controlled && end.atMs !== record.start.atMs) || record.assessmentEnd?.event.failure === 'deadline' ||
         record.assessmentEnd?.event.failure === 'aborted' || options.signal?.aborted) {
       return gaps.fail('precise_timing_replay_required', { recordId: record.id, startAtMs: record.start.atMs, terminalAtMs: end.atMs });
     }
+    if (controlled && (end.atMs < record.start.atMs || !Number.isSafeInteger(command.timeoutMs) || command.timeoutMs <= 0)) return gaps.fail('invalid_controlled_success_interval', { recordId: record.id });
     if (end.event.kind !== 'envelope_verified') return gaps.fail('recorded_model_failure', { recordId: record.id });
     check(same(end.event.command, record.start.event.command), 'model_terminal_command_mismatch');
     try {
       const admission = verifyRecordedRequestAdmission(source, command, end.event.result);
-      consumed[consumed.length - 1].admission = admission;
+      consumption.admission = admission;
     } catch (error) {
       return gaps.fail('canonical_runtime_request_invalid', { recordId: record.id, code: error.message });
     }
-    gaps.add('producer_origin_unverified', { recordId: record.id });
+    if (!record.origin) gaps.add('producer_origin_unverified', { recordId: record.id });
+    else {
+      try { require('./capture-owner-receipt.cjs').verifyOwnerInvocation(record.origin, command, end.event.result); }
+      catch (error) { return gaps.fail('producer_origin_invalid', { recordId: record.id, code: error.message }); }
+      consumption.ownerReceiptSha256 = record.origin.receiptSha256;
+    }
+    if (controlled) delivery.push({ recordId: record.id, requestId: command.requestId,
+      policy: 'successful_immediate_lexicographic_record.v1', turn: delivery.length + 1,
+      evaluationAt: clock.now().toISOString(), controlledElapsedMs: 0,
+      originalStartAtMs: record.start.atMs, originalTerminalAtMs: end.atMs });
     return clone(end.event.result);
-  } };
+  } });
   const assessmentFile = 'libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts';
+  const owned = (label, action) => controlled ? experiment.host.track(label, action) : action();
   const reviewer = () => {
     const Adapter = source.load(assessmentFile).AgentRuntimeSourceContentQualityReviewerAdapter;
-    const adapter = new Adapter({ ...controls.assessment, client, clock,
+    const createAdapter = record => new Adapter({ ...controls.assessment, client: clientFor(record), clock,
       ids: { generate() {
         generated++;
-        const id = active?.start.event.command.requestId;
+        const id = record?.start.event.command.requestId;
         check(id?.startsWith('source-content-assessment:'), 'assessment_transport_id_missing');
         return id.slice('source-content-assessment:'.length);
       } } });
-    return { promotionTiming: adapter.promotionTiming, async reviewBatch(requests, options) {
-      if (active) return gaps.fail('concurrent_response_replay_not_supported', { lane: 'assessment' });
-      requests.forEach(r => attemptedIds.add(r.candidateId));
-      active = exactRecord('assessment', requests);
-      try {
-        const reviews = await adapter.reviewBatch(requests, options);
-        assessedRecords.push(active);
-        if (!active.assessmentEnd || active.assessmentEnd.event.phase !== 'completed' ||
-            active.assessmentEnd.event.requestsJson !== active.assessment.event.requestsJson ||
-            JSON.stringify(reviews) !== active.assessmentEnd.event.reviewsJson) gaps.fail('assessment_parser_replay_mismatch', { recordId: active.id });
-        return reviews;
-      } catch (error) { gaps.add('assessment_replay_failed', { recordId: active?.id }); throw error; }
-      finally { active = undefined; }
+    const promotionTiming = createAdapter(undefined).promotionTiming;
+    return { promotionTiming, reviewBatch(requests, options) {
+      return owned('assessment:parser', async () => {
+        if (!controlled && active) return gaps.fail('concurrent_response_replay_not_supported', { lane: 'assessment' });
+        requests.forEach(r => attemptedIds.add(r.candidateId));
+        let record;
+        try {
+          if (options?.signal?.aborted || (options?.deadlineAtMs !== undefined && options.deadlineAtMs <= clock.now().getTime()))
+            return gaps.fail('assessment_request_expired', { requests });
+          record = exactRecord('assessment', requests);
+          if (!controlled) active = record;
+          const reviews = await createAdapter(record).reviewBatch(requests, options);
+          assessedRecords.push(record);
+          if (!record.assessmentEnd || record.assessmentEnd.event.phase !== 'completed' ||
+              record.assessmentEnd.event.requestsJson !== record.assessment.event.requestsJson ||
+              JSON.stringify(reviews) !== record.assessmentEnd.event.reviewsJson) gaps.fail('assessment_parser_replay_mismatch', { recordId: record.id });
+          return reviews;
+        } catch (error) { gaps.add('assessment_replay_failed', { recordId: record?.id }); throw error; }
+        finally { if (!controlled) active = undefined; }
+      });
     } };
   };
-  // Separate active slots per adapter call are needed if lanes overlap. This
-  // zero-elapsed slice serializes microtasks, and explicitly rejects overlap.
-  const relation = () => {
-    let adapter;
-    return { async verify(query) {
-      if (active) return gaps.fail('concurrent_response_replay_not_supported', { lane: query.verificationLane });
-      active = exactRecord('relation', query);
+  const relation = () => ({ verify(query) {
+    return owned(`relation:${query.verificationLane ?? 'foreground'}:parser`, async () => {
+      if (!controlled && active) return gaps.fail('concurrent_response_replay_not_supported', { lane: query.verificationLane });
+      let record;
       try {
+        if (query.signal?.aborted) return gaps.fail('relation_request_expired', query);
+        record = exactRecord('relation', query);
+        if (!controlled) active = record;
         const Adapter = source.load('libs/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter.ts').AgentRuntimeReaderSummaryStoryRelationVerifier;
-        adapter ??= new Adapter({ ...controls.relation, client });
+        const adapter = new Adapter({ ...controls.relation, client: clientFor(record) });
         const decisions = await adapter.verify(query);
-        if (active.relationEnd?.event.outcome.status !== 'validated' || !same(decisions, active.relationEnd.event.outcome.decisions)) gaps.fail('relation_parser_replay_mismatch', { recordId: active.id });
+        if (record.relationEnd?.event.outcome.status !== 'validated' || !same(decisions, record.relationEnd.event.outcome.decisions)) gaps.fail('relation_parser_replay_mismatch', { recordId: record.id });
         return decisions;
-      } catch (error) { gaps.add('relation_replay_failed', { recordId: active?.id, code: error.message }); throw error; }
-      finally { active = undefined; }
-    } };
-  };
+      } catch (error) { gaps.add('relation_replay_failed', { recordId: record?.id, code: error.message }); throw error; }
+      finally { if (!controlled) active = undefined; }
+    });
+  } });
   return { reviewer, relation, attemptedIds,
     verifyVerdicts(verdicts) {
       for (const record of assessedRecords) {
@@ -141,6 +176,12 @@ function recordedResponses(source, tapes, gaps, clock, controls) {
       }
     },
     report: () => ({ consumed, observedOutcomes: observations, generatedTransportIds: generated,
-      replayMissingRequestCount: gaps.missing(), historicalTimingVerified: false }) };
+      replayMissingRequestCount: gaps.missing(), historicalTimingVerified: false,
+      ...(controlled ? { delivery, scheduleSha256: digest(delivery), selectedResponsesSha256: digest(consumed),
+        recordHistory: clone(records), captureHistories: tapes.map(tape => ({ sealSha256: tape.sealSha256,
+          seal: clone(tape.seal), models: clone(tape.files['models.jsonl'] ?? []),
+          assessments: clone(tape.files['assessments.jsonl'] ?? []), relations: clone(tape.files['relations.jsonl'] ?? []),
+          failures: clone(tape.files['failures.jsonl'] ?? []) })), quiescence: experiment.host.quiescence(),
+        recordSelectionPolicy: 'successful_immediate_lexicographic_record.v1' } : {}) }) };
 }
 module.exports = { recordedResponses, semantic, ASSESSMENT };

--- a/scripts/evals/reader-paired-experiment/recorded-model-responses.cjs
+++ b/scripts/evals/reader-paired-experiment/recorded-model-responses.cjs
@@ -36,7 +36,7 @@ function recordedResponses(source, tapes, gaps, clock, controls, experiment = {}
     }
   }
   let active, generated = 0;
-  const exactRecord = (kind, request) => {
+  const exactRecord = (kind, request, command) => {
     let matches = records.filter(record => kind === 'assessment'
       ? record.assessment && same(JSON.parse(record.assessment.event.requestsJson), clone(request))
       : record.relation && same(record.relation.event.query, clone({ ...request, signal: undefined, aborted: request.signal?.aborted ?? false })));
@@ -47,6 +47,10 @@ function recordedResponses(source, tapes, gaps, clock, controls, experiment = {}
         (kind === 'assessment' ? record.assessmentEnd?.event.phase === 'completed' && record.assessmentEnd.event.consumed === true
           : record.relationEnd?.event.outcome.status === 'validated' && !record.relationEnd.event.outcome.aborted));
       if (!matches.length) return gaps.fail(`missing_successful_${kind}_request`, request);
+      // The first pass supplies only an original ID to the real command builder.
+      if (!command) return matches[0];
+      matches = matches.filter(record => same(semantic(command), semantic(record.start.event.command)));
+      if (!matches.length) return gaps.fail('missing_model_command', command);
       const output = record => ({ command: semantic(record.start.event.command),
         structuredOutput: record.terminal.event.result.structuredOutput, outputText: record.terminal.event.result.outputText,
         reviews: record.assessmentEnd?.event.reviewsJson, verdicts: record.assessmentEnd?.event.verdictsJson,
@@ -110,13 +114,25 @@ function recordedResponses(source, tapes, gaps, clock, controls, experiment = {}
       originalStartAtMs: record.start.atMs, originalTerminalAtMs: end.atMs });
     return clone(end.event.result);
   } });
+  // Discover the complete command through the pinned adapter, without delivering
+  // an output or consuming a record. Rebuild with the selected original ID so
+  // neither the transport identity nor its attestation needs rewriting.
+  const selectCommand = async (kind, request, build) => {
+    const seed = exactRecord(kind, request);
+    const stop = new Error('command_observed');
+    let command;
+    try { await build(seed, { async runTask(value) { command = value; throw stop; } }); }
+    catch (error) { if (error !== stop) throw error; }
+    check(command, 'model_command_not_generated');
+    return exactRecord(kind, request, command);
+  };
   const assessmentFile = 'libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts';
   const owned = (label, action) => controlled ? experiment.host.track(label, action) : action();
   const reviewer = () => {
     const Adapter = source.load(assessmentFile).AgentRuntimeSourceContentQualityReviewerAdapter;
-    const createAdapter = record => new Adapter({ ...controls.assessment, client: clientFor(record), clock,
+    const createAdapter = (record, client) => new Adapter({ ...controls.assessment, client: client ?? clientFor(record), clock,
       ids: { generate() {
-        generated++;
+        if (!client) generated++;
         const id = record?.start.event.command.requestId;
         check(id?.startsWith('source-content-assessment:'), 'assessment_transport_id_missing');
         return id.slice('source-content-assessment:'.length);
@@ -130,7 +146,8 @@ function recordedResponses(source, tapes, gaps, clock, controls, experiment = {}
         try {
           if (options?.signal?.aborted || (options?.deadlineAtMs !== undefined && options.deadlineAtMs <= clock.now().getTime()))
             return gaps.fail('assessment_request_expired', { requests });
-          record = exactRecord('assessment', requests);
+          record = controlled ? await selectCommand('assessment', requests, (seed, client) =>
+            createAdapter(seed, client).reviewBatch(requests, options)) : exactRecord('assessment', requests);
           if (!controlled) active = record;
           const reviews = await createAdapter(record).reviewBatch(requests, options);
           assessedRecords.push(record);
@@ -149,9 +166,10 @@ function recordedResponses(source, tapes, gaps, clock, controls, experiment = {}
       let record;
       try {
         if (query.signal?.aborted) return gaps.fail('relation_request_expired', query);
-        record = exactRecord('relation', query);
-        if (!controlled) active = record;
         const Adapter = source.load('libs/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter.ts').AgentRuntimeReaderSummaryStoryRelationVerifier;
+        record = controlled ? await selectCommand('relation', query, (_seed, client) =>
+          new Adapter({ ...controls.relation, client }).verify(query)) : exactRecord('relation', query);
+        if (!controlled) active = record;
         const adapter = new Adapter({ ...controls.relation, client: clientFor(record) });
         const decisions = await adapter.verify(query);
         if (record.relationEnd?.event.outcome.status !== 'validated' || !same(decisions, record.relationEnd.event.outcome.decisions)) gaps.fail('relation_parser_replay_mismatch', { recordId: record.id });

--- a/scripts/evals/reader-paired-experiment/recorded-selector-ports.cjs
+++ b/scripts/evals/reader-paired-experiment/recorded-selector-ports.cjs
@@ -43,11 +43,18 @@ function capture(ref) {
   check(new Set(events.map(e => e.sequence)).size === events.length && events.every(e => Number.isSafeInteger(e.sequence) && e.sequence > 0 && Number.isSafeInteger(e.atMs)), 'invalid_journal_sequence');
   return { seal, files, hashes, sealSha256: ref.sha256 };
 }
-function ports(source, tape, gaps) {
-  const inputs = tape.files['inputs.json'], raw = inputs.snapshot;
-  const recorded = tape.files['snapshot-query.json'];
+function ports(source, tape, gaps, evaluation) {
+  const observation = evaluation?.observation;
+  const inputs = observation ? { snapshot: observation.snapshot, query: observation.observationQuery,
+    queryKeys: observation.observationPresentKeys,
+    primaryIds: observation.snapshot.candidates.map(c => c.item.id),
+    supplementalIds: (observation.snapshot.supplementalItems || []).map(i => i.id) } : tape.files['inputs.json'];
+  const raw = inputs.snapshot;
+  const recorded = observation ? { query: observation.observationQuery, presentKeys: observation.observationPresentKeys } : tape.files['snapshot-query.json'];
   check(same(inputs.query, recorded.query) && same(inputs.queryKeys, recorded.presentKeys), 'capture_query_disagreement');
   const q = recorded.query;
+  const expected = evaluation?.controls.snapshot ?? recorded;
+  const evaluationCutoff = evaluation?.evaluationClock ?? q.observedThrough;
   check(q.timestampPolicy === 'published_at', 'unsupported_snapshot_timestamp_policy');
   const day = q.windowStartedAt.slice(0, 10);
   check(date(q.windowEndedAt).getTime() - date(q.windowStartedAt).getTime() === 86400000 && q.windowStartedAt === `${day}T00:00:00.000Z`, 'snapshot_not_one_UTC_day');
@@ -56,7 +63,7 @@ function ports(source, tape, gaps) {
   const wrapped = { ...raw, candidates: raw.candidates.map(c => ({ ...c, item: { props: c.item } })),
     supplementalItems: raw.supplementalItems?.map(props => ({ props })) };
   const FeedItem = source.load('libs/feed/domain/entities/feed-item.ts').FeedItem;
-  const hydrate = () => snapshot({ format: 'read-only-full-promotion-snapshot.v1', capturedAt: q.observedThrough,
+  const hydrate = () => snapshot({ format: 'read-only-full-promotion-snapshot.v1', capturedAt: observation?.endedAt ?? q.observedThrough,
     observedThrough: q.observedThrough, snapshot: clone(wrapped) }, day,
   { tenantId: q.tenantId, workspaceId: q.workspaceId, clock: q.observedThrough, query: q }, FeedItem);
   hydrate(); // Validate before any selector catches a port exception.
@@ -66,11 +73,11 @@ function ports(source, tape, gaps) {
     if (key !== 'readPromotionSnapshot') return deny('feed')[key];
     return async query => {
       calls.push({ port: 'snapshot', query: canonical(query) });
-      if (!same(query, withKeys(q, recorded.presentKeys))) gaps.fail('snapshot_query_mismatch', query);
+      if (!same(query, withKeys(expected.query, expected.presentKeys))) gaps.fail('snapshot_query_mismatch', query);
       return hydrate();
     };
   } });
-  const interestRecords = (tape.files['interests.jsonl'] || []).map(row => row.event);
+  const interestRecords = evaluation?.controls.interests ?? (tape.files['interests.jsonl'] || []).map(row => row.event);
   const interests = { readCurrent: async query => {
     calls.push({ port: 'interest', query: canonical(query) });
     const matches = interestRecords.filter(r => same(r.query, query));
@@ -83,6 +90,6 @@ function ports(source, tape, gaps) {
     return clone(result);
   } };
   return { feed, interests, deny, calls, primaryIds, supplementalIds, day, raw,
-    clock: { now: () => date(q.observedThrough) }, cutoff: q.observedThrough };
+    clock: { now: () => date(evaluationCutoff) }, cutoff: evaluationCutoff };
 }
 module.exports = { capture, ports, ledger, clone, canonical, same, withKeys };

--- a/scripts/evals/reader-paired-experiment/relation-completion-ledger.cjs
+++ b/scripts/evals/reader-paired-experiment/relation-completion-ledger.cjs
@@ -1,0 +1,22 @@
+'use strict';
+const { clone } = require('./recorded-selector-ports.cjs');
+// Observe terminal outcomes emitted by the actual revision's reconciliation.
+// Never throw into the source's safelyRecord boundary or change publication.
+function relationCompletionMetrics(source, gaps) {
+  const defaults = source.load('libs/summary/ports/story-ranking-metrics.port.ts').NOOP_STORY_RANKING_METRICS;
+  const terminal = (lane, metric) => {
+    if (['failed_closed', 'timed_out'].includes(metric.status))
+      gaps.add('relation_reconciliation_failed', { lane, metric: clone(metric) });
+  };
+  const aggregates = (lane, rows) => {
+    for (const row of rows) if (['verifier_failed_closed', 'verifier_unavailable'].includes(row.disposition) && row.count > 0)
+      gaps.add('relation_reconciliation_failed', { lane, aggregate: clone(row) });
+  };
+  return { ...defaults,
+    recordStoryRelationVerification: metric => terminal('foreground', metric),
+    recordRelatedTopicVerification: metric => terminal('related_topic', metric),
+    recordStoryRelationDecisionAggregates: rows => aggregates('foreground', rows),
+    recordStoryRelationSafeRecallShadowDecisions: rows => aggregates('safe_recall_shadow', rows),
+  };
+}
+module.exports = { relationCompletionMetrics };

--- a/scripts/evals/reader-paired-experiment/replay-host.cjs
+++ b/scripts/evals/reader-paired-experiment/replay-host.cjs
@@ -5,6 +5,8 @@ const { setImmediate: flush } = require('node:timers/promises');
 function replayHost() {
   let sequence = 0, closed = false;
   const immediates = new Map(), timers = new Map(), trace = [];
+  const outstanding = new Map(), failedOperations = [];
+  let operationSequence = 0;
   function schedule(kind, callback, ms, args) {
     if (closed) throw Error('replay_host_closed');
     if (typeof callback !== 'function' || !Number.isSafeInteger(ms) || ms < 0) throw Error('unsupported_host_timer');
@@ -27,11 +29,30 @@ function replayHost() {
     static abort(reason) { return AbortSignal.abort(reason); }
   }
   return {
+    // Invocation-local accounting includes parser completion, not just transport
+    // delivery. Callers wrap the entire adapter operation, including detached
+    // shadow calls. Rejections remain visible even if a selector catches them.
+    track(label, operation) {
+      if (closed) throw Error('replay_host_closed');
+      if (typeof label !== 'string' || !label.trim()) throw Error('invalid_operation_label');
+      const id = ++operationSequence;
+      outstanding.set(id, { id, label });
+      return Promise.resolve().then(operation).then(value => {
+        outstanding.delete(id); return value;
+      }, error => {
+        outstanding.delete(id);
+        failedOperations.push({ id, label });
+        throw error;
+      });
+    },
+    quiescence: () => ({ outstanding: [...outstanding.values()], failedOperations: [...failedOperations],
+      pendingImmediates: [...immediates.values()].map(({ id }) => id),
+      settled: outstanding.size === 0 && immediates.size === 0 && failedOperations.length === 0 }),
     globals: { AbortController, AbortSignal: ControlledAbortSignal, structuredClone,
       Buffer, setTimeout: timeout, clearTimeout: handle => timers.delete(handle),
       setImmediate: (fn, ...args) => schedule('immediate', fn, 0, args),
       clearImmediate: handle => immediates.delete(handle) },
-    async run(operation) {
+    async run(operation, { requireQuiescence = false } = {}) {
       let settled = false, rejected = false, value, error;
       Promise.resolve(operation).then(result => { value = result; settled = true; }, failure => { error = failure; rejected = true; settled = true; });
       for (let step = 0; step < 256; step++) {
@@ -49,7 +70,12 @@ function replayHost() {
           }
           continue;
         }
-        if (settled) { if (rejected) throw error; return value; }
+        if (settled) {
+          if (rejected) throw error;
+          if (requireQuiescence && outstanding.size) throw Error('controlled_operation_unfinished');
+          if (requireQuiescence && failedOperations.length) throw Error('controlled_operation_failed');
+          return value;
+        }
         // No permitted pending operation can need an external event here.
         throw Error('precise_timing_replay_required');
       }

--- a/scripts/evals/reader-paired-experiment/review-command-union.test.cjs
+++ b/scripts/evals/reader-paired-experiment/review-command-union.test.cjs
@@ -1,0 +1,92 @@
+'use strict';
+const test = require('node:test'), assert = require('node:assert/strict');
+const { syntheticTape } = require('./full-selector-fixture.cjs');
+const { setup, rebind, trustedFixture, clone } = require('./review-fixes-fixture.cjs');
+function assessment(tape) {
+  return tape.files['models.jsonl'].filter(r => r.event.command?.purpose.includes('assess_source_content'));
+}
+test('P2: artificial-owner contract union selects complete generated timeout command and preserves both original histories', async () => {
+  const builder = setup([syntheticTape()]), fixtures = [];
+  try {
+    for (const timeout of [300000, 299999]) fixtures.push(trustedFixture(tape => {
+      const oldId = assessment(tape)[0].event.command.requestId;
+      for (const row of tape.files['models.jsonl']) if (row.event.requestId === oldId)
+        row.event.requestId = `source-content-assessment:timeout-${timeout}`;
+      for (const row of assessment(tape)) {
+        row.event.command.timeoutMs = timeout;
+        row.event.command.requestId = `source-content-assessment:timeout-${timeout}`;
+        row.event.command.correlationId = row.event.command.requestId;
+        if (row.event.result) rebind(builder.source, row.event);
+      }
+    }));
+    const tapes = fixtures.map(f => f.admitted.tape), originals = clone(tapes);
+    for (const [pool, timeout] of [[tapes.slice(0, 1), 300000], [tapes.slice(1), 299999],
+      [tapes, 300000], [tapes, 299999], [[...tapes].reverse(), 300000]]) {
+      const s = setup(pool);
+      try {
+        const reviews = await s.host.run(s.replay.reviewer().reviewBatch(s.requests,
+          { signal: new AbortController().signal, timeoutMs: timeout }), { requireQuiescence: true });
+        assert.equal(reviews.length, 3);
+        assert.deepEqual(s.gaps.entries(), []);
+        const report = s.replay.report();
+        assert.equal(report.consumed.length, 1);
+        assert.equal(report.consumed[0].requestId, `source-content-assessment:timeout-${timeout}`);
+        assert.equal(report.captureHistories.length, pool.length);
+        assert.equal(report.recordHistory.length, pool.length * 2);
+        assert.ok(report.consumed[0].ownerReceiptSha256);
+      } finally { s.host.close(); }
+    }
+    assert.deepEqual(tapes, originals);
+  } finally { builder.host.close(); fixtures.forEach(f => f.cleanup()); }
+});
+test('P2: other prompt/schema/provider/metadata commands cannot poison exact selection; same-command conflicting outputs fail closed', async () => {
+  const base = syntheticTape(), builder = setup([base]);
+  try {
+    const variants = [
+      c => { c.systemPrompt += ' other'; c.prompt += ' '; }, c => { c.outputSchema.description = 'other'; },
+      c => { c.controls.maxOutputTokens += 1; }, c => { c.metadata.other = 'other'; },
+      c => { c.providerInstanceId = 'other'; },
+    ].map((mutate, index) => {
+      const tape = syntheticTape(); tape.sealSha256 = String(index + 1).repeat(64);
+      for (const row of assessment(tape)) { mutate(row.event.command); if (row.event.result) rebind(builder.source, row.event); }
+      return tape;
+    });
+    const s = setup([...variants, base]);
+    try {
+      await s.host.run(s.replay.reviewer().reviewBatch(s.requests), { requireQuiescence: true });
+      assert.equal(s.replay.report().consumed[0].recordId.split(':')[0], base.sealSha256);
+      assert.ok(s.gaps.entries().every(g => g.kind === 'producer_origin_unverified'));
+      assert.equal(s.replay.report().captureHistories.length, 6);
+    } finally { s.host.close(); }
+    const missing = setup(variants);
+    try {
+      await assert.rejects(missing.replay.reviewer().reviewBatch(missing.requests), /missing_model_command/);
+      assert.equal(missing.replay.report().consumed.length, 0);
+    } finally { missing.host.close(); }
+    for (const outputKind of ['outputText', 'structuredOutput']) {
+      const conflict = syntheticTape(); conflict.sealSha256 = 'f'.repeat(64);
+      const end = assessment(conflict).find(r => r.event.result).event;
+      if (outputKind === 'outputText') end.result.outputText = 'conflicting output';
+      else {
+        end.result.structuredOutput.reviews[0].reason = 'Different synthetic reason';
+        const terminal = conflict.files['assessments.jsonl'].find(r => r.event.phase === 'completed').event;
+        const reviews = JSON.parse(terminal.reviewsJson);
+        reviews[0].reason = end.result.structuredOutput.reviews[0].reason;
+        terminal.reviewsJson = JSON.stringify(reviews);
+      }
+      rebind(builder.source, end);
+      const alone = setup([conflict]);
+      try {
+        assert.equal((await alone.host.run(alone.replay.reviewer().reviewBatch(alone.requests),
+          { requireQuiescence: true })).length, 3);
+      } finally { alone.host.close(); }
+      const failed = setup([base, conflict]);
+      try {
+        await assert.rejects(failed.replay.reviewer().reviewBatch(failed.requests), /ambiguous_recorded_request/);
+        assert.equal(failed.replay.report().consumed.length, 0);
+        assert.equal(failed.host.quiescence().settled, false);
+        assert.equal(failed.replay.report().captureHistories.length, 2);
+      } finally { failed.host.close(); }
+    }
+  } finally { builder.host.close(); }
+});

--- a/scripts/evals/reader-paired-experiment/review-fixes-fixture.cjs
+++ b/scripts/evals/reader-paired-experiment/review-fixes-fixture.cjs
@@ -1,0 +1,51 @@
+'use strict';
+const fs = require('node:fs'), os = require('node:os'), path = require('node:path');
+const { p2Fixture, ownerContractReceipt } = require('./p2-fixture.cjs');
+const { p2Observation } = require('./p2-observation.cjs');
+const { controlledFixture } = require('./controlled-fixture.cjs');
+const { evaluationView, controlsDigest } = require('./controlled-evaluation-view.cjs');
+const { sha, revisionSource, FINAL } = require('./revision-source.cjs');
+const { replayHost } = require('./replay-host.cjs');
+const { ledger, clone } = require('./recorded-selector-ports.cjs');
+const { recordedResponses } = require('./recorded-model-responses.cjs');
+const { modelControls } = require('./full-selector-fixture.cjs');
+function setup(tapes) {
+  const host = replayHost(), clock = { now: () => new Date('2026-09-05T21:59:00.000Z') };
+  const source = revisionSource(process.cwd(), FINAL, clock.now().toISOString(), host), gaps = ledger();
+  const replay = recordedResponses(source, tapes, gaps, clock, modelControls, { mode: 'CONTROLLED', host });
+  const requests = JSON.parse(tapes[0].files['assessments.jsonl'][0].event.requestsJson);
+  return { host, source, gaps, replay, requests };
+}
+function rebind(source, event) {
+  const admit = source.load('apps/agent-runtime/src/subscription-runtime-purpose-model-policy.ts').admitSubscriptionRuntimeRequest;
+  const hash = source.load('libs/contracts/grpc/agent_runtime/v1/execution-attestation.ts').canonicalJsonSha256;
+  const command = event.command, result = event.result;
+  const admitted = source.invoke(admit, [{ ...command, providerInstanceId: command.providerInstanceId, cwd: undefined,
+    outputSchemaJson: JSON.stringify(command.outputSchema), controlsJson: JSON.stringify(command.controls), metadata: command.metadata ?? {} }]);
+  result.executionAttestation.requestId = command.requestId;
+  result.executionAttestation.canonicalRequestSha256 = source.invoke(hash, [admitted.canonicalRequest]);
+  result.executionAttestation.selectedOutputSha256 = source.invoke(hash, [result.structuredOutput]);
+}
+// Artificial local trust-boundary fixture only; no real capture is certified.
+function trustedFixture(mutate) {
+  const f = p2Fixture(tape => {
+    delete tape.seal.synthetic; delete tape.files['controls.json'].synthetic;
+    mutate(tape);
+  });
+  const receiptDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'review-fixes-owner-'));
+  const cleanup = () => { f.cleanup(); fs.rmSync(receiptDirectory, { recursive: true, force: true }); };
+  try {
+    const tape = p2Observation(f.ref).tape;
+    const bytes = JSON.stringify(ownerContractReceipt(tape)), filename = `${receiptDirectory}/owner.json`;
+    fs.writeFileSync(filename, bytes);
+    const admitted = p2Observation({ ...f.ref, ownerReceipt: { path: filename, sha256: sha(bytes) } }, [sha(bytes)]);
+    const observation = admitted.observation, controls = controlledFixture().controls;
+    const declaration = { kind: 'common_evaluation_controls', observationSha256: observation.observationSha256,
+      originalControlsSha256: controlsDigest({ observationQuery: observation.observationQuery,
+        observationPresentKeys: observation.observationPresentKeys, controls: observation.originalControls, interests: observation.interests }),
+      evaluationControlsSha256: controlsDigest(controls) };
+    return { ...f, cleanup, admitted, args: { revision: FINAL, mode: 'CONTROLLED', modelControls: controls.model,
+      evaluation: evaluationView(observation, controls, declaration), responseTapes: [admitted.tape] } };
+  } catch (error) { cleanup(); throw error; }
+}
+module.exports = { setup, rebind, trustedFixture, clone };

--- a/scripts/evals/reader-paired-experiment/review-reconciliation.test.cjs
+++ b/scripts/evals/reader-paired-experiment/review-reconciliation.test.cjs
@@ -1,0 +1,114 @@
+'use strict';
+const test = require('node:test'), assert = require('node:assert/strict');
+const { syntheticTape } = require('./full-selector-fixture.cjs');
+const { setup, rebind, trustedFixture, clone } = require('./review-fixes-fixture.cjs');
+const { fullSelector } = require('./revision-full-selector.cjs');
+for (const kind of ['missing', 'duplicate', 'unmatched', 'negative']) {
+  test(`P1: actual FINAL full selector retains ${kind} reconciliation outcome after successful bound parser`, async () => {
+    const builder = setup([syntheticTape()]);
+    let fixture;
+    try {
+      fixture = trustedFixture(tape => {
+        const terminal = tape.files['relations.jsonl'].find(r => r.event.phase === 'terminal');
+        const original = terminal.event.outcome.decisions[0];
+        const decisions = kind === 'missing' ? [] : kind === 'duplicate' ? [original, clone(original)]
+          : kind === 'unmatched' ? [{ ...original, rightFeedItemId: 'unmatched-item' }] : [original];
+        terminal.event.outcome.decisions = clone(decisions);
+        const envelope = tape.files['models.jsonl'].filter(r => r.event.result).at(-1).event;
+        envelope.result.structuredOutput = { decisions };
+        rebind(builder.source, envelope);
+      });
+      const result = await fullSelector(fixture.args);
+      assert.equal(result.selectorReturned, true, JSON.stringify(result.gaps));
+      assert.equal(result.replay.consumed.length, 2);
+      assert.ok(result.replay.consumed.every(r => r.admission && r.ownerReceiptSha256));
+      assert.equal(result.quiescence.settled, true);
+      assert.ok(!result.gaps.some(g => /parser|origin|command/.test(g.kind)), JSON.stringify(result.gaps));
+      assert.equal(result.controlledExperimentComplete, kind === 'negative');
+      assert.equal(result.actualProducerVerified, kind === 'negative');
+      if (kind !== 'negative') assert.ok(result.gaps.some(g => g.kind === 'relation_reconciliation_failed' &&
+        g.request.lane === 'foreground'));
+      else assert.deepEqual(result.gaps, []);
+      assert.equal(result.selection.approvedSameStoryRelations.length, 0);
+    } finally { builder.host.close(); fixture?.cleanup(); }
+  });
+}
+
+for (const lane of ['related_topic', 'safe_recall_shadow']) {
+  test(`P1: actual ${lane} source terminal metrics survive successful parsing and later success`, async () => {
+    const tape = syntheticTape(), s = setup([tape]);
+    try {
+      const raw = clone(tape.files['relations.jsonl'][0].event.query);
+      const hydrate = value => Array.isArray(value) ? value.map(hydrate) : value && typeof value === 'object'
+        ? Object.fromEntries(Object.entries(value).map(([key, item]) => [key,
+          ['publishedAt', 'observedAt', 'requestedAt', 'startedAt', 'endedAt'].includes(key) && typeof item === 'string'
+            ? new Date(item) : hydrate(item)])) : value;
+      const query = hydrate(raw), candidate = { ...query.candidates[0],
+        shadowReasonCode: 'title_normalized_entity_event_evidence',
+        subjectFeedItemId: query.candidates[0].leftFeedItemId,
+        officialAnchorFeedItemId: query.candidates[0].rightFeedItemId,
+        subjectStoryClusterId: query.candidates[0].leftClusterId,
+        targetStoryClusterId: query.candidates[0].rightClusterId };
+      // Fixture the candidate-generation seam only. The adapter, schema parser,
+      // reconciliation, terminal metrics, detached scheduling and drain are real.
+      s.source.load('libs/summary/domain/services/story-relation-safe-recall-shadow.ts')
+        .buildStoryRelationSafeRecallShadowCandidates = () => ({ candidates: [candidate], aggregates: [] });
+      s.source.load('libs/summary/domain/services/reader-summary-related-topics.ts')
+        .buildRelatedTopicCandidates = () => [candidate];
+      const metrics = require('./relation-completion-ledger.cjs').relationCompletionMetrics(s.source, s.gaps);
+      const outcomes = [], method = lane === 'related_topic'
+        ? 'recordRelatedTopicVerification' : 'recordStoryRelationSafeRecallShadowDecisions';
+      const record = metrics[method];
+      metrics[method] = value => { outcomes.push(clone(value)); record(value); };
+      const Adapter = s.source.load('libs/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter.ts')
+        .AgentRuntimeReaderSummaryStoryRelationVerifier;
+      let decisions, parserError, parsed = 0;
+      const adapter = new Adapter({ client: { async runTask(command) {
+        const result = clone(tape.files['models.jsonl'].filter(r => r.event.result).at(-1).event.result);
+        result.structuredOutput = { decisions };
+        result.executionAttestation.purpose = command.purpose;
+        rebind(s.source, { command, result });
+        require('./recorded-request-admission.cjs').verifyRecordedRequestAdmission(s.source, command, result);
+        return result;
+      } } });
+      const verifier = { verify(input) { return s.host.track(`relation:${lane}:parser`, async () => {
+        try { const result = await adapter.verify(input); parsed++; return result; }
+        catch (error) { parserError = error.stack; throw error; }
+      }); } };
+      const selection = { clusters: query.clusters, selectedEvidence: query.evidence, rankingPolicyVersion: 'fixture-ranking' };
+      const params = { query, evidence: query.evidence, deterministicSelection: selection, selection,
+        requestedAt: query.requestedAt, verifier, metrics, authoritativeCandidates: [] };
+      const run = async () => {
+        if (lane === 'safe_recall_shadow') {
+          const schedule = s.source.load('libs/summary/adapters/evidence/relevance-reader-summary-story-relation-decisions.ts')
+            .scheduleReaderSummarySafeRecallShadowObservation;
+          s.source.invoke(schedule, [params]);
+          await s.host.run(Promise.resolve('selector-returned'), { requireQuiescence: true });
+        } else {
+          const verify = s.source.load('libs/summary/adapters/evidence/relevance-reader-summary-related-topics.ts')
+            .verifiedReaderSummaryRelatedTopics;
+          assert.deepEqual(clone(await s.host.run(s.source.invoke(verify, [params]), { requireQuiescence: true })), []);
+        }
+      };
+      const negative = { leftFeedItemId: candidate.leftFeedItemId, rightFeedItemId: candidate.rightFeedItemId,
+        ...(lane === 'related_topic' ? { relation: 'unrelated' } : { sameStory: false }), confidenceScore: 0.99, rationale: 'Synthetic unrelated subjects' };
+      decisions = [negative];
+      try { await run(); } catch (error) { assert.fail(`${error.message}: ${parserError}: ${JSON.stringify(s.host.quiescence())}`); }
+      assert.equal(parsed, 1); assert.deepEqual(s.gaps.entries(), []);
+      for (const invalid of [[], [negative, clone(negative)], [{ ...negative, rightFeedItemId: 'unmatched' }]]) {
+        const before = parsed;
+        decisions = invalid; await run();
+        assert.equal(parsed, before + 1, 'actual schema parser must succeed before reconciliation rejects');
+        if (lane === 'related_topic') assert.equal(outcomes.at(-1).status, 'failed_closed');
+        else assert.ok(outcomes.at(-1).every(row => row.disposition === 'verifier_failed_closed'));
+        assert.ok(s.gaps.entries().some(g => g.kind === 'relation_reconciliation_failed' && g.request.lane === lane));
+        const sticky = clone(s.gaps.entries());
+        decisions = [negative]; await run();
+        if (lane === 'related_topic') assert.equal(outcomes.at(-1).status, 'completed');
+        else assert.ok(outcomes.at(-1).every(row => row.disposition === 'rejected_same_story_false'));
+        assert.deepEqual(s.gaps.entries(), sticky);
+      }
+      assert.equal(s.host.quiescence().settled, true);
+    } finally { s.host.close(); }
+  });
+}

--- a/scripts/evals/reader-paired-experiment/revision-full-selector.cjs
+++ b/scripts/evals/reader-paired-experiment/revision-full-selector.cjs
@@ -8,7 +8,7 @@ const { recordedResponses } = require('./recorded-model-responses.cjs');
 const { replayHost } = require('./replay-host.cjs');
 const { detach, preparationTrace, observedPreparation, auditPreparation } = require('./selector-preparation-trace.cjs');
 const glueFiles = ['revision-source.cjs', 'revision-parser-dependencies.cjs', 'revision-full-selector.cjs',
-  'capture-owner-receipt.cjs', 'capture-core-observation.cjs', 'p2-observation.cjs', 'controlled-matrix.cjs', 'run.cjs', 'controlled-evaluation-view.cjs', 'recorded-selector-ports.cjs', 'recorded-model-responses.cjs', 'recorded-request-admission.cjs', 'selector-preparation-trace.cjs', 'replay-host.cjs', 'frozen-input.cjs'];
+  'relation-completion-ledger.cjs', 'capture-owner-receipt.cjs', 'capture-core-observation.cjs', 'p2-observation.cjs', 'controlled-matrix.cjs', 'run.cjs', 'controlled-evaluation-view.cjs', 'recorded-selector-ports.cjs', 'recorded-model-responses.cjs', 'recorded-request-admission.cjs', 'selector-preparation-trace.cjs', 'replay-host.cjs', 'frozen-input.cjs'];
 const glue = () => Object.fromEntries(glueFiles.map(file => [file, sha(fs.readFileSync(path.join(__dirname, file)))]));
 function exclusionDecisions(revision, selection, native) {
   const evaluations = new Map(native.evaluatedEvidence.map(e => [e.candidateId, e.decision]));
@@ -83,7 +83,9 @@ async function fullSelector({ repo = process.cwd(), revision, tape, responseTape
     };
     if (observe) trace = preparationTrace(source);
     const Selector = load('libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts', 'RelevanceReaderSummaryEvidenceSelector');
-    const selector = new Selector(rank, io.feed, io.clock, undefined, replay.relation(), modelControls.relatedTopicVerifierTimeoutMs);
+    const selector = new Selector(rank, io.feed, io.clock,
+      controlled ? require('./relation-completion-ledger.cjs').relationCompletionMetrics(source, gaps) : undefined,
+      replay.relation(), modelControls.relatedTopicVerifierTimeoutMs);
     if (observe) {
       const originalCluster = selector.clusterer.cluster.bind(selector.clusterer);
       selector.clusterer.cluster = params => {

--- a/scripts/evals/reader-paired-experiment/revision-full-selector.cjs
+++ b/scripts/evals/reader-paired-experiment/revision-full-selector.cjs
@@ -8,7 +8,7 @@ const { recordedResponses } = require('./recorded-model-responses.cjs');
 const { replayHost } = require('./replay-host.cjs');
 const { detach, preparationTrace, observedPreparation, auditPreparation } = require('./selector-preparation-trace.cjs');
 const glueFiles = ['revision-source.cjs', 'revision-parser-dependencies.cjs', 'revision-full-selector.cjs',
-  'recorded-selector-ports.cjs', 'recorded-model-responses.cjs', 'recorded-request-admission.cjs', 'selector-preparation-trace.cjs', 'replay-host.cjs', 'frozen-input.cjs'];
+  'capture-owner-receipt.cjs', 'capture-core-observation.cjs', 'p2-observation.cjs', 'controlled-matrix.cjs', 'run.cjs', 'controlled-evaluation-view.cjs', 'recorded-selector-ports.cjs', 'recorded-model-responses.cjs', 'recorded-request-admission.cjs', 'selector-preparation-trace.cjs', 'replay-host.cjs', 'frozen-input.cjs'];
 const glue = () => Object.fromEntries(glueFiles.map(file => [file, sha(fs.readFileSync(path.join(__dirname, file)))]));
 function exclusionDecisions(revision, selection, native) {
   const evaluations = new Map(native.evaluatedEvidence.map(e => [e.candidateId, e.decision]));
@@ -20,26 +20,41 @@ function exclusionDecisions(revision, selection, native) {
     reason: exclusions.get(id) ?? evaluations.get(id) ?? assessmentReason,
   });
 }
-async function fullSelector({ repo = process.cwd(), revision, tape, responseTapes = [tape], modelControls, observe = true }) {
-  const host = replayHost(), gaps = ledger(), selectionRecord = tape.files['selection-query.json'];
+async function fullSelector({ repo = process.cwd(), revision, tape, responseTapes = [tape], modelControls, observe = true, mode, evaluation }) {
+  const controlled = mode === 'CONTROLLED';
+  check(mode === undefined || controlled, 'unsupported_experiment_mode');
+  check(controlled === Boolean(evaluation), 'controlled_evaluation_view_required');
+  if (controlled) {
+    evaluation = require('./controlled-evaluation-view.cjs').evaluationView(evaluation.observation, evaluation.controls, evaluation.declaration);
+    check(digest(modelControls) === digest(evaluation.controls.model), 'evaluation_model_controls_mismatch');
+  }
+  const host = replayHost(), gaps = ledger(), selectionRecord = controlled ? evaluation.controls.selection : tape.files['selection-query.json'];
   const cutoff = selectionRecord.query.observedThrough;
   const source = revisionSource(repo, revision, cutoff, host);
   const load = (file, symbol) => source.load(file)[symbol];
-  let result, selection, rankedItems, mappedItems, io, replay, hostReport, trace;
+  let result, selection, rankedItems, mappedItems, io, replay, hostReport, trace, quiescence;
   const groups = [], assessmentRequests = [], commands = [];
   try {
     check([OLD, FINAL].includes(revision), 'unapproved_revision');
-    gaps.add('historical_timing_not_verified');
-    if (!tape.seal.complete) gaps.add('capture_incomplete', { sealSha256: tape.sealSha256 });
+    if (!controlled) {
+      gaps.add('historical_timing_not_verified');
+      if (!tape.seal.complete) gaps.add('capture_incomplete', { sealSha256: tape.sealSha256 });
+    } else {
+      if (!evaluation.observation.provenance.integrityVerified) gaps.add('observation_integrity_unverified');
+      if (!require('./p2-observation.cjs').originFor(evaluation.observation) &&
+          !require('./capture-core-observation.cjs').coreOriginVerified(evaluation.observation))
+        gaps.add('observation_origin_unverified', evaluation.observation.observationRef);
+    }
     check(modelControls?.assessment && modelControls?.relation, 'missing_explicit_model_controls');
-    io = ports(source, tape, gaps);
+    io = ports(source, tape, gaps, evaluation);
     check(cutoff === io.cutoff, 'selection_snapshot_cutoff_mismatch');
     const query = withKeys(clone(selectionRecord.query), selectionRecord.presentKeys);
     query.observedThrough = date(cutoff);
     query.period = { ...query.period, startedAt: date(query.period.startedAt), endedAt: date(query.period.endedAt) };
-    check(query.tenantId === tape.seal.scope.tenantId && query.workspaceId === tape.seal.scope.workspaceId &&
+    const scope = controlled ? evaluation.observation.scope : tape.seal.scope;
+    check(query.tenantId === scope.tenantId && query.workspaceId === scope.workspaceId &&
       query.period.startedAt.toISOString().slice(0, 10) === io.day, 'selection_scope_or_day_mismatch');
-    replay = recordedResponses(source, responseTapes, gaps, io.clock, modelControls);
+    replay = recordedResponses(source, responseTapes, gaps, io.clock, modelControls, controlled ? { mode, host } : {});
     if (revision === FINAL) {
       const assessment = source.load('libs/relevance/features/rank-feed-items/promotion-content-assessment.ts');
       const original = assessment.assessPromotionContent;
@@ -77,7 +92,14 @@ async function fullSelector({ repo = process.cwd(), revision, tape, responseTape
         return grouped;
       };
     }
-    selection = await host.run(source.invoke(selector.select.bind(selector), [query]));
+    const selectionOperation = Promise.resolve(source.invoke(selector.select.bind(selector), [query])).then(value => {
+      selection = value; return value;
+    });
+    try { await host.run(selectionOperation, { requireQuiescence: controlled }); }
+    catch (error) {
+      if (!controlled || selection === undefined) throw error;
+      gaps.add('controlled_host_not_quiescent', { code: error.message, ...host.quiescence() });
+    }
     trace?.restore();
     for (const failure of trace?.failures ?? []) gaps.add('preparation_observation_failed', failure);
     check(rankedItems && mappedItems, 'rank_inventory_missing');
@@ -85,7 +107,14 @@ async function fullSelector({ repo = process.cwd(), revision, tape, responseTape
     check(byId.size === ids.length && ids.every(id => byId.has(id)), 'rank_inventory_partition_mismatch');
     const preparation = observe ? observedPreparation({ revision, stages: trace.stages, groups, rankedItems, mappedItems,
       primaryIds: io.primaryIds, supplementalIds: io.supplementalIds, requests: assessmentRequests }) : null;
-    const preparationAudit = observe ? auditPreparation(tape, preparation, selection, revision, gaps) : { status: 'observation_disabled', fields: [] };
+    const preparationAudit = controlled
+      ? { status: observe ? 'controlled_actual_stage_inventory' : 'observation_disabled', historicalCallbackEqualityVerified: false,
+        rankInvocations: commands.length, snapshotInvocations: io.calls.filter(c => c.port === 'snapshot').length,
+        stages: (trace?.stages ?? []).map(s => s.kind), inventoryComplete: true }
+      : observe ? auditPreparation(tape, preparation, selection, revision, gaps) : { status: 'observation_disabled', fields: [] };
+    if (controlled && (!observe || commands.length !== 1 || preparationAudit.snapshotInvocations !== 1 ||
+        !['period', 'default_provider', 'supplemental', 'verified_relations', 'promotion_policy'].every(kind =>
+          trace.stages.some(stage => stage.kind === kind)) || groups.length !== 2)) gaps.add('controlled_preparation_audit_incomplete');
     const projection = load('libs/summary/domain/services/reader-post-promotion-projection.ts', 'buildReaderPostPromotionProjection');
     const native = source.invoke(projection, [{ evidence: selection.selectedEvidence, clusters: selection.clusters,
       sourceWindow: selection.sourceWindow, approvedSameStoryRelations: selection.approvedSameStoryRelations,
@@ -131,12 +160,18 @@ async function fullSelector({ repo = process.cwd(), revision, tape, responseTape
     gaps.add('full_selector_failed', { code: error.message });
     result = { rows: null, assessmentCoverage: { pendingIds: null, unresolvedCandidateCount: null }, groupingCalls: groups,
       rankCommands: commands, assessmentRequests, partialRankedInventory: rankedItems ?? null };
-  } finally { trace?.restore(); hostReport = host.report(); host.close(); }
+  } finally { trace?.restore(); hostReport = host.report(); quiescence = host.quiescence(); host.close(); }
   const replayReport = replay?.report() ?? { consumed: [], observedOutcomes: [], replayMissingRequestCount: gaps.missing() };
+  if (controlled) replayReport.quiescence = quiescence;
   return clone({ format: 'paired-full-selector-arm.v1', revision, complete: false,
     evidenceStatus: 'uncertified_offline_full_selector_slice', actualProducerVerified: false,
     historicalTimingVerified: false, selectorReturned: selection !== undefined,
-    ...result, inputSealSha256: tape.sealSha256, controlsSha256: digest(modelControls),
+    ...result, inputSealSha256: tape?.sealSha256 ?? null, controlsSha256: digest(modelControls),
+    ...(controlled ? { format: 'paired-controlled-selector-arm.v1', mode,
+      controlledExperimentComplete: selection !== undefined && result.rows !== null && gaps.entries().length === 0 && quiescence.settled,
+      historicalReplayComplete: false, actualProducerVerified: gaps.entries().length === 0 && quiescence.settled, observation: evaluation.observation, evaluationControlsSha256: evaluation.controlsSha256,
+      evaluationClock: cutoff, evaluationDeclaration: evaluation.declaration, quiescence,
+      evidenceStatus: 'controlled_offline_execution_with_explicit_provenance_gaps' } : {}),
     source: source.identity(), instrumentation: glue(), portCalls: io?.calls ?? [], replay: replayReport,
     host: hostReport, gaps: gaps.entries(), artifactId: null });
 }

--- a/scripts/evals/reader-paired-experiment/run.cjs
+++ b/scripts/evals/reader-paired-experiment/run.cjs
@@ -78,19 +78,24 @@ function execute(manifest, repo) {
 }
 async function main(args) {
   const options = {}; for (let i = 0; i < args.length; i += 2) {
-    check(['--mode', '--manifest', '--sha256', '--out', '--repo'].includes(args[i]) && args[i + 1] && !options[args[i]], 'invalid CLI'); options[args[i]] = args[i + 1];
+    check(['--mode', '--manifest', '--sha256', '--out', '--repo', '--owner-receipt-sha256s'].includes(args[i]) && args[i + 1] && !options[args[i]], 'invalid CLI'); options[args[i]] = args[i + 1];
   }
   check(options['--out'], '--out required'); let result;
   try {
-    check(['inventory', 'policy', 'full-selector'].includes(options['--mode']), 'unknown mode');
-    result = options['--mode'] === 'full-selector'
+    check(['inventory', 'policy', 'full-selector', 'controlled'].includes(options['--mode']), 'unknown mode');
+    result = options['--mode'] === 'controlled'
+      ? await require('./controlled-matrix.cjs').executeControlled(read({ path: options['--manifest'], sha256: options['--sha256'] }), options['--repo'] || process.cwd(), options['--owner-receipt-sha256s']?.split(',') ?? [])
+      : options['--mode'] === 'full-selector'
       ? await require('./full-selector-matrix.cjs').executeFull(read({ path: options['--manifest'], sha256: options['--sha256'] }), options['--repo'] || process.cwd())
       : options['--mode'] === 'inventory' ? inventory() : execute(read({ path: options['--manifest'], sha256: options['--sha256'] }), options['--repo'] || process.cwd());
   } catch (e) { result = { complete: false, conditionalPolicyComplete: false, gaps: [{ kind: e.code ?? e.message }] }; }
-  if (['policy', 'full-selector'].includes(options['--mode'])) result.manifestFileSha256 = options['--sha256'] ?? null;
-  const out = path.resolve(options['--out']); check(out.startsWith('/tmp/'), 'outputs must be under /tmp');
+  if (['policy', 'full-selector', 'controlled'].includes(options['--mode'])) result.manifestFileSha256 = options['--sha256'] ?? null;
+  const out = path.resolve(options['--out']);
+  const controlledTemporaryOutput = options['--mode'] === 'controlled' &&
+    out.startsWith(path.resolve(require('node:os').tmpdir()) + path.sep);
+  check(out.startsWith('/tmp/') || controlledTemporaryOutput, 'outputs must be under /tmp');
   fs.mkdirSync(path.dirname(out), { recursive: true }); fs.writeFileSync(out, `${JSON.stringify(result, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
-  process.exitCode = result.conditionalPolicyComplete ? 0 : 2;
+  process.exitCode = result.conditionalPolicyComplete || result.controlledExperimentComplete ? 0 : 2;
 }
 if (require.main === module) main(process.argv.slice(2)).catch(error => { console.error(error.message); process.exitCode = 2; });
 module.exports = { inventory, execute, main };


### PR DESCRIPTION
Add a controlled comparison mode for real seven-day captures: old versus final selectors on identical AFTER inputs, and final selection on BEFORE versus AFTER data. Original observations are preserved and the two effects are reported separately.

Complete ordered inventories, genuine recorded model responses and actual revision parsers are bound to immutable captures and an out-of-band trusted local execution-owner receipt. Invalid relation reconciliation remains a sticky incomplete result across foreground, related-topic and shadow lanes. Response unions match the complete generated semantic command before checking conflicting outputs, preserving timeout, prompt, schema and provider controls.

Builds on merged #346. Independent review approved final head 837228354cafd8902d67c6c286abf6b272970b50 after both reproduced findings were fixed. Verification: 93 tests passed, including 8 new regressions; independent reviewer reran all 8; architecture, code-quality and source-line-cap gates passed. Original exact-head CI run34356600405 succeeded. The branch is now based on merged main at 84043ed89f3ea64e6bf38dbc70f370c3b5340eea; final head 963574a4d6c97b5ba80e58bacae5ced72584f49d has a byte-identical Git tree to the pre-retarget head. The controlled-eval patches are unchanged; final exact-head CI run 34419721611 passed all 14 jobs.

Real AFTER captures and final measurements remain pending. This code does not claim historical timing reproduction, quality improvement or production publication/delivery completion.

Refs #293, Refs #294
