### PR TITLE
fix(reader-summary): remove unused promotion input

### DIFF
--- a/libs/summary/domain/services/reader-post-promotion-reasons.ts
+++ b/libs/summary/domain/services/reader-post-promotion-reasons.ts
@@ -51,7 +51,7 @@ const readerPostPromotionModelStory = (
   },
   maxSummaryLength?: number,
 ): TopReadCandidate | undefined => {
-  const { selected, lead } = params;
+  const { selected } = params;
   return params.stories.find(
     (candidate) =>
       candidate.readerReasonProvenance?.kind === "model" &&


### PR DESCRIPTION
Restores the static quality gate after the latest relation-recovery merge reintroduced an unused destructured value. No runtime behavior changes.