### PR TITLE
fix(reader-summary): reuse persisted promotion assessments

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
@@ -3,7 +3,7 @@ import { FeedItem } from "@social-monitor/feed/domain";
 import { activeReaderSummaryPurposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
 import { FixedClock } from "@social-monitor/shared-kernel";
 import { sourceContentAssessmentPurpose as purpose } from "./reader-summary-new-input-refresh-assessment-runtime";
-import { createRefreshAssessmentReviewer } from "./reader-summary-new-input-refresh-assessment";
+import { createRefreshAssessmentReviewer, hasRefreshSelectableEvidence } from "./reader-summary-new-input-refresh-assessment";
 import type { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
 import { selectorOutput, selectorWiring } from "./reader-summary-new-input-refresh-selector-composition.spec-support";
 import { publicationProbe } from "./reader-summary-new-input-refresh-model-composition.spec-support";
@@ -37,6 +37,27 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
     await test.select();
     expect(test.commands.filter((c) => c.purpose === purpose)).toHaveLength(1);
     expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/u);
+  });
+
+  it("reuses exact persisted selectable assessments without another assessment call", async () => {
+    const test = await selectorWiring();
+    const selection = await test.selectComplete();
+    const assessmentCalls = test.commands.filter((command) => command.purpose === purpose).length;
+    const persisted = createRefreshAssessmentReviewer({ env: {}, runtime: test.runtime,
+      clock: new FixedClock(refreshNow), canonicalEvidence: selection.selectedEvidence });
+
+    expect(hasRefreshSelectableEvidence(selection.selectedEvidence)).toBe(true);
+    expect(() => persisted.assertComplete(0, selection)).not.toThrow();
+    expect(test.commands.filter((command) => command.purpose === purpose)).toHaveLength(assessmentCalls);
+
+    const first = selection.selectedEvidence[0]!;
+    const forged = { ...selection, selectedEvidence: [{ ...first,
+      contentQuality: { ...first.contentQuality!, qualityScore: first.contentQuality!.qualityScore + 0.01 } },
+      ...selection.selectedEvidence.slice(1)] };
+    expect(() => persisted.assertComplete(0, forged)).toThrow(/reconciliation/u);
+    expect(hasRefreshSelectableEvidence(selection.selectedEvidence.map((item) => ({ ...item,
+      contentQuality: { ...item.contentQuality!, eligibleForSummary: false,
+        reason: "promotion_assessment_not_requested:hard_gate" } })))).toBe(false);
   });
 
   it("rejects nonempty partial coverage within the configured candidate cap", async () => {

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.ts
@@ -35,6 +35,10 @@ export type RefreshAssessmentCaptureEvent = Readonly<{
   failure?: "deadline" | "aborted" | "validation_or_runtime_failure";
 }>;
 
+export function hasRefreshSelectableEvidence(items: readonly SummaryEvidenceItem[]): boolean {
+  return items.some((item) => isPersistedSelectableEvidence(item));
+}
+
 // This caller only authorizes the existing subscription pool. A direct provider
 // override cannot bypass its invocation journal, installation or date authority.
 export function createRefreshAssessmentReviewer(input: {
@@ -52,6 +56,8 @@ export function createRefreshAssessmentReviewer(input: {
   // Selected objects cannot introduce or rewrite exemption provenance.
   const exemptBindings = new Set((input.canonicalEvidence ?? [])
     .filter(isCanonicalAssessmentExemption).map(exemptionBinding));
+  const persistedAssessmentBindings = new Set((input.canonicalEvidence ?? [])
+    .filter(isPersistedSelectableEvidence).map(exemptionBinding));
   // Bind the complete sanitized source representation independently of the
   // capped assessment request, for social and exempt GitHub evidence alike.
   const sourceTextBindings = new Set((input.canonicalEvidence ?? []).map(sourceTextBinding));
@@ -114,6 +120,7 @@ export function createRefreshAssessmentReviewer(input: {
           request.promotion?.sourceItemId === item.sourceItemId &&
           request.promotion?.sourceBindingId === item.sourceBindingId &&
           request.promotion?.interestId === item.interestId);
+        if (!recorded && persistedAssessmentBindings.has(exemptionBinding(item))) continue;
         const canonicalExemption = !recorded && exemptBindings.has(exemptionBinding(item));
         if (canonicalExemption) {
           if (quality.reason.startsWith("promotion_assessment:")) fail();
@@ -197,6 +204,14 @@ export function withRefreshAssessmentCompletion(selector: ReaderSummaryEvidenceS
     assessment.assertComplete(expected, selection);
     return selection;
   } };
+}
+
+function isPersistedSelectableEvidence(item: SummaryEvidenceItem): boolean {
+  const quality = item.contentQuality;
+  return quality?.eligibleForSummary === true && !quality.needsLlmReview &&
+    ["promote", "keep", "downrank"].includes(quality.decision) &&
+    !quality.reason.startsWith("promotion_assessment_pending:") &&
+    !quality.reason.startsWith("promotion_assessment_not_requested:");
 }
 
 function isCanonicalAssessmentExemption(item: SummaryEvidenceItem): boolean {

--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -22,7 +22,8 @@ import { readRefreshJobs, readRefreshPrior, readRefreshCounts, readRefreshReconc
 import { createRefreshAdmission } from "./reader-summary-new-input-refresh-admission";
 import { withRefreshPublicationLocks, type RefreshSnapshotProtection } from "./reader-summary-new-input-refresh-publication-lock";
 import { buildRefreshModelWiring, guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
-import { createRefreshAssessmentReviewer, withRefreshAssessmentCompletion } from "./reader-summary-new-input-refresh-assessment";
+import { createRefreshAssessmentReviewer, hasRefreshSelectableEvidence,
+  withRefreshAssessmentCompletion } from "./reader-summary-new-input-refresh-assessment";
 import { RefreshPairedExport } from "./reader-summary-new-input-refresh-paired-export";
 import { refreshCaptureModelControls } from "./reader-summary-new-input-refresh-model";
 import { withRefreshSelectionAudit } from "./reader-summary-new-input-refresh-selection-audit";
@@ -103,9 +104,10 @@ async function executeRefresh(input: RefreshExecutionInput, capture?: RefreshPai
   await input.assertRuntime();
   const { assessmentCandidateCount, canonicalEvidence } = await preflightRefreshSelection({ configuredInterests: input.configuredInterests, feed, date: m.date,
     observedThrough: new Date(m.observedThrough), clock });
+  const hasSelectableEvidence = hasRefreshSelectableEvidence(canonicalEvidence);
   input.record({ status: "preflight", operation: m.operation, assessmentCandidateCount,
-    plannedSummaryGenerations: assessmentCandidateCount === 0 ? 0 : 1 });
-  if (assessmentCandidateCount === 0) {
+    plannedSummaryGenerations: assessmentCandidateCount === 0 && !hasSelectableEvidence ? 0 : 1 });
+  if (assessmentCandidateCount === 0 && !hasSelectableEvidence) {
     await assertCurrent();
     const countsAfter = await readRefreshCounts(summary, m.date);
     assertRefreshEqual(countsAfter, countsBefore, "empty input counts");

--- a/scripts/lib/reader-summary-new-input-refresh-execution.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-execution.ts
@@ -104,7 +104,7 @@ async function executeRefresh(input: RefreshExecutionInput, capture?: RefreshPai
   await input.assertRuntime();
   const { assessmentCandidateCount, canonicalEvidence } = await preflightRefreshSelection({ configuredInterests: input.configuredInterests, feed, date: m.date,
     observedThrough: new Date(m.observedThrough), clock });
-  const hasSelectableEvidence = hasRefreshSelectableEvidence(canonicalEvidence);
+  const hasSelectableEvidence = hasRefreshSelectableEvidence(canonicalEvidence ?? []);
   input.record({ status: "preflight", operation: m.operation, assessmentCandidateCount,
     plannedSummaryGenerations: assessmentCandidateCount === 0 && !hasSelectableEvidence ? 0 : 1 });
   if (assessmentCandidateCount === 0 && !hasSelectableEvidence) {


### PR DESCRIPTION
Historical refresh previously returned no_eligible_input whenever no new assessment call was required, even when the canonical snapshot already contained persisted selectable assessments. This keeps exact canonical evidence bindings, permits generation from already-assessed eligible items, and continues to reject pending/not-requested or mutated evidence.\n\nProduction evidence for 2026-09-02: 58 eligible summary items and 34 top-read eligible items were present while assessmentCandidateCount was 0; the old branch produced no publication.\n\nValidation: 91 focused tests, TypeScript build, ESLint, architecture, code-quality and source-line-cap gates.\n\nRefs #293\nRefs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refreshes now proceed when eligible selectable evidence is available, even when no new assessment candidates are found.
  * Previously persisted, valid evidence can be reused during refreshes instead of being incorrectly treated as incomplete.
  * Changes to evidence quality scores are detected and reconciled to help ensure refreshed summaries use accurate information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->