### PR TITLE
fix(reader-summary): defer locked rebuild entrypoint

### DIFF
--- a/scripts/run-reader-summary-promotion-v2-historical-rebuild.spec.ts
+++ b/scripts/run-reader-summary-promotion-v2-historical-rebuild.spec.ts
@@ -38,6 +38,33 @@ describe("historical Reader Promotion V2 CLI", () => {
     );
   });
 
+  it("initializes the locked preflight entrypoint before parsing its command", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-r",
+        "ts-node/register",
+        "-r",
+        "tsconfig-paths/register",
+        resolve(__dirname, "run-reader-summary-promotion-v2-locked-date.ts"),
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, NODE_ENV: "test" },
+        timeout: 30_000,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Locked historical promotion command is required",
+    );
+    expect(result.stderr).not.toContain(
+      "historicalPromotionLockedChildCommand) is not a function",
+    );
+  });
+
   it("defaults to dry-run with explicit dates and a batch cap of two", () => {
     expect(parseHistoricalPromotionCliOptions([
       "--dates",

--- a/scripts/run-reader-summary-promotion-v2-locked-date.ts
+++ b/scripts/run-reader-summary-promotion-v2-locked-date.ts
@@ -47,18 +47,6 @@ const datasetManifestPathEnv = "DURABLE_READER_SUMMARY_DATASET_MANIFEST_PATH";
 const datasetManifestSha256Env =
   "DURABLE_READER_SUMMARY_DATASET_MANIFEST_SHA256";
 
-if (require.main === module) {
-  loadDotenvIfPresent(".env");
-  void main().catch((error) => {
-    console.error(
-      error instanceof Error
-        ? error.message
-        : "Historical promotion locked preflight failed",
-    );
-    process.exitCode = 1;
-  });
-}
-
 export const runHistoricalPromotionLockedPreflight = async (input: {
   readonly revalidate: () => Promise<void>;
   readonly runProductionDay: () => number | null;
@@ -292,3 +280,15 @@ const requiredEnv = (name: string): string => {
   }
   return value;
 };
+
+if (require.main === module) {
+  loadDotenvIfPresent(".env");
+  void main().catch((error) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "Historical promotion locked preflight failed",
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Initialize the locked historical promotion CLI helpers before invoking its production entrypoint. Adds subprocess regression coverage for the exact ts-node startup path.

The failed production attempt stopped before the paid operation and will continue through the existing resume identity.

Refs #293
Refs #294