### PR TITLE
fix(reader-summary): accept chained relation recovery

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-successor-chain.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor-chain.spec.ts
@@ -75,8 +75,15 @@ describe("bounded two-stage successor recovery: SQL-verified chain", () => {
     await expect(assertRefreshSuccessorCurrent(client, chain.second, refreshNow)).rejects.toThrow(/story-relation/);
   });
 
-  it("rejects the chain when the root hop purpose is not the source-content assessment", async () => {
+  it("accepts the chain when the root hop is also a terminal story-relation verification failure", async () => {
     const invocation = { ...rootEvidence.invocation, purpose: "social_monitor.reader_summary.verify_story_relations.v2" };
+    await db.query("update reader_summary_new_input_refresh_reconciliations set invocation=$1::jsonb, accounting=$2::jsonb where reader_summary_job_id=$3",
+      [JSON.stringify(invocation), JSON.stringify(refreshReconciliationAccountingFor({ ...rootEvidence, invocation })), chainedRootJobId]);
+    await expect(assertRefreshSuccessorCurrent(client, chain.second, refreshNow)).resolves.toBeUndefined();
+  });
+
+  it("rejects the chain when the root hop purpose is neither the source-content assessment nor story-relation verification", async () => {
+    const invocation = { ...rootEvidence.invocation, purpose: "social_monitor.relevance.assess_other_signal.v1" };
     await db.query("update reader_summary_new_input_refresh_reconciliations set invocation=$1::jsonb, accounting=$2::jsonb where reader_summary_job_id=$3",
       [JSON.stringify(invocation), JSON.stringify(refreshReconciliationAccountingFor({ ...rootEvidence, invocation })), chainedRootJobId]);
     await expect(assertRefreshSuccessorCurrent(client, chain.second, refreshNow)).rejects.toThrow(/source-content assessment/);

--- a/scripts/lib/reader-summary-new-input-refresh-successor.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor.ts
@@ -70,8 +70,9 @@ async function readRefreshSuccessorHopEvidence(client: Client, hop: RefreshSucce
 /** Verify the committed reconciliation and the exact unchanged FAILED row.
  * Unknown provider usage remains unknown; a grant supplies no usage estimate.
  * A bounded two-stage chain additionally requires the exact production
- * recovery order: the root failed the source-content assessment and only its
- * immediate (already-resumed) successor failed the story-relation
+ * recovery order: the immediate (already-resumed) successor must have failed
+ * the story-relation verification, and the root it resumed must itself have
+ * failed either the source-content assessment or the story-relation
  * verification. Any other purpose pairing, and any depth or identity issue
  * already rejected by `assertRefreshSuccessorGrant`, keeps the chain closed. */
 export async function assertRefreshSuccessorCurrent(client: Client, m: RefreshManifest, now: Date) {
@@ -100,9 +101,9 @@ export async function assertRefreshSuccessorCurrent(client: Client, m: RefreshMa
     reconciliationId: rootGrant.reconciliationId, originalJobId: rootGrant.originalJobId,
     expectedOperation: root.operation, expectedManifestJson: rootGrant.originalManifestJson,
   });
-  if (!knownTerminalAssessment(rootEvidence.invocation) ||
-      rootEvidence.invocation.purpose !== sourceContentAssessmentPurpose) {
-    throw new Error("Refresh successor chain root requires a known terminal source-content assessment outcome");
+  if (!knownTerminalAssessment(rootEvidence.invocation) || !resumablePurposes.has(rootEvidence.invocation.purpose)) {
+    throw new Error(
+      "Refresh successor chain root requires a known terminal source-content assessment or story-relation verification outcome");
   }
 }
 


### PR DESCRIPTION
Production recovery can legitimately encounter a second terminal story-relation verification failure after resuming an earlier story-relation verification. Accept that exact bounded two-hop purpose chain while preserving reconciliation, hash, terminal-state, depth, and immediate-purpose checks.

Validation: focused successor-chain tests, 57 passed.