### PR TITLE
fix(reader-summary): reuse opened production output

### DIFF
--- a/scripts/run-reader-summary-production-day.spec.ts
+++ b/scripts/run-reader-summary-production-day.spec.ts
@@ -4,6 +4,17 @@ import { join } from "node:path";
 import { resolveProductionDayExecutionRequest } from "./lib/reader-summary-production-day-reuse-provenance";
 
 describe("production-day execution request", () => {
+  it("reuses an already opened runtime artifact directory", () => {
+    const source = readFileSync(
+      join(process.cwd(), "scripts/run-reader-summary-production-day.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      "if (!existsSync(runtimeArtifactDirectory)) {\n    mkdirSync(runtimeArtifactDirectory, { recursive: true });\n  }",
+    );
+  });
+
   it("binds production history readiness to its exact-day artifact", () => {
     const source = readFileSync(
       join(process.cwd(), "scripts/run-reader-summary-production-day.ts"),

--- a/scripts/run-reader-summary-production-day.ts
+++ b/scripts/run-reader-summary-production-day.ts
@@ -220,7 +220,9 @@ async function main(): Promise<void> {
             : []),
           ...(allowHistorical ? [] : ["--wait-for-x-readiness"]),
         ]);
-  mkdirSync(runtimeArtifactDirectory, { recursive: true });
+  if (!existsSync(runtimeArtifactDirectory)) {
+    mkdirSync(runtimeArtifactDirectory, { recursive: true });
+  }
   isolateCaptureArtifacts();
   const isolatedQuality = historicalPromotionQualityOutput({
     enabled: executionRequest.mode === "historical-regeneration" &&


### PR DESCRIPTION
The historical rebuild passes its artifact directory through a securely inherited /proc/self/fd handle. The production-day runner attempted mkdir on that already-open directory and failed with EEXIST before any paid or database operation. Reuse the existing directory and retain mkdir for ordinary paths. Adds focused regression coverage.\n\nRefs #293\nRefs #294