### PR TITLE
fix(runtime): bound assessment cleanup and report safe progress

### DIFF
--- a/apps/agent-runtime/bin/assessment-cli-launcher.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-launcher.test.mjs
@@ -89,7 +89,7 @@ async function launch(t, { hold, neverStop = false, failedTask = false, parentLo
       },
     }],
   ]);
-  const context = createContext({ process: fakeProcess, performance, Date, AbortController, console,
+  const context = createContext({ process: fakeProcess, performance: globalThis.performance, Date, AbortController, console,
     setTimeout, clearTimeout });
   const modules = new Map();
   async function load(specifier) {

--- a/apps/agent-runtime/bin/assessment-cli-launcher.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-launcher.test.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+import { createContext, SourceTextModule, SyntheticModule } from "node:vm";
+import test, { before, after } from "node:test";
+import FakeTimers from "@sinonjs/fake-timers";
+import { completed, deferred, fakeIo, legacyFixture, request, waitFor } from "./assessment-cli-test-support.mjs";
+const require = createRequire(import.meta.url);
+require("ts-node").register({ transpileOnly: true, compilerOptions: { rootDir: process.cwd() } });
+require("tsconfig-paths/register");
+const { SubscriptionRuntimeCliExecutor } = require("../src/subscription-runtime-cli-executor.ts");
+const { assessmentRequest, syntheticInstallation } = require("../src/source-content-assessment-runtime.spec-support.ts");
+const { createAssessmentProgressParser } = require("../src/subscription-runtime-cli-progress.ts");
+let fixture;
+before(async () => { fixture = await legacyFixture(); });
+after(async () => { await fixture?.close(); });
+
+// Execute the unmodified launcher source with only explicit fake filesystem/auth/executor imports.
+// Its injected legacy function is the pinned actual entrypoint with fake IO and worker factory.
+async function launch(t, { hold, neverStop = false, failedTask = false, parentLog = false, accountFailure = false } = {}) {
+  const sources = new Map();
+  for (const name of ["run-codex-subscription-runtime-agent-task.mjs", "assessment-cli-lifecycle.mjs", "assessment-cli-progress.mjs"]) {
+    sources.set(name, await readFile(new URL(name, import.meta.url), "utf8"));
+  }
+  const pure = new Map();
+  for (const name of ["codex-worker-cli-usage.mjs", "subscription-runtime-failure-details.mjs",
+    "subscription-runtime-purpose-model-policy.mjs", "codex-auth-pool-routing.mjs"]) {
+    pure.set(`./${name}`, await import(new URL(name, import.meta.url)));
+  }
+  const clock = FakeTimers.install({ now: 0, toFake: ["setTimeout", "clearTimeout", "Date", "performance"] });
+  t.after(() => clock.uninstall());
+  const events = [], records = [], gate = deferred(), turn = deferred(), stop = deferred();
+  let input = JSON.stringify(request), options, aborts = 0, runCount = 0, disposeCount = 0, returned = false;
+  const receive = createAssessmentProgressParser((record) => records.push(record));
+  const io = fakeIo(fixture.root), logs = [];
+  const parentChild = Object.assign(new EventEmitter(), {
+    stdout: Object.assign(new EventEmitter(), { destroy() {} }),
+    stderr: Object.assign(new EventEmitter(), { destroy() {} }),
+    kill(signal) { fakeProcess.emit(signal); return true; }, unref() {},
+  });
+  const fakeProcess = Object.assign(new EventEmitter(), {
+    argv: ["node", "/synthetic/launcher", "--provider", "codex", "--input", "/synthetic/request",
+      "--format", "result-json", "--state-root", "/synthetic/state", "--encryption-key-env", "SYNTHETIC_LOCAL_KEY"],
+    env: { SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS: "60000" },
+    stderr: { write: (line) => { receive(Buffer.from(line)); parentChild.stderr.emit("data", Buffer.from(line)); return false; } },
+  });
+  const pause = async (phase) => { events.push(phase); if (hold === phase) await gate.promise; };
+  class FakeExecutor {
+    constructor(value) { options = value; events.push("executor-created"); }
+    async run(job) {
+      runCount++; options.observability.emit({ name: "provider.task.started", metadata: { prompt: "synthetic-private-content" } });
+      job.abortSignal.addEventListener("abort", () => { aborts++; events.push("aborted"); });
+      await turn.promise;
+      options.observability.emit({ name: "provider.task.completed", metadata: { status: failedTask ? "failed" : "completed" } });
+      return failedTask ? { status: "failed", attempts: [], reason: "task_timeout" } : { status: "completed", result: completed };
+    }
+    async dispose() {
+      disposeCount++; events.push("pool-drain");
+      await new Promise((resolve) => setTimeout(resolve, options.shutdownTimeoutMs));
+      events.push("native-stop");
+      if (neverStop) await stop.promise;
+      else await new Promise((resolve) => setTimeout(resolve, 10_000));
+    }
+  }
+  const fs = {
+    readFile: async (file) => { if (file === "/synthetic/request") { await pause("input-read"); return input; }
+      if (file === "/synthetic/fail") throw new Error("Synthetic materialization failure");
+      await pause("account-read"); return "synthetic-account-material"; },
+    writeFile: async (file, bytes) => { if (file === "/synthetic/request") input = bytes; },
+    mkdir: async () => {}, mkdtemp: async () => "/synthetic/materialization", realpath: async (p) => p,
+    rm: async () => { await pause("auth-removal"); },
+  };
+  const namespaces = new Map([...pure, ["node:fs/promises", fs], ["node:path", path],
+    ["./pinned-codex-native-binary.mjs", { resolvePinnedCodexBinaryPath: () => "/synthetic/not-executable" }],
+    ["./codex-auth-pool-manifest.mjs", { loadCodexAuthPoolFromEnv: async () => {
+      await pause("account-setup"); return { accounts: [{ id: "synthetic-account", authJsonPath: "/synthetic/account" },
+        ...(accountFailure ? [{ id: "synthetic-failed", authJsonPath: "/synthetic/fail" }] : [])] };
+    } }],
+    ["@vioxen/subscription-runtime/worker-codex", { FileBackendCodexSafeExecutor: FakeExecutor,
+      FileBackendCodexWorker: class { constructor() { throw new Error("Real/default worker forbidden"); } },
+      NodeProcessRunner: class { constructor() { throw new Error("Native runner forbidden"); } } }],
+    ["@vioxen/subscription-runtime/worker-core", { SubscriptionWorkerError: class extends Error {} }],
+    ["../../../node_modules/@vioxen/subscription-runtime/dist/worker-local/agent-task-runner-cli.js", {
+      runSubscriptionAgentTaskCli: (argv, _io, factory) => {
+        io.readStdin = async () => input;
+        return fixture.runSubscriptionAgentTaskCli(argv.filter((arg, i) => arg !== "--input" && argv[i - 1] !== "--input"), io, factory);
+      },
+    }],
+  ]);
+  const context = createContext({ process: fakeProcess, performance, Date, AbortController, console,
+    setTimeout, clearTimeout });
+  const modules = new Map();
+  async function load(specifier) {
+    if (modules.has(specifier)) return modules.get(specifier);
+    const name = specifier.replace(/^\.\//, "");
+    let module;
+    if (sources.has(name)) {
+      module = new SourceTextModule(sources.get(name), { context,
+        importModuleDynamically: async (specifier) => {
+          const imported = await load(specifier); if (imported.status === "linked") await imported.evaluate(); return imported;
+        } });
+    } else {
+      assert.ok(namespaces.has(specifier), `Unexpected import denied: ${specifier}`);
+      const namespace = namespaces.get(specifier);
+      module = new SyntheticModule(Object.keys(namespace), function () {
+        for (const [key, value] of Object.entries(namespace)) this.setExport(key, value);
+      }, { context });
+    }
+    modules.set(specifier, module); await module.link(load); return module;
+  }
+  let parentResult;
+  if (parentLog) {
+    let spawned = false;
+    t.mock.method(require("node:child_process"), "spawn", () => { spawned = true; return parentChild; });
+    const executor = new SubscriptionRuntimeCliExecutor({ command: "/synthetic/runtime-cli", ephemeral: false,
+      installationInspector: { inspect: async () => ({ ...syntheticInstallation, packageRootRealpath: "/synthetic" }) },
+      logger: { info: (message, fields) => logs.push({ message, fields }), warn() {}, error() {} },
+    });
+    parentResult = executor.execute({ ...assessmentRequest(), timeoutMs: 60_000 });
+    await waitFor(() => spawned);
+    assert.ok(spawned);
+    const write = io.writeStdout;
+    io.writeStdout = (line) => { write(line); parentChild.stdout.emit("data", Buffer.from(line)); };
+  }
+  const module = await load("./run-codex-subscription-runtime-agent-task.mjs");
+  const result = module.evaluate().then(() => { returned = true; parentChild.emit("close", fakeProcess.exitCode, null); return fakeProcess.exitCode; });
+  const until = async (predicate) => {
+    await waitFor(predicate);
+    assert.ok(predicate(), JSON.stringify({ events, stderr: io.stderr }));
+  };
+  return { clock, records, events, gate, turn, stop, result, until, io, fakeProcess,
+    logs, parentResult, get options() { return options; }, get aborts() { return aborts; }, get runCount() { return runCount; },
+    get disposeCount() { return disposeCount; }, get returned() { return returned; } };
+}
+
+test("actual launcher/legacy/fake executor forwards existing callbacks before close and reaches bounded native disposal", async (t) => {
+  const h = await launch(t); await h.until(() => h.runCount === 1);
+  assert.equal(h.returned, false);
+  assert.ok(h.records.some((r) => r.phase === "provider.task" && r.transition === "started"));
+  assert.equal(JSON.stringify(h.records).includes("synthetic-private-content"), false);
+  assert.equal(h.options.shutdownTimeoutMs, 1000);
+  assert.equal(h.options.effectMode, "read_only"); assert.equal(h.options.maxAccountCycles, 1);
+  assert.equal(h.options.safeExecutionPolicy.maxAttempts, 1);
+  for (const key of ["retryOnCapacity", "retryOnAccountUnavailable", "retryOnReconnectRequired", "retryUnknownCleanWorkspace"]) {
+    assert.equal(h.options.safeExecutionPolicy[key], false);
+  }
+  assert.equal(h.options.accounts[0].worker.model, "gpt-5.6-sol");
+  assert.equal(h.options.accounts[0].worker.reasoningEffort, "high");
+  await h.clock.tickAsync(40_000); assert.equal(h.aborts, 1);
+  await h.clock.tickAsync(5_000); assert.equal(h.disposeCount, 1);
+  await h.clock.tickAsync(1_000); assert.ok(h.events.includes("native-stop"));
+  await h.clock.tickAsync(10_000); assert.equal(await h.result, 1);
+  // Drain 1s + stop 10s lands exactly on the 11s observation bound: no earlier receipt.
+  assert.equal(h.records.at(-1).disposeSettled, false);
+  assert.ok(h.records.every((r) => r.providerOutcome === "unknown"));
+  h.turn.resolve(); await h.clock.tickAsync(0); assert.equal(h.disposeCount, 1);
+});
+
+for (const phase of ["input-read", "account-setup", "account-read"]) test(`launcher delayed ${phase} never reaches executor after cutoff`, async (t) => {
+  const h = await launch(t, { hold: phase }); await h.until(() => h.events.includes(phase));
+  await h.clock.tickAsync(45_000); assert.equal(await h.result, 1);
+  h.gate.resolve(); await h.clock.tickAsync(0);
+  assert.equal(h.runCount, 0); assert.equal(h.events.includes("executor-created"), false);
+});
+
+test("launcher holds auth cleanup in actual task settlement and never infers provider success", async (t) => {
+  const h = await launch(t, { hold: "auth-removal", neverStop: true, failedTask: true });
+  await h.until(() => h.runCount === 1); h.turn.resolve(); await h.clock.tickAsync(0);
+  assert.ok(h.events.includes("auth-removal")); await h.clock.tickAsync(56_000);
+  assert.equal(await h.result, 1);
+  assert.ok(h.records.some((r) => r.phase === "task_settlement" && r.taskSettled === false));
+  assert.equal(h.records.at(-1).disposeSettled, false);
+  assert.ok(h.records.every((r) => r.providerOutcome === "unknown"));
+  h.gate.resolve(); h.stop.resolve(); await h.clock.tickAsync(0);
+});
+
+
+test("actual existing callback reaches the parent executor logger while the fake engine is still held", async (t) => {
+  const h = await launch(t, { parentLog: true }); await h.until(() => h.runCount === 1);
+  assert.equal(h.returned, false);
+  const log = h.logs.find(({ fields }) => fields.phase === "provider.task");
+  assert.equal(log.message, "agent runtime assessment progress");
+  assert.equal(log.fields.correlationId, assessmentRequest().correlationId);
+  assert.equal(log.fields.requestId, assessmentRequest().requestId);
+  assert.equal(JSON.stringify(h.logs).includes("synthetic-private-content"), false);
+  await h.clock.tickAsync(40_000); h.turn.resolve(); await h.clock.tickAsync(11_000);
+  assert.equal(await h.result, 1);
+  const result = await h.parentResult;
+  assert.equal(result.status, "failed"); assert.equal(result.failure.code, "agent_runtime.cli_timeout");
+  assert.equal(result.failure.retryable, false); assert.equal(result.executionAttestation, undefined);
+});
+
+
+test("parallel account setup rejection does not hide another outstanding materialization", async (t) => {
+  const h = await launch(t, { hold: "account-read", accountFailure: true });
+  await h.until(() => h.events.includes("auth-removal"));
+  assert.equal(h.returned, false);
+  await h.clock.tickAsync(45_000); assert.equal(await h.result, 1);
+  assert.ok(h.records.some((r) => r.phase === "task_settlement" && r.taskSettled === false));
+  h.gate.resolve(); await h.clock.tickAsync(0);
+  assert.equal(h.events.includes("executor-created"), false);
+});

--- a/apps/agent-runtime/bin/assessment-cli-lifecycle.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-lifecycle.mjs
@@ -1,6 +1,6 @@
 // Local promise receipts only: abort and disposal never attest remote/descendant termination.
 export function createAssessmentCliLifecycle({
-  now = () => performance.now(), wallNow = () => Date.now(), timers = globalThis,
+  now = () => globalThis.performance.now(), wallNow = () => Date.now(), timers = globalThis,
   signals = process, parentDeadline, reserveMs = 20_000, settlementMs = 5_000,
   disposalMs = 11_000, marginMs = 4_000, mark = () => {},
 } = {}) {

--- a/apps/agent-runtime/bin/assessment-cli-lifecycle.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-lifecycle.mjs
@@ -1,0 +1,131 @@
+// Local promise receipts only: abort and disposal never attest remote/descendant termination.
+export function createAssessmentCliLifecycle({
+  now = () => performance.now(), wallNow = () => Date.now(), timers = globalThis,
+  signals = process, parentDeadline, reserveMs = 20_000, settlementMs = 5_000,
+  disposalMs = 11_000, marginMs = 4_000, mark = () => {},
+} = {}) {
+  const entered = now();
+  const transported = Number(parentDeadline);
+  let deadline = Number.isFinite(transported) && transported > 0
+    ? entered + Math.max(0, transported - wallNow()) : Infinity;
+  const controller = new AbortController();
+  const pending = new Set();
+  let worker, timeout, cleanup, disposal, disposalReceipt, invocation;
+  let enabled = deadline !== Infinity, cliSettled = false, finished = false;
+  let cancelledAt;
+  let notifyCancellation;
+  const cancellation = new Promise((resolve) => { notifyCancellation = resolve; });
+  const remaining = () => Math.max(0, deadline - now());
+  const release = () => {
+    if (!finished || !cliSettled || pending.size || (disposal && !disposalReceipt)) return;
+    timers.clearTimeout(timeout);
+    signals.removeListener("SIGTERM", onSignal);
+    signals.removeListener("SIGINT", onSignal);
+  };
+  const cancel = () => {
+    if (controller.signal.aborted) return;
+    cancelledAt = now();
+    controller.abort();
+    if (enabled) mark("cancellation", "observed");
+    notifyCancellation();
+  };
+  const onSignal = () => cancel();
+  signals.on("SIGTERM", onSignal);
+  signals.on("SIGINT", onSignal);
+  const arm = () => {
+    timers.clearTimeout(timeout);
+    if (!enabled) return;
+    if (remaining() <= reserveMs) cancel();
+    else timeout = timers.setTimeout(cancel, remaining() - reserveMs);
+  };
+  const checkpoint = () => {
+    if (enabled && remaining() <= reserveMs) cancel();
+    if (controller.signal.aborted) throw new Error("Assessment local work cancelled");
+  };
+  const work = (invoke) => {
+    const promise = Promise.resolve().then(() => { checkpoint(); return invoke(); });
+    pending.add(promise);
+    const settled = () => { pending.delete(promise); release(); };
+    promise.then(settled, settled);
+    return promise.then((value) => { checkpoint(); return value; });
+  };
+  const waitUntil = async (promise, end) => {
+    let timer;
+    try {
+      return await Promise.race([promise.then(() => true, () => true),
+        new Promise((resolve) => { timer = timers.setTimeout(() => resolve(false), Math.max(0, end - now())); })]);
+    } finally { timers.clearTimeout(timer); }
+  };
+  const disposeOnce = () => {
+    if (!disposal) {
+      mark("disposal", "started");
+      disposal = Promise.resolve().then(() => worker?.dispose?.());
+      disposal.then(() => { disposalReceipt = { disposeSettled: true, disposeSucceeded: true }; release(); },
+        () => { disposalReceipt = { disposeSettled: true, disposeSucceeded: false }; release(); });
+    }
+    return disposal;
+  };
+  const settleAndDispose = () => {
+    cleanup ??= (async () => {
+      const end = Math.min(deadline - marginMs, cancelledAt + settlementMs + disposalMs);
+      const taskSettled = await waitUntil(Promise.allSettled([...pending, ...(!worker && invocation ? [invocation] : [])]), Math.min(end, cancelledAt + settlementMs));
+      mark("task_settlement", "observed", { taskSettled });
+      if (worker) await waitUntil(disposeOnce(), Math.min(end, now() + disposalMs));
+      mark("disposal", "observed", disposalReceipt ?? { disposeSettled: false });
+    })();
+    return cleanup;
+  };
+  arm();
+  return {
+    remaining, checkpoint, work, cancel,
+    configure(assessment, timeoutMs) {
+      enabled = assessment;
+      if (assessment) {
+        if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) throw new Error("Assessment requires a bounded timeout");
+        deadline = Math.min(deadline, entered + timeoutMs);
+      }
+      else {
+        signals.removeListener("SIGTERM", onSignal);
+        signals.removeListener("SIGINT", onSignal);
+      }
+      arm();
+      checkpoint();
+    },
+    decorateWorker(value) {
+      checkpoint();
+      worker = value;
+      return { start: (...args) => work(() => worker.start(...args)),
+        seedCodexAuthJsonFile: (...args) => work(() => worker.seedCodexAuthJsonFile(...args)),
+        run: (job) => work(async () => {
+          const combined = new AbortController();
+          const abort = () => { combined.abort(); if (job.abortSignal?.aborted) cancel(); };
+          const sources = [controller.signal, job.abortSignal].filter(Boolean);
+          for (const signal of sources) {
+            signal.addEventListener("abort", abort, { once: true });
+            if (signal.aborted) abort();
+          }
+          try { combined.signal.throwIfAborted(); return await worker.run({ ...job, abortSignal: combined.signal }); }
+          finally { for (const signal of sources) signal.removeEventListener("abort", abort); }
+        }),
+        dispose: () => controller.signal.aborted ? settleAndDispose() : disposeOnce(),
+      };
+    },
+    async runCli(invokeLegacyCli) {
+      const cli = invocation = Promise.resolve().then(invokeLegacyCli);
+      cli.then(() => { cliSettled = true; release(); }, () => { cliSettled = true; release(); });
+      try {
+        const normal = cli.then(async (code) => {
+          if (enabled) await Promise.allSettled([...pending]);
+          if (enabled && disposal) {
+            await disposal.catch(() => {});
+            if (!controller.signal.aborted) mark("disposal", "observed", disposalReceipt);
+          }
+          return code;
+        });
+        const code = await Promise.race([normal, cancellation.then(() => undefined)]);
+        if (controller.signal.aborted) { await settleAndDispose(); return 1; }
+        return code;
+      } finally { finished = true; release(); }
+    },
+  };
+}

--- a/apps/agent-runtime/bin/assessment-cli-lifecycle.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-lifecycle.mjs
@@ -123,6 +123,8 @@ export function createAssessmentCliLifecycle({
           return code;
         });
         const code = await Promise.race([normal, cancellation.then(() => undefined)]);
+        // Promise continuations can beat an overdue cancellation timer.
+        if (enabled && remaining() <= reserveMs) cancel();
         if (controller.signal.aborted) { await settleAndDispose(); return 1; }
         return code;
       } finally { finished = true; release(); }

--- a/apps/agent-runtime/bin/assessment-cli-lifecycle.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-lifecycle.test.mjs
@@ -156,7 +156,7 @@ test("legacy input setup held before factory is an unsettled operation", async (
   assert.equal(factories, 0); assert.equal(h.signals.listenerCount("SIGTERM"), 0);
 });
 
-test("direct admission uses entry time, and configurable small fake reserves do not restart a deadline", async (t) => {
+test("direct admission uses entry time, and configurable small fake reserves do not restart a deadline", async () => {
   const clock = FakeTimers.createClock(0), signals = new EventEmitter(), marks = [];
   const lifecycle = createAssessmentCliLifecycle({ now: () => clock.now, wallNow: () => clock.now,
     timers: clock, signals, reserveMs: 20, settlementMs: 5, disposalMs: 11, marginMs: 4,

--- a/apps/agent-runtime/bin/assessment-cli-lifecycle.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-lifecycle.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test, { before, after } from "node:test";
+import FakeTimers from "@sinonjs/fake-timers";
+import { createAssessmentCliLifecycle } from "./assessment-cli-lifecycle.mjs";
+import { withTrustedCodexWorkerUsage } from "./codex-worker-cli-usage.mjs";
+import { completed, deferred, fakeIo, legacyArgs, legacyFixture, request, waitFor } from "./assessment-cli-test-support.mjs";
+
+let fixture;
+before(async () => { fixture = await legacyFixture(); });
+after(async () => { await fixture?.close(); });
+
+function harness(t, options = {}) {
+  const clock = FakeTimers.install({ now: 0, toFake: ["setTimeout", "clearTimeout", "Date", "performance"] });
+  t.after(() => clock.uninstall());
+  const signals = new EventEmitter(), marks = [], calls = [];
+  const lifecycle = createAssessmentCliLifecycle({ signals, mark: (...args) => marks.push(args), ...options });
+  lifecycle.configure(true, 60_000);
+  const io = fakeIo(fixture.root);
+  const worker = { start: async () => { calls.push("start"); }, seedCodexAuthJsonFile: async () => { calls.push("seed"); },
+    run: async () => completed, dispose: async () => { calls.push("dispose"); } };
+  const run = (args = legacyArgs) => lifecycle.runCli(() => fixture.runSubscriptionAgentTaskCli(args, io,
+    () => lifecycle.decorateWorker(withTrustedCodexWorkerUsage(worker))));
+  // Legacy resolveRequestCwd performs a read-only realpath of this empty sandbox.
+  const started = async () => {
+    await waitFor(() => calls.includes("start"));
+    assert.ok(calls.includes("start"), io.stderr.join(""));
+  };
+  return { clock, signals, marks, calls, lifecycle, io, worker, run, started };
+}
+
+for (const rejection of [false, true]) test(`actual legacy abort ${rejection ? "rejects" : "resolves"} before one disposal`, async (t) => {
+  const h = harness(t), held = deferred();
+  let aborts = 0;
+  h.worker.run = async ({ abortSignal }) => {
+    abortSignal.addEventListener("abort", () => { aborts++; h.calls.push("abort");
+      if (rejection) held.reject(new Error("Synthetic late rejection")); else held.resolve(completed);
+    });
+    try { return await held.promise; } finally { h.calls.push("settled"); }
+  };
+  const result = h.run(); await h.started(); await h.clock.tickAsync(40_000);
+  assert.equal(await result, 1);
+  h.signals.emit("SIGTERM"); h.signals.emit("SIGINT");
+  assert.equal(aborts, 1);
+  assert.deepEqual(h.calls, ["start", "abort", "settled", "dispose"]);
+  assert.ok(h.marks.some(([p, , r]) => p === "task_settlement" && r.taskSettled === true));
+  assert.ok(h.marks.some(([p, , r]) => p === "disposal" && r?.disposeSucceeded === true));
+  assert.equal(h.clock.countTimers(), 0);
+  assert.equal(h.signals.listenerCount("SIGTERM"), 0);
+});
+
+test("actual legacy pending run gets 5s settlement, then 11s disposal; late rejection is observed", async (t) => {
+  const h = harness(t), held = deferred(), stop = deferred();
+  h.worker.run = () => held.promise;
+  h.worker.dispose = () => { h.calls.push("dispose"); return stop.promise; };
+  let returned = false;
+  const result = h.run().then((code) => { returned = true; return code; }); await h.started();
+  await h.clock.tickAsync(44_999); assert.equal(h.calls.includes("dispose"), false);
+  await h.clock.tickAsync(1); assert.equal(h.calls.filter((x) => x === "dispose").length, 1);
+  await h.clock.tickAsync(10_999); assert.equal(returned, false);
+  await h.clock.tickAsync(1); assert.equal(await result, 1);
+  assert.ok(h.marks.some(([p, , r]) => p === "task_settlement" && r.taskSettled === false));
+  assert.deepEqual(h.marks.at(-1), ["disposal", "observed", { disposeSettled: false }]);
+  assert.equal(h.signals.listenerCount("SIGTERM"), 1, "background work retains cancellation protection");
+  held.reject(new Error("Synthetic delayed rejection")); stop.resolve();
+  await h.clock.tickAsync(0);
+  assert.equal(h.calls.filter((x) => x === "dispose").length, 1);
+  assert.equal(h.signals.listenerCount("SIGTERM"), 0);
+  assert.equal(h.clock.countTimers(), 0);
+});
+
+for (const phase of ["start", "seedCodexAuthJsonFile"]) test(`cancel held ${phase} prevents later run`, async (t) => {
+  const h = harness(t), held = deferred(); let runs = 0, entered = false;
+  h.worker[phase] = () => { entered = true; h.calls.push("start"); return held.promise; };
+  h.worker.run = async () => { runs++; return completed; };
+  const result = h.run([...legacyArgs, "--codex-auth-json", "/synthetic-unused"]);
+  await waitFor(() => entered);
+  assert.equal(entered, true);
+  h.signals.emit("SIGTERM"); await h.clock.tickAsync(5_000);
+  assert.equal(await result, 1); held.resolve(); await h.clock.tickAsync(0);
+  assert.equal(runs, 0); assert.equal(h.calls.filter((x) => x === "dispose").length, 1);
+  assert.equal(h.clock.countTimers(), 0);
+});
+
+test("setup cutoff before legacy factory forbids late provider creation", async (t) => {
+  const h = harness(t), held = deferred(); let factories = 0;
+  const result = h.lifecycle.runCli(async () => {
+    await h.lifecycle.work(() => held.promise);
+    factories++; return h.run();
+  });
+  await h.clock.tickAsync(0); h.signals.emit("SIGTERM"); await h.clock.tickAsync(5_000);
+  assert.equal(await result, 1);
+  assert.deepEqual(h.marks.at(-1), ["disposal", "observed", { disposeSettled: false }]);
+  held.resolve(); await h.clock.tickAsync(0);
+  assert.equal(factories, 0); assert.equal(h.signals.listenerCount("SIGTERM"), 0);
+});
+
+test("startup budget remains anchored and wall-clock changes cannot extend it", async (t) => {
+  const h = harness(t, { parentDeadline: 55_000 });
+  await h.clock.tickAsync(30_000);
+  h.clock.setSystemTime(999_999);
+  h.lifecycle.configure(true, 60_000);
+  assert.equal(h.lifecycle.remaining(), 25_000);
+  await h.clock.tickAsync(5_000);
+  assert.throws(() => h.lifecycle.checkpoint(), /cancelled/);
+  assert.equal(h.marks.filter(([p]) => p === "cancellation").length, 1);
+  assert.equal(await h.lifecycle.runCli(async () => 0), 1);
+});
+
+test("normal legacy result preserves canonical output and usage, observes slow disposal beyond legacy 5s", async (t) => {
+  const h = harness(t), stop = deferred(); let returned = false;
+  h.worker.dispose = () => { h.calls.push("dispose"); return stop.promise; };
+  const result = h.run().then((code) => { returned = true; return code; }); await h.started();
+  await h.clock.tickAsync(5_001);
+  assert.equal(returned, false, "legacy disposal timeout is not cleanup completion");
+  assert.match(h.io.stderr.join(""), /dispose_timeout/);
+  const output = JSON.parse(h.io.stdout.join(""));
+  assert.equal(output.status, "completed"); assert.deepEqual(output.structuredOutput, { reviews: [] });
+  assert.deepEqual(output.telemetry.usage, completed.usage);
+  stop.resolve(); await h.clock.tickAsync(0);
+  assert.equal(await result, 0); assert.equal(h.clock.countTimers(), 0);
+  assert.equal(h.signals.listenerCount("SIGINT"), 0);
+});
+
+test("cancellation during normal disposal reuses the promise and bounded reserve", async (t) => {
+  const h = harness(t), stop = deferred();
+  h.worker.dispose = () => { h.calls.push("dispose"); return stop.promise; };
+  const result = h.run(); await h.started(); await h.clock.tickAsync(39_999);
+  h.signals.emit("SIGINT"); await h.clock.tickAsync(11_000);
+  assert.equal(await result, 1);
+  assert.equal(h.calls.filter((x) => x === "dispose").length, 1);
+  assert.deepEqual(h.marks.at(-1), ["disposal", "observed", { disposeSettled: false }]);
+  stop.reject(new Error("Synthetic disposal failure")); await h.clock.tickAsync(0);
+  assert.equal(h.signals.listenerCount("SIGINT"), 0);
+});
+
+test("completed fake task with pending auth removal remains unsettled", async (t) => {
+  const h = harness(t), removal = deferred();
+  h.worker.run = async () => { try { return completed; } finally { await removal.promise; } };
+  const result = h.run(); await h.started(); await h.clock.tickAsync(45_000);
+  assert.equal(await result, 1);
+  assert.ok(h.marks.some(([p, , r]) => p === "task_settlement" && r.taskSettled === false));
+  removal.resolve(); await h.clock.tickAsync(0);
+});
+
+test("legacy input setup held before factory is an unsettled operation", async (t) => {
+  const h = harness(t), input = deferred(); let factories = 0;
+  h.io.readStdin = () => input.promise;
+  const result = h.lifecycle.runCli(() => fixture.runSubscriptionAgentTaskCli(legacyArgs, h.io, () => {
+    h.lifecycle.checkpoint(); factories++; return h.lifecycle.decorateWorker(h.worker);
+  }));
+  await h.clock.tickAsync(45_000); assert.equal(await result, 1);
+  assert.ok(h.marks.some(([p, , r]) => p === "task_settlement" && r.taskSettled === false));
+  input.resolve(JSON.stringify(request));
+  await waitFor(() => h.signals.listenerCount("SIGTERM") === 0);
+  assert.equal(factories, 0); assert.equal(h.signals.listenerCount("SIGTERM"), 0);
+});
+
+test("direct admission uses entry time, and configurable small fake reserves do not restart a deadline", async (t) => {
+  const clock = FakeTimers.createClock(0), signals = new EventEmitter(), marks = [];
+  const lifecycle = createAssessmentCliLifecycle({ now: () => clock.now, wallNow: () => clock.now,
+    timers: clock, signals, reserveMs: 20, settlementMs: 5, disposalMs: 11, marginMs: 4,
+    mark: (...args) => marks.push(args) });
+  await clock.tickAsync(90);
+  assert.throws(() => lifecycle.configure(true, 100), /cancelled/);
+  let started = false;
+  assert.equal(await lifecycle.runCli(() => lifecycle.work(() => { started = true; return 0; })), 1);
+  assert.equal(started, false); assert.equal(clock.countTimers(), 0);
+  assert.equal(signals.listenerCount("SIGTERM"), 0);
+  assert.equal(marks.filter(([phase]) => phase === "cancellation").length, 1);
+});
+
+test("actual disposal rejection has a distinct failure receipt without leaking its reason", async (t) => {
+  const h = harness(t);
+  h.worker.dispose = async () => { throw new Error("Synthetic private disposal detail"); };
+  const result = h.run(); await h.started(); await h.clock.tickAsync(0);
+  assert.equal(await result, 0, "legacy result/exit semantics are unchanged by a disposal error");
+  assert.deepEqual(h.marks.at(-1), ["disposal", "observed", { disposeSettled: true, disposeSucceeded: false }]);
+  assert.equal(JSON.stringify(h.marks).includes("private disposal detail"), false);
+  assert.equal(h.clock.countTimers(), 0);
+});
+
+test("legacy job cancellation reaches the same settlement and disposal coordinator", async (t) => {
+  const h = harness(t), held = deferred(), legacy = new AbortController();
+  let aborts = 0;
+  const worker = h.lifecycle.decorateWorker({ start: async () => {},
+    run: ({ abortSignal }) => { abortSignal.addEventListener("abort", () => { aborts++; held.resolve(completed); }); return held.promise; },
+    dispose: async () => { h.calls.push("dispose"); } });
+  const result = h.lifecycle.runCli(() => worker.run({ abortSignal: legacy.signal }));
+  await h.clock.tickAsync(0); legacy.abort(); await h.clock.tickAsync(0);
+  assert.equal(await result, 1); assert.equal(aborts, 1); assert.deepEqual(h.calls, ["dispose"]);
+  assert.ok(h.marks.some(([p, , r]) => p === "task_settlement" && r.taskSettled));
+});
+
+test("already aborted legacy signal cannot launch new worker work", async (t) => {
+  const h = harness(t), legacy = new AbortController(); legacy.abort(); let runs = 0;
+  const worker = h.lifecycle.decorateWorker({ run: async () => { runs++; return completed; }, dispose: async () => {} });
+  const result = h.lifecycle.runCli(() => worker.run({ abortSignal: legacy.signal }));
+  await h.clock.tickAsync(0); assert.equal(await result, 1); assert.equal(runs, 0);
+});

--- a/apps/agent-runtime/bin/assessment-cli-lifecycle.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-lifecycle.test.mjs
@@ -198,3 +198,32 @@ test("already aborted legacy signal cannot launch new worker work", async (t) =>
   const result = h.lifecycle.runCli(() => worker.run({ abortSignal: legacy.signal }));
   await h.clock.tickAsync(0); assert.equal(await result, 1); assert.equal(runs, 0);
 });
+
+for (const assessment of [true, false]) for (const elapsed of [39_999, 40_000, 41_000, 61_000]) {
+  test(`terminal disposal checks monotonic cutoff without timer dispatch: assessment=${assessment} elapsed=${elapsed}`, async () => {
+    const clock = FakeTimers.createClock(0), signals = new EventEmitter(), marks = [];
+    let monotonic = 0, disposals = 0;
+    const lifecycle = createAssessmentCliLifecycle({ now: () => monotonic, wallNow: () => clock.now,
+      timers: clock, signals, mark: (...args) => marks.push(args) });
+    lifecycle.configure(assessment, 60_000);
+    const stop = deferred();
+    const worker = lifecycle.decorateWorker({ dispose: () => { disposals++; return stop.promise; } });
+    const result = lifecycle.runCli(async () => { await worker.dispose(); return 0; });
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    assert.equal(disposals, 1);
+    assert.equal(marks.some(([phase]) => phase === "cancellation"), false);
+    monotonic = elapsed; // Advance only monotonic time; overdue callbacks remain undispatched.
+    stop.resolve();
+    const expired = assessment && elapsed >= 40_000;
+    assert.equal(await result, expired ? 1 : 0);
+    assert.equal(marks.filter(([phase]) => phase === "cancellation").length, expired ? 1 : 0);
+    if (expired) {
+      assert.ok(marks.some(([phase, , receipt]) => phase === "task_settlement" && receipt.taskSettled));
+      assert.deepEqual(marks.at(-1), ["disposal", "observed", { disposeSettled: true, disposeSucceeded: true }]);
+    }
+    assert.equal(disposals, 1);
+    assert.equal(clock.countTimers(), 0);
+    assert.equal(signals.listenerCount("SIGTERM"), 0);
+    assert.equal(signals.listenerCount("SIGINT"), 0);
+  });
+}

--- a/apps/agent-runtime/bin/assessment-cli-progress.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-progress.mjs
@@ -1,0 +1,39 @@
+export const assessmentProgressPrefix = "assessment-progress-v1 ";
+const callbacks = new Set([
+  "session.read.started", "session.read.completed", "lease.acquire.started", "lease.acquire.completed",
+  "provider.refresh.started", "provider.refresh.completed", "provider.refresh.skipped",
+  "session.writeback.started", "session.writeback.completed", "provider.task.started", "provider.task.completed",
+  "session.task_update.writeback.started", "session.task_update.writeback.completed", "session.task_update.writeback.failed",
+]);
+const phases = new Set([...callbacks].map((name) => name.slice(0, name.lastIndexOf("."))).concat([
+  "setup", "account_materialization", "executor_run", "auth_cleanup", "cancellation", "task_settlement", "disposal",
+]));
+const transitions = new Set(["started", "completed", "skipped", "failed", "observed"]);
+
+// Never project event metadata, errors, or provider status into this local receipt.
+export function createAssessmentProgress({ write, now, remaining }) {
+  const started = now();
+  let lastObservedPhase = "setup";
+  let records = 0;
+  const mark = (phase, transition, receipt = {}) => {
+    if (!phases.has(phase) || !transitions.has(transition)) return;
+    const previous = lastObservedPhase;
+    if (!["cancellation", "task_settlement", "disposal"].includes(phase)) lastObservedPhase = phase;
+    // Keep three records for cancellation and the two final cleanup observations.
+    if (records >= (phase === "cancellation" || transition === "observed" ? 64 : 61)) return;
+    const record = { version: 1, phase, transition,
+      elapsedMs: Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.floor(now() - started))),
+      remainingMs: Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.floor(remaining()))),
+      providerOutcome: "unknown", lastObservedPhase: previous };
+    for (const key of ["taskSettled", "disposeSettled", "disposeSucceeded"]) {
+      if (typeof receipt[key] === "boolean") record[key] = receipt[key];
+    }
+    records++;
+    try { write(`${assessmentProgressPrefix}${JSON.stringify(record)}\n`); } catch { /* Diagnostics are best effort. */ }
+  };
+  return { mark, emit(event) {
+    if (!callbacks.has(event?.name)) return;
+    const split = event.name.lastIndexOf(".");
+    mark(event.name.slice(0, split), event.name.slice(split + 1));
+  }, count() {}, timing() {} };
+}

--- a/apps/agent-runtime/bin/assessment-cli-progress.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-progress.mjs
@@ -14,13 +14,22 @@ const transitions = new Set(["started", "completed", "skipped", "failed", "obser
 export function createAssessmentProgress({ write, now, remaining }) {
   const started = now();
   let lastObservedPhase = "setup";
-  let records = 0;
+  let ordinaryRecords = 0;
+  const cleanupSlots = new Set();
   const mark = (phase, transition, receipt = {}) => {
     if (!phases.has(phase) || !transitions.has(transition)) return;
     const previous = lastObservedPhase;
     if (!["cancellation", "task_settlement", "disposal"].includes(phase)) lastObservedPhase = phase;
-    // Keep three records for cancellation and the two final cleanup observations.
-    if (records >= (phase === "cancellation" || transition === "observed" ? 64 : 61)) return;
+    // Only the three actual lifecycle observations own reserved, one-shot slots.
+    const cleanup = transition === "observed" &&
+      ["cancellation", "task_settlement", "disposal"].includes(phase);
+    if (cleanup) {
+      if (cleanupSlots.has(phase)) return;
+      cleanupSlots.add(phase);
+    } else {
+      if (ordinaryRecords >= 61) return;
+      ordinaryRecords++;
+    }
     const record = { version: 1, phase, transition,
       elapsedMs: Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.floor(now() - started))),
       remainingMs: Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.floor(remaining()))),
@@ -28,7 +37,6 @@ export function createAssessmentProgress({ write, now, remaining }) {
     for (const key of ["taskSettled", "disposeSettled", "disposeSucceeded"]) {
       if (typeof receipt[key] === "boolean") record[key] = receipt[key];
     }
-    records++;
     try { write(`${assessmentProgressPrefix}${JSON.stringify(record)}\n`); } catch { /* Diagnostics are best effort. */ }
   };
   return { mark, emit(event) {

--- a/apps/agent-runtime/bin/assessment-cli-progress.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-progress.test.mjs
@@ -30,10 +30,10 @@ test("all existing callback and wrapper records survive independent validation; 
   assert.equal(lines.some((line) => /initialize|turn|journal/.test(line)), false);
 });
 
-test("bounded parser recovers after giant unterminated and oversized multiline stderr", () => {
+test("bounded parser recovers after oversized stderr within its lifetime byte budget", () => {
   const lines = [], records = []; bridge((line) => lines.push(line)).emit({ name: "provider.task.started" });
   const parse = createAssessmentProgressParser((record) => records.push(record));
-  const giant = Buffer.alloc(2 * 1024 * 1024, 120);
+  const giant = Buffer.alloc(2 * 1024, 120);
   for (let i = 0; i < 8; i++) parse(giant);
   parse(Buffer.from(`\n${lines[0]}${assessmentProgressPrefix}${"x".repeat(1025)}\n${lines[0]}`));
   assert.equal(records.length, 2);
@@ -67,4 +67,78 @@ test("flood and backpressure cannot delay cleanup markers or throw through obser
   const parse = createAssessmentProgressParser(() => { throw new Error(privateValue); });
   assert.doesNotThrow(() => parse(Buffer.from(lines.join(""))));
   assert.doesNotThrow(() => { progress.count(privateValue, 1); progress.timing(privateValue, 1); });
+});
+
+for (const invalid of ["\n", "not-progress\n", `${assessmentProgressPrefix}{\n`]) {
+  test(`invalid frame flood closes parser with bounded work: ${JSON.stringify(invalid)}`, (t) => {
+    let parsed = 0, scans = 0, received = 0;
+    const originalParse = JSON.parse, originalIndexOf = Buffer.prototype.indexOf;
+    t.mock.method(JSON, "parse", (...args) => { parsed++; return originalParse(...args); });
+    t.mock.method(Buffer.prototype, "indexOf", function (...args) {
+      scans++; return originalIndexOf.apply(this, args);
+    });
+    const parse = createAssessmentProgressParser(() => received++);
+    parse(Buffer.from(invalid.repeat(10_000)));
+    const work = { parsed, scans };
+    let valid; bridge((line) => { valid = line; }).emit({ name: "provider.task.started" });
+    for (let i = 0; i < 100; i++) parse(Buffer.from(valid));
+    assert.deepEqual({ parsed, scans }, work, "exhaustion is permanent across chunks");
+    assert.ok(parsed <= 256); assert.equal(scans, 256); assert.equal(received, 0);
+  });
+}
+
+for (const chunkSize of [17, 2 * 1024 * 1024]) {
+  test(`oversized stream has finite total scanned bytes with chunks of ${chunkSize}`, (t) => {
+    let scanned = 0, parses = 0, received = 0;
+    const originalIndexOf = Buffer.prototype.indexOf, originalParse = JSON.parse;
+    t.mock.method(Buffer.prototype, "indexOf", function (value, offset) {
+      scanned += this.length - offset;
+      return originalIndexOf.call(this, value, offset);
+    });
+    t.mock.method(JSON, "parse", (...args) => { parses++; return originalParse(...args); });
+    const parse = createAssessmentProgressParser(() => received++);
+    const chunk = Buffer.alloc(chunkSize, 120);
+    for (let i = 0; i < Math.ceil(512 * 1024 / chunkSize) + 2; i++) parse(chunk);
+    assert.equal(scanned, 256 * 1024);
+    parse(Buffer.from(`\n${assessmentProgressPrefix}{}\n`));
+    assert.equal(scanned, 256 * 1024); assert.equal(parses, 0); assert.equal(received, 0);
+  });
+}
+
+test("oversized frames count toward the frame budget; split ordinary records recover before exhaustion", () => {
+  let valid; bridge((line) => { valid = line; }).emit({ name: "provider.task.completed" });
+  const records = [], parse = createAssessmentProgressParser((record) => records.push(record));
+  // Empty and invalid lines consume 254 frames, then one oversized frame and one valid frame.
+  parse(Buffer.from("\ninvalid\n".repeat(127)));
+  parse(Buffer.alloc(1025, 120)); parse(Buffer.from("\n"));
+  const bytes = Buffer.from(valid);
+  parse(bytes.subarray(0, 7)); parse(bytes.subarray(7)); parse(bytes);
+  assert.equal(records.length, 1); assert.equal(records[0].transition, "completed");
+});
+
+test("each cleanup observation owns one slot regardless of order, repetition or ordinary observed floods", () => {
+  for (const order of [["cancellation", "task_settlement", "disposal"], ["disposal", "task_settlement", "cancellation"]]) {
+    const lines = [], progress = bridge((line) => lines.push(line));
+    for (let i = 0; i < 100; i++) progress.mark("setup", "observed");
+    for (const phase of order) {
+      for (let i = 0; i < 100; i++) {
+        progress.mark(phase, "started");
+        progress.mark(phase, "observed", { taskSettled: false, disposeSettled: false });
+      }
+    }
+    const records = lines.map((line) => parseAssessmentProgressLine(line.trimEnd()));
+    assert.equal(records.length, 64);
+    assert.deepEqual(records.slice(61).map((record) => record.phase), order);
+    assert.ok(records.slice(61).every((record) => record.transition === "observed"));
+  }
+});
+
+test("early cleanup and failed writes cannot consume another cleanup slot or the ordinary budget", () => {
+  let writes = 0;
+  const progress = bridge(() => { writes++; throw new Error(privateValue); });
+  for (let i = 0; i < 100; i++) progress.mark("cancellation", "observed");
+  for (let i = 0; i < 100; i++) progress.emit({ name: "session.read.completed" });
+  progress.mark("task_settlement", "observed", { taskSettled: true });
+  progress.mark("disposal", "observed", { disposeSettled: true, disposeSucceeded: true });
+  assert.equal(writes, 64);
 });

--- a/apps/agent-runtime/bin/assessment-cli-progress.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-progress.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRequire } from "node:module";
+import { createAssessmentProgress, assessmentProgressPrefix } from "./assessment-cli-progress.mjs";
+const require = createRequire(import.meta.url);
+require("ts-node").register({ transpileOnly: true, compilerOptions: { rootDir: process.cwd() } });
+const { createAssessmentProgressParser, parseAssessmentProgressLine } = require("../src/subscription-runtime-cli-progress.ts");
+const callbacks = ["session.read.started", "session.read.completed", "lease.acquire.started", "lease.acquire.completed",
+  "provider.refresh.started", "provider.refresh.completed", "provider.refresh.skipped", "session.writeback.started",
+  "session.writeback.completed", "provider.task.started", "provider.task.completed", "session.task_update.writeback.started",
+  "session.task_update.writeback.completed", "session.task_update.writeback.failed"];
+const privateValue = "synthetic-private-metadata";
+function bridge(write) {
+  return createAssessmentProgress({ write, now: () => 12, remaining: () => 50_000 });
+}
+
+test("all existing callback and wrapper records survive independent validation; metadata cannot leak", () => {
+  const lines = [], records = [], progress = bridge((line) => lines.push(line));
+  for (const name of callbacks) progress.emit({ name, durationMs: -99, metadata: {
+    status: "failed", prompt: privateValue, sessionId: privateValue, output: privateValue }, unexpected: privateValue });
+  for (const phase of ["setup", "account_materialization", "executor_run", "auth_cleanup", "cancellation", "task_settlement", "disposal"]) {
+    progress.mark(phase, "observed", { taskSettled: false, disposeSettled: true, disposeSucceeded: false, text: privateValue });
+  }
+  const parse = createAssessmentProgressParser((record) => records.push(record));
+  for (const line of lines) for (const byte of Buffer.from(line)) parse(Buffer.from([byte]));
+  assert.equal(records.length, callbacks.length + 7);
+  assert.equal(JSON.stringify(records).includes(privateValue), false);
+  assert.ok(records.every((r) => r.providerOutcome === "unknown"));
+  assert.ok(records.some((r) => r.phase === "provider.task" && r.transition === "completed" && r.providerOutcome === "unknown"));
+  assert.equal(lines.some((line) => /initialize|turn|journal/.test(line)), false);
+});
+
+test("bounded parser recovers after giant unterminated and oversized multiline stderr", () => {
+  const lines = [], records = []; bridge((line) => lines.push(line)).emit({ name: "provider.task.started" });
+  const parse = createAssessmentProgressParser((record) => records.push(record));
+  const giant = Buffer.alloc(2 * 1024 * 1024, 120);
+  for (let i = 0; i < 8; i++) parse(giant);
+  parse(Buffer.from(`\n${lines[0]}${assessmentProgressPrefix}${"x".repeat(1025)}\n${lines[0]}`));
+  assert.equal(records.length, 2);
+  parse(Buffer.from(lines[0].repeat(100))); assert.equal(records.length, 64);
+});
+
+test("reject malformed fields and reconstruct allowlisted scalars only", () => {
+  let line; bridge((value) => { line = value; }).emit({ name: "provider.task.started" });
+  const record = JSON.parse(line.slice(assessmentProgressPrefix.length));
+  for (const bad of [{ version: 2 }, { phase: "initialize" }, { transition: "native_settled" },
+    { remainingMs: -1 }, { elapsedMs: 0.5 }, { remainingMs: 1e99 }, { remainingMs: Infinity },
+    { elapsedMs: "1" }, { providerOutcome: "settled" }, { lastObservedPhase: privateValue }, { taskSettled: "true" }]) {
+    assert.equal(parseAssessmentProgressLine(assessmentProgressPrefix + JSON.stringify({ ...record, ...bad })), undefined);
+  }
+  for (const bad of ["{", "[]", "null", "false", '{"elapsedMs":NaN}', '{"remainingMs":1e999}']) {
+    assert.equal(parseAssessmentProgressLine(assessmentProgressPrefix + bad), undefined);
+  }
+  assert.deepEqual(parseAssessmentProgressLine(assessmentProgressPrefix + JSON.stringify({ ...record,
+    prompt: privateValue, tenantId: privateValue, metadata: { value: privateValue }, __proto__: { unexpected: privateValue } })), record);
+});
+
+test("flood and backpressure cannot delay cleanup markers or throw through observability", () => {
+  const lines = [], progress = bridge((line) => { lines.push(line); return false; });
+  for (let i = 0; i < 1000; i++) progress.emit({ name: "provider.task.started", metadata: { text: privateValue } });
+  progress.mark("cancellation", "observed"); progress.mark("task_settlement", "observed", { taskSettled: false });
+  progress.mark("disposal", "observed", { disposeSettled: false });
+  assert.equal(lines.length, 64);
+  assert.equal(JSON.parse(lines.at(-1).slice(assessmentProgressPrefix.length)).phase, "disposal");
+  const throwing = bridge(() => { throw new Error(privateValue); });
+  assert.doesNotThrow(() => throwing.emit({ name: "provider.task.started" }));
+  const parse = createAssessmentProgressParser(() => { throw new Error(privateValue); });
+  assert.doesNotThrow(() => parse(Buffer.from(lines.join(""))));
+  assert.doesNotThrow(() => { progress.count(privateValue, 1); progress.timing(privateValue, 1); });
+});

--- a/apps/agent-runtime/bin/assessment-cli-test-support.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-test-support.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { setTimeout as originalSetTimeout } from "node:timers";
+const realSetTimeout = originalSetTimeout;
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
+
+export const deferred = () => {
+  let resolve, reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+};
+export const completed = { status: "completed", outputText: "Synthetic output", structuredOutput: { reviews: [] },
+  warnings: [], usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 } };
+export const request = { protocolVersion: 1, runId: "synthetic-assessment",
+  timeoutMs: 60_000, task: { kind: "structured-prompt", prompt: "Synthetic assessment", outputSchemaName: "social_monitor_source_content_quality_review",
+    controls: { outputSchema: { type: "object" } } },
+  context: { purpose: "social_monitor.relevance.assess_source_content.v1" } };
+
+// Import the pinned legacy entrypoint, never the prepared main.41 installation or a real worker factory.
+export async function legacyFixture() {
+  const root = await mkdtemp(join(tmpdir(), "assessment-deadline-legacy-"));
+  const archive = join(process.cwd(), "vendor/vioxen-subscription-runtime-0.1.0-main.42-sm.1.tgz");
+  assert.equal(createHash("sha256").update(await readFile(archive)).digest("hex"),
+    "66a8bdf6ae680bd3548fc92df140fb9df2202c829f946b9122393090faf9e31e");
+  try {
+    execFileSync("tar", ["-xzf", archive, "-C", root], { timeout: 10_000, stdio: "pipe" });
+    const packageRoot = join(root, "package");
+    for (const name of ["@anthropic-ai/claude-agent-sdk", "@modelcontextprotocol/sdk", "@types/node", "ajv", "libsodium-wrappers", "zod"]) {
+      const destination = join(packageRoot, "node_modules", name);
+      await mkdir(dirname(destination), { recursive: true });
+      let provided;
+      try { provided = await realpath(join(process.cwd(), "node_modules/@vioxen/subscription-runtime/node_modules", name)); }
+      catch (error) {
+        if (error.code !== "ENOENT") throw error;
+        provided = await realpath(join(process.cwd(), "node_modules", name));
+      }
+      await symlink(provided, destination);
+    }
+    const { runSubscriptionAgentTaskCli } = await import(pathToFileURL(join(packageRoot, "dist/worker-local/agent-task-runner-cli.js")));
+    return { root, runSubscriptionAgentTaskCli, close: () => rm(root, { recursive: true, force: true }) };
+  } catch (error) { await rm(root, { recursive: true, force: true }); throw error; }
+}
+export function fakeIo(root, input = request) {
+  const stdout = [], stderr = [];
+  return { stdout, stderr, readStdin: async () => JSON.stringify(input), cwd: () => root,
+    env: () => ({ SYNTHETIC_LOCAL_KEY: "synthetic-test-value" }),
+    writeStdout: (line) => stdout.push(line), writeStderr: (line) => stderr.push(line) };
+}
+export const legacyArgs = ["--provider", "codex", "--format", "result-json", "--state-root", "/synthetic-unused",
+  "--encryption-key-env", "SYNTHETIC_LOCAL_KEY"];
+
+
+// Only wait for the legacy entrypoint's sandbox realpath IO; lifecycle time stays fake.
+export async function waitFor(predicate) {
+  for (let i = 0; i < 5000 && !predicate(); i++) await new Promise((resolve) => realSetTimeout(resolve, 1));
+  assert.ok(predicate(), "Synthetic fixture did not reach its awaited IO boundary");
+}

--- a/apps/agent-runtime/bin/codex-worker-cli-usage.test.mjs
+++ b/apps/agent-runtime/bin/codex-worker-cli-usage.test.mjs
@@ -29,7 +29,8 @@ test("rejects malformed and conflicting metadata without guessing missing counts
 });
 test("shared outer factory covers every selection and preserves single invocation and lifecycle", async () => {
   const source = await readFile(new URL("./run-codex-subscription-runtime-agent-task.mjs", import.meta.url), "utf8");
-  assert.match(source, /\(input\) => withTrustedCodexWorkerUsage\(createStrictCodexWorker\(input\)\)/u);
+  assert.match(source, /const worker = withTrustedCodexWorkerUsage\(createStrictCodexWorker\(input\)\);/u);
+  assert.match(source, /return isSourceContentAssessment \? lifecycle\.decorateWorker\(worker\) : worker;/u);
   for (const route of ["direct", "pooled", "strict"]) {
     const events = [];
     const worker = withTrustedCodexWorkerUsage({

--- a/apps/agent-runtime/bin/pinned-codex-native-binary.test.mjs
+++ b/apps/agent-runtime/bin/pinned-codex-native-binary.test.mjs
@@ -7,6 +7,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { createAssessmentCliLifecycle } from "./assessment-cli-lifecycle.mjs";
+import { createAssessmentProgress } from "./assessment-cli-progress.mjs";
 import { resolvePinnedCodexBinaryPath } from "./pinned-codex-native-binary.mjs";
 import { resolve as resolveProbe } from "../../../ops/deploy/support/reader-promotion-v2-canary-probe-loader.mjs";
 
@@ -144,7 +146,13 @@ test("every wrapper factory uses the native default and preserves explicit synth
     for (const override of [undefined, "/synthetic/fake-codex.mjs"]) {
       const captured = [];
       const isPool = lane.startsWith("pool") || lane === "assessment";
+      // Use the actual helpers without owning process signal handlers.
+      const lifecycle = createAssessmentCliLifecycle({ signals: new EventEmitter() });
+      lifecycle.configure(lane === "assessment", 60_000);
+      const progress = createAssessmentProgress({ write: () => {},
+        now: () => globalThis.performance.now(), remaining: lifecycle.remaining });
       const dependencies = {
+        lifecycle, progress,
         admission: { profile: { provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "high", retryMode: "never" },
           canonicalRequest: { runId: "synthetic-native-contract" } },
         authPool: isPool ? { accounts: [{ id: "fixture-account" }] } : undefined,
@@ -172,14 +180,17 @@ test("every wrapper factory uses the native default and preserves explicit synth
       };
       const create = new Function(...Object.keys(dependencies), `${body}\nreturn createStrictCodexWorker;`)(...Object.values(dependencies));
       const env = { LANG: "C.UTF-8" };
-      const worker = create({ provider: "codex", stateRootDir: "/synthetic/state", cwd: "/synthetic/task",
-        codexBinaryPath: override, env });
-      if (isPool && !lane.endsWith("canary")) await worker.run({ runId: "synthetic-native-contract" });
-      assert.equal(captured.length, 1, lane);
-      assert.equal(captured[0].codexBinaryPath, override ?? resolvePinnedCodexBinaryPath(), lane);
-      assert.equal(captured[0].sourceEnv, env, lane);
-      assert.equal(captured[0].model, "gpt-5.6-sol", lane);
-      assert.equal(captured[0].reasoningEffort, "high", lane);
+      assert.equal(await lifecycle.runCli(async () => {
+        const worker = create({ provider: "codex", stateRootDir: "/synthetic/state", cwd: "/synthetic/task",
+          codexBinaryPath: override, env });
+        if (isPool && !lane.endsWith("canary")) await worker.run({ runId: "synthetic-native-contract" });
+        assert.equal(captured.length, 1, lane);
+        assert.equal(captured[0].codexBinaryPath, override ?? resolvePinnedCodexBinaryPath(), lane);
+        assert.equal(captured[0].sourceEnv, env, lane);
+        assert.equal(captured[0].model, "gpt-5.6-sol", lane);
+        assert.equal(captured[0].reasoningEffort, "high", lane);
+        return 0;
+      }), 0);
     }
   }
 });

--- a/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
+++ b/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
@@ -11,6 +11,8 @@ import {
 import { join } from "node:path";
 import { resolvePinnedCodexBinaryPath } from "./pinned-codex-native-binary.mjs";
 import { withTrustedCodexWorkerUsage } from "./codex-worker-cli-usage.mjs";
+import { createAssessmentCliLifecycle } from "./assessment-cli-lifecycle.mjs";
+import { createAssessmentProgress } from "./assessment-cli-progress.mjs";
 import { subscriptionRuntimeFailureDetails } from "./subscription-runtime-failure-details.mjs";
 
 import {
@@ -29,6 +31,15 @@ import {
   orderCodexAuthAccountsForTask,
 } from "./codex-auth-pool-routing.mjs";
 
+let lifecycle;
+let progress = process.env.SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS === undefined ? undefined :
+  createAssessmentProgress({ write: (line) => process.stderr.write(line),
+    now: () => performance.now(), remaining: () => lifecycle?.remaining() ?? 0 });
+lifecycle = createAssessmentCliLifecycle({
+  parentDeadline: process.env.SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS,
+  mark: (...args) => progress?.mark(...args),
+});
+process.exitCode = await lifecycle.runCli(async () => {
 const argv = process.argv.slice(2);
 const canaryActivationFlag = "--activate-reader-promotion-v2-canary";
 const canaryActivationRequested = argv.includes(canaryActivationFlag);
@@ -38,7 +49,7 @@ const inputPath = requiredArgument(runtimeArgv, "--input");
 const requestedModel = optionalArgument(runtimeArgv, "--model");
 const requestedReasoningEffort =
   process.env.AGENT_RUNTIME_REASONING_EFFORT?.trim() || undefined;
-const request = JSON.parse(await readFile(inputPath, "utf8"));
+const request = JSON.parse(await lifecycle.work(() => readFile(inputPath, "utf8")));
 const admission = admitSubscriptionRuntimeWrapperRequest({
   request,
   provider,
@@ -48,28 +59,36 @@ const admission = admitSubscriptionRuntimeWrapperRequest({
   ? readerPromotionV2CanaryActivationCapability
   : undefined);
 const isSourceContentAssessment = admission.canonicalRequest.context.purpose === "social_monitor.relevance.assess_source_content.v1";
+lifecycle.configure(isSourceContentAssessment, admission.canonicalRequest.timeoutMs);
+if (isSourceContentAssessment) {
+  progress ??= createAssessmentProgress({ write: (line) => process.stderr.write(line),
+    now: () => performance.now(), remaining: lifecycle.remaining });
+  progress.mark("setup", "started");
+}
 const isReaderPromotionV2Canary = admission.canonicalRequest.context.purpose === readerPromotionV2CanaryPurpose;
 const assessmentOutputSchemas = isSourceContentAssessment
   ? sourceContentAssessmentOutputSchemas(admission.canonicalRequest.task)
   : undefined;
-await writeFile(inputPath, JSON.stringify(admission.canonicalRequest), "utf8");
+await lifecycle.work(() => writeFile(inputPath, JSON.stringify(admission.canonicalRequest), "utf8"));
 
-const { FileBackendCodexWorker, NodeProcessRunner } = await import(
+const { FileBackendCodexWorker, NodeProcessRunner } = await lifecycle.work(() => import(
   "@vioxen/subscription-runtime/worker-codex"
-);
-const { FileBackendCodexSafeExecutor } = await import(
+));
+const { FileBackendCodexSafeExecutor } = await lifecycle.work(() => import(
   "@vioxen/subscription-runtime/worker-codex"
-);
-const { SubscriptionWorkerError } = await import(
+));
+const { SubscriptionWorkerError } = await lifecycle.work(() => import(
   "@vioxen/subscription-runtime/worker-core"
-);
-const { runSubscriptionAgentTaskCli } = await import(
+));
+const { runSubscriptionAgentTaskCli } = await lifecycle.work(() => import(
   "../../../node_modules/@vioxen/subscription-runtime/dist/worker-local/agent-task-runner-cli.js"
-);
+));
 
-const authPool = await loadCodexAuthPoolFromEnv(process.env);
+const authPool = await lifecycle.work(() => loadCodexAuthPoolFromEnv(process.env));
+progress?.mark("setup", "completed");
 
 const createStrictCodexWorker = (input) => {
+  lifecycle.checkpoint();
   if (input.provider !== admission.profile.provider) {
     throw new Error("Agent runtime provider conflicts with purpose policy");
   }
@@ -272,19 +291,22 @@ function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
         taskHash,
       );
       await mkdir(workspacePath, { recursive: true, mode: 0o700 });
+      lifecycle.checkpoint();
+      progress?.mark("account_materialization", "started");
       const materializedAuthRoot = await createAuthMaterializationRoot(
         input.stateRootDir,
         taskId,
       );
 
       try {
+        lifecycle.checkpoint();
         const accounts = await Promise.all(
           orderCodexAuthAccountsForTask(authPool.accounts, taskId).map(
             async (account) => ({
-              codexAuthJsonPath: await materializeCodexAuthAccount(
+              codexAuthJsonPath: await lifecycle.work(() => materializeCodexAuthAccount(
                 materializedAuthRoot,
                 account,
-              ),
+              )),
               worker: {
                 providerInstanceId: `codex:${account.id}`,
                 capacityAccountId: account.id,
@@ -300,6 +322,8 @@ function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
             }),
           ),
         );
+        lifecycle.checkpoint();
+        progress?.mark("account_materialization", "completed");
         executor = new FileBackendCodexSafeExecutor({
           executorId: `social-monitor-agent-task:${taskHash}`,
           stateRootDir: input.stateRootDir,
@@ -318,9 +342,12 @@ function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
           accounts,
           // Assessment never consumes native startup guidance or continuation.
           ...(isSourceContentAssessment ? {
+            observability: progress, shutdownTimeoutMs: 1_000,
             controlInbox: { consumeForContinuation: async () => undefined },
           } : {}),
         });
+        lifecycle.checkpoint();
+        progress?.mark("executor_run", "started");
         const result = await executor.run({
           ...job,
           taskId,
@@ -328,6 +355,7 @@ function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
           effectMode: "read_only",
           maxAccountCycles: 1,
         });
+        progress?.mark("executor_run", "completed");
         if (result.status === "completed") {
           return result.result;
         }
@@ -345,7 +373,9 @@ function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
           },
         );
       } finally {
+        progress?.mark("auth_cleanup", "started");
         await removeAuthMaterialization(materializedAuthRoot);
+        progress?.mark("auth_cleanup", "completed");
       }
     },
 
@@ -378,10 +408,13 @@ async function removeAuthMaterialization(path) {
   }
 }
 
-process.exitCode = await runSubscriptionAgentTaskCli(
+return await runSubscriptionAgentTaskCli(
   withExactModel(runtimeArgv, admission.profile.model),
   undefined,
-  (input) => withTrustedCodexWorkerUsage(createStrictCodexWorker(input)),
+  (input) => {
+    const worker = withTrustedCodexWorkerUsage(createStrictCodexWorker(input));
+    return isSourceContentAssessment ? lifecycle.decorateWorker(worker) : worker;
+  },
 );
 
 function nonEmptyRunId(value) {
@@ -422,3 +455,5 @@ function optionalArgument(args, name) {
   }
   return values[0];
 }
+
+});

--- a/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
+++ b/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
@@ -34,7 +34,7 @@ import {
 let lifecycle;
 let progress = process.env.SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS === undefined ? undefined :
   createAssessmentProgress({ write: (line) => process.stderr.write(line),
-    now: () => performance.now(), remaining: () => lifecycle?.remaining() ?? 0 });
+    now: () => globalThis.performance.now(), remaining: () => lifecycle?.remaining() ?? 0 });
 lifecycle = createAssessmentCliLifecycle({
   parentDeadline: process.env.SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS,
   mark: (...args) => progress?.mark(...args),
@@ -62,7 +62,7 @@ const isSourceContentAssessment = admission.canonicalRequest.context.purpose ===
 lifecycle.configure(isSourceContentAssessment, admission.canonicalRequest.timeoutMs);
 if (isSourceContentAssessment) {
   progress ??= createAssessmentProgress({ write: (line) => process.stderr.write(line),
-    now: () => performance.now(), remaining: lifecycle.remaining });
+    now: () => globalThis.performance.now(), remaining: lifecycle.remaining });
   progress.mark("setup", "started");
 }
 const isReaderPromotionV2Canary = admission.canonicalRequest.context.purpose === readerPromotionV2CanaryPurpose;

--- a/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
@@ -226,6 +226,8 @@ for (const [firstAccount, available] of [["account-b", false], ["account-a", fal
     const fixture = await createFixture(available);
     try {
       const request = agentTaskRequest(taskIdStartingWith(["account-a", "account-b"], firstAccount));
+      // Exercise schema handling after admission above the 20s cleanup reserve.
+      request.timeoutMs = 60_000;
       request.context.purpose = "social_monitor.relevance.assess_source_content.v1";
       request.task.outputSchemaName = "social_monitor_source_content_quality_review";
       request.task.controls.outputSchemaName = "social_monitor_source_content_quality_review";
@@ -234,7 +236,7 @@ for (const [firstAccount, available] of [["account-b", false], ["account-a", fal
       const execution = await execFileAsync(process.execPath, [runtimeBridgePath,
         "--provider", "codex", "--input", fixture.requestPath, "--format", "result-json",
         "--state-root", fixture.stateRoot, "--codex-binary", fixture.codexBinaryPath,
-        "--model", "gpt-5.6-sol", "--timeout-ms", "15000"], {
+        "--model", "gpt-5.6-sol", "--timeout-ms", "60000"], {
         cwd: fixture.sandboxProject, maxBuffer: 1024 * 1024,
         env: { PATH: process.env.PATH, HOME: process.env.HOME, LANG: "C.UTF-8",
           AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT: fixture.poolRoot,
@@ -267,6 +269,8 @@ for (const invalid of ["missing-name", "wrong-name", "conflicting-name", "missin
     const fixture = await createFixture();
     try {
       const request = agentTaskRequest("sandbox-invalid-schema");
+      // Exercise schema handling after admission above the 20s cleanup reserve.
+      request.timeoutMs = 60_000;
       request.context.purpose = "social_monitor.relevance.assess_source_content.v1";
       request.task.outputSchemaName = "social_monitor_source_content_quality_review";
       request.task.controls.outputSchema = promotionResponseSchema;

--- a/apps/agent-runtime/bin/subscription-runtime-failure-details.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-failure-details.test.mjs
@@ -20,9 +20,10 @@ const { assessmentRequest } = require("../src/source-content-assessment-runtime.
 
 // Exercise the installed CLI's actual catch/factory/serialization with an inert
 // worker. No pool, auth, provider process or runtime service is created.
+// Leave work time above the 20s assessment cleanup reserve for classification.
 async function serializeFailure(result) {
   const sandbox = await mkdtemp(join(tmpdir(), "classification-boundary-"));
-  const request = { ...assessmentRequest(), timeoutMs: 5_000 };
+  const request = { ...assessmentRequest(), timeoutMs: 60_000 };
   const canonical = admitSubscriptionRuntimeRequest(request).canonicalRequest;
   const output = [];
   let calls = 0;
@@ -175,7 +176,7 @@ for (const key of ["capacityReason", "safeExecutorStatus"]) {
             retryable: false, details,
           },
         }),
-        exitCode: 1, request: { ...assessmentRequest(), timeoutMs: 5_000 },
+        exitCode: 1, request: { ...assessmentRequest(), timeoutMs: 60_000 },
       };
       const parsed = parseSubscriptionRuntimeCliResult(serialized.stdout);
       assert.deepEqual(parsed.failure.details, expected);

--- a/apps/agent-runtime/src/source-content-assessment-cli-lifecycle.spec.ts
+++ b/apps/agent-runtime/src/source-content-assessment-cli-lifecycle.spec.ts
@@ -3,10 +3,12 @@ import { spawn } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { SubscriptionRuntimeCliExecutor } from "./subscription-runtime-cli-executor";
 import type { SubscriptionRuntimeInstallationIdentity } from "./subscription-runtime-installation";
-import { assessmentRequest, syntheticInstallation } from "./source-content-assessment-runtime.spec-support";
+import { assessmentRequest as shortAssessmentRequest, syntheticInstallation } from "./source-content-assessment-runtime.spec-support";
 
 jest.mock("node:child_process", () => ({ spawn: jest.fn() }));
 jest.mock("node:fs/promises", () => ({ mkdtemp: jest.fn(), rm: jest.fn(), writeFile: jest.fn() }));
+
+const assessmentRequest = (id?: string) => ({ ...shortAssessmentRequest(id), timeoutMs: 60_000 });
 
 const children: SyntheticChild[] = [];
 class SyntheticChild extends EventEmitter {
@@ -118,7 +120,7 @@ it.each(["timeout", "signal"])("rejects output after %s without retry", async (s
   const result = run(assessmentRequest());
   const child = await waitForChild(1);
   if (scenario === "timeout") {
-    await jest.advanceTimersByTimeAsync(100);
+    await jest.advanceTimersByTimeAsync(40_000);
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
   }
   child.close(null, "SIGTERM");
@@ -144,9 +146,9 @@ it("bounds cleanup when a child ignores SIGTERM and never closes", async () => {
   const run = makeRun();
   const result = run(assessmentRequest());
   const child = await waitForChild(1);
-  await jest.advanceTimersByTimeAsync(1_100);
+  await jest.advanceTimersByTimeAsync(61_000);
   expect(await result).toMatchObject({ status: "failed", failure: { code: "agent_runtime.cli_timeout", retryable: false } });
-  expect(child.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+  expect(child.kill.mock.calls).toEqual([["SIGTERM"], ["SIGTERM"], ["SIGKILL"]]);
   expect(child.stdout.destroy).toHaveBeenCalledTimes(1);
   expect(child.stderr.destroy).toHaveBeenCalledTimes(1);
   expect(child.unref).toHaveBeenCalledTimes(1);
@@ -190,11 +192,47 @@ it("cleanup exceptions cannot replace the timeout failure", async () => {
   const child = await waitForChild(1);
   child.kill.mockImplementation(() => { throw new Error("Synthetic signal failure"); });
   child.stdout.destroy.mockImplementation(() => { throw new Error("Synthetic cleanup failure"); });
-  await jest.advanceTimersByTimeAsync(1_100);
+  await jest.advanceTimersByTimeAsync(61_000);
   expect(await result).toMatchObject({ status: "failed", failure: {
     code: "agent_runtime.cli_timeout", retryable: false,
   } });
   expect(child.stderr.destroy).toHaveBeenCalled();
   expect(child.unref).toHaveBeenCalled();
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+
+it.each([100, 20_000])("assessment budget %i cannot start provider work", async (timeoutMs) => {
+  const result = await makeRun()({ ...assessmentRequest(), timeoutMs });
+  expect(result).toMatchObject({ status: "failed", failure: { code: "agent_runtime.cli_timeout", retryable: false } });
+  expect(result.executionAttestation).toBeUndefined();
+  expect(spawn).not.toHaveBeenCalled();
+});
+
+it("delivers bounded progress to the existing logger before close, with parent-owned correlation", async () => {
+  const result = makeRun()(assessmentRequest());
+  const child = await waitForChild(1);
+  const record = { version: 1, phase: "provider.task", transition: "started", lastObservedPhase: "setup",
+    elapsedMs: 123, remainingMs: 55_000, providerOutcome: "unknown", tenantId: "synthetic-child-untrusted",
+    metadata: { text: "synthetic-private-text" } };
+  child.stderr.emit("data", Buffer.from("assessment-prog"));
+  child.stderr.emit("data", Buffer.from(`ress-v1 ${JSON.stringify(record)}\n`));
+  expect(logger.info).toHaveBeenCalledWith("agent runtime assessment progress", expect.objectContaining({
+    phase: "provider.task", transition: "started", correlationId: assessmentRequest().correlationId,
+    requestId: assessmentRequest().requestId, providerOutcome: "unknown",
+  }));
+  expect(JSON.stringify(logger.info.mock.calls)).not.toContain("synthetic-private-text");
+  expect(JSON.stringify(logger.info.mock.calls)).not.toContain("synthetic-child-untrusted");
+  logger.info.mockImplementationOnce(() => { throw new Error("Synthetic logger failure"); });
+  expect(() => child.stderr.emit("data", Buffer.from(`assessment-progress-v1 ${JSON.stringify(record)}\n`))).not.toThrow();
+  child.close(); expect((await result).status).toBe("completed");
+});
+
+it("late clean successful stdout after T-minus20 remains an unattested timeout", async () => {
+  jest.useFakeTimers();
+  const result = makeRun()(assessmentRequest()); const child = await waitForChild(1);
+  await jest.advanceTimersByTimeAsync(40_000); child.close();
+  expect(await result).toMatchObject({ status: "failed", failure: { code: "agent_runtime.cli_timeout", retryable: false } });
+  expect((await result).executionAttestation).toBeUndefined();
   expect(jest.getTimerCount()).toBe(0);
 });

--- a/apps/agent-runtime/src/source-content-assessment-pool.test.mjs
+++ b/apps/agent-runtime/src/source-content-assessment-pool.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import { URL } from "node:url";
 import * as core from "@vioxen/subscription-runtime/worker-core";
 import * as routing from "../bin/codex-auth-pool-routing.mjs";
+import { createAssessmentCliLifecycle } from "../bin/assessment-cli-lifecycle.mjs";
+import { createAssessmentProgress } from "../bin/assessment-cli-progress.mjs";
+import { subscriptionRuntimeFailureDetails } from "../bin/subscription-runtime-failure-details.mjs";
 
 // Actual wrapper function and native safe executor/pool, with inert worker and
 // in-memory journal/locks/capacity. No CLI, provider, credentials or child launch.
@@ -14,7 +18,19 @@ const bridgeSource = await readFile(new URL("../bin/run-codex-subscription-runti
 const drain = async () => { for (let i = 0; i < 150; i++) await Promise.resolve(); };
 const job = (runId) => ({ runId, prompt: `Synthetic input ${runId}`, controls: {}, metadata: {} });
 
+// These extracted functions use the real lifecycle checkpoint/work methods.
+// CLI deadline configuration is outside this extraction; isolate signal listeners
+// from process and leave deadline/timer tests to the lifecycle suite.
+function lifecycleFixture() {
+  return createAssessmentCliLifecycle({ signals: new EventEmitter() });
+}
+
 async function fixture() {
+  const lifecycle = lifecycleFixture();
+  const receipts = [];
+  const progress = createAssessmentProgress({
+    write: (line) => receipts.push(line), now: () => 0, remaining: () => 60_000,
+  });
   const attempts = [];
   const pending = new Map();
   const instances = [];
@@ -57,7 +73,7 @@ async function fixture() {
   }
   const body = bridgeSource.slice(bridgeSource.indexOf("function createPooledCodexWorker("),
     bridgeSource.indexOf("async function createAuthMaterializationRoot("));
-  const dependencies = { ...routing, join, mkdir: async () => {},
+  const dependencies = { ...routing, lifecycle, progress, subscriptionRuntimeFailureDetails, join, mkdir: async () => {},
     createAuthMaterializationRoot: async () => "/synthetic/auth-materialization",
     materializeCodexAuthAccount: async () => "/synthetic/unused-auth",
     removeAuthMaterialization: async () => {},
@@ -70,7 +86,7 @@ async function fixture() {
   const worker = () => create({ model: "gpt-5.6-sol", input: { stateRootDir: "/synthetic/state" },
     authPool: { accounts: [{ id: "synthetic-shared-account" }] } });
   const complete = (id) => pending.get(id).resolve({ status: "completed", structuredOutput: { request: id }, warnings: [] });
-  return { worker, instances, attempts, pending, complete, journal, capacityStore };
+  return { worker, instances, attempts, pending, complete, journal, capacityStore, lifecycle, receipts };
 }
 
 test("independent wrapper invocations share one available account after observation loss without replaying A", async () => {
@@ -185,6 +201,7 @@ test("missing pool fails closed for assessment while ordinary worker selection s
     bridgeSource.indexOf("function createReaderPromotionV2CanaryWorker("));
   let directStarts = 0;
   const dependencies = {
+    lifecycle: lifecycleFixture(),
     admission: { profile: { provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "high" } },
     authPool: undefined, isReaderPromotionV2Canary: false,
     FileBackendCodexWorker: class { constructor() { directStarts++; } },
@@ -218,4 +235,37 @@ test("native completed cache is not an input, scope or untrimmed identity admiss
     assert.equal(f.attempts.length, 1);
     assert.equal(f.attempts[0].prompt, "Synthetic input cached");
   } finally { await Promise.all(workers.map((worker) => worker.dispose())); }
+});
+
+
+test("extracted pool honors lifecycle cancellation before materialization or execution", async () => {
+  const f = await fixture();
+  const worker = f.worker();
+  f.lifecycle.cancel();
+  try {
+    await assert.rejects(worker.run(job("cancelled")), /Assessment local work cancelled/);
+    assert.equal(f.instances.length, 0);
+    assert.equal(f.attempts.length, 0);
+    assert.deepEqual(f.receipts, []);
+  } finally { await worker.dispose(); }
+});
+
+test("extracted pool preserves native failure translation and cleanup receipts", async () => {
+  const f = await fixture();
+  const worker = f.worker();
+  try {
+    const running = worker.run(job("failed"));
+    const rejected = assert.rejects(running, (error) => {
+      assert.ok(error instanceof core.SubscriptionWorkerError);
+      assert.equal(error.code, "subscription_worker_run_failed");
+      return true;
+    });
+    await drain();
+    assert.equal(f.attempts.length, 1);
+    f.pending.get("failed").reject(new Error("Synthetic observation failure"));
+    await rejected;
+    assert.equal(f.attempts.length, 1);
+    assert.ok(f.receipts.some((line) => line.includes('"phase":"account_materialization","transition":"completed"')));
+    assert.ok(f.receipts.some((line) => line.includes('"phase":"auth_cleanup","transition":"completed"')));
+  } finally { await worker.dispose(); }
 });

--- a/apps/agent-runtime/src/subscription-runtime-cli-executor.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-executor.ts
@@ -119,6 +119,11 @@ export class SubscriptionRuntimeCliExecutor implements AgentRuntimeExecutorPort 
             admission.profile,
           ),
           timeoutMs: request.timeoutMs,
+          ...(request.purpose === "social_monitor.relevance.assess_source_content.v1" ? {
+            assessment: { onProgress: (fields) => this.logger.info("agent runtime assessment progress", {
+              ...fields, ...taskFields(request),
+            }) },
+          } : {}),
         }),
       );
       if (admission.profile.retryMode === "never") {

--- a/apps/agent-runtime/src/subscription-runtime-cli-progress.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-progress.ts
@@ -31,17 +31,23 @@ export const parseAssessmentProgressLine = (line: string): AssessmentProgress | 
   } catch { return undefined; }
 };
 
-// Fixed storage, including for unterminated/oversized stderr; no raw text reaches logging.
+// Fixed storage and lifetime work budgets, including invalid/oversized stderr.
+// Exhaustion permanently closes diagnostics; no raw text reaches logging.
 export const createAssessmentProgressParser = (receive: (record: AssessmentProgress) => void) => {
   const line = Buffer.alloc(1024);
-  let size = 0, dropping = false, records = 0;
+  let size = 0, dropping = false, records = 0, frames = 0;
+  let remainingBytes = 256 * 1024;
   return (chunk: Buffer): void => {
-    for (let offset = 0; offset < chunk.length && records < 64;) {
-      const newline = chunk.indexOf(10, offset);
-      const end = newline < 0 ? chunk.length : newline;
+    if (records >= 64 || frames >= 256 || remainingBytes === 0) return;
+    const input = chunk.subarray(0, remainingBytes);
+    for (let offset = 0; offset < input.length && records < 64 && frames < 256;) {
+      const newline = input.indexOf(10, offset);
+      const end = newline < 0 ? input.length : newline;
+      remainingBytes -= end - offset + (newline < 0 ? 0 : 1);
       if (size + end - offset > line.length) dropping = true;
-      if (!dropping) { chunk.copy(line, size, offset, end); size += end - offset; }
+      if (!dropping) { input.copy(line, size, offset, end); size += end - offset; }
       if (newline < 0) return;
+      frames++;
       if (!dropping) {
         const record = parseAssessmentProgressLine(line.toString("utf8", 0, size));
         if (record) { records++; try { receive(record); } catch { /* Logging cannot fail execution. */ } }

--- a/apps/agent-runtime/src/subscription-runtime-cli-progress.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-progress.ts
@@ -1,0 +1,52 @@
+const prefix = "assessment-progress-v1 ";
+const phases = new Set([
+  "session.read", "lease.acquire", "provider.refresh", "session.writeback", "provider.task",
+  "session.task_update.writeback", "setup", "account_materialization", "executor_run", "auth_cleanup",
+  "cancellation", "task_settlement", "disposal",
+]);
+const transitions = new Set(["started", "completed", "skipped", "failed", "observed"]);
+export type AssessmentProgress = Readonly<Record<string, string | number | boolean>>;
+
+export const parseAssessmentProgressLine = (line: string): AssessmentProgress | undefined => {
+  if (Buffer.byteLength(line) > 1024 || !line.startsWith(prefix)) return undefined;
+  try {
+    const value: unknown = JSON.parse(line.slice(prefix.length));
+    if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+    const v = value as Record<string, unknown>;
+    if (v.version !== 1 || typeof v.phase !== "string" || !phases.has(v.phase) ||
+        typeof v.transition !== "string" || !transitions.has(v.transition) ||
+        typeof v.lastObservedPhase !== "string" || !phases.has(v.lastObservedPhase) ||
+        v.providerOutcome !== "unknown") return undefined;
+    const result: Record<string, string | number | boolean> = { version: 1,
+      phase: v.phase, transition: v.transition, lastObservedPhase: v.lastObservedPhase, providerOutcome: "unknown" };
+    for (const key of ["elapsedMs", "remainingMs"]) {
+      if (typeof v[key] !== "number" || !Number.isSafeInteger(v[key]) || v[key] < 0) return undefined;
+      result[key] = v[key];
+    }
+    for (const key of ["taskSettled", "disposeSettled", "disposeSucceeded"]) {
+      if (v[key] !== undefined && typeof v[key] !== "boolean") return undefined;
+      if (typeof v[key] === "boolean") result[key] = v[key];
+    }
+    return result;
+  } catch { return undefined; }
+};
+
+// Fixed storage, including for unterminated/oversized stderr; no raw text reaches logging.
+export const createAssessmentProgressParser = (receive: (record: AssessmentProgress) => void) => {
+  const line = Buffer.alloc(1024);
+  let size = 0, dropping = false, records = 0;
+  return (chunk: Buffer): void => {
+    for (let offset = 0; offset < chunk.length && records < 64;) {
+      const newline = chunk.indexOf(10, offset);
+      const end = newline < 0 ? chunk.length : newline;
+      if (size + end - offset > line.length) dropping = true;
+      if (!dropping) { chunk.copy(line, size, offset, end); size += end - offset; }
+      if (newline < 0) return;
+      if (!dropping) {
+        const record = parseAssessmentProgressLine(line.toString("utf8", 0, size));
+        if (record) { records++; try { receive(record); } catch { /* Logging cannot fail execution. */ } }
+      }
+      size = 0; dropping = false; offset = end + 1;
+    }
+  };
+};

--- a/apps/agent-runtime/src/subscription-runtime-cli-support.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-support.spec.ts
@@ -1,4 +1,7 @@
-import { cliExecutionResult, parseSubscriptionRuntimeCliResult } from "./subscription-runtime-cli-support";
+import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+jest.mock("node:child_process", () => ({ spawn: jest.fn() }));
+import { cliExecutionResult, parseSubscriptionRuntimeCliResult, runCli } from "./subscription-runtime-cli-support";
 
 describe("subscription-runtime CLI result telemetry", () => {
   it("reads exact usage and duration from protocol telemetry only", () => {
@@ -87,5 +90,63 @@ describe("subscription CLI safe failure diagnostic values", () => {
     }));
     expect(result.failure?.details).toEqual(details);
     expect(result.failure?.code).toBe("provider_session_invalid");
+  });
+});
+
+
+describe("assessment spawn budget and incremental transport", () => {
+  const child = () => Object.assign(new EventEmitter(), {
+    stdout: Object.assign(new EventEmitter(), { destroy: jest.fn() }),
+    stderr: Object.assign(new EventEmitter(), { destroy: jest.fn() }),
+    kill: jest.fn(() => true), unref: jest.fn(),
+  });
+  beforeEach(() => { jest.useFakeTimers({ now: 1_000_000 }); jest.clearAllMocks(); });
+  afterEach(() => jest.useRealTimers());
+
+  it("counts synchronous spawn startup against the same early and hard deadlines", async () => {
+    const process = child();
+    jest.mocked(spawn).mockImplementation(() => {
+      jest.advanceTimersByTime(10_000);
+      return process as unknown as ReturnType<typeof spawn>;
+    });
+    const result = runCli({ command: "/synthetic", args: [], timeoutMs: 60_000,
+      env: { SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS: "9999999999" }, assessment: { onProgress: jest.fn() } });
+    expect(jest.mocked(spawn).mock.calls[0]?.[2]).toMatchObject({ env: { SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS: "1060000" } });
+    await jest.advanceTimersByTimeAsync(29_999); expect(process.kill).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(1); expect(process.kill.mock.calls).toEqual([["SIGTERM"]]);
+    await jest.advanceTimersByTimeAsync(20_000); expect(process.kill.mock.calls).toEqual([["SIGTERM"], ["SIGTERM"]]);
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(await result).toMatchObject({ timedOut: true, exitCode: null, signal: null });
+    expect(process.kill.mock.calls).toEqual([["SIGTERM"], ["SIGTERM"], ["SIGKILL"]]);
+    process.emit("close", 0, null); process.emit("error", new Error("Synthetic late error"));
+    expect(await result).toMatchObject({ exitCode: null, signal: null }); expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("non-assessment/health invocation strips ambient and explicit transport and keeps its old deadline", async () => {
+    const process = child(); jest.mocked(spawn).mockReturnValue(process as unknown as ReturnType<typeof spawn>);
+    const result = runCli({ command: "/synthetic", args: ["--help"], timeoutMs: 100,
+      env: { SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS: "9999999999" } });
+    expect(jest.mocked(spawn).mock.calls[0]?.[2]?.env).not.toHaveProperty("SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS");
+    process.stderr.emit("data", Buffer.from("subscription-runtime-run-agent-task"));
+    await jest.advanceTimersByTimeAsync(99); expect(process.kill).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(1); expect(process.kill).toHaveBeenCalledWith("SIGTERM");
+    process.emit("close", 1, "SIGTERM");
+    expect(await result).toMatchObject({ stderr: "subscription-runtime-run-agent-task", timedOut: true, exitCode: 1 });
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("does not retain raw assessment stderr and bounds logging at 64 records", async () => {
+    const process = child(), receive = jest.fn();
+    jest.mocked(spawn).mockReturnValue(process as unknown as ReturnType<typeof spawn>);
+    const result = runCli({ command: "/synthetic", args: [], timeoutMs: 60_000, assessment: { onProgress: receive } });
+    const line = `assessment-progress-v1 ${JSON.stringify({ version: 1, phase: "setup", transition: "started",
+      elapsedMs: 0, remainingMs: 60_000, lastObservedPhase: "setup", providerOutcome: "unknown" })}\n`;
+    const junk = Buffer.alloc(2_000_000, 120); process.stderr.emit("data", junk);
+    process.stderr.emit("data", Buffer.from(`\n${line.repeat(100)}`));
+    expect(receive).toHaveBeenCalledTimes(64);
+    process.emit("close", 1, null);
+    const receipt = await result;
+    expect(receipt.stderr).toBe(""); expect(receipt.stderrBytes).toBe(junk.length + 1 + 100 * Buffer.byteLength(line));
+    expect(cliExecutionResult(receipt).failure?.details).toMatchObject({ stderrBytes: String(receipt.stderrBytes) });
   });
 });

--- a/apps/agent-runtime/src/subscription-runtime-cli-support.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-support.spec.ts
@@ -160,15 +160,16 @@ describe("assessment spawn budget and incremental transport", () => {
     expect(jest.getTimerCount()).toBe(0);
   });
 
-  it("does not retain raw assessment stderr and bounds logging at 64 records", async () => {
+  it.each([[2_000, 64], [2_000_000, 0]])(
+    "does not retain raw assessment stderr: %i junk bytes allow %i records", async (junkBytes, expectedRecords) => {
     const process = child(), receive = jest.fn();
     jest.mocked(spawn).mockReturnValue(process as unknown as ReturnType<typeof spawn>);
     const result = runCli({ command: "/synthetic", args: [], timeoutMs: 60_000, assessment: { onProgress: receive } });
     const line = `assessment-progress-v1 ${JSON.stringify({ version: 1, phase: "setup", transition: "started",
       elapsedMs: 0, remainingMs: 60_000, lastObservedPhase: "setup", providerOutcome: "unknown" })}\n`;
-    const junk = Buffer.alloc(2_000_000, 120); process.stderr.emit("data", junk);
+    const junk = Buffer.alloc(junkBytes, 120); process.stderr.emit("data", junk);
     process.stderr.emit("data", Buffer.from(`\n${line.repeat(100)}`));
-    expect(receive).toHaveBeenCalledTimes(64);
+    expect(receive).toHaveBeenCalledTimes(expectedRecords);
     process.emit("close", 1, null);
     const receipt = await result;
     expect(receipt.stderr).toBe(""); expect(receipt.stderrBytes).toBe(junk.length + 1 + 100 * Buffer.byteLength(line));

--- a/apps/agent-runtime/src/subscription-runtime-cli-support.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-support.spec.ts
@@ -103,6 +103,31 @@ describe("assessment spawn budget and incremental transport", () => {
   beforeEach(() => { jest.useFakeTimers({ now: 1_000_000 }); jest.clearAllMocks(); });
   afterEach(() => jest.useRealTimers());
 
+  it.each([
+    [true, 39_999, false], [true, 40_000, true], [true, 41_000, true],
+    [true, 61_000, true], [false, 61_000, false],
+  ])("checks terminal monotonic time without timer dispatch: assessment=%s elapsed=%s", async (assessment, elapsed, timedOut) => {
+    let monotonic = 0;
+    const now = jest.spyOn(globalThis.performance, "now").mockImplementation(() => monotonic);
+    try {
+      const process = child();
+      jest.mocked(spawn).mockReturnValue(process as unknown as ReturnType<typeof spawn>);
+      const result = runCli({ command: "/synthetic", args: [], timeoutMs: 60_000,
+        ...(assessment ? { assessment: { onProgress: jest.fn() } } : {}) });
+      monotonic = elapsed;
+      jest.setSystemTime(1); // Wall-clock rollback cannot extend the work budget.
+      expect(process.kill).not.toHaveBeenCalled();
+      process.stdout.emit("data", Buffer.from(JSON.stringify({ status: "completed", warnings: [], structuredOutput: {} })));
+      process.emit("close", 0, null);
+      const receipt = await result;
+      expect(receipt.timedOut).toBe(timedOut);
+      expect(cliExecutionResult(receipt).status).toBe(timedOut ? "failed" : "completed");
+      if (timedOut) expect(cliExecutionResult(receipt).failure?.code).toBe("agent_runtime.cli_timeout");
+      expect(jest.getTimerCount()).toBe(0);
+      expect(process.kill).not.toHaveBeenCalled();
+    } finally { now.mockRestore(); }
+  });
+
   it("counts synchronous spawn startup against the same early and hard deadlines", async () => {
     const process = child();
     jest.mocked(spawn).mockImplementation(() => {

--- a/apps/agent-runtime/src/subscription-runtime-cli-support.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-support.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createAssessmentProgressParser, type AssessmentProgress } from "./subscription-runtime-cli-progress";
 
 import type {
   AgentRuntimeExecutionFailure,
@@ -76,7 +77,7 @@ export const cliExecutionResult = (
         details: {
           exitCode: result.exitCode === null ? "null" : String(result.exitCode),
           signal: result.signal ?? "",
-          stderrBytes: String(Buffer.byteLength(result.stderr)),
+          stderrBytes: String(result.stderrBytes ?? Buffer.byteLength(result.stderr)),
         },
       },
     };
@@ -105,22 +106,37 @@ export const runCli = async (params: {
   readonly args: readonly string[];
   readonly env?: Readonly<Record<string, string>>;
   readonly timeoutMs: number;
+  readonly assessment?: { readonly onProgress: (record: AssessmentProgress) => void };
 }): Promise<{
   readonly exitCode: number | null;
   readonly signal: NodeJS.Signals | null;
   readonly stdout: string;
   readonly stderr: string;
+  readonly stderrBytes?: number;
   readonly timedOut: boolean;
 }> =>
   new Promise((resolve, reject) => {
+    const deadline = Date.now() + params.timeoutMs;
+    const startedAt = performance.now();
+    const remaining = () => Math.max(0, params.timeoutMs - (performance.now() - startedAt));
+    if (params.assessment && params.timeoutMs <= 20_000) {
+      resolve({ exitCode: null, signal: null, stdout: "", stderr: "", timedOut: true });
+      return;
+    }
+    const env = { ...subscriptionRuntimeChildBaseEnv(process.env), ...params.env };
+    delete env.SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS;
+    if (params.assessment) env.SOCIAL_MONITOR_ASSESSMENT_DEADLINE_MS = String(deadline);
+    const progress = params.assessment && createAssessmentProgressParser(params.assessment.onProgress);
+    let stderrBytes = 0;
     const child = spawn(params.command, params.args, {
-      env: { ...subscriptionRuntimeChildBaseEnv(process.env), ...params.env },
+      env,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
     let timedOut = false;
     let settled = false;
+    let earlyTimeout: ReturnType<typeof setTimeout> | undefined;
     let cleanupTimeout: ReturnType<typeof setTimeout> | undefined;
     const stopLocalChild = () => {
       // Best-effort local cleanup only; signals never acknowledge remote termination.
@@ -134,9 +150,10 @@ export const runCli = async (params: {
       settled = true;
       clearTimeout(timeout);
       clearTimeout(cleanupTimeout);
+      clearTimeout(earlyTimeout);
       resolve({ exitCode, signal,
         stdout: Buffer.concat(stdout).toString("utf8"),
-        stderr: Buffer.concat(stderr).toString("utf8"), timedOut });
+        stderr: Buffer.concat(stderr).toString("utf8"), stderrBytes, timedOut });
     };
     const timeout = setTimeout(() => {
       timedOut = true;
@@ -146,14 +163,23 @@ export const runCli = async (params: {
         finish(null, null);
       }, 1_000);
       try { child.kill("SIGTERM"); } catch { /* Cleanup deadline still applies. */ }
-    }, params.timeoutMs);
+    }, params.assessment ? remaining() : params.timeoutMs);
+    if (params.assessment) earlyTimeout = setTimeout(() => {
+      timedOut = true;
+      try { child.kill("SIGTERM"); } catch { /* Hard deadline remains authoritative. */ }
+    }, Math.max(0, remaining() - 20_000));
     child.stdout!.on("data", (chunk: Buffer) => { if (!settled) stdout.push(chunk); });
-    child.stderr!.on("data", (chunk: Buffer) => { if (!settled) stderr.push(chunk); });
+    child.stderr!.on("data", (chunk: Buffer) => {
+      if (settled) return;
+      stderrBytes = Math.min(Number.MAX_SAFE_INTEGER, stderrBytes + chunk.length);
+      if (progress) progress(chunk); else stderr.push(chunk);
+    });
     child.on("error", (error) => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
       clearTimeout(cleanupTimeout);
+      clearTimeout(earlyTimeout);
       stopLocalChild();
       reject(error);
     });

--- a/apps/agent-runtime/src/subscription-runtime-cli-support.ts
+++ b/apps/agent-runtime/src/subscription-runtime-cli-support.ts
@@ -147,6 +147,8 @@ export const runCli = async (params: {
     };
     const finish = (exitCode: number | null, signal: NodeJS.Signals | null) => {
       if (settled) return;
+      // Close can run before an overdue timer after event-loop starvation.
+      if (params.assessment && remaining() <= 20_000) timedOut = true;
       settled = true;
       clearTimeout(timeout);
       clearTimeout(cleanupTimeout);

--- a/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.spec.ts
@@ -32,6 +32,8 @@ import {
 
 const launcherName = "run-codex-subscription-runtime-agent-task.mjs";
 const dependencyNames = [
+  "assessment-cli-lifecycle.mjs",
+  "assessment-cli-progress.mjs",
   "pinned-codex-native-binary.mjs",
   "subscription-runtime-failure-details.mjs",
   "codex-worker-cli-usage.mjs",

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -14,7 +14,7 @@ import {
 export const approvedSubscriptionRuntimePackageVersion =
   "0.1.0-main.42-sm.1";
 export const approvedSubscriptionRuntimeLauncherSha256 =
-  "36bdad8282a593107380545c25b607fe3a42aeb26e421b84f18f4fb7b60d096e";
+  "dea632563dce502f42e6fca28ce82d0e0438a23c5c28c23f251f828bf0cb31a0";
 
 // Repository wrapper approval, separate from the vendored package provenance.
 // Pin the local import closure too: launcher bytes alone do not bind helpers.
@@ -23,7 +23,7 @@ const approvedSubscriptionRuntimeDependencies = Object.freeze({
   "assessment-cli-progress.mjs":
     "f53430794ef6aaccf002dc47e7c7bbd0b2749a517556c0c46b261625ad24fe6d",
   "assessment-cli-lifecycle.mjs":
-    "be50c50e909dd6aefcdc053df502cf5b4b94996d5bdd5b745c666b7a59c9eb42",
+    "51d15e38070782eebf142acb46a985097b3b16f8b3813971aa40012ae04682cb",
   "pinned-codex-native-binary.mjs":
     "77a32f1ed6f6429b11428c0501d0d5f1712cc8bd913c74027f4ad0204facfb21",
   "subscription-runtime-failure-details.mjs":

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -23,7 +23,7 @@ const approvedSubscriptionRuntimeDependencies = Object.freeze({
   "assessment-cli-progress.mjs":
     "f53430794ef6aaccf002dc47e7c7bbd0b2749a517556c0c46b261625ad24fe6d",
   "assessment-cli-lifecycle.mjs":
-    "51d15e38070782eebf142acb46a985097b3b16f8b3813971aa40012ae04682cb",
+    "5220f2a668cf77f1d763a690dead7eb233e076e245d544870399f3d9f72423ca",
   "pinned-codex-native-binary.mjs":
     "77a32f1ed6f6429b11428c0501d0d5f1712cc8bd913c74027f4ad0204facfb21",
   "subscription-runtime-failure-details.mjs":

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -14,13 +14,16 @@ import {
 export const approvedSubscriptionRuntimePackageVersion =
   "0.1.0-main.42-sm.1";
 export const approvedSubscriptionRuntimeLauncherSha256 =
-  "a7bd7dc219461a1e42f957657b7fa628df201cd8ae74fe91159b842a42d0eef9";
+  "36bdad8282a593107380545c25b607fe3a42aeb26e421b84f18f4fb7b60d096e";
 
 // Repository wrapper approval, separate from the vendored package provenance.
 // Pin the local import closure too: launcher bytes alone do not bind helpers.
-// These literal pins track the reviewed source at 209858aa9a914bc86685cf5ef6e82065f4fa25a9;
-// changes to any member require a coordinated, reviewed admission update.
+// Changes to any member require a coordinated, reviewed admission update.
 const approvedSubscriptionRuntimeDependencies = Object.freeze({
+  "assessment-cli-progress.mjs":
+    "f53430794ef6aaccf002dc47e7c7bbd0b2749a517556c0c46b261625ad24fe6d",
+  "assessment-cli-lifecycle.mjs":
+    "be50c50e909dd6aefcdc053df502cf5b4b94996d5bdd5b745c666b7a59c9eb42",
   "pinned-codex-native-binary.mjs":
     "77a32f1ed6f6429b11428c0501d0d5f1712cc8bd913c74027f4ad0204facfb21",
   "subscription-runtime-failure-details.mjs":

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -21,7 +21,7 @@ export const approvedSubscriptionRuntimeLauncherSha256 =
 // Changes to any member require a coordinated, reviewed admission update.
 const approvedSubscriptionRuntimeDependencies = Object.freeze({
   "assessment-cli-progress.mjs":
-    "f53430794ef6aaccf002dc47e7c7bbd0b2749a517556c0c46b261625ad24fe6d",
+    "76e82b76acd1f8664e78980d7cc75d8485e73316fef183bb4ee97e2466bef002",
   "assessment-cli-lifecycle.mjs":
     "5220f2a668cf77f1d763a690dead7eb233e076e245d544870399f3d9f72423ca",
   "pinned-codex-native-binary.mjs":


### PR DESCRIPTION
Assessment calls could reach the outer CLI timeout before cancellation and disposal finished. This change reserves cleanup time within the existing hard deadline and forwards bounded, allowlisted progress to the parent logger. Terminal completion also rechecks monotonic time so delayed timer callbacks cannot admit late success. Timed-out provider outcomes remain unknown and nonretryable.

Source-content assessment keeps its existing model, account ordering, quality gates and retry policy. Launcher integrity pins cover the lifecycle and progress helpers. Extracted native-pool tests now receive their actual lifecycle dependencies and retain existing assertions. Progress parsing bounds total bytes and frames, including malformed messages, and the emitter reserves one record for each cleanup phase.

Validation: independent review confirmed the deadline fix and preserved attestation behavior (153 Jest tests, 38 focused Node tests and 9 race reproductions passed). The corrected full auth-pool suite passed 56/56 independently. The progress-budget delta passed independent review with 42 Node and 67 Jest tests. Full CI 34415249783 passed on cdef9726909bc3b211ae7159652df21289088f2e.

A separate controlled real-runtime canary remains required. This cleanup and diagnostic change does not yet prove the cause or resolution of the production inference stall.

Refs #293
Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staged lifecycle management for source-content assessments, including startup deadlines, cancellation, and cleanup handling.
  * Added structured progress updates for setup, account, execution, timeout, and cleanup phases.
  * Progress updates can be forwarded to parent logging with bounded output and redacted metadata.

* **Bug Fixes**
  * Improved timeout behavior to stop work promptly and prevent late results from being treated as successful.
  * Improved handling of delayed setup, authentication cleanup, worker disposal, and parallel setup failures.
  * Added safeguards for malformed, oversized, or interrupted progress output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->