### PR TITLE
fix(reader-summary): preserve historical output descriptors

### DIFF
--- a/scripts/lib/reader-summary-promotion-v2-historical-subprocess.ts
+++ b/scripts/lib/reader-summary-promotion-v2-historical-subprocess.ts
@@ -127,6 +127,7 @@ export class ProductionDayHistoricalPromotionMutation
       ],
       {
         ...this.input.environment,
+        READER_SUMMARY_PROMOTION_INHERITED_DIRECTORY_FDS: "9,10,11",
         READER_SUMMARY_PRODUCTION_DAY_ARTIFACT_DIR: "/proc/self/fd/9",
         READER_SUMMARY_PRODUCTION_DAY_REPORT_DIR: "/proc/self/fd/10",
         DURABLE_READER_SUMMARY_DATASET_MANIFEST_PATH:

--- a/scripts/run-reader-summary-promotion-v2-locked-date.ts
+++ b/scripts/run-reader-summary-promotion-v2-locked-date.ts
@@ -262,7 +262,7 @@ async function main(): Promise<void> {
       runProductionDay: () => spawnSync(command[0]!, command.slice(1), {
         cwd: process.cwd(),
         env: process.env,
-        stdio: "inherit",
+        stdio: inheritedDirectoryStdio(process.env),
       }).status,
     });
   } finally {
@@ -272,6 +272,21 @@ async function main(): Promise<void> {
 }
 
 class UnderLockDriftError extends Error {}
+
+const inheritedDirectoryStdio = (
+  environment: NodeJS.ProcessEnv,
+): Array<"inherit" | "ignore" | number> => {
+  const inherited = new Set(
+    (environment.READER_SUMMARY_PROMOTION_INHERITED_DIRECTORY_FDS ?? "")
+      .split(",")
+      .filter((value) => /^\d+$/u.test(value))
+      .map(Number)
+      .filter((value) => value > 2),
+  );
+  const highest = Math.max(2, ...inherited);
+  return Array.from({ length: highest + 1 }, (_, fd) =>
+    fd < 3 ? "inherit" : inherited.has(fd) ? fd : "ignore");
+};
 
 const requiredEnv = (name: string): string => {
   const value = process.env[name]?.trim();

--- a/scripts/run-with-timeout.mjs
+++ b/scripts/run-with-timeout.mjs
@@ -30,8 +30,21 @@ const child = spawn(childCommand, childArgs, {
   detached: process.platform !== 'win32',
   env: childEnv,
   shell: process.platform === 'win32',
-  stdio: 'inherit',
+  stdio: buildChildStdio(childEnv),
 });
+
+function buildChildStdio(environment) {
+  const inherited = new Set(
+    String(environment.READER_SUMMARY_PROMOTION_INHERITED_DIRECTORY_FDS ?? '')
+      .split(',')
+      .filter((value) => /^\d+$/.test(value))
+      .map(Number)
+      .filter((value) => value > 2),
+  );
+  const highest = Math.max(2, ...inherited);
+  return Array.from({ length: highest + 1 }, (_, fd) =>
+    fd < 3 ? 'inherit' : inherited.has(fd) ? fd : 'ignore');
+}
 
 let timedOut = false;
 const timer = setTimeout(() => {


### PR DESCRIPTION
Historical regeneration keeps its output directories open as file descriptors, but two nested Node wrappers closed descriptors above stderr. The production child then reused fd 9 for another resource and failed with ENOTDIR before the model ran.

Preserve only the explicitly declared historical directory descriptors through both wrapper processes. A two-level runtime probe read a marker through fd 9, and both changed TypeScript entrypoints loaded successfully in the production image.

Refs #293
Refs #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of reader summary promotion jobs by preserving required process streams and file descriptors when running nested commands.
  - Prevented unrelated file descriptors from being passed to child processes, reducing potential process execution and resource-handling issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->