### PR TITLE
docs(x): mark historical recovery as dormant

### DIFF
--- a/apps/x-collector/src/x_collector/x_observation/__init__.py
+++ b/apps/x-collector/src/x_collector/x_observation/__init__.py
@@ -1,1 +1,6 @@
-"""Private retained-X observation. No runtime composition or implicit clients."""
+"""Dormant historical X-recovery experiment, not an approved runtime path.
+
+Prefer a simpler bounded and auditable recovery for a concrete missed-post
+incident. Do not compose, activate, or extend this package without fresh
+explicit owner agreement and evidence that the simpler path is insufficient.
+"""

--- a/libs/ingestion/domain/x-observation/x-observation-contract.ts
+++ b/libs/ingestion/domain/x-observation/x-observation-contract.ts
@@ -1,4 +1,9 @@
 import type { XAcquisitionPayload, XSupplementary, XPredecessorEvidence } from "./x-observation-acquisition-contract";
+
+// OWNER STATUS: dormant historical-recovery experiment, not an approved runtime path.
+// Prefer a simpler bounded and auditable recovery for any concrete missed-post incident.
+// Do not compose, activate, or extend this design without fresh explicit owner agreement
+// and evidence that the simpler recovery path cannot safely meet the requirement.
 // Incident-only values. Generated transport types never enter the authority model.
 export const xOperationId = "seven-day-6101-6102/x-observation-v1";
 export const xTenantId = "00000000-0000-7000-8000-000000006101";


### PR DESCRIPTION
Records the owner decision directly in the TypeScript and Python observation code boundaries. The historical X recovery approach remains dormant and must not be composed, activated or extended without fresh explicit owner agreement. A simpler bounded and auditable recovery path is preferred for any concrete missed-post incident.\n\nRelated: #333\nRelated: #338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the X-recovery experiment is dormant and not an approved runtime path.
  - Documented that activation or extension requires explicit owner approval and evidence that simpler recovery is insufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->