### PR TITLE
fix(auth): ignore runtime capacity metadata in snapshots

### DIFF
--- a/ops/deploy/host/refresh-codex-auth.sh
+++ b/ops/deploy/host/refresh-codex-auth.sh
@@ -460,7 +460,7 @@ prune_expired_auth_pool_snapshots() {
     ((now - modified_at >= retention_seconds)) || continue
     remove_auth_pool_directory "$snapshot"
   done < <(find "$POOL_SNAPSHOT_ROOT/snapshots" -mindepth 1 -maxdepth 1 \
-    -type d -print0)
+    -type d ! -name '.*' -print0)
 }
 
 is_manifest_account() {

--- a/ops/deploy/refresh-codex-auth.test.sh
+++ b/ops/deploy/refresh-codex-auth.test.sh
@@ -316,6 +316,8 @@ fi
 [[ $(cksum < "$TARGET_DIR/auth.json") == "$before_legacy_status" ]]
 [[ $(jq -r '.snapshotId' "$POOL_SNAPSHOT_ROOT/current.json") == "$current_generation" ]]
 expired_generation=$(printf 'f%.0s' {1..64})
+capacity_store="$POOL_SNAPSHOT_ROOT/snapshots/.subscription-runtime-account-capacity"
+install -d "$capacity_store"
 install -d "$POOL_SNAPSHOT_ROOT/snapshots/$expired_generation/account-old"
 printf '{"account":"old"}\n' > \
   "$POOL_SNAPSHOT_ROOT/snapshots/$expired_generation/account-old/auth.json"
@@ -323,6 +325,7 @@ touch -t 202001010000 "$POOL_SNAPSHOT_ROOT/snapshots/$expired_generation"
 run_refresh >/dev/null
 [[ ! -e $POOL_SNAPSHOT_ROOT/snapshots/$expired_generation ]]
 [[ -d $POOL_SNAPSHOT_ROOT/snapshots/$current_generation ]]
+[[ -d $capacity_store ]]
 
 rm -f "$CHANGED_MARKER"
 SOCIAL_MONITOR_TEST_ACCOUNTS='["account-b"]' run_refresh >/dev/null


### PR DESCRIPTION
Fixes production auth refresh when subscription-runtime creates its expected hidden capacity store beside immutable snapshot generations. Snapshot pruning remains fail-closed for unexpected visible directories and only ignores hidden runtime metadata.\n\nChecks: bash syntax and diff checks pass. The GNU flock integration fixture is delegated to Linux CI because macOS has no flock binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired snapshot cleanup now preserves hidden directories used for capacity tracking.
  * Retention-based cleanup continues to remove expired generation snapshots without deleting required system data.

* **Tests**
  * Added coverage confirming capacity store directories remain intact after cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->