### PR TITLE
fix(reader-summary): accept reported reconciliation usage

### DIFF
--- a/prisma/migrations/20260911120000_reader_summary_reconciliation_reported_usage/migration.sql
+++ b/prisma/migrations/20260911120000_reader_summary_reconciliation_reported_usage/migration.sql
@@ -1,0 +1,62 @@
+-- @social-monitor-forward-migration
+-- A consumed provider request can return authoritative token counters even when
+-- the response cannot be converted into a summary. Preserve those counters in
+-- the append-only reconciliation instead of rejecting the reviewed evidence.
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL ROLE "social_monitor_public_schema_owner";
+
+ALTER TABLE "reader_summary_new_input_refresh_reconciliations"
+  DROP CONSTRAINT "rs_nir_reconciliations_accounting_check";
+
+ALTER TABLE "reader_summary_new_input_refresh_reconciliations"
+  ADD CONSTRAINT "rs_nir_reconciliations_accounting_check" CHECK (
+    jsonb_typeof("invocation") = 'object'
+    AND jsonb_typeof("accounting") = 'object'
+    AND "invocation" ?& ARRAY[
+      'requestId', 'purpose', 'requestSha256', 'attemptSha256',
+      'consumedAt', 'returnedAt', 'outcome', 'providerUsageReported'
+    ]
+    AND jsonb_typeof("invocation"->'requestId') = 'string'
+    AND jsonb_typeof("invocation"->'purpose') = 'string'
+    AND "invocation"->>'requestSha256' ~ '^[0-9a-f]{64}$'
+    AND "invocation"->>'attemptSha256' ~ '^[0-9a-f]{64}$'
+    AND "accounting" ?& ARRAY[
+      'summaryGenerations', 'publications', 'artifacts',
+      'providerInvocations', 'providerUsage'
+    ]
+    AND "accounting"->'summaryGenerations' = '0'::JSONB
+    AND "accounting"->'publications' = '0'::JSONB
+    AND "accounting"->'artifacts' = '0'::JSONB
+    AND "accounting"->'providerInvocations' = '1'::JSONB
+    AND (
+      (
+        "invocation"->'providerUsageReported' = 'false'::JSONB
+        AND NOT ("invocation" ? 'usage')
+        AND "accounting"->>'providerUsage' = 'unknown'
+        AND NOT ("accounting" ? 'usage')
+      )
+      OR
+      (
+        "invocation"->'providerUsageReported' = 'true'::JSONB
+        AND jsonb_typeof("invocation"->'usage') = 'object'
+        AND "invocation"->'usage' ?& ARRAY['inputTokens', 'outputTokens', 'totalTokens']
+        AND jsonb_typeof("invocation"->'usage'->'inputTokens') = 'number'
+        AND jsonb_typeof("invocation"->'usage'->'outputTokens') = 'number'
+        AND jsonb_typeof("invocation"->'usage'->'totalTokens') = 'number'
+        AND "invocation"->'usage'->>'inputTokens' ~ '^[0-9]+$'
+        AND "invocation"->'usage'->>'outputTokens' ~ '^[0-9]+$'
+        AND "invocation"->'usage'->>'totalTokens' ~ '^[0-9]+$'
+        AND ("invocation"->'usage'->>'inputTokens')::BIGINT >= 0
+        AND ("invocation"->'usage'->>'outputTokens')::BIGINT >= 0
+        AND ("invocation"->'usage'->>'totalTokens')::BIGINT =
+          ("invocation"->'usage'->>'inputTokens')::BIGINT +
+          ("invocation"->'usage'->>'outputTokens')::BIGINT
+        AND "accounting"->>'providerUsage' = 'reported'
+        AND "accounting"->'usage' = "invocation"->'usage'
+      )
+    )
+  );
+
+RESET ROLE;
+COMMIT;

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
@@ -6,7 +6,8 @@ import { refreshBytesHash, refreshHash, refreshKeyPrefix, refreshScope } from
 
 /** Operator-reviewed statement that one consumed new-input-refresh attempt is
  * accounted for. It asserts consumption, never success: the original job row is
- * never written to, and provider usage stays explicitly unknown. */
+ * never written to. Provider usage is preserved when the reviewed provider
+ * response reports it, and otherwise stays explicitly unknown. */
 export type RefreshReconciliationEvidence = Readonly<{
   format: "reader-summary-new-input-refresh-reconciliation-v1";
   tenantId: string; workspaceId: string; date: string;


### PR DESCRIPTION
A failed historical assessment can return authoritative token usage even when no summary is produced. The runtime already preserves those counters, but the database constraint only accepted unknown usage and rejected production reconciliation. This migration accepts either the original unknown shape or matching nonnegative reported counters while keeping append-only accounting and zero summary/publication/artifact invariants.\n\nValidation: diff check passed. Local dependency-based checks are unavailable because this clean workspace has no installed Prisma/Jest binaries; CI will run the canonical migration and PostgreSQL gates.\n\nRefs #293\nRefs #294