### PR TITLE
fix(reader-summary): propagate historical output descriptors

### DIFF
--- a/scripts/lib/reader-summary-promotion-v2-historical-subprocess.ts
+++ b/scripts/lib/reader-summary-promotion-v2-historical-subprocess.ts
@@ -127,6 +127,7 @@ export class ProductionDayHistoricalPromotionMutation
       ],
       {
         ...this.input.environment,
+        READER_SUMMARY_PROMOTION_INHERITED_DIRECTORY_FDS: "9,10,11",
         READER_SUMMARY_PRODUCTION_DAY_ARTIFACT_DIR: "/proc/self/fd/9",
         READER_SUMMARY_PRODUCTION_DAY_REPORT_DIR: "/proc/self/fd/10",
         DURABLE_READER_SUMMARY_DATASET_MANIFEST_PATH:

--- a/scripts/run-with-timeout.mjs
+++ b/scripts/run-with-timeout.mjs
@@ -30,7 +30,7 @@ const child = spawn(childCommand, childArgs, {
   detached: process.platform !== 'win32',
   env: childEnv,
   shell: process.platform === 'win32',
-  stdio: childStdio(args.slice(0, separatorIndex)),
+  stdio: childStdio(args.slice(0, separatorIndex), childEnv),
 });
 
 let timedOut = false;
@@ -148,8 +148,10 @@ function buildChildEnv(optionArgs) {
   return env;
 }
 
-function childStdio(optionArgs) {
-  const inheritedFds = [];
+function childStdio(optionArgs, environment) {
+  const inheritedFds = String(
+    environment.READER_SUMMARY_PROMOTION_INHERITED_DIRECTORY_FDS ?? '',
+  ).split(',').filter(Boolean).map(Number);
   for (let index = 0; index < optionArgs.length; index += 1) {
     if (optionArgs[index] === '--inherit-fd') {
       const fd = Number(optionArgs[index + 1]);
@@ -159,6 +161,9 @@ function childStdio(optionArgs) {
       inheritedFds.push(fd);
       index += 1;
     }
+  }
+  if (inheritedFds.some((fd) => !Number.isInteger(fd) || fd < 3)) {
+    throw new Error('Invalid inherited file descriptor environment');
   }
   if (inheritedFds.length === 0) return 'inherit';
   const inherited = new Set(inheritedFds);


### PR DESCRIPTION
Historical regeneration launches additional timeout-wrapped quality commands after the locked preflight. Preserve the already-open output descriptors through those descendants using a narrowly scoped environment declaration, so quality artifacts continue writing to the secured directories.

A three-level runtime probe verified fd 9, 10 and 11 remain readable. The changed TypeScript module also loaded successfully in the production image.

Refs #293
Refs #294
