### PR TITLE
fix(reader-summary): admit inherited fence output fd

### DIFF
--- a/ops/deploy/production-runtime/reader-summary-date-lock.sh
+++ b/ops/deploy/production-runtime/reader-summary-date-lock.sh
@@ -178,7 +178,10 @@ if [[ -n $token_output ]]; then
   mkdir -p "$(dirname -- "$token_output")"
   token_dir=$(dirname -- "$token_output")
   token_name=$(basename -- "$token_output")
-  [[ ! -L $token_dir && ! -L $token_output ]] || {
+  inherited_fd_dir=false
+  [[ $token_dir =~ ^/proc/self/fd/[0-9]+$ ]] && inherited_fd_dir=true
+  [[ ( ! -L $token_dir || $inherited_fd_dir == true ) &&
+     ! -L $token_output ]] || {
     echo "reader-summary fence token output cannot be a symlink" >&2
     exit 76
   }

--- a/scripts/reader-summary-date-lock.spec.ts
+++ b/scripts/reader-summary-date-lock.spec.ts
@@ -1,8 +1,11 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import {
+  closeSync,
+  constants,
   existsSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -130,6 +133,29 @@ describe("reader-summary common date lock", () => {
     expect(result.status).toBe(76);
     expect(String(result.stderr)).toContain("cannot be a symlink");
     expect(readFileSync(global, "utf8")).toBe("sentinel");
+  });
+
+  it("writes a token through an explicitly inherited directory descriptor", () => {
+    const descriptor = openSync(
+      directory,
+      constants.O_RDONLY | constants.O_DIRECTORY,
+    );
+    try {
+      const result = spawnSync("bash", [
+        lockScript(), "--date", "2026-08-01",
+        "--date-lock-dir", join(directory, "date-locks"),
+        "--fence-dir", join(directory, "fences"),
+        "--wait-seconds", "1",
+        "--token-output", "/proc/self/fd/3/inherited.token",
+        "--", "bash", "-c", "true",
+      ], { stdio: ["ignore", "pipe", "pipe", descriptor] });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(join(directory, "inherited.token"), "utf8").trim())
+        .toBe("reader-summary-date:2026-08-01:1");
+    } finally {
+      closeSync(descriptor);
+    }
   });
 
   const startLocked = (input: {


### PR DESCRIPTION
Allow the historical Reader Promotion V2 runner to write its fence receipt through the already-open inherited output directory descriptor. Arbitrary symlink directories and token paths remain rejected.

Adds regression coverage for inherited descriptor output.

Refs #293
Refs #294