### PR TITLE
fix(reader-summary): complete historical assessment recovery

### DIFF
--- a/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
+++ b/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
@@ -15,10 +15,12 @@ const observed = (review: Wire, second = false): Wire => ({
   ...(second ? { justification: "Synthetic", screeningFlagResolutions: [] }
     : { reason: "Synthetic", flagResolutions: [] }),
 });
+const compatible = {
+  "observed batch one": (o: { reviews: Wire[] }) => ({ results: o.reviews.map((r) => observed(r)) }),
+  "observed batch two": (o: { reviews: Wire[] }) => ({ results: o.reviews.map((r) => observed(r, true)) }),
+  "results alias only": (o: { reviews: Wire[] }) => ({ results: o.reviews }),
+} as const;
 const mutations: Record<string, (output: { reviews: Wire[] }) => Wire> = {
-  "observed batch one": (o) => ({ results: o.reviews.map((r) => observed(r)) }),
-  "observed batch two": (o) => ({ results: o.reviews.map((r) => observed(r, true)) }),
-  "results alias only": (o) => ({ results: o.reviews }),
   "relevant decision": (o) => ({ reviews: o.reviews.map((r) => ({ ...r, decision: "relevant" })) }),
   "not_relevant decision": (o) => ({ reviews: o.reviews.map((r) => ({ ...r, decision: "not_relevant" })) }),
 };
@@ -40,6 +42,22 @@ describe("assessment schema consumer protocol", () => {
       expect(() => parseReviews(JSON.stringify(output))).toThrow("protocol requires a reviews array");
     });
 
+  it.each(Object.entries(compatible))(
+    "accepts a nonempty completed %s response with exact request binding", async (_name, mutate) => {
+    let calls = 0;
+    const adapter = new AgentRuntimeSourceContentQualityReviewerAdapter({
+      clock: new FixedClock(cutoff), ids: { generate: () => `sandbox-compatible-${++calls}` },
+      batchTimeoutMs: 300_000, totalTimeoutMs: 600_000,
+      client: refreshTestRuntimeClient(async (request) =>
+        attestRefreshExecution(request, mutate(outputFor(request)))),
+    });
+    const result = await run([fixture("protocol")], adapter);
+    expect(calls).toBe(1);
+    expect(result.items[0]!.contentQuality).toMatchObject({ qualityScore: 0.8,
+      needsLlmReview: false, eligibleForSummary: true });
+    expect(result.ranking.orderedCandidateIds).toEqual(["protocol"]);
+  });
+
   it.each(Object.keys(mutations))("rejects %s through attested structured output and keeps candidates pending", async (name) => {
     const failures: string[] = [];
     let calls = 0;
@@ -60,15 +78,12 @@ describe("assessment schema consumer protocol", () => {
     expect(calls).toBe(1);
     expect(failures).toHaveLength(1);
     expect(failures[0]).not.toContain("runtime completion");
-    if (name.includes("observed") || name === "results alias only") {
-      expect(failures[0]).toBe("Quality review protocol requires a reviews array");
-    }
     expect(result.ranking.orderedCandidateIds).toHaveLength(0);
     expect(result.items[0]!.contentQuality).toMatchObject({ qualityScore: 0,
       needsLlmReview: true, eligibleForTopRead: false });
   });
 
-  it.each([true, false])("preserves valid siblings=%s when the third batch times out without retry", async (valid) => {
+  it.each([true, false])("preserves canonical=%s compatible siblings when the third batch times out without retry", async (canonical) => {
     jest.useFakeTimers();
     jest.setSystemTime(cutoff);
     let calls = 0;
@@ -80,8 +95,8 @@ describe("assessment schema consumer protocol", () => {
           calls++;
           if (calls === 3) return new Promise(() => {});
           const output = outputFor(request);
-          return attestRefreshExecution(request, valid ? output
-            : mutations[calls === 1 ? "observed batch one" : "observed batch two"]!(output));
+          return attestRefreshExecution(request, canonical ? output
+            : compatible[calls === 1 ? "observed batch one" : "observed batch two"](output));
         }),
       });
       const pending = run(Array.from({ length: 24 }, (_, i) => fixture(`wire-${String(i).padStart(2, "0")}`)),
@@ -89,11 +104,11 @@ describe("assessment schema consumer protocol", () => {
       await jest.advanceTimersByTimeAsync(300_001);
       const result = await pending;
       expect(calls).toBe(3);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 16 : 0);
-      expect(result.items.filter((item) => item.contentQuality.needsLlmReview)).toHaveLength(valid ? 8 : 24);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(16);
+      expect(result.items.filter((item) => item.contentQuality.needsLlmReview)).toHaveLength(8);
       await jest.advanceTimersByTimeAsync(300_000);
       expect(calls).toBe(3);
-      expect(result.ranking.orderedCandidateIds).toHaveLength(valid ? 16 : 0);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(16);
     } finally { jest.useRealTimers(); }
   });
 });

--- a/libs/relevance/adapters/model/source-content-quality-review-wire.ts
+++ b/libs/relevance/adapters/model/source-content-quality-review-wire.ts
@@ -25,16 +25,25 @@ export const parseReviews = (
   }
 
   const parsed = asRecord(JSON.parse(outputText), "quality review output");
-  if (!Array.isArray(parsed.reviews)) {
+  const compatibilityResults = parsed.reviews === undefined && Array.isArray(parsed.results) && requests !== undefined
+    ? parsed.results : undefined;
+  if (!Array.isArray(parsed.reviews) && compatibilityResults === undefined) {
     throw new Error("Quality review protocol requires a reviews array");
   }
-  const reviews = parsed.reviews;
+  const reviews = (parsed.reviews ?? compatibilityResults) as JsonValue[];
 
   return reviews.map((review) => {
-    const record = asRecord(review, "quality review item");
+    const raw = asRecord(review, "quality review item");
 
-    const candidateId = nonEmptyString(record.candidateId, "candidateId");
+    const candidateId = nonEmptyString(raw.candidateId, "candidateId");
     const request = requests?.find((request) => request.candidateId === candidateId);
+    // Two attested native completions used the earlier `results` dialect even
+    // though the canonical schema was supplied. Normalize only that complete,
+    // request-bound dialect. Its single quality/support score supplies the
+    // missing relevance score; integrity retains the deterministic assessment.
+    // No source, identity, evidence or blocker is inferred.
+    const record = compatibilityResults === undefined || request === undefined ? raw
+      : normalizeCompatiblePromotionReview(raw, request);
     if (requests !== undefined && (request === undefined ||
         ![record.confidence, record.qualityScore, record.interestRelevanceScore,
           record.engagementIntegrityScore].every((score) => typeof score === "number" &&
@@ -56,6 +65,23 @@ export const parseReviews = (
       reason: nonEmptyString(record.reason, "reason"),
     };
   });
+};
+
+const normalizeCompatiblePromotionReview = (
+  record: JsonObject, request: SourceContentQualityReviewRequest,
+): JsonObject => {
+  const decision = record.decision === "relevant" ? "promote"
+    : record.decision === "not_relevant" ? "reject" : record.decision;
+  const reason = Object.hasOwn(record, "reason") ? record.reason : record.justification;
+  const resolutions = Object.hasOwn(record, "resolvedSoftFlags") ? record.resolvedSoftFlags
+    : Object.hasOwn(record, "flagResolutions") ? record.flagResolutions : record.screeningFlagResolutions;
+  return { ...record, decision: decision ?? null,
+    interestRelevanceScore: Object.hasOwn(record, "interestRelevanceScore")
+      ? record.interestRelevanceScore ?? null : record.qualityScore ?? null,
+    engagementIntegrityScore: Object.hasOwn(record, "engagementIntegrityScore")
+      ? record.engagementIntegrityScore ?? null : request.deterministic.engagementIntegrityScore,
+    flags: Object.hasOwn(record, "flags") ? record.flags ?? null : [], reason: reason ?? null,
+    resolvedSoftFlags: resolutions ?? null };
 };
 
 const readDecision = (

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.spec.ts
@@ -1,3 +1,4 @@
+import { SystemClock } from "@social-monitor/shared-kernel";
 import type { SourceContentQualityReviewerPort, SourceContentQualityReviewRequest } from "../../ports";
 import { accepting, body, cutoff, fixture, query, review, run, scope } from "../../../../test/support/promotion-content-assessment";
 
@@ -44,6 +45,34 @@ describe("promotion assessment through Summary candidate and V2 (synthetic revie
     expect(high!.components.total).toBeGreaterThan(low!.components.total);
     expect(high!.components.relevance).toBe(low!.components.relevance);
     expect(high!.components.evidenceQuality).toBe(low!.components.evidenceQuality);
+  });
+
+  it("finishes the 81-candidate historical universe in two bounded pool waves", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(cutoff);
+    let active = 0;
+    let peak = 0;
+    let calls = 0;
+    try {
+      const reviewer = {
+        promotionTiming: { batchTimeoutMs: 600_000, totalTimeoutMs: 600_000, batchConcurrency: 6 },
+        reviewBatch: async (requests: readonly SourceContentQualityReviewRequest[]) => {
+          calls++;
+          peak = Math.max(peak, ++active);
+          await new Promise((resolve) => setTimeout(resolve, 225_711));
+          active--;
+          return requests.map((request) => review(request));
+        },
+      } as SourceContentQualityReviewerPort;
+      const pending = run(Array.from({ length: 81 }, (_, i) => fixture(`throughput-${String(i).padStart(2, "0")}`)),
+        reviewer, { clock: new SystemClock(), execution: { deadlineAtMs: cutoff.getTime() + 600_000 } });
+      await jest.advanceTimersByTimeAsync(451_423);
+      const result = await pending;
+      expect(calls).toBe(11);
+      expect(peak).toBe(6);
+      expect(result.ranking.orderedCandidateIds).toHaveLength(81);
+      expect(result.items.every((item) => !item.contentQuality.needsLlmReview)).toBe(true);
+    } finally { jest.useRealTimers(); }
   });
 
   it("reviews clean lists alongside product experience and preserves popularity competition", async () => {

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
@@ -14,7 +14,8 @@ export const PROMOTION_ASSESSMENT_BOUNDS = Object.freeze({
 
 // All supplied requests have already passed immutable non-content gates.
 // Every candidate starts pending; budget, transport and protocol failures cannot
-// fall through to a heuristic pass. Batches are sequential and popularity-free.
+// fall through to a heuristic pass. Batches are popularity-free; callers may
+// explicitly opt into bounded concurrency when their reviewer owns a safe pool.
 export const assessPromotionContent = async (input: {
   readonly observeHeadlineDiagnostic?: PromotionHeadlineDiagnosticObserver;
   readonly execution?: { readonly deadlineAtMs: number; readonly signal?: AbortSignal };
@@ -27,8 +28,10 @@ export const assessPromotionContent = async (input: {
   const timing = input.reviewer?.promotionTiming;
   const totalTimeoutMs = timing?.totalTimeoutMs ?? bounds.deadlineMs;
   const batchTimeoutMs = timing?.batchTimeoutMs ?? bounds.batchTimeoutMs;
+  const batchConcurrency = timing?.batchConcurrency ?? 1;
   if (!Number.isSafeInteger(batchTimeoutMs) || batchTimeoutMs <= 0 || batchTimeoutMs > 600_000 ||
-      !Number.isSafeInteger(totalTimeoutMs) || totalTimeoutMs <= 0 || totalTimeoutMs > 3_600_000) {
+      !Number.isSafeInteger(totalTimeoutMs) || totalTimeoutMs <= 0 || totalTimeoutMs > 3_600_000 ||
+      !Number.isSafeInteger(batchConcurrency) || batchConcurrency < 1 || batchConcurrency > 8) {
     throw new Error("Invalid promotion assessment deadline");
   }
   const verdicts = new Map(input.requests.map((request) => [request.candidateId,
@@ -52,8 +55,8 @@ export const assessPromotionContent = async (input: {
   let bytesUsed = 0;
   let count = 0;
   try {
-    while (requests.length > 0 && count < bounds.candidates &&
-        !controller.signal.aborted && input.clock.now().getTime() < deadline) {
+    const batches: SourceContentQualityReviewRequest[][] = [];
+    while (requests.length > 0 && count < bounds.candidates) {
       const batch: SourceContentQualityReviewRequest[] = [];
       let bytes = 2;
       bytesUsed += 2;
@@ -69,29 +72,37 @@ export const assessPromotionContent = async (input: {
         requests.shift(); batch.push(request); bytes += size; bytesUsed += size; count++;
       }
       if (batch.length === 0) break;
-      const now = input.clock.now().getTime();
-      const batchDeadline = Math.min(deadline, now + batchTimeoutMs);
-      const response = await reviewWithinDeadline(input.reviewer, batch, controller.signal,
-        batchDeadline - now, batchDeadline);
-      const timelyResponse = !controller.signal.aborted && input.clock.now().getTime() < deadline ? response : undefined;
-      const malformed = timelyResponse !== undefined && (!Array.isArray(timelyResponse) ||
-        timelyResponse.some((review) => !review || !batch.some((r) => r.candidateId === review.candidateId)) ||
-        new Set(timelyResponse.map((review) => review.candidateId)).size !== timelyResponse.length);
-      for (const request of batch) {
-        const verdict = malformed
-          ? pendingPromotionAssessment(request.deterministic, "invalid_batch")
-          : timelyResponse === undefined
-            ? pendingPromotionAssessment(request.deterministic, "unavailable_or_timeout")
-            : assessedPromotionVerdict(request,
-                timelyResponse.find((review) => review.candidateId === request.candidateId), input.policy);
-        verdicts.set(request.candidateId, verdict);
-        readerHeadlines.set(request.candidateId,
-          malformed || timelyResponse === undefined || verdict.reason.startsWith("promotion_assessment_pending:")
-            ? unavailablePromotionHeadline("invalid_assessment")
-            : assessPromotionReaderHeadline(request,
-                timelyResponse.find((review) => review.candidateId === request.candidateId), input.observeHeadlineDiagnostic));
-      }
+      batches.push(batch);
     }
+    let next = 0;
+    const processBatches = async () => {
+      while (next < batches.length && !controller.signal.aborted && input.clock.now().getTime() < deadline) {
+        const batch = batches[next++]!;
+        const now = input.clock.now().getTime();
+        const batchDeadline = Math.min(deadline, now + batchTimeoutMs);
+        const response = await reviewWithinDeadline(input.reviewer, batch, controller.signal,
+          batchDeadline - now, batchDeadline);
+        const timelyResponse = !controller.signal.aborted && input.clock.now().getTime() < deadline ? response : undefined;
+        const malformed = timelyResponse !== undefined && (!Array.isArray(timelyResponse) ||
+          timelyResponse.some((review) => !review || !batch.some((r) => r.candidateId === review.candidateId)) ||
+          new Set(timelyResponse.map((review) => review.candidateId)).size !== timelyResponse.length);
+        for (const request of batch) {
+          const verdict = malformed
+            ? pendingPromotionAssessment(request.deterministic, "invalid_batch")
+            : timelyResponse === undefined
+              ? pendingPromotionAssessment(request.deterministic, "unavailable_or_timeout")
+              : assessedPromotionVerdict(request,
+                  timelyResponse.find((review) => review.candidateId === request.candidateId), input.policy);
+          verdicts.set(request.candidateId, verdict);
+          readerHeadlines.set(request.candidateId,
+            malformed || timelyResponse === undefined || verdict.reason.startsWith("promotion_assessment_pending:")
+              ? unavailablePromotionHeadline("invalid_assessment")
+              : assessPromotionReaderHeadline(request,
+                  timelyResponse.find((review) => review.candidateId === request.candidateId), input.observeHeadlineDiagnostic));
+        }
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(batchConcurrency, batches.length) }, processBatches));
   } finally {
     clearTimeout(timer);
     input.execution?.signal?.removeEventListener("abort", abort);

--- a/libs/relevance/ports/source-content-quality-reviewer.port.ts
+++ b/libs/relevance/ports/source-content-quality-reviewer.port.ts
@@ -18,7 +18,11 @@ export type SourceContentQualityReviewResult = SourceContentQualityReview & {
 };
 
 export interface SourceContentQualityReviewerPort {
-  readonly promotionTiming?: { readonly batchTimeoutMs: number; readonly totalTimeoutMs: number };
+  readonly promotionTiming?: {
+    readonly batchTimeoutMs: number;
+    readonly totalTimeoutMs: number;
+    readonly batchConcurrency?: number;
+  };
   reviewBatch(
     requests: readonly SourceContentQualityReviewRequest[],
     options?: { readonly signal: AbortSignal; readonly timeoutMs?: number; readonly deadlineAtMs?: number },

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.spec.ts
@@ -26,6 +26,25 @@ function wiring(mutate?: (result: AgentRuntimeTaskResult) => AgentRuntimeTaskRes
 }
 
 describe("refresh operation assessment runtime budgets and receipts", () => {
+  it("admits six bound assessment batches concurrently and keeps other work exclusive", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const runTask = jest.fn(async (request: AgentRuntimeTaskCommand) => {
+      await gate;
+      return completedRefreshModelRequest(request, { reviews: [] });
+    });
+    const runtime = guardedRefreshRuntime({ delegate: { runTask, checkHealth: jest.fn() }, manifest: refreshManifest(),
+      assertLocal: () => undefined, assertCurrent: async () => undefined, record: jest.fn() });
+    const pending = Array.from({ length: 6 }, (_, i) => runtime.runTask(command(i)));
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(runTask).toHaveBeenCalledTimes(6);
+    await expect(runtime.runTask(command(6))).rejects.toThrow(/budget/u);
+    expect(() => runtime.assertUsable()).not.toThrow();
+    release();
+    await expect(Promise.all(pending)).resolves.toHaveLength(6);
+    expect(() => runtime.assertUsable()).not.toThrow();
+  });
+
   it("consumes exactly 200 candidates then blocks another batch without refunding", async () => {
     const test = wiring();
     for (let i = 0; i < 200; i += 8) await test.runtime.runTask(command(i, 8));

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-runtime.ts
@@ -12,7 +12,7 @@ export const refreshAssessmentLimits = Object.freeze({ ...PROMOTION_ASSESSMENT_B
 // alone cannot prevent a second assessment of the same captured candidate.
 export function refreshAssessmentBudget(now: () => number) {
   let deadline: number | undefined;
-  let batchDeadline: number | undefined;
+  const batchDeadlines = new Map<string, number>();
   let attempts = 0;
   let bytes = 0;
   const candidates = new Set<string>();
@@ -31,15 +31,18 @@ export function refreshAssessmentBudget(now: () => number) {
           command.timeoutMs! > bounds.batchTimeoutMs || now() + command.timeoutMs! > deadline) {
         throw new Error("Refresh assessment budget exhausted or duplicate candidate");
       }
-      batchDeadline = now() + command.timeoutMs!;
+      batchDeadlines.set(command.requestId, now() + command.timeoutMs!);
       ids.forEach((id) => candidates.add(id as string));
       bytes += size;
       attempts++;
       return { assessmentAttempts: attempts, assessmentCandidates: candidates.size,
         assessmentBytes: bytes, assessmentDeadlineAtMs: deadline };
     },
-    assertTimely() {
-      if ((deadline !== undefined && now() >= deadline) || (batchDeadline !== undefined && now() >= batchDeadline)) throw new Error("Refresh assessment deadline exhausted");
+    assertTimely(command: AgentRuntimeTaskCommand) {
+      const batchDeadline = batchDeadlines.get(command.requestId);
+      if ((deadline !== undefined && now() >= deadline) || batchDeadline === undefined || now() >= batchDeadline) {
+        throw new Error("Refresh assessment deadline exhausted");
+      }
     },
   };
 }

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.ts
@@ -82,7 +82,10 @@ export function createRefreshAssessmentReviewer(input: {
     throw new Error("Refresh assessment is incomplete; original operation requires reconciliation");
   };
   return {
-    promotionTiming: reviewer.promotionTiming,
+    // Six workers put the evidenced eleven 8-item batches into two waves
+    // (about 452s at 225.7s each), with the existing 600s operation deadline.
+    promotionTiming: Object.freeze({ batchTimeoutMs: reviewer.promotionTiming!.batchTimeoutMs,
+      totalTimeoutMs: reviewer.promotionTiming!.totalTimeoutMs, batchConcurrency: 6 }),
     assertCaptureComplete: () => {
       if ((input.capture || input.captureCanonical) && (captureFailures > 0 || terminalBatches !== batches)) {
         throw new Error("Refresh assessment capture is incomplete");

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -117,7 +117,8 @@ export function guardedRefreshRuntime(input: {
   const seen = new Set<string>();
   let ambiguous = false;
   let generated = false;
-  let inFlight = false;
+  let exclusiveInFlight = false;
+  const assessmentInFlight = new Set<string>();
   const assertUsable = () => {
     if (ambiguous) throw new Error("Refresh invocation budget requires reconciliation");
     try { input.assertLocal(); } catch (error) { ambiguous = true; throw error; }
@@ -140,7 +141,11 @@ export function guardedRefreshRuntime(input: {
       catch (error) { ambiguous = true; throw error; }
     },
     runTask: async (command, options) => {
-      if (ambiguous || inFlight || seen.has(command.requestId) ||
+      const isAssessment = command.purpose === sourceContentAssessmentPurpose;
+      const concurrencyFull = isAssessment
+        ? exclusiveInFlight || assessmentInFlight.size >= 6
+        : exclusiveInFlight || assessmentInFlight.size > 0;
+      if (ambiguous || concurrencyFull || seen.has(command.requestId) ||
           (generated && command.purpose === activeReaderSummaryPurposes.generate)) {
         // Only scoped, allowed task inputs can enter the private tape. This is
         // an attempt, not admission, and must not change guard state.
@@ -149,7 +154,7 @@ export function guardedRefreshRuntime(input: {
             command.provider === "codex" && command.controls.model === "gpt-5.6-sol" &&
             command.controls.reasoningEffort === expectedReasoningEffort(command.purpose)) {
           capture({ kind: "invocation_rejected", command, delegated: false,
-            reason: ambiguous ? "authority_rejected" : inFlight ? "in_flight" :
+            reason: ambiguous ? "authority_rejected" : concurrencyFull ? "in_flight" :
               seen.has(command.requestId) ? "duplicate_request" : "generation_already_consumed" });
         }
         throw new Error("Refresh invocation budget or model authority rejected");
@@ -163,7 +168,8 @@ export function guardedRefreshRuntime(input: {
       }
       seen.add(command.requestId);
       if (command.purpose === activeReaderSummaryPurposes.generate) generated = true;
-      inFlight = true;
+      if (isAssessment) assessmentInFlight.add(command.requestId);
+      else exclusiveInFlight = true;
       let delegated = false;
       let returnedResult: AgentRuntimeTaskResult | undefined;
       let canonicalRequestSha256: string | undefined;
@@ -225,7 +231,7 @@ export function guardedRefreshRuntime(input: {
         assertUsable(); // fsync/recording can itself cross the cutoff.
 
         if (command.purpose === sourceContentAssessmentPurpose) {
-          assessment.assertTimely();
+          assessment.assertTimely(command);
           if (options?.signal?.aborted) throw new Error("Refresh assessment cancelled");
         }
         if (input.capture && options?.signal) {
@@ -249,7 +255,7 @@ export function guardedRefreshRuntime(input: {
           throw new Error("Refresh invocation outcome requires reconciliation");
         }
         if (command.purpose === sourceContentAssessmentPurpose) {
-          try { assessment.assertTimely(); }
+          try { assessment.assertTimely(command); }
           catch (error) { notConsumedReason = "deadline"; throw error; }
           if (options?.signal?.aborted) { notConsumedReason = "aborted"; throw new Error("Refresh assessment cancelled"); }
         }
@@ -288,7 +294,11 @@ export function guardedRefreshRuntime(input: {
         capture({ kind: "invocation_failed", requestId: command.requestId, delegated });
         input.record({ ...identity, status: "requires_reconciliation" });
         throw new Error("Refresh invocation failed or is ambiguous; original operation remains consumed");
-      } finally { removeAbortCapture?.(); inFlight = false; }
+      } finally {
+        removeAbortCapture?.();
+        if (isAssessment) assessmentInFlight.delete(command.requestId);
+        else exclusiveInFlight = false;
+      }
     },
   };
 }

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.ts
@@ -240,10 +240,16 @@ export class RefreshPairedExport {
         this.append("models.jsonl", { ...event, assessmentBatch: context.assessmentBatch, relationId: context.relationId });
         return;
       }
-      const assessmentBatch = [...this.activeAssessmentBatches][0];
       const relationId = [...this.pendingRelations].at(-1);
       const assessmentPurpose = event.command.purpose === sourceContentAssessmentPurpose;
-      if ((assessmentPurpose && (assessmentBatch === undefined || this.activeAssessmentBatches.size !== 1)) ||
+      const matchingAssessmentBatches = assessmentPurpose ? [...this.activeAssessmentBatches].filter((batch) => {
+        const attempt = this.assessments.find((entry) => entry.phase === "attempt" && entry.batch === batch);
+        if (!attempt) return false;
+        const requests = JSON.parse(attempt.requestsJson) as SourceContentQualityReviewRequest[];
+        return event.command.prompt === JSON.stringify({ candidates: requests.map(promotionWireCandidate) });
+      }) : [];
+      const assessmentBatch = matchingAssessmentBatches[0];
+      if ((assessmentPurpose && matchingAssessmentBatches.length !== 1) ||
           (!assessmentPurpose && relationId === undefined)) throw new Error("Unbound model request");
       if (!assessmentPurpose) {
         const query = this.relationQueries.get(relationId!);


### PR DESCRIPTION
Accept the attested request-bound assessment dialect observed in production and process historical assessment batches through a bounded six-slot pool. Generation remains exclusive, failures stay fail-closed, and each batch retains its own deadline and capture binding.

This unblocks the reconciled historical Reader Promotion V2 refresh needed to verify popular relevant posts against the public summary.

Refs #293
Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Content assessments can now process multiple review batches concurrently, improving throughput while preserving safety limits.
  - Assessment responses using an alternative results format are now accepted and normalized automatically.

- **Bug Fixes**
  - Improved deadline tracking for concurrent assessment requests.
  - Improved matching of assessment results to the correct content batches.
  - Malformed or incomplete responses are handled consistently and remain pending review.

- **Tests**
  - Added coverage for concurrent processing, response compatibility, timeout handling, and runtime limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->