### PR TITLE
fix(relevance): partition promotion assessment batches

### DIFF
--- a/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
+++ b/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
@@ -89,11 +89,11 @@ describe("assessment schema consumer protocol", () => {
       await jest.advanceTimersByTimeAsync(300_001);
       const result = await pending;
       expect(calls).toBe(3);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 16 : 0);
-      expect(result.items.filter((item) => item.contentQuality.needsLlmReview)).toHaveLength(valid ? 8 : 24);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 8 : 0);
+      expect(result.items.filter((item) => item.contentQuality.needsLlmReview)).toHaveLength(valid ? 16 : 24);
       await jest.advanceTimersByTimeAsync(300_000);
       expect(calls).toBe(3);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 16 : 0);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 8 : 0);
     } finally { jest.useRealTimers(); }
   });
 });

--- a/libs/relevance/adapters/model/promotion-reader-headline-budget.spec.ts
+++ b/libs/relevance/adapters/model/promotion-reader-headline-budget.spec.ts
@@ -37,7 +37,7 @@ it("counts JSON escape expansion too", () => {
   expect(assess(request, headlineReview(request, proposal)).status).toBe("unavailable");
 });
 
-it("preserves all quality verdicts with malformed or oversized annotations in a completed bounded actual adapter batch", async () => {
+it("preserves all quality verdicts with malformed or oversized annotations in completed bounded actual adapter batches", async () => {
   const { request, proposal } = fixture(100, 8, 8);
   const clock = new FixedClock(new Date("2026-09-09T00:00:00Z"));
   const requests = Array.from({ length: 8 }, (_, i) => ({ ...request, candidateId: `synthetic-${i}` }));
@@ -51,7 +51,10 @@ it("preserves all quality verdicts with malformed or oversized annotations in a 
       ids: { generate: () => "synthetic-budget" }, batchTimeoutMs: 15000, totalTimeoutMs: 60000,
       client: refreshTestRuntimeClient(async (command) => {
         calls++;
-        const reviews = requests.map((input) => {
+        const candidates = JSON.parse(command.prompt).candidates as { candidateId: string }[];
+        expect(candidates).toHaveLength(4);
+        const reviews = candidates.map(({ candidateId }) => {
+          const input = requests.find((request) => request.candidateId === candidateId)!;
           const { assessment, ...quality } = headlineReview(input, readerHeadline);
           return { ...quality, bindingId: promotionWireCandidate(input).bindingId,
             evidence: assessment.evidence, resolvedSoftFlags: [], readerHeadline };
@@ -63,7 +66,7 @@ it("preserves all quality verdicts with malformed or oversized annotations in a 
     });
     const result = await assessPromotionContent({ requests, reviewer: adapter, clock,
       policy: new SourceContentQualityPolicy() });
-    expect(calls).toBe(1);
+    expect(calls).toBe(2);
     expect(result.verdicts.size).toBe(8);
     expect([...result.verdicts.values()].every((verdict) => verdict.qualityScore === 0.8)).toBe(true);
     expect([...result.readerHeadlines.values()].every((headline) => headline.status === "unavailable")).toBe(true);

--- a/libs/relevance/features/rank-feed-items/promotion-assessment-failures.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-assessment-failures.spec.ts
@@ -9,7 +9,7 @@ describe("promotion assessment protocol and budgets through V2", () => {
     const result = await run(items, { reviewBatch });
     expect(result.ranking.ranked).toHaveLength(37);
     const calls = reviewBatch.mock.calls;
-    expect(calls.map(([requests]) => requests.length)).toEqual([8, 8, 8, 8, 5]);
+    expect(calls.map(([requests]) => requests.length)).toEqual([4, 4, 4, 4, 4, 4, 4, 4, 4, 1]);
     expect(calls.flatMap(([requests]) => requests.map((r) => r.candidateId)))
       .toEqual(items.map((i) => i.toSnapshot().id).sort());
     for (const [requests] of calls) expect(new TextEncoder().encode(JSON.stringify(requests)).length)

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.spec.ts
@@ -14,6 +14,38 @@ describe("promotion assessment through Summary candidate and V2 (synthetic revie
     expect(result.candidates[0]!.evidenceQualityScore).toBe(0.8);
   });
 
+  it("reviews eight candidates sequentially in ordered fours and retains second-batch popularity", async () => {
+    const ids = Array.from({ length: 8 }, (_, i) => `candidate-${i}`);
+    let active = 0;
+    let peak = 0;
+    const reviewBatch = jest.fn(async (requests: readonly SourceContentQualityReviewRequest[]) => {
+      peak = Math.max(peak, ++active);
+      await Promise.resolve();
+      active--;
+      return requests.map((request) => review(request));
+    });
+    const items = ids.map((id, i) => fixture(id, "reddit", {
+      providerMetadata: { kind: "reddit_post", score: i === 7 ? 900 : 90, upvoteRatio: 0.95 },
+    })).reverse();
+    const result = await run(items, { reviewBatch });
+    expect(reviewBatch).toHaveBeenCalledTimes(2);
+    expect(reviewBatch.mock.calls.map(([requests]) => requests.map((r) => r.candidateId)))
+      .toEqual([ids.slice(0, 4), ids.slice(4)]);
+    expect(peak).toBe(1);
+    expect(result.items.map((item) => item.feedItemId).sort()).toEqual(ids);
+    for (const item of result.items) expect(item.contentQuality).toMatchObject({
+      qualityScore: 0.8, decision: "promote", needsLlmReview: false,
+    });
+    expect(result.candidates.map((candidate) => candidate.candidateId).sort()).toEqual(ids);
+    expect(result.candidates.every((candidate) => candidate.evidenceQualityScore === 0.8)).toBe(true);
+    expect([...result.ranking.orderedCandidateIds].sort()).toEqual(ids);
+    expect(result.ranking.orderedCandidateIds[0]).toBe("candidate-7");
+    const [high, low] = result.ranking.ranked;
+    expect(high!.components.total).toBeGreaterThan(low!.components.total);
+    expect(high!.components.relevance).toBe(low!.components.relevance);
+    expect(high!.components.evidenceQuality).toBe(low!.components.evidenceQuality);
+  });
+
   it("reviews clean lists alongside product experience and preserves popularity competition", async () => {
     const items = [fixture("low"), fixture("high", "reddit", {
       providerMetadata: { kind: "reddit_post", score: 900, upvoteRatio: 0.95 },

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
@@ -8,7 +8,7 @@ import { unavailablePromotionHeadline, type PromotionReaderHeadline } from "../.
 import { assessPromotionReaderHeadline } from "./promotion-reader-headline-assessment";
 
 export const PROMOTION_ASSESSMENT_BOUNDS = Object.freeze({
-  candidates: 200, batchCandidates: 8, batchBytes: 64_000,
+  candidates: 200, batchCandidates: 4, batchBytes: 64_000,
   totalBytes: 512_000, batchTimeoutMs: 15_000, deadlineMs: 60_000,
 });
 

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.spec.ts
@@ -28,12 +28,13 @@ function wiring(mutate?: (result: AgentRuntimeTaskResult) => AgentRuntimeTaskRes
 describe("refresh operation assessment runtime budgets and receipts", () => {
   it("consumes exactly 200 candidates then blocks another batch without refunding", async () => {
     const test = wiring();
-    for (let i = 0; i < 200; i += 8) await test.runtime.runTask(command(i, 8));
+    for (let i = 0; i < 200; i += 4) await test.runtime.runTask(command(i, 4));
     await expect(test.runtime.runTask(command(200))).rejects.toThrow(/consumed/u);
-    expect(test.runTask).toHaveBeenCalledTimes(25);
+    await expect(test.runtime.runTask(command(201, 4))).rejects.toThrow(/budget/u);
+    expect(test.runTask).toHaveBeenCalledTimes(50);
     expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/u);
     expect(test.events).toContainEqual(expect.objectContaining({ status: "invocation_consumed",
-      assessmentAttempts: 25, assessmentCandidates: 200 }));
+      assessmentAttempts: 50, assessmentCandidates: 200 }));
   });
   it("exhausts actual wire bytes independently of candidate count", async () => {
     const test = wiring();

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
@@ -98,7 +98,7 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
       expect(test.commands).toEqual([]);
       const selection = await test.selectComplete();
       const calls = test.commands.filter((c) => c.purpose === purpose);
-      expect(calls).toHaveLength(25);
+      expect(calls).toHaveLength(50);
       const reviewedIds = calls.flatMap((call) =>
         (JSON.parse(call.prompt).candidates as { candidateId: string }[]).map((c) => c.candidateId));
       expect(reviewedIds).toHaveLength(200);

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.spec.ts
@@ -138,7 +138,7 @@ describe("synthetic bounded refresh paired export", () => {
     const statuses = json(fixture.path, "candidate-status.json");
     expect(statuses.filter((s: { attempted: boolean }) => s.attempted)).toHaveLength(200);
     expect(statuses.filter((s: { status: string }) => s.status === "pending").length).toBe(3);
-    expect(fixture.delegate.runTask.mock.calls.filter(([c]) => c.purpose.includes("assess_source_content"))).toHaveLength(25);
+    expect(fixture.delegate.runTask.mock.calls.filter(([c]) => c.purpose.includes("assess_source_content"))).toHaveLength(50);
   });
 
   it("refuses absent swallowed P1 callback and keeps capture failures separate from selection", async () => {

--- a/scripts/lib/source-content-assessment-lifecycle.spec.ts
+++ b/scripts/lib/source-content-assessment-lifecycle.spec.ts
@@ -83,13 +83,14 @@ describe("assessment completed receipts and caller abandonment", () => {
       await jest.advanceTimersByTimeAsync(100_001);
       const result = await pending;
       expect(timeouts).toEqual([100_000, 30_000]);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(8);
-      expect(result.candidates.filter((item) => item.evidenceQualityScore === 0)).toHaveLength(16);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(4);
+      expect(result.candidates.filter((item) => item.evidenceQualityScore === 0)).toHaveLength(20);
       await jest.advanceTimersByTimeAsync(60_000);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(8);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(4);
     } finally { jest.useRealTimers(); }
   });
-  it.each([[20_000, 200], [70_000, 64]])("accounts for all 200 candidates at %i ms per batch", async (latency, admitted) => {
+  // Completion at the 600-second deadline is late: 29 or 8 timely batches of four.
+  it.each([[20_000, 116], [70_000, 32]])("accounts for all 200 candidates at %i ms per batch", async (latency, admitted) => {
     jest.useFakeTimers();
     jest.setSystemTime(cutoff);
     try {

--- a/scripts/lib/source-content-assessment-runtime.spec.ts
+++ b/scripts/lib/source-content-assessment-runtime.spec.ts
@@ -30,12 +30,12 @@ describe("pool-backed assessment through runtime transport and actual promotion"
     const result = await run(Array.from({ length: 32 }, (_, index) =>
       fixture(`pool-${index}`, ["reddit", "hacker-news", "x-twitter"][index % 3])), reviewer);
     expect(result.ranking.orderedCandidateIds).toHaveLength(32);
-    expect(requests).toHaveLength(4);
-    expect(new Set(requests.map((request) => request.requestId)).size).toBe(4);
+    expect(requests).toHaveLength(8);
+    expect(new Set(requests.map((request) => request.requestId)).size).toBe(8);
     for (const request of requests) {
       expect(request).toMatchObject({ tenantId: scope.tenantId, workspaceId: scope.workspaceId,
         providerInstanceId: "synthetic-existing-pool", timeoutMs: 300_000 });
-      expect(JSON.parse(request.prompt).candidates).toHaveLength(8);
+      expect(JSON.parse(request.prompt).candidates).toHaveLength(4);
       expect(request.prompt).not.toMatch(/canonicalUrl|deterministic|upvoteRatio/);
     }
   });
@@ -50,8 +50,8 @@ describe("pool-backed assessment through runtime transport and actual promotion"
       return attestRefreshExecution(request, output);
     });
     const result = await run(Array.from({ length: 32 }, (_, index) => fixture(`partial-${index}`)), reviewer);
-    expect(calls).toBe(4);
-    expect(result.ranking.orderedCandidateIds).toHaveLength(23);
+    expect(calls).toBe(8);
+    expect(result.ranking.orderedCandidateIds).toHaveLength(27);
   });
 
   it.each(["binding", "identity", "range"])("rejects mismatched %s evidence", async (mutation) => {
@@ -75,7 +75,7 @@ describe("pool-backed assessment through runtime transport and actual promotion"
         return attestRefreshExecution(request, outputFor(request));
       });
       const pending = run(Array.from({ length: 32 }, (_, i) => fixture(`latency-${i}`)), reviewer);
-      await jest.advanceTimersByTimeAsync(80_001);
+      await jest.advanceTimersByTimeAsync(160_001);
       expect((await pending).ranking.orderedCandidateIds).toHaveLength(32);
     } finally { jest.useRealTimers(); }
   });
@@ -96,9 +96,9 @@ describe("pool-backed assessment through runtime transport and actual promotion"
         { clock: new SystemClock() });
       await jest.advanceTimersByTimeAsync(60_001);
       const result = await pending;
-      expect(result.ranking.orderedCandidateIds).toHaveLength(8);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(4);
       await jest.advanceTimersByTimeAsync(40_000);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(8);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(4);
       expect(requests).toHaveLength(2);
       expect(requests.map((request) => request.timeoutMs)).toEqual([50_000, 20_000]);
     } finally { jest.useRealTimers(); }


### PR DESCRIPTION
Reduces promotion content assessment batches from 8 to 4 while preserving deterministic sequential coverage of the full candidate set. Adds regression coverage for ordered disjoint batching and a popular eligible candidate winning from the second batch.

Refs #293
Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Promotion assessments now process candidates in smaller batches of up to four.
  * Improved sequential batch processing helps preserve candidate metadata and consistent quality scoring.
  * Popularity-based ranking remains accurate across multiple assessment batches.

* **Tests**
  * Added coverage for multi-batch promotion assessment behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->