### PR TITLE
fix(summary): seal rendered promotion summaries

### DIFF
--- a/libs/summary/features/execute-reader-summary-job/reader-summary-promotion-artifact-fields.ts
+++ b/libs/summary/features/execute-reader-summary-job/reader-summary-promotion-artifact-fields.ts
@@ -33,6 +33,7 @@ export const buildReaderSummaryPromotionArtifactFields = (params: {
             params.modelEvidence.approvedSameStoryRelations,
           relatedTopicRelations: params.modelEvidence.relatedTopicRelations,
           editorialSlate: params.modelEvidence.editorialSlate,
+          topStories: params.draft.topStories,
           attestationBinding: {
             artifactId: params.artifactId,
             sourceWindow: params.modelEvidence.sourceWindow,

--- a/libs/summary/features/execute-reader-summary-job/reader-summary-promotion-reasons.spec.ts
+++ b/libs/summary/features/execute-reader-summary-job/reader-summary-promotion-reasons.spec.ts
@@ -2,6 +2,8 @@ import { artifact, dailyEvidenceSelection } from
   "../../domain/policies/reader-summary-publication-policy-test-fixtures";
 import { buildReaderSummaryDraftWithPromotionContent } from
   "./reader-summary-promotion-content";
+import { buildReaderSummaryPromotionArtifactFields } from
+  "./reader-summary-promotion-artifact-fields";
 import type { TopReadCandidate } from "../../domain/entities/top-read";
 
 const placeholder = "Authoritative promotion snapshot candidate";
@@ -42,6 +44,23 @@ const fixture = () => {
 };
 
 describe("promotion reader explanations", () => {
+  it("seals the same model summary that is rendered in the promotion card", () => {
+    const { evidence, draft } = fixture();
+    const renderedDraft = buildReaderSummaryDraftWithPromotionContent(evidence, draft);
+    const fields = buildReaderSummaryPromotionArtifactFields({
+      artifactId: "reader-summary-display-seal",
+      modelEvidence: evidence,
+      draft: renderedDraft,
+    });
+
+    expect(renderedDraft.content.topReads[0]?.summary).toBe(substantive);
+    const attestation = fields.promotionAttestations?.[0];
+    if (attestation === undefined || !("displaySummary" in attestation)) {
+      throw new Error("Expected a V2 promotion attestation with a display summary");
+    }
+    expect(attestation.displaySummary).toBe(substantive);
+  });
+
   it.each([true, false])("preserves complete model prose through authoritative assembly (slate=%s)", (slate) => {
     const { evidence, draft } = fixture();
     const selection = { ...evidence, editorialSlate: slate ? evidence.editorialSlate : undefined };


### PR DESCRIPTION
## Summary
- rebuild promotion attestations with the same model top stories used by rendered cards
- add a regression test for display summary identity

## Verification
- focused Jest: 14 passed
- git diff --check