### PR TITLE
fix(reader-summary): bind historical recovery root

### DIFF
--- a/scripts/lib/reader-summary-promotion-v2-historical-subprocess.ts
+++ b/scripts/lib/reader-summary-promotion-v2-historical-subprocess.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { readFileSync, rmSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import type {
   HistoricalPromotionDurableStateReader,
@@ -131,6 +131,9 @@ export class ProductionDayHistoricalPromotionMutation
         READER_SUMMARY_PRODUCTION_DAY_REPORT_DIR: "/proc/self/fd/10",
         DURABLE_READER_SUMMARY_DATASET_MANIFEST_PATH:
           input.bundle.datasetManifestPath,
+        READER_SUMMARY_PRODUCTION_DAY_RECOVERY_DIR: dirname(
+          input.bundle.datasetManifestPath,
+        ),
         DURABLE_READER_SUMMARY_DATASET_MANIFEST_SHA256:
           input.bundle.datasetManifestSha256,
         DURABLE_READER_SUMMARY_RECOVERY_TIMESTAMP_POLICY:


### PR DESCRIPTION
Pass the immutable dataset manifest directory to the production-day child as its recovery root. This keeps the existing immutable-input guard active while allowing the reviewed historical manifest to be read.

The production attempt stopped before the paid operation and continues through the same resume identity.

Refs #293
Refs #294