### PR TITLE
fix(reader-summary): bound assessment latency

### DIFF
--- a/apps/agent-runtime/bin/assessment-cli-launcher.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-launcher.test.mjs
@@ -147,7 +147,7 @@ test("actual launcher/legacy/fake executor forwards existing callbacks before cl
     assert.equal(h.options.safeExecutionPolicy[key], false);
   }
   assert.equal(h.options.accounts[0].worker.model, "gpt-5.6-sol");
-  assert.equal(h.options.accounts[0].worker.reasoningEffort, "high");
+  assert.equal(h.options.accounts[0].worker.reasoningEffort, "low");
   await h.clock.tickAsync(40_000); assert.equal(h.aborts, 1);
   await h.clock.tickAsync(5_000); assert.equal(h.disposeCount, 1);
   await h.clock.tickAsync(1_000); assert.ok(h.events.includes("native-stop"));

--- a/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-auth-pool.e2e.test.mjs
@@ -241,7 +241,7 @@ for (const [firstAccount, available] of [["account-b", false], ["account-a", fal
         env: { PATH: process.env.PATH, HOME: process.env.HOME, LANG: "C.UTF-8",
           AGENT_RUNTIME_CODEX_AUTH_POOL_ROOT: fixture.poolRoot,
           AGENT_RUNTIME_CODEX_AUTH_POOL_MANIFEST: "current.json",
-          AGENT_RUNTIME_REASONING_EFFORT: "high",
+          AGENT_RUNTIME_REASONING_EFFORT: "low",
           SUBSCRIPTION_RUNTIME_LOCAL_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString("base64") },
       }).then(({ stdout }) => JSON.parse(stdout), (error) => JSON.parse(error.stdout));
       const attempts = (await readFile(fixture.attemptLogPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));

--- a/apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.mjs
@@ -45,6 +45,12 @@ const activeReaderSummaryTextProfile = Object.freeze({
   responseFormat: "text",
 });
 
+const sourceContentAssessmentStructuredProfile = Object.freeze({
+  ...activeReaderSummaryStructuredProfile,
+  reasoningEffort: "low",
+  retryMode: "never",
+});
+
 const readerPromotionV2CanaryProfile = Object.freeze({
   provider: "codex",
   model: "gpt-5.6-sol",
@@ -55,9 +61,8 @@ const readerPromotionV2CanaryProfile = Object.freeze({
 });
 
 const profilesByPurpose = Object.freeze({
-  "social_monitor.relevance.assess_source_content.v1": Object.freeze({
-    ...activeReaderSummaryStructuredProfile, retryMode: "never",
-  }),
+  "social_monitor.relevance.assess_source_content.v1":
+    sourceContentAssessmentStructuredProfile,
   "social_monitor.summary.generate": genericSummaryStructuredProfile,
   "social_monitor.reader_summary.generate.v2": activeReaderSummaryStructuredProfile,
   "social_monitor.reader_summary.repair.v2": activeReaderSummaryStructuredProfile,

--- a/apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.test.mjs
+++ b/apps/agent-runtime/bin/subscription-runtime-purpose-model-policy.test.mjs
@@ -364,5 +364,5 @@ test("assessment uses the standard structured pool profile with no retry", () =>
   assert.equal(result.profile.retryMode, "never");
   assert.equal(result.profile.outputKind, "structured_output");
   assert.equal(result.profile.model, "gpt-5.6-sol");
-  assert.equal(result.profile.reasoningEffort, "high");
+  assert.equal(result.profile.reasoningEffort, "low");
 });

--- a/apps/agent-runtime/src/source-content-assessment-cli-lifecycle.spec.ts
+++ b/apps/agent-runtime/src/source-content-assessment-cli-lifecycle.spec.ts
@@ -44,7 +44,7 @@ const expectIndependentCompletion = async (run: ReturnType<typeof makeRun>) => {
   (await waitForChild(count)).close();
   expect(await result).toMatchObject({ status: "completed", executionAttestation: {
     requestId: `independent-${count}`, purpose: assessmentRequest().purpose,
-    model: "gpt-5.6-sol", reasoningEffort: "high", selectedOutputKind: "structured_output",
+    model: "gpt-5.6-sol", reasoningEffort: "low", selectedOutputKind: "structured_output",
   } });
 };
 

--- a/apps/agent-runtime/src/source-content-assessment-pool.test.mjs
+++ b/apps/agent-runtime/src/source-content-assessment-pool.test.mjs
@@ -79,7 +79,7 @@ async function fixture() {
     removeAuthMaterialization: async () => {},
     subscriptionOnlyCodexEnvironment: () => ({}), resolvePinnedCodexBinaryPath: () => "/synthetic/never-executed",
     isSourceContentAssessment: true,
-    admission: { profile: { retryMode: "never", reasoningEffort: "high" } },
+    admission: { profile: { retryMode: "never", reasoningEffort: "low" } },
     FileBackendCodexSafeExecutor: SyntheticExecutor, SubscriptionWorkerError: core.SubscriptionWorkerError,
   };
   const create = new Function(...Object.keys(dependencies), `${body}\nreturn createPooledCodexWorker;`)(...Object.values(dependencies));
@@ -202,7 +202,7 @@ test("missing pool fails closed for assessment while ordinary worker selection s
   let directStarts = 0;
   const dependencies = {
     lifecycle: lifecycleFixture(),
-    admission: { profile: { provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "high" } },
+    admission: { profile: { provider: "codex", model: "gpt-5.6-sol", reasoningEffort: "low" } },
     authPool: undefined, isReaderPromotionV2Canary: false,
     FileBackendCodexWorker: class { constructor() { directStarts++; } },
     resolvePinnedCodexBinaryPath: () => "/synthetic/unused", subscriptionOnlyCodexEnvironment: () => ({}),

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -35,7 +35,7 @@ const approvedSubscriptionRuntimeDependencies = Object.freeze({
   "codex-auth-pool-routing.mjs":
     "5b76a13787a92852282488d5beec8ebb3bfd27f9dfbc059daa8bb521b5524c49",
   "subscription-runtime-purpose-model-policy.mjs":
-    "0c60d62aa38ed04db9643f708a780e9dc72b337d8e0709f92d89d366f5a8f355",
+    "203f73ebb8bad9d268779db902150f987a61c0cbd93518c0d70101155df626bc",
   "reader-promotion-v2-canary-contract.cjs":
     "13432d41d7999d15f22880017e73cbd943c209db62161b2a6a2bec6b0766775c",
 });

--- a/apps/agent-runtime/src/subscription-runtime-purpose-model-policy.spec.ts
+++ b/apps/agent-runtime/src/subscription-runtime-purpose-model-policy.spec.ts
@@ -82,14 +82,14 @@ describe("subscription runtime purpose policy", () => {
       expect(admission.profile).toEqual({
         provider: "codex",
         model: "gpt-5.6-sol",
-        reasoningEffort: "high",
+        reasoningEffort: purpose === "social_monitor.relevance.assess_source_content.v1" ? "low" : "high",
         outputKind: "structured_output",
         responseFormat: "json",
         ...(purpose === "social_monitor.relevance.assess_source_content.v1" ? { retryMode: "never" } : {}),
       });
       expect(controls).toMatchObject({
         model: "gpt-5.6-sol",
-        reasoningEffort: "high",
+        reasoningEffort: purpose === "social_monitor.relevance.assess_source_content.v1" ? "low" : "high",
         responseFormat: "json",
         outputSchema: { type: "object" },
       });

--- a/apps/agent-runtime/src/subscription-runtime-purpose-model-policy.ts
+++ b/apps/agent-runtime/src/subscription-runtime-purpose-model-policy.ts
@@ -20,7 +20,7 @@ export type SubscriptionRuntimeRetryMode = "standard" | "never";
 export type SubscriptionRuntimePurposeProfile = {
   readonly provider: "codex";
   readonly model: "gpt-5.6-sol";
-  readonly reasoningEffort: "high" | "xhigh";
+  readonly reasoningEffort: "low" | "high" | "xhigh";
   readonly outputKind: SubscriptionRuntimeOutputKind;
   readonly responseFormat: "json" | "text";
   readonly retryMode?: SubscriptionRuntimeRetryMode;
@@ -66,6 +66,12 @@ const activeReaderSummaryTextProfile = Object.freeze({
   responseFormat: "text",
 } as const satisfies SubscriptionRuntimePurposeProfile);
 
+const sourceContentAssessmentStructuredProfile = Object.freeze({
+  ...activeReaderSummaryStructuredProfile,
+  reasoningEffort: "low",
+  retryMode: "never",
+} as const satisfies SubscriptionRuntimePurposeProfile);
+
 const readerPromotionV2CanaryProfile = Object.freeze({
   provider: "codex",
   model: productionAgentRuntimeModel,
@@ -78,9 +84,8 @@ const readerPromotionV2CanaryProfile = Object.freeze({
 const profilesByPurpose: Readonly<
   Record<string, SubscriptionRuntimePurposeProfile>
 > = Object.freeze({
-  "social_monitor.relevance.assess_source_content.v1": Object.freeze({
-    ...activeReaderSummaryStructuredProfile, retryMode: "never",
-  }),
+  "social_monitor.relevance.assess_source_content.v1":
+    sourceContentAssessmentStructuredProfile,
   "social_monitor.summary.generate": genericSummaryStructuredProfile,
   "social_monitor.reader_summary.generate.v2": activeReaderSummaryStructuredProfile,
   "social_monitor.reader_summary.repair.v2": activeReaderSummaryStructuredProfile,

--- a/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts
+++ b/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts
@@ -61,7 +61,7 @@ export class AgentRuntimeSourceContentQualityReviewerAdapter implements SourceCo
       provider: "codex" as const, providerInstanceId: this.options.providerInstanceId,
       purpose: sourceContentAssessmentPurpose,
       systemPrompt: promotionReviewInstructions, prompt, outputSchema: promotionResponseSchema,
-      controls: { interactive: false, model: "gpt-5.6-sol", reasoningEffort: "high",
+      controls: { interactive: false, model: "gpt-5.6-sol", reasoningEffort: "low",
         outputSchemaName: "social_monitor_source_content_quality_review",
         schemaVersion: "source_content_assessment.v1", maxOutputTokens: 6_000 },
       timeoutMs, metadata: { adapter: "agent-runtime-source-content-quality-reviewer" },

--- a/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
+++ b/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
@@ -89,11 +89,11 @@ describe("assessment schema consumer protocol", () => {
       await jest.advanceTimersByTimeAsync(300_001);
       const result = await pending;
       expect(calls).toBe(3);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 8 : 0);
-      expect(result.items.filter((item) => item.contentQuality.needsLlmReview)).toHaveLength(valid ? 16 : 24);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 16 : 0);
+      expect(result.items.filter((item) => item.contentQuality.needsLlmReview)).toHaveLength(valid ? 8 : 24);
       await jest.advanceTimersByTimeAsync(300_000);
       expect(calls).toBe(3);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 8 : 0);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 16 : 0);
     } finally { jest.useRealTimers(); }
   });
 });

--- a/libs/relevance/adapters/model/promotion-reader-headline-budget.spec.ts
+++ b/libs/relevance/adapters/model/promotion-reader-headline-budget.spec.ts
@@ -52,7 +52,7 @@ it("preserves all quality verdicts with malformed or oversized annotations in co
       client: refreshTestRuntimeClient(async (command) => {
         calls++;
         const candidates = JSON.parse(command.prompt).candidates as { candidateId: string }[];
-        expect(candidates).toHaveLength(4);
+        expect(candidates).toHaveLength(8);
         const reviews = candidates.map(({ candidateId }) => {
           const input = requests.find((request) => request.candidateId === candidateId)!;
           const { assessment, ...quality } = headlineReview(input, readerHeadline);
@@ -66,7 +66,7 @@ it("preserves all quality verdicts with malformed or oversized annotations in co
     });
     const result = await assessPromotionContent({ requests, reviewer: adapter, clock,
       policy: new SourceContentQualityPolicy() });
-    expect(calls).toBe(2);
+    expect(calls).toBe(1);
     expect(result.verdicts.size).toBe(8);
     expect([...result.verdicts.values()].every((verdict) => verdict.qualityScore === 0.8)).toBe(true);
     expect([...result.readerHeadlines.values()].every((headline) => headline.status === "unavailable")).toBe(true);

--- a/libs/relevance/adapters/model/promotion-reader-headline-wire.spec.ts
+++ b/libs/relevance/adapters/model/promotion-reader-headline-wire.spec.ts
@@ -59,7 +59,7 @@ describe("existing batch headline wire and authenticated runtime", () => {
       batchTimeoutMs: 15_000, totalTimeoutMs: 60_000,
       client: refreshTestRuntimeClient(async (command) => {
         calls++;
-        expect(JSON.parse(command.controlsJson)).toMatchObject({ model: "gpt-5.6-sol", reasoningEffort: "high",
+        expect(JSON.parse(command.controlsJson)).toMatchObject({ model: "gpt-5.6-sol", reasoningEffort: "low",
           schemaVersion: "source_content_assessment.v1", maxOutputTokens: 6_000 });
         expect(JSON.parse(command.outputSchemaJson)).toEqual(promotionResponseSchema);
         const old = outputFor(command);

--- a/libs/relevance/features/rank-feed-items/promotion-assessment-failures.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-assessment-failures.spec.ts
@@ -9,7 +9,7 @@ describe("promotion assessment protocol and budgets through V2", () => {
     const result = await run(items, { reviewBatch });
     expect(result.ranking.ranked).toHaveLength(37);
     const calls = reviewBatch.mock.calls;
-    expect(calls.map(([requests]) => requests.length)).toEqual([4, 4, 4, 4, 4, 4, 4, 4, 4, 1]);
+    expect(calls.map(([requests]) => requests.length)).toEqual([8, 8, 8, 8, 5]);
     expect(calls.flatMap(([requests]) => requests.map((r) => r.candidateId)))
       .toEqual(items.map((i) => i.toSnapshot().id).sort());
     for (const [requests] of calls) expect(new TextEncoder().encode(JSON.stringify(requests)).length)

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.spec.ts
@@ -14,7 +14,7 @@ describe("promotion assessment through Summary candidate and V2 (synthetic revie
     expect(result.candidates[0]!.evidenceQualityScore).toBe(0.8);
   });
 
-  it("reviews eight candidates sequentially in ordered fours and retains second-batch popularity", async () => {
+  it("reviews eight candidates in one ordered batch and retains second-batch popularity", async () => {
     const ids = Array.from({ length: 8 }, (_, i) => `candidate-${i}`);
     let active = 0;
     let peak = 0;
@@ -28,9 +28,9 @@ describe("promotion assessment through Summary candidate and V2 (synthetic revie
       providerMetadata: { kind: "reddit_post", score: i === 7 ? 900 : 90, upvoteRatio: 0.95 },
     })).reverse();
     const result = await run(items, { reviewBatch });
-    expect(reviewBatch).toHaveBeenCalledTimes(2);
+    expect(reviewBatch).toHaveBeenCalledTimes(1);
     expect(reviewBatch.mock.calls.map(([requests]) => requests.map((r) => r.candidateId)))
-      .toEqual([ids.slice(0, 4), ids.slice(4)]);
+      .toEqual([ids]);
     expect(peak).toBe(1);
     expect(result.items.map((item) => item.feedItemId).sort()).toEqual(ids);
     for (const item of result.items) expect(item.contentQuality).toMatchObject({

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
@@ -8,7 +8,7 @@ import { unavailablePromotionHeadline, type PromotionReaderHeadline } from "../.
 import { assessPromotionReaderHeadline } from "./promotion-reader-headline-assessment";
 
 export const PROMOTION_ASSESSMENT_BOUNDS = Object.freeze({
-  candidates: 200, batchCandidates: 4, batchBytes: 64_000,
+  candidates: 200, batchCandidates: 8, batchBytes: 64_000,
   totalBytes: 512_000, batchTimeoutMs: 15_000, deadlineMs: 60_000,
 });
 

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.spec.ts
@@ -9,7 +9,7 @@ const command = (index = 0, count = 1, padding = 0): AgentRuntimeTaskCommand => 
   prompt: JSON.stringify({ candidates: Array.from({ length: count }, (_, i) => ({
     candidateId: `candidate-${index + i}`, text: "x".repeat(padding),
   })) }),
-  controls: { model: "gpt-5.6-sol", reasoningEffort: "high", interactive: false,
+  controls: { model: "gpt-5.6-sol", reasoningEffort: "low", interactive: false,
     outputSchemaName: "social_monitor_source_content_quality_review", schemaVersion: "source_content_assessment.v1" },
 });
 function wiring(mutate?: (result: AgentRuntimeTaskResult) => AgentRuntimeTaskResult) {
@@ -28,13 +28,13 @@ function wiring(mutate?: (result: AgentRuntimeTaskResult) => AgentRuntimeTaskRes
 describe("refresh operation assessment runtime budgets and receipts", () => {
   it("consumes exactly 200 candidates then blocks another batch without refunding", async () => {
     const test = wiring();
-    for (let i = 0; i < 200; i += 4) await test.runtime.runTask(command(i, 4));
+    for (let i = 0; i < 200; i += 8) await test.runtime.runTask(command(i, 8));
     await expect(test.runtime.runTask(command(200))).rejects.toThrow(/consumed/u);
     await expect(test.runtime.runTask(command(201, 4))).rejects.toThrow(/budget/u);
-    expect(test.runTask).toHaveBeenCalledTimes(50);
+    expect(test.runTask).toHaveBeenCalledTimes(25);
     expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/u);
     expect(test.events).toContainEqual(expect.objectContaining({ status: "invocation_consumed",
-      assessmentAttempts: 50, assessmentCandidates: 200 }));
+      assessmentAttempts: 25, assessmentCandidates: 200 }));
   });
   it("exhausts actual wire bytes independently of candidate count", async () => {
     const test = wiring();

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
@@ -39,6 +39,14 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
     expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/u);
   });
 
+  it("rejects nonempty partial coverage within the configured candidate cap", async () => {
+    const fixture = await selectorWiring();
+    const selection = await fixture.selectComplete();
+    expect(selection.selectedEvidence).not.toHaveLength(0);
+    expect(() => fixture.assessment.assertComplete(3, selection)).toThrow(/reconciliation/u);
+    expect(() => fixture.runtime.assertUsable()).toThrow(/reconciliation/u);
+  });
+
   it.each(["missing", "one missing", "wrong binding", "wrong quote", "duplicate"])(
     "keeps %s assessment pending and prevents publication and subsequent spend", async (kind) => {
       const test = await selectorWiring({ output: (command) => {
@@ -98,7 +106,7 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
       expect(test.commands).toEqual([]);
       const selection = await test.selectComplete();
       const calls = test.commands.filter((c) => c.purpose === purpose);
-      expect(calls).toHaveLength(50);
+      expect(calls).toHaveLength(25);
       const reviewedIds = calls.flatMap((call) =>
         (JSON.parse(call.prompt).candidates as { candidateId: string }[]).map((c) => c.candidateId));
       expect(reviewedIds).toHaveLength(200);

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.ts
@@ -90,9 +90,10 @@ export function createRefreshAssessmentReviewer(input: {
     },
     assertComplete: (expected, selection) => {
       input.runtime.assertUsable();
-      // The snapshot count is an upper bound, not a mandate to spend on every
-      // candidate. Every attempted batch must still have a verified outcome.
-      if (!Number.isSafeInteger(expected) || expected < completed || completed !== seen.size) fail();
+      // Historical refresh must assess the complete captured universe. Partial
+      // UUID-ordered coverage would bias selection toward whichever batches ran first.
+      const required = Math.min(expected, PROMOTION_ASSESSMENT_BOUNDS.candidates);
+      if (!Number.isSafeInteger(expected) || expected < 0 || required !== completed || completed !== seen.size) fail();
       if (selection === undefined) return;
       // An empty bounded/uncertain result cannot support exhaustive no-signal.
       if (selection.selectedEvidence.length === 0 && (completed < expected || abstained > 0)) {

--- a/scripts/lib/reader-summary-new-input-refresh-model.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.spec-support.ts
@@ -10,6 +10,7 @@ import { createAgentRuntimeGrpcService } from "../../apps/agent-runtime/src/agen
 import type { AgentRuntimeExecutionRequest, AgentRuntimeExecutorPort } from "../../apps/agent-runtime/src/agent-runtime-executor.port";
 import { attachExecutorOwnedExecutionAttestation } from "../../apps/agent-runtime/src/subscription-runtime-execution-attestation";
 import { admitSubscriptionRuntimeRequest } from "../../apps/agent-runtime/src/subscription-runtime-purpose-model-policy";
+import { sourceContentAssessmentPurpose } from "./reader-summary-new-input-refresh-assessment-runtime";
 import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
 
 export const refreshModelCommand = (purpose: string = purposes.generate): AgentRuntimeTaskCommand => ({
@@ -17,7 +18,7 @@ export const refreshModelCommand = (purpose: string = purposes.generate): AgentR
   tenantId: tenantId(refreshManifest().tenantId), workspaceId: workspaceId(refreshManifest().workspaceId),
   provider: "codex", prompt: "Synthetic prompt", systemPrompt: "Synthetic instruction",
   outputSchema: {}, timeoutMs: 1000, controls: {
-    model: "gpt-5.6-sol", reasoningEffort: "high",
+    model: "gpt-5.6-sol", reasoningEffort: purpose === sourceContentAssessmentPurpose ? "low" : "high",
     ...(purpose === purposes.relatedTopicRelations ? {
       outputSchemaName: "social_monitor_reader_summary_related_topic_relations",
       schemaVersion: "reader_summary.related_topic_relation.v1",

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -125,6 +125,8 @@ export function guardedRefreshRuntime(input: {
   const purposes: readonly string[] = [activeReaderSummaryPurposes.generate, activeReaderSummaryPurposes.topicLabel,
     activeReaderSummaryPurposes.topicRelations, activeReaderSummaryPurposes.storyRelations,
     activeReaderSummaryPurposes.relatedTopicRelations, sourceContentAssessmentPurpose];
+  const expectedReasoningEffort = (purpose: string) =>
+    purpose === sourceContentAssessmentPurpose ? "low" : "high";
   return {
     assertUsable,
     invalidateAdapter: (taskRole) => {
@@ -145,7 +147,7 @@ export function guardedRefreshRuntime(input: {
         if (purposes.includes(command.purpose) && command.metadata?.attempt !== "repair" &&
             command.tenantId === input.manifest.tenantId && command.workspaceId === input.manifest.workspaceId &&
             command.provider === "codex" && command.controls.model === "gpt-5.6-sol" &&
-            command.controls.reasoningEffort === "high") {
+            command.controls.reasoningEffort === expectedReasoningEffort(command.purpose)) {
           capture({ kind: "invocation_rejected", command, delegated: false,
             reason: ambiguous ? "authority_rejected" : inFlight ? "in_flight" :
               seen.has(command.requestId) ? "duplicate_request" : "generation_already_consumed" });
@@ -155,7 +157,7 @@ export function guardedRefreshRuntime(input: {
       if (!purposes.includes(command.purpose) || command.metadata?.attempt === "repair" ||
           command.tenantId !== input.manifest.tenantId || command.workspaceId !== input.manifest.workspaceId ||
           command.provider !== "codex" || command.controls.model !== "gpt-5.6-sol" ||
-          command.controls.reasoningEffort !== "high") {
+          command.controls.reasoningEffort !== expectedReasoningEffort(command.purpose)) {
         ambiguous = true;
         throw new Error("Refresh invocation budget or model authority rejected");
       }
@@ -174,7 +176,8 @@ export function guardedRefreshRuntime(input: {
       }
       const identity = { requestId: command.requestId, purpose: command.purpose,
         requestSha256: refreshHash(command), operation: input.manifest.operation,
-        observedThrough: input.manifest.observedThrough, model: "gpt-5.6-sol", reasoningEffort: "high" };
+        observedThrough: input.manifest.observedThrough, model: "gpt-5.6-sol",
+        reasoningEffort: expectedReasoningEffort(command.purpose) };
       const verifyResponse = (result: AgentRuntimeTaskResult): void | Promise<unknown> => {
         const taskRole = ({
           [activeReaderSummaryPurposes.generate]: "summary",

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.spec.ts
@@ -138,7 +138,7 @@ describe("synthetic bounded refresh paired export", () => {
     const statuses = json(fixture.path, "candidate-status.json");
     expect(statuses.filter((s: { attempted: boolean }) => s.attempted)).toHaveLength(200);
     expect(statuses.filter((s: { status: string }) => s.status === "pending").length).toBe(3);
-    expect(fixture.delegate.runTask.mock.calls.filter(([c]) => c.purpose.includes("assess_source_content"))).toHaveLength(50);
+    expect(fixture.delegate.runTask.mock.calls.filter(([c]) => c.purpose.includes("assess_source_content"))).toHaveLength(25);
   });
 
   it("refuses absent swallowed P1 callback and keeps capture failures separate from selection", async () => {

--- a/scripts/lib/source-content-assessment-lifecycle.spec.ts
+++ b/scripts/lib/source-content-assessment-lifecycle.spec.ts
@@ -83,14 +83,14 @@ describe("assessment completed receipts and caller abandonment", () => {
       await jest.advanceTimersByTimeAsync(100_001);
       const result = await pending;
       expect(timeouts).toEqual([100_000, 30_000]);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(4);
-      expect(result.candidates.filter((item) => item.evidenceQualityScore === 0)).toHaveLength(20);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(8);
+      expect(result.candidates.filter((item) => item.evidenceQualityScore === 0)).toHaveLength(16);
       await jest.advanceTimersByTimeAsync(60_000);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(4);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(8);
     } finally { jest.useRealTimers(); }
   });
-  // Completion at the 600-second deadline is late: 29 or 8 timely batches of four.
-  it.each([[20_000, 116], [70_000, 32]])("accounts for all 200 candidates at %i ms per batch", async (latency, admitted) => {
+  // Completion at the 600-second deadline is late: all 25 or 8 timely batches of eight.
+  it.each([[20_000, 200], [70_000, 64]])("accounts for all 200 candidates at %i ms per batch", async (latency, admitted) => {
     jest.useFakeTimers();
     jest.setSystemTime(cutoff);
     try {

--- a/scripts/lib/source-content-assessment-runtime.spec.ts
+++ b/scripts/lib/source-content-assessment-runtime.spec.ts
@@ -30,12 +30,12 @@ describe("pool-backed assessment through runtime transport and actual promotion"
     const result = await run(Array.from({ length: 32 }, (_, index) =>
       fixture(`pool-${index}`, ["reddit", "hacker-news", "x-twitter"][index % 3])), reviewer);
     expect(result.ranking.orderedCandidateIds).toHaveLength(32);
-    expect(requests).toHaveLength(8);
-    expect(new Set(requests.map((request) => request.requestId)).size).toBe(8);
+    expect(requests).toHaveLength(4);
+    expect(new Set(requests.map((request) => request.requestId)).size).toBe(4);
     for (const request of requests) {
       expect(request).toMatchObject({ tenantId: scope.tenantId, workspaceId: scope.workspaceId,
         providerInstanceId: "synthetic-existing-pool", timeoutMs: 300_000 });
-      expect(JSON.parse(request.prompt).candidates).toHaveLength(4);
+      expect(JSON.parse(request.prompt).candidates).toHaveLength(8);
       expect(request.prompt).not.toMatch(/canonicalUrl|deterministic|upvoteRatio/);
     }
   });
@@ -50,8 +50,8 @@ describe("pool-backed assessment through runtime transport and actual promotion"
       return attestRefreshExecution(request, output);
     });
     const result = await run(Array.from({ length: 32 }, (_, index) => fixture(`partial-${index}`)), reviewer);
-    expect(calls).toBe(8);
-    expect(result.ranking.orderedCandidateIds).toHaveLength(27);
+    expect(calls).toBe(4);
+    expect(result.ranking.orderedCandidateIds).toHaveLength(23);
   });
 
   it.each(["binding", "identity", "range"])("rejects mismatched %s evidence", async (mutation) => {
@@ -96,9 +96,9 @@ describe("pool-backed assessment through runtime transport and actual promotion"
         { clock: new SystemClock() });
       await jest.advanceTimersByTimeAsync(60_001);
       const result = await pending;
-      expect(result.ranking.orderedCandidateIds).toHaveLength(4);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(8);
       await jest.advanceTimersByTimeAsync(40_000);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(4);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(8);
       expect(requests).toHaveLength(2);
       expect(requests.map((request) => request.timeoutMs)).toEqual([50_000, 20_000]);
     } finally { jest.useRealTimers(); }


### PR DESCRIPTION
The seven-day production refresh consumed its first assessment invocation but timed out after 279 seconds on only four candidates, leaving the operation correctly quarantined for reconciliation. This change keeps the same model, strict schema, attestation, no-retry rule, byte limits and total deadline while routing source-content assessment at low reasoning effort and processing up to eight candidates per batch.

Validation:
- 132 focused Jest tests passed
- 41 native/runtime policy and auth-pool tests passed
- source line cap passed across 4429 files

Refs #293
Refs #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source-content assessments now use low reasoning effort, while other assessment purposes retain their existing settings.
  * Promotion content reviews can process up to eight candidates per batch, improving batching efficiency.

* **Bug Fixes**
  * Updated assessment validation and runtime checks to consistently enforce purpose-specific reasoning settings.

* **Tests**
  * Updated integration, end-to-end, and batching coverage for the revised reasoning and batch-size behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->