### PR TITLE
fix(relevance): normalize legacy assessment items

### DIFF
--- a/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
+++ b/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
@@ -18,11 +18,22 @@ const observed = (review: Wire, second = false): Wire => ({
 const compatible = {
   "observed batch one": (o: { reviews: Wire[] }) => ({ results: o.reviews.map((r) => observed(r)) }),
   "observed batch two": (o: { reviews: Wire[] }) => ({ results: o.reviews.map((r) => observed(r, true)) }),
+  // The same two dialects under the schema-compliant `reviews` envelope instead
+  // of the legacy `results` envelope. Normalization must key
+  // off the item shape, not the outer key.
+  "observed batch one under reviews envelope": (o: { reviews: Wire[] }) => ({ reviews: o.reviews.map((r) => observed(r)) }),
+  "observed batch two under reviews envelope": (o: { reviews: Wire[] }) => ({ reviews: o.reviews.map((r) => observed(r, true)) }),
   "results alias only": (o: { reviews: Wire[] }) => ({ results: o.reviews }),
 } as const;
 const mutations: Record<string, (output: { reviews: Wire[] }) => Wire> = {
+  // A single tampered field on an otherwise-complete canonical item is not a
+  // legacy dialect and must stay rejected, not reinterpreted.
   "relevant decision": (o) => ({ reviews: o.reviews.map((r) => ({ ...r, decision: "relevant" })) }),
   "not_relevant decision": (o) => ({ reviews: o.reviews.map((r) => ({ ...r, decision: "not_relevant" })) }),
+  // A genuine legacy-shaped item with a tampered binding must still be
+  // rejected: item-dialect normalization cannot weaken the binding check.
+  "legacy dialect with tampered binding": (o) => ({ reviews: o.reviews.map((r) =>
+    observed({ ...r, bindingId: `${String(r.bindingId)}-tampered` })) }),
 };
 for (const field of ["confidence", "qualityScore", "interestRelevanceScore", "engagementIntegrityScore", "flags", "reason", "resolvedSoftFlags"]) {
   mutations[`missing ${field}`] = (o) => ({ reviews: o.reviews.map((r) => {

--- a/libs/relevance/adapters/model/source-content-quality-review-wire.spec.ts
+++ b/libs/relevance/adapters/model/source-content-quality-review-wire.spec.ts
@@ -52,4 +52,59 @@ describe("source content quality review wire contract", () => {
     expect(() => parseReviews(JSON.stringify({ reviews: [review(input, { qualityScore: 8 })] }),
       [input])).toThrow("Invalid promotion review result");
   });
+
+  describe("legacy item dialect normalization (envelope-independent)", () => {
+    // Two attested native completions historically used this dialect: legacy
+    // relevant/not_relevant decisions, missing interestRelevanceScore /
+    // engagementIntegrityScore / flags, and reason/resolvedSoftFlags aliased as
+    // justification/flagResolutions. It was first observed under a `results`
+    // outer envelope. The same item dialect can arrive under the schema-compliant
+    // `reviews` envelope, so detection must key off the item shape, not the key.
+    const legacyItem = (input: SourceContentQualityReviewRequest, overrides: Record<string, unknown> = {}) => ({
+      candidateId: input.candidateId, bindingId: promotionWireCandidate(input).bindingId,
+      decision: "relevant", confidence: 0.95, qualityScore: 0.8,
+      evidence: [{ field: "title", start: 0, end: input.title.length, quote: input.title }],
+      justification: "Synthetic legacy reason", flagResolutions: [], ...overrides,
+    });
+
+    it("accepts the documented legacy shape under a reviews envelope and fills the missing fields", () => {
+      const input = request();
+      const [result] = parseReviews(JSON.stringify({ reviews: [legacyItem(input)] }), [input]);
+      expect(result!.decision).toBe("promote");
+      expect(result!.qualityScore).toBe(0.8);
+      expect(result!.interestRelevanceScore).toBe(0.8);
+      expect(result!.engagementIntegrityScore).toBe(input.deterministic.engagementIntegrityScore);
+      expect(result!.flags).toEqual([]);
+      expect(result!.reason).toBe("Synthetic legacy reason");
+    });
+
+    it("accepts the not_relevant variant the same way", () => {
+      const input = request();
+      const [result] = parseReviews(JSON.stringify({ reviews: [legacyItem(input, { decision: "not_relevant" })] }),
+        [input]);
+      expect(result!.decision).toBe("reject");
+    });
+
+    it("still rejects a legacy-shaped item when the binding is tampered", () => {
+      const input = request();
+      expect(() => parseReviews(JSON.stringify({
+        reviews: [legacyItem(input, { bindingId: `${promotionWireCandidate(input).bindingId}-tampered` })],
+      }), [input])).toThrow();
+    });
+
+    it("does not normalize an otherwise-complete canonical item merely because decision was tampered to relevant", () => {
+      const input = request();
+      const tampered = { ...review(input), decision: "relevant" };
+      expect(() => parseReviews(JSON.stringify({ reviews: [tampered] }), [input]))
+        .toThrow("Invalid promotion review result");
+    });
+
+    it("does not normalize a canonical item that is simply missing a field with no legacy marker present", () => {
+      const input = request();
+      const missingFlags: Record<string, unknown> = { ...review(input) };
+      delete missingFlags.flags;
+      expect(() => parseReviews(JSON.stringify({ reviews: [missingFlags] }), [input]))
+        .toThrow("Invalid promotion review result");
+    });
+  });
 });

--- a/libs/relevance/adapters/model/source-content-quality-review-wire.ts
+++ b/libs/relevance/adapters/model/source-content-quality-review-wire.ts
@@ -37,12 +37,19 @@ export const parseReviews = (
 
     const candidateId = nonEmptyString(raw.candidateId, "candidateId");
     const request = requests?.find((request) => request.candidateId === candidateId);
-    // Two attested native completions used the earlier `results` dialect even
-    // though the canonical schema was supplied. Normalize only that complete,
-    // request-bound dialect. Its single quality/support score supplies the
-    // missing relevance score; integrity retains the deterministic assessment.
-    // No source, identity, evidence or blocker is inferred.
-    const record = compatibilityResults === undefined || request === undefined ? raw
+    // Two attested native completions used an earlier item dialect even though
+    // the canonical schema was supplied under a `results` outer envelope. The
+    // same item dialect can also arrive under the schema-compliant `reviews`
+    // envelope, so detection is
+    // item-level and envelope-independent: only the exact documented legacy
+    // markers (relevant/not_relevant plus a missing score/flags field or a
+    // documented alias key) trigger normalization, so a merely incomplete
+    // canonical item or a single tampered field is never silently reinterpreted.
+    // Its single quality/support score supplies the missing relevance score;
+    // integrity retains the deterministic assessment. No source, identity,
+    // evidence or blocker is inferred, and binding/evidence checks below run
+    // unchanged against the normalized record.
+    const record = request === undefined || !isLegacyPromotionReviewItem(raw) ? raw
       : normalizeCompatiblePromotionReview(raw, request);
     if (requests !== undefined && (request === undefined ||
         ![record.confidence, record.qualityScore, record.interestRelevanceScore,
@@ -66,6 +73,23 @@ export const parseReviews = (
     };
   });
 };
+
+const hasLegacyAliasKey = (record: JsonObject): boolean =>
+  (!Object.hasOwn(record, "reason") && Object.hasOwn(record, "justification")) ||
+  (!Object.hasOwn(record, "resolvedSoftFlags") &&
+    (Object.hasOwn(record, "flagResolutions") || Object.hasOwn(record, "screeningFlagResolutions")));
+
+// The legacy `relevant`/`not_relevant` decision never appears in a canonical
+// response (the schema enum only allows promote/keep/downrank/reject/needs_context),
+// so it is an unambiguous dialect signal on its own. It is still not sufficient
+// alone: a tampered but otherwise-complete canonical item (every newer field
+// present, no alias keys) must keep being rejected, not reinterpreted. Only the
+// combination with a missing newer field or a documented alias key marks a
+// genuine legacy-shaped item.
+const isLegacyPromotionReviewItem = (record: JsonObject): boolean =>
+  (record.decision === "relevant" || record.decision === "not_relevant") &&
+  (!Object.hasOwn(record, "interestRelevanceScore") || !Object.hasOwn(record, "engagementIntegrityScore") ||
+    !Object.hasOwn(record, "flags") || hasLegacyAliasKey(record));
 
 const normalizeCompatiblePromotionReview = (
   record: JsonObject, request: SourceContentQualityReviewRequest,


### PR DESCRIPTION
Source-content assessment supports a previously observed request-bound legacy item dialect only when the outer envelope is `results`. Detect that exact legacy item shape independently of the envelope so `reviews` responses can be normalized through the same strict binding, evidence, flag, and score checks. Canonical malformed items and tampered bindings remain rejected.

Validation: focused protocol tests, 33 passed; worker broader suite, 532 passed; TypeScript typecheck passed.