### PR TITLE
fix(summary): derive executive copy from canonical narrative

### DIFF
--- a/libs/summary/adapters/model/agent-runtime-reader-summary-model.adapter.spec.ts
+++ b/libs/summary/adapters/model/agent-runtime-reader-summary-model.adapter.spec.ts
@@ -19,6 +19,38 @@ import type { VerifiedReaderSummaryExecutionAttestation } from "./reader-summary
 import { currentReaderSummaryPromptRelease } from "./openai-responses-reader-summary-prompt";
 
 describe("AgentRuntimeReaderSummaryModelAdapter", () => {
+  it("renders the canonical narrative when the duplicate executive summary is empty", async () => {
+    const providerDraft = validReaderProviderDraft();
+    providerDraft.executiveSummary = "";
+    const client = new CapturingAgentRuntimeClient({
+      status: "completed",
+      structuredOutput: providerDraft,
+      warnings: [],
+    });
+    const adapter = new AgentRuntimeReaderSummaryModelAdapter({
+      client,
+      agentProvider: "codex",
+    });
+    const input = readerSummaryInput();
+    const route = adapter.route(
+      input,
+      {
+        preferredProvider: "agent-runtime",
+        maxInputTokens: 24_000,
+        maxOutputTokens: 16_000,
+        maxEstimatedCostUsd: 1,
+      },
+      { remainingTokens: 40_000, remainingCostUsd: 1 },
+    );
+
+    const attempt = await adapter.generate(input, route);
+
+    expect(attempt.draft.executiveSummary).toContain(
+      "Developers are comparing agent runtime reliability",
+    );
+    expect(client.commands).toHaveLength(1);
+  });
+
   it("uses the strict production Codex model and effort by default", async () => {
     const client = new CapturingAgentRuntimeClient({
       status: "completed",

--- a/libs/summary/adapters/model/openai-responses-reader-summary-draft-normalizer.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-draft-normalizer.ts
@@ -60,10 +60,14 @@ export const normalizeOpenAiReaderSummaryDraft = (
   const headline = readerSummaryHeadline(
     requiredString(raw.headline, "reader summary headline"),
   );
-  const legacyExecutiveSummary = requiredString(
-    raw.executiveSummary,
-    "reader summary executive summary",
-  );
+  const legacyExecutiveSummary =
+    typeof raw.executiveSummary === "string" &&
+      raw.executiveSummary.trim().length === 0
+      ? ""
+      : requiredString(
+          raw.executiveSummary,
+          "reader summary executive summary",
+        );
   const topStories = normalizeRecordArray(raw.topStories);
   const normalizedTopStories = normalizeTopStories(
     topStories,


### PR DESCRIPTION
## Summary
- allow an empty duplicate executiveSummary when canonical narrativeSections are valid
- render the published executive summary from the grounded canonical narrative
- add an agent-runtime regression test

## Verification
- focused Jest: 11 passed
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved summary generation when an executive summary is missing or empty.
  * The system now falls back to the canonical narrative instead of failing, producing a complete summary in supported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->