### PR TITLE
feat(summary): capture private headline rejection diagnostics

### DIFF
--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
@@ -1,3 +1,4 @@
+import type { PromotionHeadlineDiagnosticObserver } from "./promotion-headline-diagnostic";
 import type { Clock } from "@social-monitor/shared-kernel";
 import type { SourceContentQualityPolicy } from "../../domain";
 import type { SourceContentQualityReviewerPort, SourceContentQualityReviewRequest,
@@ -15,6 +16,7 @@ export const PROMOTION_ASSESSMENT_BOUNDS = Object.freeze({
 // Every candidate starts pending; budget, transport and protocol failures cannot
 // fall through to a heuristic pass. Batches are sequential and popularity-free.
 export const assessPromotionContent = async (input: {
+  readonly observeHeadlineDiagnostic?: PromotionHeadlineDiagnosticObserver;
   readonly execution?: { readonly deadlineAtMs: number; readonly signal?: AbortSignal };
   readonly requests: readonly SourceContentQualityReviewRequest[];
   readonly reviewer?: SourceContentQualityReviewerPort;
@@ -86,7 +88,7 @@ export const assessPromotionContent = async (input: {
           malformed || timelyResponse === undefined || verdict.reason.startsWith("promotion_assessment_pending:")
             ? unavailablePromotionHeadline("invalid_assessment")
             : assessPromotionReaderHeadline(request,
-                timelyResponse.find((review) => review.candidateId === request.candidateId)));
+                timelyResponse.find((review) => review.candidateId === request.candidateId), input.observeHeadlineDiagnostic));
       }
     }
   } finally {

--- a/libs/relevance/features/rank-feed-items/promotion-headline-diagnostic.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-headline-diagnostic.spec.ts
@@ -1,0 +1,75 @@
+import { FixedClock } from "@social-monitor/shared-kernel";
+import { SourceContentQualityPolicy } from "../../domain";
+import { assessPromotionReaderHeadline as assess } from "./promotion-reader-headline-assessment";
+import { assessPromotionContent } from "./promotion-content-assessment";
+import { headlineRequest, headlineReview, subjectProposal } from "../../../../test/support/promotion-reader-headline";
+import type { PromotionHeadlineDiagnostic } from "./promotion-headline-diagnostic";
+
+describe("private actual headline branch diagnostics", () => {
+  it.each([
+    ["refusal", "model_incomplete_source", null, null, null],
+    ["shape", "whole_input_shape", false, null, null],
+    ["title", "whole_input_count", true, false, null],
+    ["body", "whole_input_count", true, true, false],
+    ["truncated", "request_truncated", null, null, null],
+    ["length", "request_length", null, null, null],
+    ["availability", "request_availability", null, null, null],
+  ] as const)("distinguishes %s without changing reduced result", (mode, origin, shape, title, body) => {
+    const base = headlineRequest(mode === "length" ? "x".repeat(12_001) : undefined);
+    const request = mode === "truncated" || mode === "availability"
+      ? { ...base, promotion: { ...base.promotion!, availability: mode === "truncated" ? "truncated" as const : "title_only" as const } } : base;
+    const proposal = subjectProposal(request);
+    const raw = mode === "refusal" || mode === "truncated" || mode === "availability" || mode === "length"
+      ? { status: "unavailable", reasonCode: "incomplete_source" }
+      : { ...proposal, wholeInput: mode === "shape" ? {} : { ...proposal.wholeInput,
+        ...(mode === "title" ? { titleLength: 0 } : { bodyLength: 0 }) } };
+    const review = headlineReview(request, raw);
+    const observe = jest.fn();
+    expect(assess(request, review, observe)).toEqual(assess(request, review));
+    expect(assess(request, review)).toEqual({ status: "unavailable", reasonCode: "incomplete_source" });
+    expect(observe).toHaveBeenCalledWith(request.candidateId, expect.objectContaining({
+      reasonOrigin: origin, wholeInputShape: shape, titleCountEqual: title, bodyCountEqual: body,
+    }));
+  });
+
+  it("preserves malformed binding/proposal precedence before request/whole checks", () => {
+    const base = headlineRequest();
+    const request = { ...base, promotion: { ...base.promotion!, availability: "truncated" as const } };
+    const observe = jest.fn();
+    assess(request, headlineReview(base, null), observe);
+    expect(observe.mock.calls[0]![1].reasonOrigin).toBe("invalid_binding");
+    assess(base, headlineReview(base, { ...subjectProposal(base), confidence: 0, wholeInput: {} }), observe);
+    expect(observe.mock.calls[1]![1]).toMatchObject({ reasonOrigin: "invalid_proposal", wholeInputShape: null });
+    assess(request, undefined, observe);
+    expect(observe.mock.calls[2]![1].reasonOrigin).toBe("not_assessed");
+  });
+
+  it("counts UTF-16 and emits only the fixed private allowlist", () => {
+    const request = headlineRequest("Orion benchmark 😀 e\u0301", "Orion benchmark 😀");
+    let row: PromotionHeadlineDiagnostic | undefined;
+    const result = assess(request, headlineReview(request), (_id, diagnostic) => { row = diagnostic; });
+    expect(result.status).toBe("accepted");
+    expect(row).toEqual({ reasonOrigin: "accepted", reviewedTitleUtf16: request.title.length,
+      reviewedBodyUtf16: request.bodyPreview!.length, availability: "body_present",
+      wholeInputShape: true, titleCountEqual: true, bodyCountEqual: true });
+    expect(Object.isFrozen(row)).toBe(true);
+    expect(JSON.stringify(row)).not.toContain("Orion");
+    expect(result).not.toHaveProperty("reasonOrigin");
+  });
+
+  it.each(["throw", "reject", "pending"])("isolates %s sinks without retries or annotation differences", async (failure) => {
+    const request = headlineRequest();
+    const reviewBatch = jest.fn(async () => [headlineReview(request)]);
+    const input = { requests: [request], reviewer: { reviewBatch }, policy: new SourceContentQualityPolicy(),
+      clock: new FixedClock(new Date("2026-09-10T00:00:00Z")) };
+    const baseline = await assessPromotionContent(input);
+    const observe = jest.fn(() => {
+      if (failure === "throw") throw new Error("synthetic sink failure");
+      return failure === "reject" ? Promise.reject(new Error("synthetic sink rejection")) : new Promise<void>(() => {});
+    });
+    const observed = await assessPromotionContent({ ...input, observeHeadlineDiagnostic: observe });
+    expect(observed).toEqual(baseline);
+    expect(observe).toHaveBeenCalledTimes(1);
+    expect(reviewBatch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/relevance/features/rank-feed-items/promotion-headline-diagnostic.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-headline-diagnostic.ts
@@ -1,0 +1,22 @@
+/** Private observation only; never part of a headline or ranking result. */
+export type PromotionHeadlineReasonOrigin =
+  | "not_assessed" | "invalid_binding" | "request_truncated" | "request_length"
+  | "request_availability" | "input_unsafe" | "model_incomplete_source"
+  | "model_unresolved_qualifications" | "model_insufficient_support"
+  | "invalid_proposal" | "whole_input_shape" | "whole_input_count"
+  | "headline_unsafe" | "invalid_qualification" | "reference_budget"
+  | "claim_qualification" | "subject_support" | "accepted";
+
+export type PromotionHeadlineDiagnostic = Readonly<{
+  reasonOrigin: PromotionHeadlineReasonOrigin;
+  reviewedTitleUtf16: number;
+  reviewedBodyUtf16: number;
+  availability: "title_only" | "body_present" | "truncated" | "unknown";
+  wholeInputShape: boolean | null;
+  titleCountEqual: boolean | null;
+  bodyCountEqual: boolean | null;
+}>;
+
+export type PromotionHeadlineDiagnosticObserver = (
+  candidateId: string, diagnostic: PromotionHeadlineDiagnostic,
+) => void | Promise<void>;

--- a/libs/relevance/features/rank-feed-items/promotion-reader-headline-assessment.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-reader-headline-assessment.ts
@@ -1,3 +1,4 @@
+import type { PromotionHeadlineDiagnosticObserver, PromotionHeadlineReasonOrigin } from "./promotion-headline-diagnostic";
 import {
   isConcisePromotionHeadline, isRoundTrippingHeadlineText, unavailablePromotionHeadline,
   type PromotionEvidenceReference, type PromotionHeadlineQualification,
@@ -12,48 +13,73 @@ import { validPromotionReferences } from "./promotion-evidence-reference";
 export const assessPromotionReaderHeadline = (
   request: SourceContentQualityReviewRequest,
   review: SourceContentQualityReviewResult | undefined,
+  observe?: PromotionHeadlineDiagnosticObserver,
 ): PromotionReaderHeadline => {
-  const unavailable = unavailablePromotionHeadline;
+  let wholeInputShape: boolean | null = null;
+  let titleCountEqual: boolean | null = null;
+  let bodyCountEqual: boolean | null = null;
+  const record = (reasonOrigin: PromotionHeadlineReasonOrigin): void => {
+    if (observe === undefined) return;
+    try {
+      const availability = request.promotion?.availability;
+      const pending = observe(request.candidateId, Object.freeze({ reasonOrigin,
+        reviewedTitleUtf16: request.title.length, reviewedBodyUtf16: (request.bodyPreview ?? "").length,
+        availability: availability === "body_present" || availability === "title_only" || availability === "truncated"
+          ? availability : "unknown", wholeInputShape, titleCountEqual, bodyCountEqual }));
+      if (pending !== undefined) void Promise.resolve(pending).catch(() => {});
+    } catch { /* Diagnostics never affect the assessment or its caller's retries. */ }
+  };
+  const unavailable = (reason: Parameters<typeof unavailablePromotionHeadline>[0], origin: PromotionHeadlineReasonOrigin) => {
+    record(origin);
+    return unavailablePromotionHeadline(reason);
+  };
   const assessment = review?.assessment;
   const input = assessment?.headlineInput;
   const context = request.promotion;
-  if (assessment?.readerHeadline === undefined) return unavailable("not_assessed");
+  if (assessment?.readerHeadline === undefined) return unavailable("not_assessed", "not_assessed");
   if (!context || assessment.binding !== context || review?.candidateId !== request.candidateId ||
       input?.request !== request || input.title !== request.title ||
       input.body !== (request.bodyPreview ?? "") || !/^[a-f0-9]{64}$/.test(input.reviewedInputDigest)) {
-    return unavailable("invalid_assessment");
+    return unavailable("invalid_assessment", "invalid_binding");
   }
-  if (context.availability === "truncated" || request.title.length > 2_000 || input.body.length > 12_000 ||
-      !["body_present", "title_only"].includes(context.availability) ||
-      (context.availability === "title_only") !== !input.body.trim()) return unavailable("incomplete_source");
+  if (context.availability === "truncated") return unavailable("incomplete_source", "request_truncated");
+  if (request.title.length > 2_000 || input.body.length > 12_000) return unavailable("incomplete_source", "request_length");
+  if (!["body_present", "title_only"].includes(context.availability) ||
+      (context.availability === "title_only") !== !input.body.trim()) return unavailable("incomplete_source", "request_availability");
   if (!isRoundTrippingHeadlineText(input.title) || !isRoundTrippingHeadlineText(input.body)) {
-    return unavailable("unsafe_text");
+    return unavailable("unsafe_text", "input_unsafe");
   }
   const raw = assessment.readerHeadline;
   if (hasKeys(raw, ["status", "reasonCode"]) && raw.status === "unavailable" &&
       typeof raw.reasonCode === "string" &&
       ["incomplete_source", "unresolved_qualifications", "insufficient_support"].includes(raw.reasonCode)) {
-    return unavailable(raw.reasonCode as "incomplete_source" | "unresolved_qualifications" | "insufficient_support");
+    return unavailable(raw.reasonCode as "incomplete_source" | "unresolved_qualifications" | "insufficient_support",
+      raw.reasonCode === "incomplete_source" ? "model_incomplete_source"
+        : raw.reasonCode === "unresolved_qualifications" ? "model_unresolved_qualifications" : "model_insufficient_support");
   }
   if (!hasKeys(raw, ["status", "kind", "text", "support", "qualifications", "confidence", "wholeInput"]) ||
       raw.status !== "available" || (raw.kind !== "claim" && raw.kind !== "subject_label") ||
       !isConcisePromotionHeadline(raw.text) || typeof raw.confidence !== "number" ||
       !Number.isFinite(raw.confidence) || raw.confidence < 0.8 || raw.confidence > 1 ||
       !strictReferences(request, raw.support) || !Array.isArray(raw.qualifications) ||
-      raw.qualifications.length > 8) return unavailable("invalid_assessment");
+      raw.qualifications.length > 8) return unavailable("invalid_assessment", "invalid_proposal");
   const whole = raw.wholeInput;
-  if (!hasKeys(whole, ["titleLength", "bodyLength", "qualificationJudgment"]) ||
-      whole.titleLength !== input.title.length || whole.bodyLength !== input.body.length) {
-    return unavailable("incomplete_source");
-  }
+  wholeInputShape = hasKeys(whole, ["titleLength", "bodyLength", "qualificationJudgment"]);
+  if (!wholeInputShape) return unavailable("incomplete_source", "whole_input_shape");
+  // Preserve short-circuit evaluation: the body comparison is only reached after title equality.
+  const shapedWhole = whole as Record<string, unknown>;
+  titleCountEqual = shapedWhole.titleLength === input.title.length;
+  if (!titleCountEqual) return unavailable("incomplete_source", "whole_input_count");
+  bodyCountEqual = shapedWhole.bodyLength === input.body.length;
+  if (!bodyCountEqual) return unavailable("incomplete_source", "whole_input_count");
   const text = raw.text;
   const safety = new SourceContentSafetyPolicy().evaluate({ title: text, providerKey: request.providerKey });
-  if (safety.status !== "allowed" || safety.sanitizedTitle !== text) return unavailable("unsafe_text");
+  if (safety.status !== "allowed" || safety.sanitizedTitle !== text) return unavailable("unsafe_text", "headline_unsafe");
   const qualifications: PromotionHeadlineQualification[] = [];
   for (const entry of raw.qualifications) {
     if (!hasKeys(entry, ["phrase", "evidence"]) || !isConcisePromotionHeadline(entry.phrase) ||
         !text.includes(entry.phrase) || !strictReferences(request, entry.evidence) ||
-        qualifications.some((q) => q.phrase === entry.phrase)) return unavailable("invalid_assessment");
+        qualifications.some((q) => q.phrase === entry.phrase)) return unavailable("invalid_assessment", "invalid_qualification");
     qualifications.push(Object.freeze({ phrase: entry.phrase, evidence: copyReferences(entry.evidence) }));
   }
   // Count every serialized occurrence, including repeated coordinates across roles.
@@ -61,21 +87,22 @@ export const assessPromotionReaderHeadline = (
   const allRefs = [...raw.support, ...qualifications.flatMap((q) => q.evidence)];
   if (allRefs.length > 8 || allRefs.some((ref) => ref.quote.length > 256) ||
       allRefs.reduce((sum, ref) => sum + ref.quote.length, 0) > 512 ||
-      allRefs.reduce((sum, ref) => sum + JSON.stringify(ref.quote).length, 0) > 1_024) return unavailable("unresolved_qualifications");
+      allRefs.reduce((sum, ref) => sum + JSON.stringify(ref.quote).length, 0) > 1_024) return unavailable("unresolved_qualifications", "reference_budget");
   if (raw.kind === "claim") {
-    if ((qualifications.length === 0 && whole.qualificationJudgment !== "none") ||
-        (qualifications.length > 0 && whole.qualificationJudgment !== "preserved")) {
-      return unavailable("unresolved_qualifications");
+    if ((qualifications.length === 0 && shapedWhole.qualificationJudgment !== "none") ||
+        (qualifications.length > 0 && shapedWhole.qualificationJudgment !== "preserved")) {
+      return unavailable("unresolved_qualifications", "claim_qualification");
     }
-  } else if (whole.qualificationJudgment !== "subject_only" || qualifications.length !== 0 ||
-      renderSubjectLabel(request, raw.support) !== text) return unavailable("insufficient_support");
+  } else if (shapedWhole.qualificationJudgment !== "subject_only" || qualifications.length !== 0 ||
+      renderSubjectLabel(request, raw.support) !== text) return unavailable("insufficient_support", "subject_support");
+  record("accepted");
   return Object.freeze({ status: "accepted", kind: raw.kind, text,
     binding: Object.freeze({ ...context, candidateId: request.candidateId, providerKey: request.providerKey,
       availability: context.availability, reviewedInputDigest: input.reviewedInputDigest }),
     confidence: raw.confidence, support: copyReferences(raw.support),
     qualifications: Object.freeze(qualifications),
     wholeInput: Object.freeze({ titleLength: input.title.length, bodyLength: input.body.length,
-      qualificationJudgment: whole.qualificationJudgment as "none" | "preserved" | "subject_only" }),
+      qualificationJudgment: shapedWhole.qualificationJudgment as "none" | "preserved" | "subject_only" }),
   });
 };
 

--- a/libs/relevance/features/rank-feed-items/rank-feed-items.command.ts
+++ b/libs/relevance/features/rank-feed-items/rank-feed-items.command.ts
@@ -1,3 +1,4 @@
+import type { PromotionHeadlineDiagnosticObserver } from "./promotion-headline-diagnostic";
 import type { TenantId, WorkspaceId } from "@social-monitor/shared-kernel";
 
 import type { PromotionSnapshotPreparationObserver } from "./promotion-snapshot-preparation";
@@ -15,6 +16,7 @@ export type RankFeedItemsCommand = {
   readonly publishedAtOrAfter?: Date;
   readonly publishedBefore?: Date;
   readonly promotionAssessmentExecution?: { readonly deadlineAtMs: number; readonly signal?: AbortSignal };
+  readonly observeHeadlineDiagnostic?: PromotionHeadlineDiagnosticObserver;
   readonly observePromotionPreparation?: PromotionSnapshotPreparationObserver;
   readonly rankingProfile?: "reader_post_promotion";
 };

--- a/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
@@ -205,6 +205,7 @@ export const rankPromotionSnapshot = async (params: {
   });
   const assessed = await assessPromotionContent({ requests: reviewRequests,
     execution: command.promotionAssessmentExecution,
+    observeHeadlineDiagnostic: command.observeHeadlineDiagnostic,
     reviewer: params.qualityReviewer, policy: params.qualityPolicy, clock: params.clock });
   for (const [index, item] of projected.entries()) {
     const quality = assessed.verdicts.get(item.feedItemId);

--- a/scripts/lib/reader-summary-daily-story-relation-verifier.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-verifier.ts
@@ -1,4 +1,4 @@
-import { createHeadlineDiagnosticArtifact, type HeadlineDiagnosticArtifactOptions } from "./reader-summary-headline-diagnostic-artifact";
+import { createHeadlineDiagnosticArtifact, type HeadlineDiagnosticArtifactOptions, type HeadlineDiagnosticPersist } from "./reader-summary-headline-diagnostic-artifact";
 import { InMemoryMetricsRecorder } from "@social-monitor/platform-metrics";
 import { InMemoryUserRelevanceProfileRepository } from "@social-monitor/relevance/adapters/persistence/in-memory-user-relevance-profile.repository";
 import type { RankFeedItemsCommand } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.command";
@@ -41,6 +41,7 @@ export const createReaderSummaryDailyCapturePublicationWiring = (
     storyRelationVerifierGuard,
     preparationObserver,
     headlineDiagnosticArtifact,
+    headlineDiagnosticPersist,
     rankCommandCapture,
     relationCapture,
     ...publicationInput
@@ -101,10 +102,10 @@ export const createReaderSummaryDailyCapturePublicationWiring = (
     rankFeedItems.execute = async (command) => {
       // Diagnostic setup failures also fall back to the exact original invocation.
       let artifact: ReturnType<typeof createHeadlineDiagnosticArtifact> | undefined;
-      try { artifact = createHeadlineDiagnosticArtifact(headlineDiagnosticArtifact, command); } catch { /* fail safe */ }
+      try { artifact = createHeadlineDiagnosticArtifact(headlineDiagnosticArtifact, command, headlineDiagnosticPersist); } catch { /* fail safe */ }
       try {
         return await execute(artifact === undefined ? command : { ...command, observeHeadlineDiagnostic: artifact.observe });
-      } finally { artifact?.flush(); }
+      } finally { void artifact?.flush(); }
     };
   }
   return Object.freeze({
@@ -140,6 +141,7 @@ type StoryRelationCompositionInput = {
     failed(): void;
   };
   readonly preparationObserver?: ReaderSummaryPreparationObserver;
+  readonly headlineDiagnosticPersist?: HeadlineDiagnosticPersist;
   readonly headlineDiagnosticArtifact?: HeadlineDiagnosticArtifactOptions;
   readonly relationCapture?: ReaderSummaryDailyRelationCapture;
   readonly storyRelationVerifierGuard?: {

--- a/scripts/lib/reader-summary-daily-story-relation-verifier.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-verifier.ts
@@ -1,3 +1,4 @@
+import { createHeadlineDiagnosticArtifact, type HeadlineDiagnosticArtifactOptions } from "./reader-summary-headline-diagnostic-artifact";
 import { InMemoryMetricsRecorder } from "@social-monitor/platform-metrics";
 import { InMemoryUserRelevanceProfileRepository } from "@social-monitor/relevance/adapters/persistence/in-memory-user-relevance-profile.repository";
 import type { RankFeedItemsCommand } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.command";
@@ -39,6 +40,7 @@ export const createReaderSummaryDailyCapturePublicationWiring = (
     summaryModelMode,
     storyRelationVerifierGuard,
     preparationObserver,
+    headlineDiagnosticArtifact,
     rankCommandCapture,
     relationCapture,
     ...publicationInput
@@ -60,7 +62,7 @@ export const createReaderSummaryDailyCapturePublicationWiring = (
         }),
 
   };
-  if ((preparationObserver === undefined && rankCommandCapture === undefined) || publicationInput.replay !== null) {
+  if ((preparationObserver === undefined && rankCommandCapture === undefined && headlineDiagnosticArtifact === undefined) || publicationInput.replay !== null) {
     return createReaderSummaryDailyPublicationExecutionWiring(dependencies);
   }
   // This is the same fresh composition as the finalizer, with P1's trailing
@@ -79,7 +81,8 @@ export const createReaderSummaryDailyCapturePublicationWiring = (
     const execute = rankFeedItems.execute.bind(rankFeedItems);
     rankFeedItems.execute = (command) => {
       try {
-        const { observePromotionPreparation: _observer, promotionAssessmentExecution, ...values } = command;
+        const { observePromotionPreparation: _observer, observeHeadlineDiagnostic: _headlineObserver, promotionAssessmentExecution, ...values } = command;
+        void _headlineObserver;
         void _observer;
         rankCommandCapture.captured({
           ...values,
@@ -91,6 +94,17 @@ export const createReaderSummaryDailyCapturePublicationWiring = (
         try { rankCommandCapture.failed(); } catch { /* Capture cannot alter policy. */ }
       }
       return execute(command);
+    };
+  }
+  if (headlineDiagnosticArtifact !== undefined) {
+    const execute = rankFeedItems.execute.bind(rankFeedItems);
+    rankFeedItems.execute = async (command) => {
+      // Diagnostic setup failures also fall back to the exact original invocation.
+      let artifact: ReturnType<typeof createHeadlineDiagnosticArtifact> | undefined;
+      try { artifact = createHeadlineDiagnosticArtifact(headlineDiagnosticArtifact, command); } catch { /* fail safe */ }
+      try {
+        return await execute(artifact === undefined ? command : { ...command, observeHeadlineDiagnostic: artifact.observe });
+      } finally { artifact?.flush(); }
     };
   }
   return Object.freeze({
@@ -126,6 +140,7 @@ type StoryRelationCompositionInput = {
     failed(): void;
   };
   readonly preparationObserver?: ReaderSummaryPreparationObserver;
+  readonly headlineDiagnosticArtifact?: HeadlineDiagnosticArtifactOptions;
   readonly relationCapture?: ReaderSummaryDailyRelationCapture;
   readonly storyRelationVerifierGuard?: {
     assertUsable(): void;

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -75,7 +75,7 @@ describe("reader summary daily story relation production wiring", () => {
     const options = { sameStory: false, attested: true,
       secondTitle: "Go rewrite of the TypeScript compiler reaches developers" };
     const plain = await selectDailyEvidence(options);
-    const persist = jest.fn((_path: string, _bytes: string, _signal: AbortSignal) => {
+    const persist = jest.fn<Promise<void>, [string, string, AbortSignal]>(() => {
       if (mode === "throw") throw new Error("synthetic persistence failure");
       return mode === "reject" ? Promise.reject(new Error("synthetic persistence rejection")) : new Promise<void>(() => undefined);
     });

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { accepting } from "../../test/support/promotion-content-assessment";
 import { InMemoryFeedItemReadRepository } from
   "@social-monitor/feed/adapters/persistence/in-memory-feed-item-read.repository";
@@ -40,6 +43,29 @@ const period = buildReaderSummaryPeriod({
 });
 
 describe("reader summary daily story relation production wiring", () => {
+  it("persists actual headline observations through fresh composition without changing selection or calls", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "headline-wiring-"));
+    try {
+      const options = { sameStory: false, attested: true,
+        secondTitle: "Go rewrite of the TypeScript compiler reaches developers" };
+      const plain = await selectDailyEvidence(options);
+      const rankCommandCapture = { captured: jest.fn(), failed: jest.fn() };
+      const path = join(directory, "private.json");
+      const observed = await selectDailyEvidence({ ...options, rankCommandCapture,
+        headlineDiagnosticArtifact: { path, attemptId: "synthetic-attempt" } });
+      expect(observed.selection).toEqual(plain.selection);
+      expect(observed.runtime.storyCommands).toEqual(plain.runtime.storyCommands);
+      const rows = JSON.parse(readFileSync(path, "utf8"));
+      expect(rows).toHaveLength(2);
+      expect(rows.every((row: { reasonOrigin: string }) => row.reasonOrigin === "not_assessed")).toBe(true);
+      expect(rankCommandCapture.captured.mock.calls[0]![0]).not.toHaveProperty("observeHeadlineDiagnostic");
+      const failed = await selectDailyEvidence({ ...options,
+        headlineDiagnosticArtifact: { path: directory, attemptId: "synthetic-attempt" } });
+      expect(failed.selection).toEqual(plain.selection);
+      expect(failed.runtime.storyCommands).toEqual(plain.runtime.storyCommands);
+    } finally { rmSync(directory, { recursive: true, force: true }); }
+  });
+
   it("captures preparation and validated rejected relations without changing selection or calls", async () => {
     const rankCommandCapture = { captured: jest.fn(), failed: jest.fn() };
     const promotionSnapshot = jest.fn();
@@ -337,7 +363,7 @@ describe("reader summary daily story relation production wiring", () => {
 
 const selectDailyEvidence = async (input: Pick<
   Parameters<typeof createReaderSummaryDailyCapturePublicationWiring>[0],
-  "preparationObserver" | "relationCapture" | "rankCommandCapture"
+  "preparationObserver" | "relationCapture" | "rankCommandCapture" | "headlineDiagnosticArtifact"
 > & {
   readonly sameStory: boolean;
   readonly attested: boolean;
@@ -356,6 +382,7 @@ const selectDailyEvidence = async (input: Pick<
   });
   const wiring = createReaderSummaryDailyCapturePublicationWiring({
     rankCommandCapture: input.rankCommandCapture,
+    headlineDiagnosticArtifact: input.headlineDiagnosticArtifact,
     preparationObserver: input.preparationObserver,
     relationCapture: input.relationCapture,
     qualityReviewer: accepting, // Explicit synthetic content evidence; this suite tests story relations.

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -1,3 +1,5 @@
+import { writeFile } from "node:fs/promises";
+import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -51,10 +53,13 @@ describe("reader summary daily story relation production wiring", () => {
       const plain = await selectDailyEvidence(options);
       const rankCommandCapture = { captured: jest.fn(), failed: jest.fn() };
       const path = join(directory, "private.json");
+      let persisted!: Promise<void>;
       const observed = await selectDailyEvidence({ ...options, rankCommandCapture,
+        headlineDiagnosticPersist: (path, bytes, signal) => (persisted = writeFile(path, bytes, { flag: "wx", mode: 0o600, signal })),
         headlineDiagnosticArtifact: { path, attemptId: "synthetic-attempt" } });
       expect(observed.selection).toEqual(plain.selection);
       expect(observed.runtime.storyCommands).toEqual(plain.runtime.storyCommands);
+      await persisted;
       const rows = JSON.parse(readFileSync(path, "utf8"));
       expect(rows).toHaveLength(2);
       expect(rows.every((row: { reasonOrigin: string }) => row.reasonOrigin === "not_assessed")).toBe(true);
@@ -64,6 +69,32 @@ describe("reader summary daily story relation production wiring", () => {
       expect(failed.selection).toEqual(plain.selection);
       expect(failed.runtime.storyCommands).toEqual(plain.runtime.storyCommands);
     } finally { rmSync(directory, { recursive: true, force: true }); }
+  });
+
+  it.each(["throw", "reject", "pending"] as const)("isolates %s persistence at composition on success and failure", async (mode) => {
+    const options = { sameStory: false, attested: true,
+      secondTitle: "Go rewrite of the TypeScript compiler reaches developers" };
+    const plain = await selectDailyEvidence(options);
+    const persist = jest.fn((_path: string, _bytes: string, _signal: AbortSignal) => {
+      if (mode === "throw") throw new Error("synthetic persistence failure");
+      return mode === "reject" ? Promise.reject(new Error("synthetic persistence rejection")) : new Promise<void>(() => undefined);
+    });
+    const diagnostic = { headlineDiagnosticArtifact: { path: "unused", attemptId: "synthetic" },
+      headlineDiagnosticPersist: persist };
+    const observed = await selectDailyEvidence({ ...options, ...diagnostic });
+    expect(observed.selection).toEqual(plain.selection);
+    expect(observed.runtime.storyCommands).toEqual(plain.runtime.storyCommands);
+    expect(persist).toHaveBeenCalledTimes(1);
+    if (mode === "pending") expect(persist.mock.calls[0]![2].aborted).toBe(false);
+    const failure = new Error("synthetic rank failure");
+    const rank = jest.spyOn(RankFeedItemsUseCase.prototype, "execute").mockRejectedValue(failure);
+    try {
+      await expect(selectDailyEvidence({ ...options, ...diagnostic })).rejects.toBe(failure);
+      await Promise.resolve();
+      expect(rank).toHaveBeenCalledTimes(1);
+      expect(persist).toHaveBeenCalledTimes(2);
+      if (mode === "pending") expect(persist.mock.calls[1]![2].aborted).toBe(false);
+    } finally { rank.mockRestore(); }
   });
 
   it("captures preparation and validated rejected relations without changing selection or calls", async () => {
@@ -363,7 +394,7 @@ describe("reader summary daily story relation production wiring", () => {
 
 const selectDailyEvidence = async (input: Pick<
   Parameters<typeof createReaderSummaryDailyCapturePublicationWiring>[0],
-  "preparationObserver" | "relationCapture" | "rankCommandCapture" | "headlineDiagnosticArtifact"
+  "preparationObserver" | "relationCapture" | "rankCommandCapture" | "headlineDiagnosticArtifact" | "headlineDiagnosticPersist"
 > & {
   readonly sameStory: boolean;
   readonly attested: boolean;
@@ -383,6 +414,7 @@ const selectDailyEvidence = async (input: Pick<
   const wiring = createReaderSummaryDailyCapturePublicationWiring({
     rankCommandCapture: input.rankCommandCapture,
     headlineDiagnosticArtifact: input.headlineDiagnosticArtifact,
+    headlineDiagnosticPersist: input.headlineDiagnosticPersist,
     preparationObserver: input.preparationObserver,
     relationCapture: input.relationCapture,
     qualityReviewer: accepting, // Explicit synthetic content evidence; this suite tests story relations.

--- a/scripts/lib/reader-summary-headline-diagnostic-artifact.spec.ts
+++ b/scripts/lib/reader-summary-headline-diagnostic-artifact.spec.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHeadlineDiagnosticArtifact, HEADLINE_DIAGNOSTIC_BOUNDS } from "./reader-summary-headline-diagnostic-artifact";
+import type { PromotionHeadlineDiagnostic } from "@social-monitor/relevance/features/rank-feed-items/promotion-headline-diagnostic";
+
+const row: PromotionHeadlineDiagnostic = { reasonOrigin: "model_incomplete_source", reviewedTitleUtf16: 17,
+  reviewedBodyUtf16: 31, availability: "body_present", wholeInputShape: null, titleCountEqual: null, bodyCountEqual: null };
+const scope = { tenantId: "synthetic-tenant", workspaceId: "synthetic-workspace" };
+
+describe("bounded private headline artifact", () => {
+  it("persists only allowlisted fields, bounded count/bytes, scoped correlation and private permissions", () => {
+    const directory = mkdtempSync(join(tmpdir(), "headline-diagnostic-"));
+    try {
+      const path = join(directory, "diagnostic.json");
+      const sink = createHeadlineDiagnosticArtifact({ path, attemptId: "synthetic-attempt" }, scope);
+      for (let i = 0; i < 300; i++) sink.observe(`synthetic-candidate-${i}`, { ...row, title: "synthetic private content" } as PromotionHeadlineDiagnostic);
+      sink.flush();
+      const bytes = readFileSync(path, "utf8");
+      const records = JSON.parse(bytes);
+      expect(records).toHaveLength(HEADLINE_DIAGNOSTIC_BOUNDS.count);
+      expect(Buffer.byteLength(bytes)).toBeLessThanOrEqual(HEADLINE_DIAGNOSTIC_BOUNDS.bytes);
+      expect(Object.keys(records[0]).sort()).toEqual(["schemaVersion", "scopeHash", "candidateHash", ...Object.keys(row)].sort());
+      expect(bytes).not.toContain("synthetic");
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+      const replacement = createHeadlineDiagnosticArtifact({ path, attemptId: "different-attempt" }, scope);
+      replacement.flush();
+      expect(readFileSync(path, "utf8")).toBe(bytes);
+    } finally { rmSync(directory, { recursive: true, force: true }); }
+  });
+
+  it("stops at the byte budget even before the count cap", () => {
+    let bytes = "";
+    const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: "attempt" }, scope,
+      (_path, value) => { bytes = value; });
+    for (let i = 0; i < 300; i++) sink.observe("candidate", { ...row,
+      reasonOrigin: "model_unresolved_qualifications", reviewedTitleUtf16: Number.MAX_SAFE_INTEGER,
+      reviewedBodyUtf16: Number.MAX_SAFE_INTEGER });
+    sink.flush();
+    expect(JSON.parse(bytes).length).toBeGreaterThan(0);
+    expect(JSON.parse(bytes).length).toBeLessThan(HEADLINE_DIAGNOSTIC_BOUNDS.count);
+    expect(Buffer.byteLength(bytes)).toBeLessThanOrEqual(HEADLINE_DIAGNOSTIC_BOUNDS.bytes);
+  });
+
+  it("flushes once after capture and isolates persistence failures without retry", () => {
+    const persist = jest.fn(() => { throw new Error("synthetic disk failure"); });
+    const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: "attempt" }, scope, persist);
+    sink.observe("candidate", row);
+    expect(persist).not.toHaveBeenCalled();
+    expect(() => sink.flush()).not.toThrow();
+    sink.observe("later", row); sink.flush();
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unknown enum values and invalid counts; correlation changes with attempt and workspace", () => {
+    const captures: string[] = [];
+    for (const [attemptId, workspaceId] of [["a", "w"], ["b", "w"], ["a", "v"]]) {
+      const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: attemptId! },
+        { ...scope, workspaceId: workspaceId! }, (_path, bytes) => { captures.push(bytes); });
+      sink.observe("candidate", { ...row, reasonOrigin: "private source text" } as never);
+      sink.observe("candidate", { ...row, reviewedTitleUtf16: NaN });
+      sink.observe("candidate", row); sink.flush();
+    }
+    expect(captures.map((bytes) => JSON.parse(bytes).length)).toEqual([1, 1, 1]);
+    expect(new Set(captures.map((bytes) => JSON.parse(bytes)[0].candidateHash)).size).toBe(3);
+  });
+});

--- a/scripts/lib/reader-summary-headline-diagnostic-artifact.spec.ts
+++ b/scripts/lib/reader-summary-headline-diagnostic-artifact.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createHeadlineDiagnosticArtifact, HEADLINE_DIAGNOSTIC_BOUNDS } from "./reader-summary-headline-diagnostic-artifact";
+import { createHeadlineDiagnosticArtifact, HEADLINE_DIAGNOSTIC_COMPLETION_MS, HEADLINE_DIAGNOSTIC_BOUNDS } from "./reader-summary-headline-diagnostic-artifact";
 import type { PromotionHeadlineDiagnostic } from "@social-monitor/relevance/features/rank-feed-items/promotion-headline-diagnostic";
 
 const row: PromotionHeadlineDiagnostic = { reasonOrigin: "model_incomplete_source", reviewedTitleUtf16: 17,
@@ -9,13 +9,13 @@ const row: PromotionHeadlineDiagnostic = { reasonOrigin: "model_incomplete_sourc
 const scope = { tenantId: "synthetic-tenant", workspaceId: "synthetic-workspace" };
 
 describe("bounded private headline artifact", () => {
-  it("persists only allowlisted fields, bounded count/bytes, scoped correlation and private permissions", () => {
+  it("persists only allowlisted fields, bounded count/bytes, scoped correlation and private permissions", async () => {
     const directory = mkdtempSync(join(tmpdir(), "headline-diagnostic-"));
     try {
       const path = join(directory, "diagnostic.json");
       const sink = createHeadlineDiagnosticArtifact({ path, attemptId: "synthetic-attempt" }, scope);
       for (let i = 0; i < 300; i++) sink.observe(`synthetic-candidate-${i}`, { ...row, title: "synthetic private content" } as PromotionHeadlineDiagnostic);
-      sink.flush();
+      await sink.flush();
       const bytes = readFileSync(path, "utf8");
       const records = JSON.parse(bytes);
       expect(records).toHaveLength(HEADLINE_DIAGNOSTIC_BOUNDS.count);
@@ -24,42 +24,64 @@ describe("bounded private headline artifact", () => {
       expect(bytes).not.toContain("synthetic");
       expect(statSync(path).mode & 0o777).toBe(0o600);
       const replacement = createHeadlineDiagnosticArtifact({ path, attemptId: "different-attempt" }, scope);
-      replacement.flush();
+      await replacement.flush();
       expect(readFileSync(path, "utf8")).toBe(bytes);
     } finally { rmSync(directory, { recursive: true, force: true }); }
   });
 
-  it("stops at the byte budget even before the count cap", () => {
+  it("stops at the byte budget even before the count cap", async () => {
     let bytes = "";
     const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: "attempt" }, scope,
       (_path, value) => { bytes = value; });
     for (let i = 0; i < 300; i++) sink.observe("candidate", { ...row,
       reasonOrigin: "model_unresolved_qualifications", reviewedTitleUtf16: Number.MAX_SAFE_INTEGER,
       reviewedBodyUtf16: Number.MAX_SAFE_INTEGER });
-    sink.flush();
+    await sink.flush();
     expect(JSON.parse(bytes).length).toBeGreaterThan(0);
     expect(JSON.parse(bytes).length).toBeLessThan(HEADLINE_DIAGNOSTIC_BOUNDS.count);
     expect(Buffer.byteLength(bytes)).toBeLessThanOrEqual(HEADLINE_DIAGNOSTIC_BOUNDS.bytes);
   });
 
-  it("flushes once after capture and isolates persistence failures without retry", () => {
+  it("flushes once after capture and isolates persistence failures without retry", async () => {
     const persist = jest.fn(() => { throw new Error("synthetic disk failure"); });
     const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: "attempt" }, scope, persist);
     sink.observe("candidate", row);
     expect(persist).not.toHaveBeenCalled();
-    expect(() => sink.flush()).not.toThrow();
-    sink.observe("later", row); sink.flush();
+    await expect(sink.flush()).resolves.toBeUndefined();
+    sink.observe("later", row); await sink.flush();
     expect(persist).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects unknown enum values and invalid counts; correlation changes with attempt and workspace", () => {
+  it("bounds pending completion, aborts once, consumes late rejection and never retries", async () => {
+    jest.useFakeTimers();
+    try {
+      let reject!: (reason: Error) => void;
+      const persist = jest.fn((_path: string, _bytes: string, _signal: AbortSignal) =>
+        new Promise<void>((_resolve, fail) => { reject = fail; }));
+      const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: "attempt" }, scope, persist);
+      sink.observe("candidate", row);
+      const completion = sink.flush();
+      await Promise.resolve();
+      expect(persist.mock.calls[0]![2].aborted).toBe(false);
+      await jest.advanceTimersByTimeAsync(HEADLINE_DIAGNOSTIC_COMPLETION_MS);
+      await expect(completion).resolves.toBeUndefined();
+      expect(persist.mock.calls[0]![2].aborted).toBe(true);
+      reject(new Error("synthetic late rejection"));
+      await Promise.resolve();
+      await sink.flush();
+      expect(persist).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(0);
+    } finally { jest.useRealTimers(); }
+  });
+
+  it("rejects unknown enum values and invalid counts; correlation changes with attempt and workspace", async () => {
     const captures: string[] = [];
     for (const [attemptId, workspaceId] of [["a", "w"], ["b", "w"], ["a", "v"]]) {
       const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: attemptId! },
         { ...scope, workspaceId: workspaceId! }, (_path, bytes) => { captures.push(bytes); });
       sink.observe("candidate", { ...row, reasonOrigin: "private source text" } as never);
       sink.observe("candidate", { ...row, reviewedTitleUtf16: NaN });
-      sink.observe("candidate", row); sink.flush();
+      sink.observe("candidate", row); await sink.flush();
     }
     expect(captures.map((bytes) => JSON.parse(bytes).length)).toEqual([1, 1, 1]);
     expect(new Set(captures.map((bytes) => JSON.parse(bytes)[0].candidateHash)).size).toBe(3);

--- a/scripts/lib/reader-summary-headline-diagnostic-artifact.spec.ts
+++ b/scripts/lib/reader-summary-headline-diagnostic-artifact.spec.ts
@@ -14,7 +14,7 @@ describe("bounded private headline artifact", () => {
     try {
       const path = join(directory, "diagnostic.json");
       const sink = createHeadlineDiagnosticArtifact({ path, attemptId: "synthetic-attempt" }, scope);
-      for (let i = 0; i < 300; i++) sink.observe(`synthetic-candidate-${i}`, { ...row, title: "synthetic private content" } as PromotionHeadlineDiagnostic);
+      for (let i = 0; i < 300; i++) await sink.observe(`synthetic-candidate-${i}`, { ...row, title: "synthetic private content" } as PromotionHeadlineDiagnostic);
       await sink.flush();
       const bytes = readFileSync(path, "utf8");
       const records = JSON.parse(bytes);
@@ -33,7 +33,7 @@ describe("bounded private headline artifact", () => {
     let bytes = "";
     const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: "attempt" }, scope,
       (_path, value) => { bytes = value; });
-    for (let i = 0; i < 300; i++) sink.observe("candidate", { ...row,
+    for (let i = 0; i < 300; i++) await sink.observe("candidate", { ...row,
       reasonOrigin: "model_unresolved_qualifications", reviewedTitleUtf16: Number.MAX_SAFE_INTEGER,
       reviewedBodyUtf16: Number.MAX_SAFE_INTEGER });
     await sink.flush();
@@ -45,10 +45,10 @@ describe("bounded private headline artifact", () => {
   it("flushes once after capture and isolates persistence failures without retry", async () => {
     const persist = jest.fn(() => { throw new Error("synthetic disk failure"); });
     const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: "attempt" }, scope, persist);
-    sink.observe("candidate", row);
+    await sink.observe("candidate", row);
     expect(persist).not.toHaveBeenCalled();
     await expect(sink.flush()).resolves.toBeUndefined();
-    sink.observe("later", row); await sink.flush();
+    await sink.observe("later", row); await sink.flush();
     expect(persist).toHaveBeenCalledTimes(1);
   });
 
@@ -56,10 +56,10 @@ describe("bounded private headline artifact", () => {
     jest.useFakeTimers();
     try {
       let reject!: (reason: Error) => void;
-      const persist = jest.fn((_path: string, _bytes: string, _signal: AbortSignal) =>
+      const persist = jest.fn<Promise<void>, [string, string, AbortSignal]>(() =>
         new Promise<void>((_resolve, fail) => { reject = fail; }));
       const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: "attempt" }, scope, persist);
-      sink.observe("candidate", row);
+      await sink.observe("candidate", row);
       const completion = sink.flush();
       await Promise.resolve();
       expect(persist.mock.calls[0]![2].aborted).toBe(false);
@@ -79,9 +79,9 @@ describe("bounded private headline artifact", () => {
     for (const [attemptId, workspaceId] of [["a", "w"], ["b", "w"], ["a", "v"]]) {
       const sink = createHeadlineDiagnosticArtifact({ path: "unused", attemptId: attemptId! },
         { ...scope, workspaceId: workspaceId! }, (_path, bytes) => { captures.push(bytes); });
-      sink.observe("candidate", { ...row, reasonOrigin: "private source text" } as never);
-      sink.observe("candidate", { ...row, reviewedTitleUtf16: NaN });
-      sink.observe("candidate", row); await sink.flush();
+      await sink.observe("candidate", { ...row, reasonOrigin: "private source text" } as never);
+      await sink.observe("candidate", { ...row, reviewedTitleUtf16: NaN });
+      await sink.observe("candidate", row); await sink.flush();
     }
     expect(captures.map((bytes) => JSON.parse(bytes).length)).toEqual([1, 1, 1]);
     expect(new Set(captures.map((bytes) => JSON.parse(bytes)[0].candidateHash)).size).toBe(3);

--- a/scripts/lib/reader-summary-headline-diagnostic-artifact.ts
+++ b/scripts/lib/reader-summary-headline-diagnostic-artifact.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { writeFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import type {
   PromotionHeadlineDiagnostic, PromotionHeadlineDiagnosticObserver,
 } from "@social-monitor/relevance/features/rank-feed-items/promotion-headline-diagnostic";
@@ -12,6 +12,8 @@ const origins = new Set([
 ]);
 export const HEADLINE_DIAGNOSTIC_BOUNDS = Object.freeze({ count: 200, bytes: 80_000 });
 export type HeadlineDiagnosticArtifactOptions = Readonly<{ path: string; attemptId: string }>;
+export type HeadlineDiagnosticPersist = (path: string, bytes: string, signal: AbortSignal) => void | Promise<void>;
+export const HEADLINE_DIAGNOSTIC_COMPLETION_MS = 1_000;
 const digest = (values: readonly string[]) => createHash("sha256").update(JSON.stringify(values)).digest("hex");
 
 /** One private artifact per fresh rank invocation. No raw identifiers or source data.
@@ -21,8 +23,8 @@ const digest = (values: readonly string[]) => createHash("sha256").update(JSON.s
 export const createHeadlineDiagnosticArtifact = (
   options: HeadlineDiagnosticArtifactOptions,
   scope: { tenantId: string; workspaceId: string },
-  persist: (path: string, bytes: string) => void = (path, bytes) =>
-    writeFileSync(path, bytes, { flag: "wx", mode: 0o600 }),
+  persist: HeadlineDiagnosticPersist = (path, bytes, signal) =>
+    writeFile(path, bytes, { flag: "wx", mode: 0o600, signal }),
 ) => {
   const rows: string[] = [];
   let bytes = 2;
@@ -42,11 +44,24 @@ export const createHeadlineDiagnosticArtifact = (
       rows.push(row); bytes += size;
     } catch { /* Private diagnostics cannot change selection. */ }
   };
-  return Object.freeze({ observe, flush: (): void => {
+  return Object.freeze({ observe, flush: async (): Promise<void> => {
     if (flushed) return;
     flushed = true;
-    try { persist(options.path, `[${rows.join(",")}]`); }
-    catch { /* No retries, logs containing source data, or propagation. */ }
+    const payload = `[${rows.join(",")}]`;
+    rows.length = 0;
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const expired = new Promise<void>((resolve) => {
+        timer = setTimeout(() => { controller.abort(); resolve(); }, HEADLINE_DIAGNOSTIC_COMPLETION_MS);
+        timer.unref();
+      });
+      // Async fs keeps the event loop free. Abort is best effort, not syscall
+      // preemption. Injected implementations must also avoid blocking code.
+      const pending = Promise.resolve().then(() => persist(options.path, payload, controller.signal));
+      await Promise.race([pending, expired]);
+    } catch { /* Consume throws and rejections; no retries or source logs. */ }
+    finally { if (timer !== undefined) clearTimeout(timer); }
   } });
 };
 

--- a/scripts/lib/reader-summary-headline-diagnostic-artifact.ts
+++ b/scripts/lib/reader-summary-headline-diagnostic-artifact.ts
@@ -1,0 +1,56 @@
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import type {
+  PromotionHeadlineDiagnostic, PromotionHeadlineDiagnosticObserver,
+} from "@social-monitor/relevance/features/rank-feed-items/promotion-headline-diagnostic";
+
+const origins = new Set([
+  "not_assessed", "invalid_binding", "request_truncated", "request_length", "request_availability",
+  "input_unsafe", "model_incomplete_source", "model_unresolved_qualifications", "model_insufficient_support",
+  "invalid_proposal", "whole_input_shape", "whole_input_count", "headline_unsafe", "invalid_qualification",
+  "reference_budget", "claim_qualification", "subject_support", "accepted",
+]);
+export const HEADLINE_DIAGNOSTIC_BOUNDS = Object.freeze({ count: 200, bytes: 80_000 });
+export type HeadlineDiagnosticArtifactOptions = Readonly<{ path: string; attemptId: string }>;
+const digest = (values: readonly string[]) => createHash("sha256").update(JSON.stringify(values)).digest("hex");
+
+/** One private artifact per fresh rank invocation. No raw identifiers or source data.
+ * Buffering occurs at the branch; file I/O occurs only after ranking has settled.
+ * A pre-existing path is never overwritten. Composition owns path and attempt identity.
+ */
+export const createHeadlineDiagnosticArtifact = (
+  options: HeadlineDiagnosticArtifactOptions,
+  scope: { tenantId: string; workspaceId: string },
+  persist: (path: string, bytes: string) => void = (path, bytes) =>
+    writeFileSync(path, bytes, { flag: "wx", mode: 0o600 }),
+) => {
+  const rows: string[] = [];
+  let bytes = 2;
+  let flushed = false;
+  const scopeHash = digest([scope.tenantId, scope.workspaceId, options.attemptId]);
+  const observe: PromotionHeadlineDiagnosticObserver = (candidateId, diagnostic) => {
+    try {
+      if (flushed || rows.length >= HEADLINE_DIAGNOSTIC_BOUNDS.count || !valid(diagnostic)) return;
+      // Deliberate projection: unknown keys can never enter the private artifact.
+      const row = JSON.stringify({ schemaVersion: "headline_branch.v1", scopeHash,
+        candidateHash: digest([scopeHash, candidateId]), reasonOrigin: diagnostic.reasonOrigin,
+        reviewedTitleUtf16: diagnostic.reviewedTitleUtf16, reviewedBodyUtf16: diagnostic.reviewedBodyUtf16,
+        availability: diagnostic.availability, wholeInputShape: diagnostic.wholeInputShape,
+        titleCountEqual: diagnostic.titleCountEqual, bodyCountEqual: diagnostic.bodyCountEqual });
+      const size = Buffer.byteLength(row) + (rows.length === 0 ? 0 : 1);
+      if (bytes + size > HEADLINE_DIAGNOSTIC_BOUNDS.bytes) return;
+      rows.push(row); bytes += size;
+    } catch { /* Private diagnostics cannot change selection. */ }
+  };
+  return Object.freeze({ observe, flush: (): void => {
+    if (flushed) return;
+    flushed = true;
+    try { persist(options.path, `[${rows.join(",")}]`); }
+    catch { /* No retries, logs containing source data, or propagation. */ }
+  } });
+};
+
+const valid = (d: PromotionHeadlineDiagnostic): boolean => origins.has(d.reasonOrigin) &&
+  [d.reviewedTitleUtf16, d.reviewedBodyUtf16].every((n) => Number.isSafeInteger(n) && n >= 0) &&
+  ["body_present", "title_only", "truncated", "unknown"].includes(d.availability) &&
+  [d.wholeInputShape, d.titleCountEqual, d.bodyCountEqual].every((v) => v === null || typeof v === "boolean");

--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import type { ConfiguredInterestReaderPort } from "@social-monitor/relevance/ports";
 import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
 import { InMemoryMetricsRecorder } from "@social-monitor/platform-metrics";
@@ -170,7 +171,11 @@ async function executeRefresh(input: RefreshExecutionInput, capture?: RefreshPai
     } catch { capture.fail("controls_capture_failed"); }
     capture.assessmentCompletion(() => assessment.assertCaptureComplete());
   }
+  const reservedCaptureRoot = capture?.reservedDirectory;
   const canonical = createReaderSummaryDailyCapturePublicationWiring({
+    ...(reservedCaptureRoot === undefined ? {} : { headlineDiagnosticArtifact: {
+      path: join(reservedCaptureRoot, "headline-diagnostic.json"), attemptId: request.value.readerSummaryJobId,
+    } }),
     qualityReviewer: assessment,
     replay: null, configuredInterests: capture?.interests(input.configuredInterests) ?? input.configuredInterests,
     feedItems: capture?.feed(feed) ?? feed, summaryClient: summary, clock, attestationSink: sink,

--- a/scripts/lib/reader-summary-new-input-refresh-headline-diagnostic.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-headline-diagnostic.spec.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { PrismaReaderSummaryPolicyRepository } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-policy.repository";
+import { RequestReaderSummaryUseCase } from "@social-monitor/summary/features/request-reader-summary/request-reader-summary.use-case";
+import { ExecuteReaderSummaryJobUseCase } from "@social-monitor/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case";
+import type { ReaderSummaryEvidenceSelectorPort } from "@social-monitor/summary/ports";
+import { executeNewInputRefresh } from "./reader-summary-new-input-refresh-execution";
+import * as postgres from "./reader-summary-new-input-refresh-postgres";
+import * as capture from "./reader-summary-new-input-refresh-capture";
+import * as composition from "./reader-summary-daily-story-relation-verifier";
+import { NewInputRefreshGuard } from "./reader-summary-new-input-refresh-guard";
+import { pairedFixture } from "./reader-summary-new-input-refresh-paired-export.spec-support";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+
+// Actual refresh entry and rank/assessment composition, with inert authority and
+// a job harness that stops after selection. No publication, SQL or native IO.
+describe("fresh refresh headline diagnostic reachability", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("uses the reserved root and consumed job on the same model pass; failed reservation writes nothing", async () => {
+    const run = async (mode: "off" | "reserved" | "existing") => {
+      const fixture = pairedFixture({ capture: false, supplemental: 0, response: (command) => {
+        const { candidates } = JSON.parse(command.prompt);
+        return { reviews: candidates.map((c: { candidateId: string; bindingId: string; untrustedSource: { bodyPreview: string } }) => ({
+          candidateId: c.candidateId, bindingId: c.bindingId, decision: "promote", confidence: 0.96,
+          qualityScore: 0.85, interestRelevanceScore: 0.95, engagementIntegrityScore: 0.95,
+          flags: [], reason: "Synthetic parser result", resolvedSoftFlags: [],
+          evidence: [{ field: "bodyPreview", start: 0, end: c.untrustedSource.bodyPreview.length, quote: c.untrustedSource.bodyPreview }],
+        })) };
+      } });
+      const manifest = refreshManifest();
+      const diagnosticPath = join(fixture.path, "headline-diagnostic.json");
+      if (mode === "existing") {
+        mkdirSync(fixture.path, { mode: 0o700 });
+        writeFileSync(join(fixture.path, "sentinel"), "untouched");
+      }
+      const jobId = "synthetic-consumed-refresh-job";
+      jest.spyOn(postgres, "readRefreshCounts").mockResolvedValue({ publications: 1, outbox: 1, jobs: 1, artifacts: 1 });
+      jest.spyOn(postgres, "readRefreshPrior").mockResolvedValue(manifest.prior);
+      jest.spyOn(postgres, "readRefreshJobs").mockResolvedValue([]);
+      jest.spyOn(postgres, "readRefreshReconciliations").mockResolvedValue([]);
+      jest.spyOn(capture, "captureRefreshAuthority").mockResolvedValue(manifest.authority);
+      jest.spyOn(capture, "assertRefreshHasNewInput").mockResolvedValue();
+      jest.spyOn(PrismaReaderSummaryPolicyRepository.prototype, "findByScope").mockResolvedValue({ toSnapshot: () => ({}) } as never);
+      jest.spyOn(RequestReaderSummaryUseCase.prototype, "execute").mockResolvedValue({ ok: true,
+        value: { created: true, readerSummaryJobId: jobId } } as never);
+      jest.spyOn(NewInputRefreshGuard.prototype, "assertCurrent").mockResolvedValue();
+      jest.spyOn(NewInputRefreshGuard.prototype, "selector").mockImplementation((selector) => selector);
+      let selection: unknown;
+      const terminal = new Error("synthetic stop after selection");
+      jest.spyOn(ExecuteReaderSummaryJobUseCase.prototype, "execute").mockImplementation(async function (this: ExecuteReaderSummaryJobUseCase) {
+        selection = await (this as unknown as { evidenceSelector: ReaderSummaryEvidenceSelectorPort }).evidenceSelector.select(fixture.query);
+        throw terminal;
+      });
+      const realComposition = composition.createReaderSummaryDailyCapturePublicationWiring;
+      let persistence: Promise<void> | undefined;
+      const persist = jest.fn((path: string, bytes: string, signal: AbortSignal) =>
+        (persistence = writeFile(path, bytes, { flag: "wx", mode: 0o600, signal })));
+      const wiring = jest.spyOn(composition, "createReaderSummaryDailyCapturePublicationWiring")
+        .mockImplementation((input) => realComposition({ ...input, headlineDiagnosticPersist: persist }));
+      try {
+        await expect(executeNewInputRefresh({ manifest, ...(mode === "off" ? {} : { capturePath: fixture.path }),
+          summary: {} as never, feed: fixture.feed, configuredInterests: fixture.interests, clock: fixture.clock,
+          env: {}, runtime: fixture.delegate, assertFences: () => undefined, assertSource: () => undefined,
+          assertRuntime: async () => undefined, record: () => undefined })).rejects.toBe(terminal);
+        await persistence;
+        expect(wiring).toHaveBeenCalledTimes(1);
+        if (mode === "reserved") {
+          expect(wiring.mock.calls[0]![0].headlineDiagnosticArtifact).toEqual({ path: diagnosticPath, attemptId: jobId });
+          expect(persist).toHaveBeenCalledTimes(1);
+          const rows = JSON.parse(readFileSync(diagnosticPath, "utf8"));
+          expect(rows.length).toBeGreaterThan(0);
+          const scopeHash = createHash("sha256").update(JSON.stringify([manifest.tenantId, manifest.workspaceId, jobId])).digest("hex");
+          expect(rows.every((row: { scopeHash: string }) => row.scopeHash === scopeHash)).toBe(true);
+        } else {
+          expect(wiring.mock.calls[0]![0].headlineDiagnosticArtifact).toBeUndefined();
+          expect(persist).not.toHaveBeenCalled();
+          expect(existsSync(diagnosticPath)).toBe(false);
+          if (mode === "existing") expect(readFileSync(join(fixture.path, "sentinel"), "utf8")).toBe("untouched");
+        }
+        return { selection, modelCalls: fixture.delegate.runTask.mock.calls.length,
+          modelPurposes: fixture.delegate.runTask.mock.calls.map(([command]) => command.purpose) };
+      } finally {
+        jest.restoreAllMocks();
+        rmSync(fixture.parent!, { recursive: true, force: true });
+      }
+    };
+    const plain = await run("off");
+    expect(plain.modelCalls).toBeGreaterThan(0);
+    expect(await run("reserved")).toEqual(plain);
+    expect(await run("existing")).toEqual(plain);
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.ts
@@ -104,6 +104,11 @@ export class RefreshPairedExport {
     });
   }
 
+  /** Private sidecars may use only this invocation's exclusive reservation. */
+  get reservedDirectory(): string | undefined {
+    return this.initialized ? this.directory : undefined;
+  }
+
   fail = (reason: string): void => {
     // Only fixed codes from our concrete closures, never exception messages.
     this.failures.add(reason);


### PR DESCRIPTION
Fresh reader refresh captures now preserve bounded, private branch diagnostics for headline assessment failures. The sidecar uses the existing exclusive capture reservation and consumed job identity; asynchronous best-effort persistence preserves selection results and model-call counts.

Independent review of ebe9e7acbe46bb413250838bf12d00c51139a854 closed all three findings. Writer focused checks: 144 tests plus architecture, code quality, source line cap and focused typecheck. Independent delta checks: 27 tests and real-timer rejection/reservation probes. Full generated-Prisma typecheck remains for CI. Historical failure cause and production E2E remain unproven.

Refs #293
Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional headline diagnostics for promotion ranking, including validation outcomes and content-shape metrics.
  * Added private diagnostic artifact capture with bounded storage, hashed identifiers, secure file permissions, and timeout safeguards.
  * Added support for persisting diagnostics during daily reader-summary captures.

* **Bug Fixes**
  * Diagnostic collection and persistence failures no longer affect ranking, selection, retries, or primary execution.
  * Preserved existing behavior when diagnostic capture is unavailable or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->