### PR TITLE
fix(reader-summary): bind inherited output to parent

### DIFF
--- a/scripts/lib/reader-summary-inherited-directory-path.spec.ts
+++ b/scripts/lib/reader-summary-inherited-directory-path.spec.ts
@@ -1,0 +1,19 @@
+import { bindInheritedDirectoryPath } from
+  "./reader-summary-inherited-directory-path";
+
+describe("bindInheritedDirectoryPath", () => {
+  it("keeps an inherited directory reachable by nested child processes", () => {
+    expect(bindInheritedDirectoryPath("/proc/self/fd/10", 85)).toBe(
+      "/proc/85/fd/10",
+    );
+    expect(bindInheritedDirectoryPath("/proc/self/fd/10/quality", 85)).toBe(
+      "/proc/85/fd/10/quality",
+    );
+  });
+
+  it("leaves ordinary artifact paths unchanged", () => {
+    expect(bindInheritedDirectoryPath("/var/data/artifacts", 85)).toBe(
+      "/var/data/artifacts",
+    );
+  });
+});

--- a/scripts/lib/reader-summary-inherited-directory-path.ts
+++ b/scripts/lib/reader-summary-inherited-directory-path.ts
@@ -1,0 +1,7 @@
+export const bindInheritedDirectoryPath = (
+  path: string,
+  ownerPid = process.pid,
+): string => path.replace(
+  /^\/proc\/self\/fd\/(\d+)(?=\/|$)/u,
+  `/proc/${ownerPid}/fd/$1`,
+);

--- a/scripts/run-reader-summary-production-day.ts
+++ b/scripts/run-reader-summary-production-day.ts
@@ -72,6 +72,8 @@ import { readerSummaryProductionHistoryScope } from "./lib/reader-summary-daily-
 import { productionHistoryCollection } from "./lib/reader-summary-production-history-collection";
 import { type YesterdaySocialProviderReadiness } from "./lib/yesterday-social-collection-quality";
 import { readProductionDayScope } from "./lib/reader-summary-production-day-scope";
+import { bindInheritedDirectoryPath } from
+  "./lib/reader-summary-inherited-directory-path";
 import {
   probeProductionRuntimeLiveIdentity,
   runtimeLiveIdentityProofRequired,
@@ -82,9 +84,9 @@ type StepReport = ProductionDayStepReport;
 
 loadDotenvIfPresent(".env");
 
-const reportDirectory = resolve(
+const reportDirectory = bindInheritedDirectoryPath(resolve(
   process.env.READER_SUMMARY_PRODUCTION_DAY_REPORT_DIR ?? "ops/evals",
-);
+));
 const outputPath = join(
   reportDirectory,
   "reader-summary-production-day-run.v1.json",
@@ -601,7 +603,7 @@ function initializeProductionDayRuntime(): void {
   topicLabeler = resolveTopicLabeler();
   periodStartedAt = `${collectionDate}T00:00:00.000Z`;
   periodEndedAt = nextDate(collectionDate);
-  runtimeArtifactDirectory = resolve(
+  runtimeArtifactDirectory = bindInheritedDirectoryPath(resolve(
     process.env.READER_SUMMARY_PRODUCTION_DAY_ARTIFACT_DIR ??
       join(
         tmpdir(),
@@ -609,7 +611,7 @@ function initializeProductionDayRuntime(): void {
         "reader-summary-production-day",
         collectionDate,
       ),
-  );
+  ));
   evidencePath = join(
     runtimeArtifactDirectory,
     `durable-reader-summary-${collectionDate}.v1.json`,


### PR DESCRIPTION
Bind inherited /proc/self/fd artifact paths to the live production-day process PID before nested npm commands run. This keeps the securely opened directory reachable without relying on npm to preserve extra descriptors, fixing the observed ENOTDIR quality-output failure before paid execution. Includes focused path regression tests.\n\nRefs #293\nRefs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for accessing report and runtime artifact directories from nested child processes.
  * Paths inherited through process file descriptors are now resolved to remain accessible across process boundaries.

* **Tests**
  * Added coverage for inherited file-descriptor paths, including paths with trailing segments and ordinary artifact paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->