### PR TITLE
fix(reader-summary): remove unused promotion input

### DIFF
--- a/libs/summary/domain/services/reader-post-promotion-reasons.ts
+++ b/libs/summary/domain/services/reader-post-promotion-reasons.ts
@@ -15,7 +15,7 @@ export const buildReaderPostPromotionReasons = (params: {
   readonly lead: SummaryEvidenceItem;
   readonly stories: readonly TopReadCandidate[];
 }): readonly string[] => {
-  const { selected, lead } = params;
+  const { selected } = params;
   // Model prose may describe only this lead and its admitted support. Retain
   // the complete summary, including qualifications; never salvage a claim by
   // dropping its out-of-scope citation or clipping its limiting sentence.


### PR DESCRIPTION
Restores static quality on current main after #380 by removing the unused local binding reported by ESLint. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * No user-visible changes identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->