### PR TITLE
test(reader-summary): align compact prompt assertions

### DIFF
--- a/libs/summary/adapters/model/agent-runtime-reader-summary-model.adapter.spec.ts
+++ b/libs/summary/adapters/model/agent-runtime-reader-summary-model.adapter.spec.ts
@@ -66,10 +66,10 @@ describe("AgentRuntimeReaderSummaryModelAdapter", () => {
       "Preserve material qualifiers exactly as stated",
     );
     expect(client.commands[0]?.systemPrompt).toContain(
-      "must explain why the item matters",
+      "its concrete product or workflow impact",
     );
     expect(client.commands[0]?.systemPrompt).toContain(
-      "each topStories summary 420-650 characters",
+      "each topStories summary 140-300 characters",
     );
     expect(client.commands[0]?.systemPrompt).toContain(
       "Keep source validation out of topStories summary prose",


### PR DESCRIPTION
The production deploy gate still asserted the previous long top-story prompt wording after the compact-summary change. Update the two stale substring assertions to the current impact requirement and 140-300 character contract; the production prompt itself is unchanged.

Validation: affected adapter spec passes 10/10 in the isolated Agent Deck worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation for the default production summary prompt to require explanations of concrete product or workflow impact.
  * Adjusted the expected top-story summary length to 140–300 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->