### PR TITLE
fix(agent-runtime): admit reviewed subscription runtime version

### DIFF
--- a/apps/agent-runtime/bin/subscription-runtime-active-usage-contract.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-active-usage-contract.test.mjs
@@ -16,7 +16,7 @@ import { withTrustedCodexWorkerUsage } from "./codex-worker-cli-usage.mjs";
 // usage instead of the cumulative thread counter.
 const artifactPath = join(
   process.cwd(),
-  process.env.USAGE_CONTRACT_ARTIFACT ?? "vendor/vioxen-subscription-runtime-0.1.0-main.42.tgz",
+  process.env.USAGE_CONTRACT_ARTIFACT ?? "vendor/vioxen-subscription-runtime-0.1.0-main.42-sm.1.tgz",
 );
 
 try {

--- a/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
@@ -47,13 +47,13 @@ describe("subscription runtime installation admission", () => {
   let previousPath: string | undefined;
 
   beforeAll(async () => {
-    installationRoot = await mkdtemp(join(tmpdir(), "runtime-main42-installation-"));
+    installationRoot = await mkdtemp(join(tmpdir(), "runtime-main42-sm1-installation-"));
     const modules = join(installationRoot, "node_modules");
     const packageRoot = join(modules, "@vioxen/subscription-runtime");
     await mkdir(packageRoot, { recursive: true });
-    const archive = join(process.cwd(), "vendor/vioxen-subscription-runtime-0.1.0-main.42.tgz");
+    const archive = join(process.cwd(), "vendor/vioxen-subscription-runtime-0.1.0-main.42-sm.1.tgz");
     expect(createHash("sha256").update(await readFile(archive)).digest("hex")).toBe(
-      "338499bc01bc08958d53bcad6fdf0da9ab4dbc542705b947eed8eb59afdc49ae",
+      "66a8bdf6ae680bd3548fc92df140fb9df2202c829f946b9122393090faf9e31e",
     );
     await promisify(execFile)("tar", [
       "-xzf", archive, "-C", packageRoot, "--strip-components=1",
@@ -69,7 +69,7 @@ describe("subscription runtime installation admission", () => {
       await symlink(join(providedModules, "@vioxen", name), join(modules, "@vioxen", name));
     }
     expect(JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"))).toMatchObject({
-      name: "@vioxen/subscription-runtime", version: "0.1.0-main.42",
+      name: "@vioxen/subscription-runtime", version: "0.1.0-main.42-sm.1",
     });
   }, 15_000);
 
@@ -96,7 +96,7 @@ describe("subscription runtime installation admission", () => {
     }
   });
 
-  it("admits the exact repository launcher and vendored main.42 in a sandbox", async () => {
+  it("admits the exact repository launcher and vendored main.42-sm.1 in a sandbox", async () => {
     const command = join(await copyInstallation(), launcherName);
 
     await expect(
@@ -237,6 +237,8 @@ describe("subscription runtime installation admission", () => {
   );
 
   it.each([
+    { name: "@vioxen/subscription-runtime", version: "0.1.0-main.42" },
+    { name: "@vioxen/subscription-runtime", version: "0.1.0-main.42-sm.2" },
     { name: "@vioxen/subscription-runtime", version: "0.0.0-unapproved" },
     { name: "unapproved-runtime", version: approvedSubscriptionRuntimePackageVersion },
   ])("rejects an unapproved package manifest %j", async (manifest) => {

--- a/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
@@ -47,6 +47,10 @@ describe("subscription runtime installation admission", () => {
   let previousPath: string | undefined;
 
   beforeAll(async () => {
+    const rootManifest = JSON.parse(await readFile(join(process.cwd(), "package.json"), "utf8"));
+    expect(rootManifest.dependencies["@vioxen/subscription-runtime"]).toBe(
+      `file:vendor/vioxen-subscription-runtime-${approvedSubscriptionRuntimePackageVersion}.tgz`,
+    );
     installationRoot = await mkdtemp(join(tmpdir(), "runtime-main42-sm1-installation-"));
     const modules = join(installationRoot, "node_modules");
     const packageRoot = join(modules, "@vioxen/subscription-runtime");

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -12,7 +12,7 @@ import {
 } from "node:path";
 
 export const approvedSubscriptionRuntimePackageVersion =
-  "0.1.0-main.42";
+  "0.1.0-main.42-sm.1";
 export const approvedSubscriptionRuntimeLauncherSha256 =
   "a7bd7dc219461a1e42f957657b7fa628df201cd8ae74fe91159b842a42d0eef9";
 


### PR DESCRIPTION
Production CheckHealth rejects the reviewed main.42-sm.1 runtime because installation admission still expects main.42. Update the exact approved version while preserving every launcher and helper hash check.

The regression binds the root dependency to the approval constant and verifies the real pinned archive. It rejects the old version and an unapproved successor. Independent review approved 9e738203073c4033e810c29bc1935077113fdbd1; a disposable mutation changing only the declared bundle correctly fails the new assertion.

Validation: 33 focused tests and architecture, code-quality, source-line-cap and runtime-profile checks passed. Final CI: https://github.com/777genius/social-monitor/actions/runs/34396997852 (in progress). Production health and seven-day E2E remain to be verified after deployment.

Refs #293
Refs #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the approved subscription runtime package to version `0.1.0-main.42-sm.1`.
  * Subscription runtime installations must now use the approved package version to be accepted.
  * The previously approved `0.1.0-main.42` version is no longer accepted.
  * Added validation coverage for the updated package archive and integrity checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->