### PR TITLE
fix(reader-summary): defer historical CLI entrypoint

### DIFF
--- a/scripts/run-reader-summary-promotion-v2-historical-rebuild.spec.ts
+++ b/scripts/run-reader-summary-promotion-v2-historical-rebuild.spec.ts
@@ -1,9 +1,43 @@
+import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 
 import { parseHistoricalPromotionCliOptions } from
   "./run-reader-summary-promotion-v2-historical-rebuild";
 
 describe("historical Reader Promotion V2 CLI", () => {
+  it("initializes exported CLI helpers before starting the entrypoint", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-r",
+        "ts-node/register",
+        "-r",
+        "tsconfig-paths/register",
+        resolve(
+          __dirname,
+          "run-reader-summary-promotion-v2-historical-rebuild.ts",
+        ),
+        "--prepare",
+        "--dates",
+        "2999-01-01",
+        "--artifact-output",
+        "/tmp/historical-reader-summary-entrypoint-test",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, NODE_ENV: "test" },
+        timeout: 30_000,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("closed UTC date");
+    expect(result.stderr).not.toContain(
+      "parseHistoricalPromotionCliOptions) is not a function",
+    );
+  });
+
   it("defaults to dry-run with explicit dates and a batch cap of two", () => {
     expect(parseHistoricalPromotionCliOptions([
       "--dates",

--- a/scripts/run-reader-summary-promotion-v2-historical-rebuild.ts
+++ b/scripts/run-reader-summary-promotion-v2-historical-rebuild.ts
@@ -43,18 +43,6 @@ export type HistoricalPromotionCliOptions = Readonly<{
   timestampPolicy: "published_at" | "observed_at";
 }>;
 
-if (require.main === module) {
-  loadDotenvIfPresent(".env");
-  void main().catch((error) => {
-    console.error(
-      error instanceof Error
-        ? error.message
-        : "Historical promotion rebuild failed",
-    );
-    process.exitCode = 1;
-  });
-}
-
 async function main(): Promise<void> {
   const options = parseHistoricalPromotionCliOptions(process.argv.slice(2));
   const now = new Date();
@@ -352,3 +340,15 @@ const assertHttpUrl = (value: string): void => {
     throw new Error("Promotion rebuild API base URL must use HTTP(S)");
   }
 };
+
+if (require.main === module) {
+  loadDotenvIfPresent(".env");
+  void main().catch((error) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "Historical promotion rebuild failed",
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Historical Reader Summary regeneration failed before database or provider work because the CLI invoked main before its exported parser binding was initialized. Move the guarded entrypoint after module initialization and add a subprocess regression that proves the real ts-node command reaches closed-date validation.

Validation: focused Jest 8/8 in the pinned production daily-runner image.

Refs #294
