### PR TITLE
fix(reader-summary): preserve assessment recovery

### DIFF
--- a/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts
+++ b/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts
@@ -26,8 +26,8 @@ export class AgentRuntimeSourceContentQualityReviewerAdapter implements SourceCo
   readonly promotionTiming: { readonly batchTimeoutMs: number; readonly totalTimeoutMs: number };
 
   constructor(private readonly options: AgentRuntimeSourceContentQualityOptions) {
-    if (![options.batchTimeoutMs, options.totalTimeoutMs].every((ms) =>
-      Number.isSafeInteger(ms) && ms > 0 && ms <= 600_000)) {
+    if (!Number.isSafeInteger(options.batchTimeoutMs) || options.batchTimeoutMs <= 0 || options.batchTimeoutMs > 600_000 ||
+        !Number.isSafeInteger(options.totalTimeoutMs) || options.totalTimeoutMs <= 0 || options.totalTimeoutMs > 3_600_000) {
       throw new Error("Invalid agent runtime assessment timeout");
     }
     this.promotionTiming = Object.freeze({ batchTimeoutMs: options.batchTimeoutMs,

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
@@ -27,7 +27,8 @@ export const assessPromotionContent = async (input: {
   const timing = input.reviewer?.promotionTiming;
   const totalTimeoutMs = timing?.totalTimeoutMs ?? bounds.deadlineMs;
   const batchTimeoutMs = timing?.batchTimeoutMs ?? bounds.batchTimeoutMs;
-  if (![totalTimeoutMs, batchTimeoutMs].every((ms) => Number.isSafeInteger(ms) && ms > 0 && ms <= 600_000)) {
+  if (!Number.isSafeInteger(batchTimeoutMs) || batchTimeoutMs <= 0 || batchTimeoutMs > 600_000 ||
+      !Number.isSafeInteger(totalTimeoutMs) || totalTimeoutMs <= 0 || totalTimeoutMs > 3_600_000) {
     throw new Error("Invalid promotion assessment deadline");
   }
   const verdicts = new Map(input.requests.map((request) => [request.candidateId,

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.spec.ts
@@ -52,7 +52,7 @@ describe("refresh operation assessment runtime budgets and receipts", () => {
   it("never resets the elapsed operation budget for a new batch", async () => {
     const test = wiring();
     await test.runtime.runTask(command());
-    test.advance(600_000);
+    test.advance(3_600_000);
     await expect(test.runtime.runTask(command(1))).rejects.toThrow(/consumed/u);
     expect(test.runTask).toHaveBeenCalledTimes(1);
   });

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.ts
@@ -6,7 +6,7 @@ import type { AgentRuntimeTaskCommand, AgentRuntimeTaskResult } from "@social-mo
 
 export { sourceContentAssessmentPurpose };
 export const refreshAssessmentLimits = Object.freeze({ ...PROMOTION_ASSESSMENT_BOUNDS,
-  totalTimeoutMs: 600_000, batchTimeoutMs: 600_000 });
+  totalTimeoutMs: 3_600_000, batchTimeoutMs: 600_000 });
 
 // Per consumed operation, not per selection or adapter instance. Request IDs
 // alone cannot prevent a second assessment of the same captured candidate.

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.ts
@@ -163,7 +163,8 @@ export function createRefreshAssessmentReviewer(input: {
             // These reasons are emitted only after binding, shape and quote
             // validation. All other pending outcomes remain authority failures.
             if (verdict.reason !== "promotion_assessment_pending:needs_context" &&
-                verdict.reason !== "promotion_assessment_pending:low_confidence") fail();
+                verdict.reason !== "promotion_assessment_pending:low_confidence" &&
+                verdict.reason !== "promotion_assessment_pending:invalid_assessment") fail();
             abstained++;
           } else if (verdict.eligibleForSummary) eligible.set(request.candidateId, { request, verdict });
         }

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec.ts
@@ -31,6 +31,15 @@ describe("new-input refresh consumed-job reconciliation", () => {
     database.assertJobsUntouched();
   });
 
+  it("accounts for a completed provider response with exact reported usage", async () => {
+    const database = new FakeReconciliationDatabase([{ ...consumed }]);
+    const usage = { inputTokens: 90_824, outputTokens: 6_325, totalTokens: 97_149 };
+    const receipt = await apply(database, { invocation: {
+      ...reconciliationEvidence().invocation, providerUsageReported: true, usage } });
+    expect(receipt.accounting).toEqual(expect.objectContaining({ providerUsage: "reported", usage }));
+    database.assertJobsUntouched();
+  });
+
   it("is idempotent: an exact replay returns the committed record and adds nothing", async () => {
     const database = new FakeReconciliationDatabase([{ ...consumed }]);
     const first = await apply(database);

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
@@ -15,14 +15,20 @@ export type RefreshReconciliationEvidence = Readonly<{
   invocation: Readonly<{
     requestId: string; purpose: string; requestSha256: string;
     attemptSha256: string; consumedAt: string; returnedAt: string;
-    outcome: string; providerUsageReported: false;
+    outcome: string; providerUsageReported: boolean;
+    usage?: Readonly<{ inputTokens: number; outputTokens: number; totalTokens: number }>;
   }>;
 }>;
 
 export const refreshReconciliationAccounting = Object.freeze({
   summaryGenerations: 0, publications: 0, artifacts: 0,
-  providerInvocations: 1, providerUsage: "unknown",
+  providerInvocations: 1, providerUsage: "unknown" as const,
 });
+export const refreshReconciliationAccountingFor = (evidence: RefreshReconciliationEvidence) =>
+  evidence.invocation.providerUsageReported
+    ? Object.freeze({ ...refreshReconciliationAccounting, providerUsage: "reported" as const,
+      usage: evidence.invocation.usage! })
+    : refreshReconciliationAccounting;
 
 const uuid = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/u;
 const sha256 = /^[0-9a-f]{64}$/u;
@@ -54,9 +60,12 @@ export function assertRefreshReconciliationEvidence(
       !isoInstant(invocation.consumedAt) || !isoInstant(invocation.returnedAt) ||
       Date.parse(invocation.returnedAt) < Date.parse(invocation.consumedAt) ||
       typeof invocation.outcome !== "string" || invocation.outcome.trim().length === 0 ||
-      // A reported-usage invocation is not this failure mode and must not be
-      // laundered through the reconciliation path.
-      invocation.providerUsageReported !== false) {
+      typeof invocation.providerUsageReported !== "boolean" ||
+      (invocation.providerUsageReported
+        ? invocation.usage === undefined || ![invocation.usage.inputTokens, invocation.usage.outputTokens,
+          invocation.usage.totalTokens].every((count) => Number.isSafeInteger(count) && count >= 0) ||
+          invocation.usage.totalTokens !== invocation.usage.inputTokens + invocation.usage.outputTokens
+        : invocation.usage !== undefined)) {
     throw new Error("Refresh reconciliation invocation identity is invalid");
   }
 }
@@ -119,7 +128,7 @@ const insertReconciliation = (client: WriteClient, input: {
       encode(sha256(convert_to(to_jsonb(j)::text, 'UTF8')), 'hex'),
       ${e.manifestSha256}, ${input.evidenceSha256}, ${e.reason},
       ${JSON.stringify(e.invocation)}::jsonb,
-      ${JSON.stringify(refreshReconciliationAccounting)}::jsonb,
+      ${JSON.stringify(refreshReconciliationAccountingFor(e))}::jsonb,
       ${input.now}::timestamptz
     from reader_summary_jobs j
     where j.id = ${e.jobId}::uuid
@@ -164,7 +173,7 @@ export type RefreshReconciliationReceipt = Readonly<{
   status: "reconciled" | "already_reconciled";
   reconciliationId: string; jobId: string; operation: string;
   jobSha256: string; evidenceSha256: string; reconciledAt: string;
-  accounting: typeof refreshReconciliationAccounting;
+  accounting: ReturnType<typeof refreshReconciliationAccountingFor>;
 }>;
 
 /** Idempotent: an exact replay returns the committed record; anything that
@@ -174,6 +183,7 @@ export async function reconcileConsumedRefreshJob(input: {
   evidenceSha256: string; now: Date; ids: IdGenerator;
 }): Promise<RefreshReconciliationReceipt> {
   const { client, evidence, evidenceSha256 } = input;
+  const accounting = refreshReconciliationAccountingFor(evidence);
   const inserted = await insertReconciliation(client,
     { id: input.ids.generate(), evidence, evidenceSha256, now: input.now });
   const rows = await selectReconciliation(client, evidence.jobId);
@@ -188,11 +198,11 @@ export async function reconcileConsumedRefreshJob(input: {
       row.manifestSha256 !== evidence.manifestSha256 ||
       row.evidenceSha256 !== evidenceSha256 || row.reason !== evidence.reason ||
       refreshHash(row.invocation) !== refreshHash(evidence.invocation) ||
-      refreshHash(row.accounting) !== refreshHash(refreshReconciliationAccounting)) {
+      refreshHash(row.accounting) !== refreshHash(accounting)) {
     throw new Error("Refresh reconciliation conflicts with the committed record for this job");
   }
   return { status: inserted.length === 1 ? "reconciled" : "already_reconciled",
     reconciliationId: row.id, jobId: row.readerSummaryJobId, operation: row.operation,
     jobSha256: row.jobSha256, evidenceSha256: row.evidenceSha256,
-    reconciledAt: row.reconciledAt.toISOString(), accounting: refreshReconciliationAccounting };
+    reconciledAt: row.reconciledAt.toISOString(), accounting };
 }


### PR DESCRIPTION
A real Sep 2 production successor returned a valid attested provider response but failed semantic admission. Recovery then rejected reconciliation because usage was reported, while the 10 minute operation window could not cover all 81 candidates.

This keeps invalid individual assessments abstained, extends only the historical aggregate deadline to one hour while preserving the 10 minute per-call cap, and records exact reported usage during reconciliation.

Validation: 115 focused tests passed, including the reported-usage reconciliation regression.

Refs #293
Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promotion assessments can now run for up to one hour while individual batches remain limited to ten minutes.
  * Completed provider responses can include detailed token usage in reconciliation records.
  * Refresh reconciliation now supports additional pending assessment outcomes.

* **Bug Fixes**
  * Improved validation and accounting for assessment timeouts and reported usage.
  * Preserved consumed-job status during reconciliation when provider usage is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->