### PR TITLE
fix(reader-summary): hoist historical CLI parser

### DIFF
--- a/scripts/run-reader-summary-promotion-v2-historical-rebuild.ts
+++ b/scripts/run-reader-summary-promotion-v2-historical-rebuild.ts
@@ -43,18 +43,6 @@ export type HistoricalPromotionCliOptions = Readonly<{
   timestampPolicy: "published_at" | "observed_at";
 }>;
 
-if (require.main === module) {
-  loadDotenvIfPresent(".env");
-  void main().catch((error) => {
-    console.error(
-      error instanceof Error
-        ? error.message
-        : "Historical promotion rebuild failed",
-    );
-    process.exitCode = 1;
-  });
-}
-
 async function main(): Promise<void> {
   const options = parseHistoricalPromotionCliOptions(process.argv.slice(2));
   const now = new Date();
@@ -352,3 +340,15 @@ const assertHttpUrl = (value: string): void => {
     throw new Error("Promotion rebuild API base URL must use HTTP(S)");
   }
 };
+
+if (require.main === module) {
+  loadDotenvIfPresent(".env");
+  void main().catch((error) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "Historical promotion rebuild failed",
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Fix the production historical Reader Promotion V2 command failing before read-only preparation because its parser was invoked before const initialization.

The parser is now a hoisted function declaration; behavior and CLI contract are unchanged.

Refs #293
Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal command-line parsing declaration without changing its behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->