### PR TITLE
fix(reader-summary): allow bounded second recovery successor

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-manifest.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-manifest.ts
@@ -56,8 +56,8 @@ export const refreshOperation = (m: Omit<RefreshManifest, "operation">): string 
     runtime: m.runtime, model: m.model, effort: m.reasoningEffort,
   });
 
-export function assertRefreshManifest(m: RefreshManifest, now: Date, fresh = true): void {
-  if (m.successor !== undefined) assertRefreshSuccessorGrant(m, now, { assertOriginal: assertRefreshManifest, hash: refreshHash });
+export function assertRefreshManifest(m: RefreshManifest, now: Date, fresh = true, depth = 0): void {
+  if (m.successor !== undefined) assertRefreshSuccessorGrant(m, now, { assertOriginal: assertRefreshManifest, hash: refreshHash }, depth);
   if (m.format !== "reader-summary-seven-day-new-input-v1" ||
       m.tenantId !== refreshScope.tenantId || m.workspaceId !== refreshScope.workspaceId ||
       !refreshDates.includes(m.date) || m.timezone !== "UTC" ||

--- a/scripts/lib/reader-summary-new-input-refresh-successor-chain.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor-chain.spec.ts
@@ -1,0 +1,108 @@
+import type * as PGliteModule from "@electric-sql/pglite";
+import { assertRefreshSuccessorCurrent } from "./reader-summary-new-input-refresh-successor";
+import { refreshOperation } from "./reader-summary-new-input-refresh-manifest";
+import { refreshReconciliationAccounting, refreshReconciliationAccountingFor } from
+  "./reader-summary-new-input-refresh-reconciliation";
+import { refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import { chainedSuccessorManifests, chainedRootEvidence, chainedFirstSuccessorEvidence,
+  chainedRootJobId, chainedFirstSuccessorJobId } from "./reader-summary-new-input-refresh-successor.spec-support";
+
+// The production defect: a reconciled terminal story-relation-verification
+// failure inside the FIRST successor manifest needs its own successor. This
+// suite proves the exact bounded two-stage shape is admitted end to end
+// (through the real SQL, not a mocked predicate) while depth-3, wrong-purpose
+// and tampered variants stay rejected.
+describe("bounded two-stage successor recovery: SQL-verified chain", () => {
+  let db: PGliteModule.PGlite;
+  const chain = chainedSuccessorManifests();
+  const rootEvidence = chainedRootEvidence(chain);
+  const firstEvidence = chainedFirstSuccessorEvidence(chain);
+  const client = { $queryRaw: async <T>(strings: TemplateStringsArray, ...values: readonly unknown[]): Promise<T> => {
+    const sql = strings.reduce((text, part, index) => text + (index ? `$${index}` : "") + part, "");
+    return (await db.query(sql, [...values])).rows as T;
+  } };
+
+  const insertHop = async (jobId: string, reconciliationId: string,
+    evidence: ReturnType<typeof chainedRootEvidence>) => {
+    await db.query(`insert into reader_summary_jobs (id, tenant_id, workspace_id, status, idempotency_key,
+      failed_at, cadence, scope_type, scope_key, period_timezone, period_started_at, period_ended_at)
+      values ($1, $2, $3, 'FAILED', $4, $5, 'daily', 'workspace', 'workspace', 'UTC', $6, $7)`,
+    [jobId, chain.second.tenantId, chain.second.workspaceId, evidence.operation, refreshNow.toISOString(),
+      chain.second.startedAt, chain.second.endedAt]);
+    await db.query(`insert into reader_summary_new_input_refresh_reconciliations
+      select $1, j.tenant_id, j.workspace_id, j.id, j.idempotency_key, j.status,
+        encode(sha256(convert_to(to_jsonb(j)::text, 'UTF8')), 'hex'), $2,
+        j.period_started_at, j.period_ended_at, $3, $4::jsonb, $5::jsonb from reader_summary_jobs j where j.id = $6`,
+    [reconciliationId, evidence.manifestSha256, evidence.reason, JSON.stringify(evidence.invocation),
+      JSON.stringify(refreshReconciliationAccounting), jobId]);
+  };
+
+  beforeAll(async () => {
+    // Native loader keeps PGlite's internal dynamic imports outside Jest's VM;
+    // the ordinary repository test command needs no experimental VM flags.
+    const { PGlite: MemoryPostgres } = process.getBuiltinModule("module").createRequire(__filename)("@electric-sql/pglite") as typeof PGliteModule;
+    db = new MemoryPostgres();
+    await db.exec(`create table reader_summary_jobs (
+      id uuid primary key, tenant_id uuid, workspace_id uuid, status text, idempotency_key text,
+      reader_summary_artifact_id uuid, completed_at timestamptz, failed_at timestamptz,
+      cadence text, scope_type text, scope_key text, period_timezone text,
+      interest_id uuid, user_id text, subscription_id uuid,
+      period_started_at timestamptz, period_ended_at timestamptz,
+      unique(tenant_id, idempotency_key));
+      create table reader_summary_publications (reader_summary_job_id uuid);
+      create table reader_summary_new_input_refresh_reconciliations (
+        id uuid primary key, tenant_id uuid, workspace_id uuid, reader_summary_job_id uuid,
+        operation text, job_status text, job_sha256 text, manifest_sha256 text,
+        period_started_at timestamptz, period_ended_at timestamptz, reason text, invocation jsonb, accounting jsonb,
+        unique(tenant_id, workspace_id, reader_summary_job_id), unique(tenant_id, operation));`);
+  }, 30_000);
+  afterAll(async () => { await db?.close(); });
+  beforeEach(async () => {
+    await db.exec("begin");
+    await insertHop(chainedRootJobId, chain.first.successor!.reconciliationId, rootEvidence);
+    await insertHop(chainedFirstSuccessorJobId, chain.second.successor!.reconciliationId, firstEvidence);
+  });
+  afterEach(async () => { await db.exec("rollback"); });
+
+  it("accepts the exact production-shaped two-stage recovery chain", async () => {
+    await expect(assertRefreshSuccessorCurrent(client, chain.second, refreshNow)).resolves.toBeUndefined();
+  });
+
+  it("rejects the chain when the immediate (first-successor) hop purpose is not story-relation verification", async () => {
+    const invocation = { ...firstEvidence.invocation, purpose: "social_monitor.relevance.assess_source_content.v1" };
+    await db.query("update reader_summary_new_input_refresh_reconciliations set invocation=$1::jsonb, accounting=$2::jsonb where reader_summary_job_id=$3",
+      [JSON.stringify(invocation), JSON.stringify(refreshReconciliationAccountingFor({ ...firstEvidence, invocation })), chainedFirstSuccessorJobId]);
+    await expect(assertRefreshSuccessorCurrent(client, chain.second, refreshNow)).rejects.toThrow(/story-relation/);
+  });
+
+  it("rejects the chain when the root hop purpose is not the source-content assessment", async () => {
+    const invocation = { ...rootEvidence.invocation, purpose: "social_monitor.reader_summary.verify_story_relations.v2" };
+    await db.query("update reader_summary_new_input_refresh_reconciliations set invocation=$1::jsonb, accounting=$2::jsonb where reader_summary_job_id=$3",
+      [JSON.stringify(invocation), JSON.stringify(refreshReconciliationAccountingFor({ ...rootEvidence, invocation })), chainedRootJobId]);
+    await expect(assertRefreshSuccessorCurrent(client, chain.second, refreshNow)).rejects.toThrow(/source-content assessment/);
+  });
+
+  it("rejects the chain when the root hop is not itself a terminal outcome", async () => {
+    const invocation = { ...rootEvidence.invocation, outcome: "running" };
+    await db.query("update reader_summary_new_input_refresh_reconciliations set invocation=$1::jsonb, accounting=$2::jsonb where reader_summary_job_id=$3",
+      [JSON.stringify(invocation), JSON.stringify(refreshReconciliationAccountingFor({ ...rootEvidence, invocation })), chainedRootJobId]);
+    await expect(assertRefreshSuccessorCurrent(client, chain.second, refreshNow)).rejects.toThrow(/source-content assessment/);
+  });
+
+  it("rejects the chain when the root hop's committed manifest bytes no longer match", async () => {
+    await db.query("update reader_summary_new_input_refresh_reconciliations set manifest_sha256=repeat('b',64) where reader_summary_job_id=$1",
+      [chainedRootJobId]);
+    await expect(assertRefreshSuccessorCurrent(client, chain.second, refreshNow)).rejects.toThrow(/missing, changed/);
+  });
+
+  it("rejects a third-stage extension of the chain before any query is even needed", async () => {
+    const thirdDraft = { ...chain.second, successor: {
+      format: "reader-summary-new-input-refresh-successor-v1" as const,
+      originalJobId: "00000000-0000-4000-8000-000000000050",
+      reconciliationId: "00000000-0000-4000-8000-000000000051",
+      originalManifestJson: JSON.stringify(chain.second), expiresAt: "2026-09-05T22:25:00.000Z",
+    } };
+    const third = { ...thirdDraft, operation: refreshOperation(thirdDraft) };
+    await expect(assertRefreshSuccessorCurrent(client, third, refreshNow)).rejects.toThrow(/depth/);
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-successor-grant.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor-grant.spec.ts
@@ -1,7 +1,7 @@
 import { assertRefreshManifest, refreshOperation, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
 import { parseRefreshCommand } from "../run-reader-summary-new-input-refresh";
 import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
-import { successorManifest } from "./reader-summary-new-input-refresh-successor.spec-support";
+import { successorManifest, chainedSuccessorManifests } from "./reader-summary-new-input-refresh-successor.spec-support";
 
 describe("explicit one-time successor manifest", () => {
   it("requires an explicit date, grant file and reviewed digest", () => {
@@ -58,5 +58,56 @@ describe("explicit one-time successor manifest", () => {
     const m = refreshManifest();
     expect(refreshOperation({ ...m, preparedAt: refreshNow.toISOString() })).toBe(m.operation);
     expect(refreshOperation({ ...m, authority: { ...m.authority, engagementSha256: "b".repeat(64) } })).not.toBe(m.operation);
+  });
+});
+
+describe("bounded two-stage successor recovery chain", () => {
+  it("admits a second successor whose original is itself a resumed successor of a root with no successor", () => {
+    const { second } = chainedSuccessorManifests();
+    expect(() => assertRefreshManifest(second, refreshNow)).not.toThrow();
+  });
+  it("admits an expired historical nested grant while requiring the active grant to remain live", () => {
+    const { second } = chainedSuccessorManifests();
+    const later = new Date("2026-09-05T22:24:00.000Z");
+    const first = JSON.parse(second.successor!.originalManifestJson) as RefreshManifest;
+    const expiredNested = { ...first, successor: { ...first.successor!, expiresAt: "2026-09-05T22:15:00.000Z" } };
+    const activeDraft = { ...second, successor: { ...second.successor!, originalManifestJson: JSON.stringify(expiredNested) } };
+    const active = { ...activeDraft, operation: refreshOperation(activeDraft) };
+    expect(() => assertRefreshManifest(active, later)).not.toThrow();
+    expect(() => assertRefreshManifest(active, new Date("2026-09-05T22:25:00.000Z"))).toThrow(/expired/);
+  });
+  it("rejects a third successor stage on top of an already-nested chain", () => {
+    const { second } = chainedSuccessorManifests();
+    const thirdDraft = { ...second, successor: {
+      format: "reader-summary-new-input-refresh-successor-v1" as const,
+      originalJobId: "00000000-0000-4000-8000-000000000050",
+      reconciliationId: "00000000-0000-4000-8000-000000000051",
+      originalManifestJson: JSON.stringify(second), expiresAt: "2026-09-05T22:25:00.000Z",
+    } };
+    const third = { ...thirdDraft, operation: refreshOperation(thirdDraft) };
+    expect(() => assertRefreshManifest(third, refreshNow)).toThrow(/depth/);
+  });
+  it("rejects a nested chain that reuses the same original job/reconciliation identity across both stages", () => {
+    const { first } = chainedSuccessorManifests();
+    // Both stages point at the exact same root job/reconciliation instead of
+    // the first successor authorizing the second: a degenerate, non-advancing chain.
+    const secondDraft = { ...first, successor: { ...first.successor!, originalManifestJson: JSON.stringify(first) } };
+    const second = { ...secondDraft, operation: refreshOperation(secondDraft) };
+    expect(() => assertRefreshManifest(second, refreshNow)).toThrow(/chain/);
+  });
+  it("rejects a chain whose nested root bytes were altered after being embedded", () => {
+    const { root, first, second } = chainedSuccessorManifests();
+    const tamperedRootDraft = { ...root, authority: { ...root.authority, engagementSha256: "b".repeat(64) } };
+    const tamperedRoot = { ...tamperedRootDraft, operation: refreshOperation(tamperedRootDraft) };
+    const tamperedFirst = { ...first, successor: { ...first.successor!, originalManifestJson: JSON.stringify(tamperedRoot) } };
+    const tamperedSecondDraft = { ...second, successor: { ...second.successor!, originalManifestJson: JSON.stringify(tamperedFirst) } };
+    const tamperedSecond = { ...tamperedSecondDraft, operation: refreshOperation(tamperedSecondDraft) };
+    expect(() => assertRefreshManifest(tamperedSecond, refreshNow)).toThrow(/differs from the original authority/);
+  });
+  it("rejects a chain that reuses the root's job id for the second stage's own grant, even with a distinct reconciliation id", () => {
+    const { first, second } = chainedSuccessorManifests();
+    const secondDraft = { ...second, successor: { ...second.successor!, originalJobId: first.successor!.originalJobId } };
+    const partiallyReused = { ...secondDraft, operation: refreshOperation(secondDraft) };
+    expect(() => assertRefreshManifest(partiallyReused, refreshNow)).toThrow(/chain/);
   });
 });

--- a/scripts/lib/reader-summary-new-input-refresh-successor-grant.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor-grant.ts
@@ -17,10 +17,19 @@ export function refreshSuccessorIdentity(grant: RefreshSuccessorGrant) {
     reconciliationId: grant.reconciliationId };
 }
 
+/** A successor chain is bounded to exactly two stages: the manifest under
+ * active preparation (depth 0) may authorize against an original that is
+ * itself a successor (the resumed first attempt), but that nested original's
+ * own original must be a root with no further successor. Depth counts hops
+ * already unwrapped by the caller, so depth 1 is the deepest nested grant
+ * this function will ever unwrap; anything past it is an unbounded chain. */
+const nestedGrantDepthLimit = 1;
+
 // Dependencies are supplied by manifest validation, avoiding a runtime cycle.
 export function assertRefreshSuccessorGrant(
   m: Omit<RefreshManifest, "operation">, now: Date,
-  deps: { assertOriginal(m: RefreshManifest, now: Date, fresh: boolean): void; hash(value: unknown): string },
+  deps: { assertOriginal(m: RefreshManifest, now: Date, fresh: boolean, depth: number): void; hash(value: unknown): string },
+  depth = 0,
 ): RefreshManifest {
   const grant = m.successor;
   const uuid = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/u;
@@ -33,17 +42,29 @@ export function assertRefreshSuccessorGrant(
     throw new Error("Refresh successor grant is malformed");
   }
   const expires = new Date(grant.expiresAt);
+  // A nested (depth > 0) grant already lived out its window when its own
+  // successor was consumed; only its bounded shape is re-checked here, never
+  // whether it is still open right now.
   if (!Number.isFinite(expires.getTime()) || expires.toISOString() !== grant.expiresAt ||
-      expires.getTime() <= now.getTime() ||
+      (depth === 0 && expires.getTime() <= now.getTime()) ||
       expires.getTime() <= Date.parse(m.preparedAt) ||
       expires.getTime() > Date.parse(m.preparedAt) + 30 * 60_000) {
     throw new Error("Refresh successor grant is expired or has invalid expiry");
   }
   const original = JSON.parse(grant.originalManifestJson) as RefreshManifest;
-  if (!original || original.successor !== undefined) {
+  if (!original) {
     throw new Error("Refresh successor cannot authorize a successor chain");
   }
-  deps.assertOriginal(original, now, false);
+  if (original.successor !== undefined) {
+    if (depth >= nestedGrantDepthLimit) {
+      throw new Error("Refresh successor chain depth exceeds the bounded two-stage recovery limit");
+    }
+    if (grant.originalJobId === original.successor.originalJobId ||
+        grant.reconciliationId === original.successor.reconciliationId) {
+      throw new Error("Refresh successor chain cannot reuse the same original reconciliation");
+    }
+  }
+  deps.assertOriginal(original, now, false, depth + 1);
   if (original.date !== m.date || original.tenantId !== m.tenantId || original.workspaceId !== m.workspaceId ||
       original.startedAt !== m.startedAt || original.endedAt !== m.endedAt || original.timezone !== m.timezone ||
       deps.hash(original.prior) !== deps.hash(m.prior) || deps.hash(original.authority) !== deps.hash(m.authority)) {

--- a/scripts/lib/reader-summary-new-input-refresh-successor.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor.spec-support.ts
@@ -28,3 +28,39 @@ export function successorJob(m = successorManifest(), id = "00000000-0000-4000-8
       startedAt: new Date(m.startedAt), endedAt: new Date(m.endedAt) }),
     idempotencyKey: m.operation, requestedAt: refreshNow });
 }
+
+// The bounded two-stage recovery shape: a root that failed the source-content
+// assessment, a first successor that resumed it and failed the story-relation
+// verification, and a second successor resuming that first successor.
+export const chainedRootJobId = "00000000-0000-4000-8000-000000000030";
+export const chainedRootReconciliationId = "00000000-0000-4000-8000-000000000031";
+export const chainedFirstSuccessorJobId = "00000000-0000-4000-8000-000000000040";
+export const chainedFirstSuccessorReconciliationId = "00000000-0000-4000-8000-000000000041";
+export function chainedSuccessorManifests(): { root: RefreshManifest; first: RefreshManifest; second: RefreshManifest } {
+  const root = refreshManifest();
+  const firstDraft = { ...root, successor: {
+    format: "reader-summary-new-input-refresh-successor-v1" as const,
+    originalJobId: chainedRootJobId, reconciliationId: chainedRootReconciliationId,
+    originalManifestJson: JSON.stringify(root), expiresAt: "2026-09-05T22:25:00.000Z",
+  } };
+  const first = { ...firstDraft, operation: refreshOperation(firstDraft) };
+  const secondDraft = { ...first, successor: {
+    format: "reader-summary-new-input-refresh-successor-v1" as const,
+    originalJobId: chainedFirstSuccessorJobId, reconciliationId: chainedFirstSuccessorReconciliationId,
+    originalManifestJson: JSON.stringify(first), expiresAt: "2026-09-05T22:25:00.000Z",
+  } };
+  const second = { ...secondDraft, operation: refreshOperation(secondDraft) };
+  return { root, first, second };
+}
+export function chainedRootEvidence(chain = chainedSuccessorManifests()) {
+  const base = reconciliationEvidence();
+  return { ...base, date: chain.root.date, jobId: chainedRootJobId, operation: chain.root.operation,
+    manifestSha256: refreshBytesHash(Buffer.from(JSON.stringify(chain.root))),
+    invocation: { ...base.invocation, purpose: "social_monitor.relevance.assess_source_content.v1", outcome: "failed" } };
+}
+export function chainedFirstSuccessorEvidence(chain = chainedSuccessorManifests()) {
+  const base = reconciliationEvidence();
+  return { ...base, date: chain.first.date, jobId: chainedFirstSuccessorJobId, operation: chain.first.operation,
+    manifestSha256: refreshBytesHash(Buffer.from(JSON.stringify(chain.first))),
+    invocation: { ...base.invocation, purpose: "social_monitor.reader_summary.verify_story_relations.v2", outcome: "failed" } };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-successor.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor.ts
@@ -14,57 +14,95 @@ import { assertRefreshSuccessorGrant } from "./reader-summary-new-input-refresh-
 import { withRefreshPublicationLocks } from "./reader-summary-new-input-refresh-publication-lock";
 
 type Client = Pick<PrismaReaderSummaryClient, "$queryRaw">;
-/** Verify the committed reconciliation and the exact unchanged FAILED row.
- * Unknown provider usage remains unknown; a grant supplies no usage estimate. */
-export async function assertRefreshSuccessorCurrent(client: Client, m: RefreshManifest, now: Date) {
-  assertRefreshManifest(m, now);
-  const original = assertRefreshSuccessorGrant(m, now, { assertOriginal: assertRefreshManifest, hash: refreshHash });
-  const grant = m.successor!;
+const sourceContentAssessmentPurpose = "social_monitor.relevance.assess_source_content.v1";
+const storyRelationVerificationPurpose = "social_monitor.reader_summary.verify_story_relations.v2";
+const resumablePurposes = new Set([sourceContentAssessmentPurpose, storyRelationVerificationPurpose]);
+const knownTerminalAssessment = (invocation: RefreshReconciliationEvidence["invocation"]) =>
+  invocation.outcome === "failed" || (invocation.outcome === "completed" && invocation.providerUsageReported);
+
+type RefreshSuccessorHop = Readonly<{
+  tenantId: string; workspaceId: string; date: string; startedAt: string; endedAt: string;
+  reconciliationId: string; originalJobId: string; expectedOperation: string; expectedManifestJson: string;
+}>;
+/** Verify the committed reconciliation and the exact unchanged FAILED row for
+ * one hop of the chain (the manifest under preparation, or a nested original). */
+async function readRefreshSuccessorHopEvidence(client: Client, hop: RefreshSuccessorHop):
+  Promise<RefreshReconciliationEvidence> {
   const rows = await client.$queryRaw<readonly {
     evidence: RefreshReconciliationEvidence; accounting: unknown; valid: boolean;
   }[]>`
     select jsonb_build_object('format', 'reader-summary-new-input-refresh-reconciliation-v1',
-      'tenantId', r.tenant_id, 'workspaceId', r.workspace_id, 'date', ${m.date}::text,
+      'tenantId', r.tenant_id, 'workspaceId', r.workspace_id, 'date', ${hop.date}::text,
       'jobId', r.reader_summary_job_id, 'operation', r.operation,
       'manifestSha256', btrim(r.manifest_sha256), 'reason', r.reason,
       'invocation', r.invocation) as evidence, r.accounting,
       (j.status::text = 'FAILED' and r.job_status = 'FAILED'
         and j.reader_summary_artifact_id is null and j.completed_at is null and j.failed_at is not null
         and btrim(r.job_sha256) = encode(sha256(convert_to(to_jsonb(j)::text, 'UTF8')), 'hex')
-        and j.idempotency_key = r.operation and r.operation = ${original.operation}
-        and btrim(r.manifest_sha256) = ${refreshBytesHash(Buffer.from(grant.originalManifestJson))}
+        and j.idempotency_key = r.operation and r.operation = ${hop.expectedOperation}
+        and btrim(r.manifest_sha256) = ${refreshBytesHash(Buffer.from(hop.expectedManifestJson))}
         and j.cadence = 'daily' and j.scope_type = 'workspace' and j.scope_key = 'workspace'
         and j.period_timezone = 'UTC' and j.interest_id is null
         and j.user_id is null and j.subscription_id is null
-        and j.period_started_at = ${m.startedAt}::timestamptz
-        and j.period_ended_at = ${m.endedAt}::timestamptz
+        and j.period_started_at = ${hop.startedAt}::timestamptz
+        and j.period_ended_at = ${hop.endedAt}::timestamptz
         and r.period_started_at = j.period_started_at and r.period_ended_at = j.period_ended_at
         and not exists (select 1 from reader_summary_publications p where p.reader_summary_job_id = j.id)
       ) as valid
     from reader_summary_new_input_refresh_reconciliations r
     join reader_summary_jobs j on j.id = r.reader_summary_job_id
       and j.tenant_id = r.tenant_id and j.workspace_id = r.workspace_id
-    where r.id = ${grant.reconciliationId}::uuid
-      and r.reader_summary_job_id = ${grant.originalJobId}::uuid
-      and r.tenant_id = ${m.tenantId}::uuid and r.workspace_id = ${m.workspaceId}::uuid
+    where r.id = ${hop.reconciliationId}::uuid
+      and r.reader_summary_job_id = ${hop.originalJobId}::uuid
+      and r.tenant_id = ${hop.tenantId}::uuid and r.workspace_id = ${hop.workspaceId}::uuid
   `;
   const row = rows[0];
   if (rows.length !== 1 || row?.valid !== true) {
     throw new Error("Refresh successor original/reconciliation is missing, changed or not an unpublished failure");
   }
-  assertRefreshReconciliationEvidence(row.evidence, [m.date]);
+  assertRefreshReconciliationEvidence(row.evidence, [hop.date]);
   if (refreshHash(row.accounting) !== refreshHash(refreshReconciliationAccountingFor(row.evidence))) {
     throw new Error("Refresh successor original/reconciliation is missing, changed or not an unpublished failure");
   }
-  const invocation = row.evidence.invocation;
-  const knownTerminalAssessment = invocation.outcome === "failed" ||
-    (invocation.outcome === "completed" && invocation.providerUsageReported);
-  const resumablePurposes = new Set([
-    "social_monitor.relevance.assess_source_content.v1",
-    "social_monitor.reader_summary.verify_story_relations.v2",
-  ]);
-  if (!knownTerminalAssessment || !resumablePurposes.has(invocation.purpose)) {
-    throw new Error("Refresh successor requires a known terminal resumable provider outcome");
+  return row.evidence;
+}
+
+/** Verify the committed reconciliation and the exact unchanged FAILED row.
+ * Unknown provider usage remains unknown; a grant supplies no usage estimate.
+ * A bounded two-stage chain additionally requires the exact production
+ * recovery order: the root failed the source-content assessment and only its
+ * immediate (already-resumed) successor failed the story-relation
+ * verification. Any other purpose pairing, and any depth or identity issue
+ * already rejected by `assertRefreshSuccessorGrant`, keeps the chain closed. */
+export async function assertRefreshSuccessorCurrent(client: Client, m: RefreshManifest, now: Date) {
+  assertRefreshManifest(m, now);
+  const original = assertRefreshSuccessorGrant(m, now, { assertOriginal: assertRefreshManifest, hash: refreshHash });
+  const grant = m.successor!;
+  const evidence = await readRefreshSuccessorHopEvidence(client, {
+    tenantId: m.tenantId, workspaceId: m.workspaceId, date: m.date, startedAt: m.startedAt, endedAt: m.endedAt,
+    reconciliationId: grant.reconciliationId, originalJobId: grant.originalJobId,
+    expectedOperation: original.operation, expectedManifestJson: grant.originalManifestJson,
+  });
+  if (original.successor === undefined) {
+    if (!knownTerminalAssessment(evidence.invocation) || !resumablePurposes.has(evidence.invocation.purpose)) {
+      throw new Error("Refresh successor requires a known terminal resumable provider outcome");
+    }
+    return;
+  }
+  if (!knownTerminalAssessment(evidence.invocation) ||
+      evidence.invocation.purpose !== storyRelationVerificationPurpose) {
+    throw new Error("Refresh successor requires a known terminal story-relation verification outcome");
+  }
+  const rootGrant = original.successor;
+  const root = JSON.parse(rootGrant.originalManifestJson) as RefreshManifest;
+  const rootEvidence = await readRefreshSuccessorHopEvidence(client, {
+    tenantId: m.tenantId, workspaceId: m.workspaceId, date: m.date, startedAt: m.startedAt, endedAt: m.endedAt,
+    reconciliationId: rootGrant.reconciliationId, originalJobId: rootGrant.originalJobId,
+    expectedOperation: root.operation, expectedManifestJson: rootGrant.originalManifestJson,
+  });
+  if (!knownTerminalAssessment(rootEvidence.invocation) ||
+      rootEvidence.invocation.purpose !== sourceContentAssessmentPurpose) {
+    throw new Error("Refresh successor chain root requires a known terminal source-content assessment outcome");
   }
 }
 


### PR DESCRIPTION
A production story-relation verification failed inside the first authorized recovery successor, but the manifest gate rejected the second and final recovery attempt as an unbounded chain. This change permits exactly the production sequence root assessment failure -> story-relation failure -> final successor, validates both committed reconciliation rows and immutable manifest hashes, and still rejects a third hop, purpose changes, identity reuse, expiry extension, and tampering.

Validation:
- 56 focused successor tests passed with PGlite-backed SQL coverage
- adjacent refresh tests passed (53 tests)
- TypeScript check passed for touched files; unrelated existing eval files still lack ajv types
- independent Claude review approved after adding explicit expired nested-grant coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recovery workflows can now support a bounded two-stage successor chain, allowing eligible follow-up processing after successive failures.
  - Nested recovery records are validated for consistency, including distinct identifiers and unchanged embedded history.
  - Historical nested recovery grants can remain valid after expiry while active grants continue to require current validity.

- **Bug Fixes**
  - Improved validation of multi-stage recovery scenarios, rejecting unsupported chain lengths, altered records, and invalid failure sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->