### PR TITLE
fix(reader-summary): resume reconciled relation checks

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-successor-current.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor-current.spec.ts
@@ -52,6 +52,13 @@ describe("successor original and reconciliation SQL", () => {
     expect((await db.query<{ accounting: unknown }>("select accounting from reader_summary_new_input_refresh_reconciliations")).rows[0]!.accounting)
       .toEqual(refreshReconciliationAccounting);
   });
+  it("accepts a terminal story-relation verification failure", async () => {
+    const invocation = { ...e.invocation,
+      purpose: "social_monitor.reader_summary.verify_story_relations.v2", outcome: "failed" as const };
+    await db.query("update reader_summary_new_input_refresh_reconciliations set invocation=$1::jsonb, accounting=$2::jsonb",
+      [JSON.stringify(invocation), JSON.stringify(refreshReconciliationAccountingFor({ ...e, invocation }))]);
+    await expect(assertRefreshSuccessorCurrent(client, m, refreshNow)).resolves.toBeUndefined();
+  });
   it("accepts exact provider-reported usage preserved by reconciliation", async () => {
     const usage = { inputTokens: 90_824, outputTokens: 6_325, totalTokens: 97_149 };
     const invocation = { ...e.invocation, outcome: "completed", providerUsageReported: true, usage };

--- a/scripts/lib/reader-summary-new-input-refresh-successor.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor.ts
@@ -59,9 +59,12 @@ export async function assertRefreshSuccessorCurrent(client: Client, m: RefreshMa
   const invocation = row.evidence.invocation;
   const knownTerminalAssessment = invocation.outcome === "failed" ||
     (invocation.outcome === "completed" && invocation.providerUsageReported);
-  if (!knownTerminalAssessment ||
-      invocation.purpose !== "social_monitor.relevance.assess_source_content.v1") {
-    throw new Error("Refresh successor requires a known terminal assessment outcome");
+  const resumablePurposes = new Set([
+    "social_monitor.relevance.assess_source_content.v1",
+    "social_monitor.reader_summary.verify_story_relations.v2",
+  ]);
+  if (!knownTerminalAssessment || !resumablePurposes.has(invocation.purpose)) {
+    throw new Error("Refresh successor requires a known terminal resumable provider outcome");
   }
 }
 


### PR DESCRIPTION
A terminal provider failure during story-relation verification leaves an unpublished FAILED job that is safely reconciled but cannot currently receive a one-time successor. Allow that exact resumable purpose under the existing immutable reconciliation and successor checks.\n\nValidation: npx jest scripts/lib/reader-summary-new-input-refresh-successor-current.spec.ts --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refresh recovery now correctly continues when story-relation verification ends in a recognized resumable failure.
  - Updated validation messaging more accurately reflects the range of terminal outcomes that can be safely resumed.
- **Tests**
  - Added coverage to verify that refresh recovery succeeds with the newly supported story-relation verification outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->