### PR TITLE
test(reader-summary): preserve split reason provenance

### DIFF
--- a/libs/summary/adapters/model/reader-summary-reason-provenance.spec.ts
+++ b/libs/summary/adapters/model/reader-summary-reason-provenance.spec.ts
@@ -16,8 +16,11 @@ const expectReason = (
   const draft = normalizeReasonDraft(evidence, stories);
   assertReaderSummaryCitationsAgainstEvidence(draft, evidence);
   const assembled = buildReaderSummaryDraftWithPromotionContent(evidence, draft);
+  const editorialReason = evidence.editorialSlate === undefined
+    ? "Selected by the reader promotion policy."
+    : "Selected by editorial policy: reader_promotion_v2_admitted, semantic_story_representative, top_slot_assigned.";
   for (const content of [draft.content!, assembled.content]) {
-    expect(content.topReads[0]?.reason).toBe(reason);
+    expect(content.topReads[0]?.reason).toBe(editorialReason);
     expect(content.topReads[0]?.whyImportant[0]).toBe(reason);
     expect(content.topReads[0]?.citationIds).toEqual(["c1"]);
   }
@@ -154,7 +157,10 @@ describe("original reader explanation provenance through model normalization", (
       const result = buildReaderSummaryDraftWithPromotionContent(evidence, {
         ...draft, topStories: [{ ...draft.topStories[0]!, ...override }],
       });
-      expect(result.content.topReads[0]?.reason).toBe(metricReason);
+      expect(result.content.topReads[0]?.reason).toBe(
+        "Selected by editorial policy: reader_promotion_v2_admitted, semantic_story_representative, top_slot_assigned.",
+      );
+      expect(result.content.topReads[0]?.whyImportant[0]).toBe(metricReason);
     }
   });
 });


### PR DESCRIPTION
Compact reader summaries split the fixed editorial selection reason from the evidence-backed reader explanation, but the provenance spec still expected both fields to contain the explanation. Assert the current editorial reason contract separately while preserving all model/metric fallback and injection checks on `whyImportant`.

Validation: focused provenance spec passes 25/25.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated provenance coverage to verify consistent editorial-policy reasoning in generated top-read summaries.
  * Retained validation for metric and model explanations, including normalized, promoted, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->