### PR TITLE
fix(reader-summary): admit completed assessment recovery

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-successor-current.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor-current.spec.ts
@@ -54,7 +54,7 @@ describe("successor original and reconciliation SQL", () => {
   });
   it("accepts exact provider-reported usage preserved by reconciliation", async () => {
     const usage = { inputTokens: 90_824, outputTokens: 6_325, totalTokens: 97_149 };
-    const invocation = { ...e.invocation, providerUsageReported: true, usage };
+    const invocation = { ...e.invocation, outcome: "completed", providerUsageReported: true, usage };
     await db.query("update reader_summary_new_input_refresh_reconciliations set invocation=$1::jsonb, accounting=$2::jsonb",
       [JSON.stringify(invocation), JSON.stringify(refreshReconciliationAccountingFor({ ...e, invocation }))]);
     await expect(assertRefreshSuccessorCurrent(client, m, refreshNow)).resolves.toBeUndefined();

--- a/scripts/lib/reader-summary-new-input-refresh-successor.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor.ts
@@ -56,9 +56,12 @@ export async function assertRefreshSuccessorCurrent(client: Client, m: RefreshMa
   if (refreshHash(row.accounting) !== refreshHash(refreshReconciliationAccountingFor(row.evidence))) {
     throw new Error("Refresh successor original/reconciliation is missing, changed or not an unpublished failure");
   }
-  if (row.evidence.invocation.outcome !== "failed" ||
-      row.evidence.invocation.purpose !== "social_monitor.relevance.assess_source_content.v1") {
-    throw new Error("Refresh successor requires a known failed assessment, never unknown completion");
+  const invocation = row.evidence.invocation;
+  const knownTerminalAssessment = invocation.outcome === "failed" ||
+    (invocation.outcome === "completed" && invocation.providerUsageReported);
+  if (!knownTerminalAssessment ||
+      invocation.purpose !== "social_monitor.relevance.assess_source_content.v1") {
+    throw new Error("Refresh successor requires a known terminal assessment outcome");
   }
 }
 


### PR DESCRIPTION
The production provider completed the paid assessment and reported exact usage, but local schema admission rejected its response before a summary existed. Treat that attested terminal outcome as recoverable while continuing to reject completed outcomes without reported usage and every unrelated purpose.\n\nRefs #293\nRefs #294