### PR TITLE
fix(relevance): align assessment schema with parser

### DIFF
--- a/libs/relevance/adapters/model/promotion-review-wire.spec.ts
+++ b/libs/relevance/adapters/model/promotion-review-wire.spec.ts
@@ -1,4 +1,5 @@
 import { OpenAiSourceContentQualityReviewerAdapter } from "./openai-source-content-quality-reviewer.adapter";
+import { promotionReviewInstructions } from "./promotion-review-wire";
 import { SourceContentQualityPolicy } from "../../domain";
 import { assessedPromotionVerdict } from "../../features/rank-feed-items/promotion-assessment-verdict";
 import type { SourceContentQualityReviewRequest } from "../../ports";
@@ -20,6 +21,11 @@ const response = (reviews: unknown) => new Response(JSON.stringify({ status: "co
 ] }] }), { status: 200 });
 
 describe("existing review adapter promotion wire contract", () => {
+  it("states the 0-1 fraction scale for every numeric score field the parser bounds", () => {
+    expect(promotionReviewInstructions).toContain(
+      "confidence, qualityScore, interestRelevanceScore and engagementIntegrityScore are each a fraction from 0 to 1 inclusive");
+  });
+
   it.each(["hacker-news", "reddit", "x-twitter"])("separates trusted intent, binds %s text and omits popularity", async (provider) => {
     const input = request(provider);
     const adapter = new OpenAiSourceContentQualityReviewerAdapter({ apiKey: "synthetic-test-key", fetchFn: async (_url, init) => {

--- a/libs/relevance/adapters/model/promotion-review-wire.ts
+++ b/libs/relevance/adapters/model/promotion-review-wire.ts
@@ -10,6 +10,7 @@ export const promotionReviewInstructions = [
   "Assess specific contextual relevance and usefulness, including clean-looking lists and first-person observations.",
   "A first-person observation supports only that observation, not independent verification of broader claims.",
   "Screening flags are heuristic warnings, not evidence of support; trusted/official author flags cannot certify evidence.",
+  "confidence, qualityScore, interestRelevanceScore and engagementIntegrityScore are each a fraction from 0 to 1 inclusive, never a percentage or a 1-10 rating.",
   "qualityScore measures support in captured text, not absence of bad patterns or headline length.",
   "A self-contained headline can support its literal statement; if judgment needs an unseen article return needs_context.",
   "Treat truncated text as incomplete. Never invent a body. Empty bodies follow the same rule regardless of provider.",

--- a/libs/relevance/adapters/model/source-content-quality-review-wire.spec.ts
+++ b/libs/relevance/adapters/model/source-content-quality-review-wire.spec.ts
@@ -1,0 +1,55 @@
+import { SourceContentQualityPolicy } from "../../domain";
+import type { SourceContentQualityReviewRequest } from "../../ports";
+import { promotionWireCandidate } from "./promotion-review-wire";
+import {
+  parseReviews,
+  promotionResponseSchema,
+  responseSchema,
+  sourceContentQualityFlagValues,
+} from "./source-content-quality-review-wire";
+
+const request = (): SourceContentQualityReviewRequest => ({
+  candidateId: "synthetic-wire", providerKey: "reddit", title: "Measured compiler diagnostics",
+  bodyPreview: "Concrete first-party benchmark numbers for the compiler release.",
+  deterministic: new SourceContentQualityPolicy().evaluate({ providerKey: "reddit",
+    title: "Measured compiler diagnostics", providerMetadata: { query: "compiler diagnostics" } }),
+  promotion: Object.freeze({ tenantId: "synthetic-tenant", workspaceId: "synthetic-workspace",
+    interestId: "synthetic-interest", sourceBindingId: "synthetic-binding", sourceItemId: "synthetic-source",
+    trustedIntent: "compiler diagnostics", availability: "body_present" }),
+});
+
+const review = (input: SourceContentQualityReviewRequest, overrides: Record<string, unknown> = {}) => ({
+  candidateId: input.candidateId, bindingId: promotionWireCandidate(input).bindingId,
+  decision: "promote", confidence: 0.9, qualityScore: 0.7, interestRelevanceScore: 0.9,
+  engagementIntegrityScore: 0.9, flags: [], reason: "Synthetic review",
+  evidence: [{ field: "title", start: 0, end: input.title.length, quote: input.title }],
+  resolvedSoftFlags: [], ...overrides,
+});
+
+describe("source content quality review wire contract", () => {
+  it("keeps the flags schema enum in lockstep with the parser's allowed flag set", () => {
+    expect(responseSchema.properties.reviews.items.properties.flags.items.enum)
+      .toEqual(sourceContentQualityFlagValues);
+    expect(promotionResponseSchema.properties.reviews.items.properties.flags.items.enum)
+      .toEqual(sourceContentQualityFlagValues);
+  });
+
+  it("accepts a review carrying only vocabulary flags", () => {
+    const input = request();
+    const [result] = parseReviews(JSON.stringify({ reviews: [review(input, { flags: ["trusted_author"] })] }),
+      [input]);
+    expect(result!.flags).toEqual(["trusted_author"]);
+  });
+
+  it("still rejects a flag outside the vocabulary through the parser, even though the schema now constrains it", () => {
+    const input = request();
+    expect(() => parseReviews(JSON.stringify({ reviews: [review(input, { flags: ["not_a_real_flag"] })] }),
+      [input])).toThrow("Invalid promotion review result");
+  });
+
+  it("rejects an out-of-range score even when every other field is valid", () => {
+    const input = request();
+    expect(() => parseReviews(JSON.stringify({ reviews: [review(input, { qualityScore: 8 })] }),
+      [input])).toThrow("Invalid promotion review result");
+  });
+});

--- a/libs/relevance/adapters/model/source-content-quality-review-wire.ts
+++ b/libs/relevance/adapters/model/source-content-quality-review-wire.ts
@@ -151,7 +151,11 @@ export const asOptionalRecord = (value: unknown): JsonObject | undefined =>
     ? (value as JsonObject)
     : undefined;
 
-const allowedFlags = new Set<SourceContentQualityFlag>([
+// Single source of truth for the review-flag vocabulary. The schema enum and
+// the parser's semantic check must stay in lockstep: a flag value that the
+// schema lets the model emit but the parser rejects turns an otherwise valid,
+// attested completion into a hard adapter failure.
+export const sourceContentQualityFlagValues = [
   "crypto_promo",
   "engagement_bait",
   "generic_question",
@@ -173,7 +177,9 @@ const allowedFlags = new Set<SourceContentQualityFlag>([
   "llm_needs_context",
   "llm_promoted",
   "llm_rejected",
-]);
+] as const satisfies readonly SourceContentQualityFlag[];
+
+const allowedFlags = new Set<SourceContentQualityFlag>(sourceContentQualityFlagValues);
 
 export const responseSchema = {
   type: "object",
@@ -207,7 +213,7 @@ export const responseSchema = {
           engagementIntegrityScore: { type: "number", minimum: 0, maximum: 1 },
           flags: {
             type: "array",
-            items: { type: "string" },
+            items: { type: "string", enum: sourceContentQualityFlagValues },
           },
           reason: { type: "string", minLength: 1 },
         },


### PR DESCRIPTION
Reader Summary production refresh received attested source-content assessment responses that passed the model schema but failed strict adapter validation. Constrain assessment flags to the parser vocabulary from one shared source and state the required 0..1 score scale in the prompt, while retaining the parser rejection for unknown flags and out-of-range scores.

Validation: focused adapter contract tests, 9 passed; worker relevance suite 524 passed; TypeScript build typecheck passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clarified that review confidence and quality metrics use inclusive 0–1 fraction scores rather than percentages or 1–10 ratings.
  * Standardized supported source-content quality flags across review responses.
  * Added validation to reject unsupported flags and out-of-range quality scores, improving consistency and reliability of review results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->