### PR TITLE
fix(reader-summary): admit reconciled reported usage

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-successor-current.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor-current.spec.ts
@@ -1,7 +1,8 @@
 import type * as PGliteModule from "@electric-sql/pglite";
 import { assertRefreshSuccessorCurrent } from "./reader-summary-new-input-refresh-successor";
 import { refreshOperation } from "./reader-summary-new-input-refresh-manifest";
-import { refreshReconciliationAccounting } from "./reader-summary-new-input-refresh-reconciliation";
+import { refreshReconciliationAccounting, refreshReconciliationAccountingFor } from
+  "./reader-summary-new-input-refresh-reconciliation";
 import { refreshNow } from "./reader-summary-new-input-refresh.spec-support";
 import { successorManifest, successorEvidence } from "./reader-summary-new-input-refresh-successor.spec-support";
 
@@ -50,6 +51,13 @@ describe("successor original and reconciliation SQL", () => {
     await expect(assertRefreshSuccessorCurrent(client, m, refreshNow)).resolves.toBeUndefined();
     expect((await db.query<{ accounting: unknown }>("select accounting from reader_summary_new_input_refresh_reconciliations")).rows[0]!.accounting)
       .toEqual(refreshReconciliationAccounting);
+  });
+  it("accepts exact provider-reported usage preserved by reconciliation", async () => {
+    const usage = { inputTokens: 90_824, outputTokens: 6_325, totalTokens: 97_149 };
+    const invocation = { ...e.invocation, providerUsageReported: true, usage };
+    await db.query("update reader_summary_new_input_refresh_reconciliations set invocation=$1::jsonb, accounting=$2::jsonb",
+      [JSON.stringify(invocation), JSON.stringify(refreshReconciliationAccountingFor({ ...e, invocation }))]);
+    await expect(assertRefreshSuccessorCurrent(client, m, refreshNow)).resolves.toBeUndefined();
   });
   it.each([
     "update reader_summary_jobs set status='RUNNING'",

--- a/scripts/lib/reader-summary-new-input-refresh-successor.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor.ts
@@ -4,7 +4,7 @@ import type { PrismaSummaryConnection } from "@social-monitor/summary/adapters/p
 import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-client";
 import { assertRefreshManifest, refreshBytesHash, refreshHash,
   type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
-import { refreshReconciliationAccounting, assertRefreshReconciliationEvidence,
+import { refreshReconciliationAccountingFor, assertRefreshReconciliationEvidence,
   type RefreshReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
 import { captureRefreshDatabaseAuthority } from "./reader-summary-new-input-refresh-capture";
 import { lockRefreshAuthority, readRefreshJobs, readRefreshPrior, readRefreshReconciliations } from
@@ -49,11 +49,13 @@ export async function assertRefreshSuccessorCurrent(client: Client, m: RefreshMa
       and r.tenant_id = ${m.tenantId}::uuid and r.workspace_id = ${m.workspaceId}::uuid
   `;
   const row = rows[0];
-  if (rows.length !== 1 || row?.valid !== true ||
-      refreshHash(row.accounting) !== refreshHash(refreshReconciliationAccounting)) {
+  if (rows.length !== 1 || row?.valid !== true) {
     throw new Error("Refresh successor original/reconciliation is missing, changed or not an unpublished failure");
   }
   assertRefreshReconciliationEvidence(row.evidence, [m.date]);
+  if (refreshHash(row.accounting) !== refreshHash(refreshReconciliationAccountingFor(row.evidence))) {
+    throw new Error("Refresh successor original/reconciliation is missing, changed or not an unpublished failure");
+  }
   if (row.evidence.invocation.outcome !== "failed" ||
       row.evidence.invocation.purpose !== "social_monitor.relevance.assess_source_content.v1") {
     throw new Error("Refresh successor requires a known failed assessment, never unknown completion");


### PR DESCRIPTION
Successor admission still compared reconciliation accounting against the legacy unknown-usage constant. Validate the stored evidence first, derive its exact expected accounting shape, and cover real provider-reported counters.\n\nRefs #293\nRefs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for refreshed reconciliation records with exact usage information.
  - Accounting checks now consistently reflect the usage details recorded in the reconciliation evidence.
  - Added coverage to verify successful validation when input, output, and total usage values are reported precisely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->