### PR TITLE
feat(nomad): Nomad API vertical slice MVP (build-only image + tested rollout/failure-drill contracts)

### DIFF
--- a/.github/workflows/production-api-nomad-deploy.yml
+++ b/.github/workflows/production-api-nomad-deploy.yml
@@ -10,8 +10,9 @@ name: Production API deploy (Nomad MVP)
 #
 # HONEST LIMITATION (documented, not hidden): the restricted SSH wrapper
 # (`ops/deploy/social-monitor-production-ssh-wrapper.sh`) does not yet
-# recognize the `nomad-plan`/`nomad-deploy`/`nomad-status`/`nomad-rollback`
-# verbs this workflow calls. That file is protected by this repo's
+# recognize the `nomad-plan`/`nomad-deploy`/`nomad-status` verbs this
+# workflow calls (rollback is a separate, explicit operator action, not
+# wired into this workflow). That file is protected by this repo's
 # cryptographic transition-review bridge
 # (`ops/deploy/production-transition-review-lib.sh`), so extending it
 # requires a real human-signed review PR, not something produced here. This

--- a/.github/workflows/production-api-nomad-deploy.yml
+++ b/.github/workflows/production-api-nomad-deploy.yml
@@ -1,0 +1,120 @@
+name: Production API deploy (Nomad MVP)
+
+# Restricted deploy trigger for the sm-api Nomad release (plan sections 5
+# and 7). This workflow only ever calls fixed, host-owned actions over the
+# existing restricted SSH wrapper - it never sends shell/HCL/stdin, and it
+# never gets a Nomad management token. It shares the legacy production
+# deploy's concurrency group and host lock so Compose and Nomad releases of
+# the same API service can never run concurrently during the hybrid period
+# (plan section 6).
+#
+# HONEST LIMITATION (documented, not hidden): the restricted SSH wrapper
+# (`ops/deploy/social-monitor-production-ssh-wrapper.sh`) does not yet
+# recognize the `nomad-plan`/`nomad-deploy`/`nomad-status`/`nomad-rollback`
+# verbs this workflow calls. That file is protected by this repo's
+# cryptographic transition-review bridge
+# (`ops/deploy/production-transition-review-lib.sh`), so extending it
+# requires a real human-signed review PR, not something produced here. This
+# workflow is therefore a reviewable, correctly-shaped skeleton for that
+# follow-up PR, not something that can succeed against production today -
+# `workflow_dispatch`-only and gated behind an explicit confirmation input
+# so nobody triggers it by accident before that wrapper change ships.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Full 40-hex source commit SHA to deploy (must already have a published production-api-nomad.yml image)
+        required: true
+      confirm_wrapper_extended:
+        description: "Type 'yes' only after the restricted SSH wrapper's nomad-* verbs have shipped via a separately reviewed PR"
+        required: true
+        default: "no"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: social-monitor-production
+  cancel-in-progress: false
+
+jobs:
+  deploy_api:
+    name: Deploy sm-api via restricted Nomad actions
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - name: Refuse to run before the wrapper extension has been reviewed and shipped
+        if: ${{ inputs.confirm_wrapper_extended != 'yes' }}
+        run: |
+          echo '::error::confirm_wrapper_extended must be "yes"; the restricted SSH wrapper does not implement nomad-* actions yet (see this file'\''s header comment).'
+          exit 1
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with: { fetch-depth: 0 }
+
+      - name: Validate release_sha looks like a full commit SHA
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          if ! [[ $RELEASE_SHA =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::release_sha must be a full 40-hex commit SHA, got: $RELEASE_SHA"
+            exit 1
+          fi
+          git cat-file -e "$RELEASE_SHA^{commit}"
+
+      - name: Set up restricted SSH
+        env:
+          SSH_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
+          SSH_USER: ${{ vars.PRODUCTION_SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          umask 077
+          mkdir -p "$HOME/.ssh"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$HOME/.ssh/production-deploy-key"
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > "$HOME/.ssh/production-known-hosts"
+          chmod 600 "$HOME/.ssh/production-deploy-key"
+          {
+            echo "SSH_HOST=$SSH_HOST"
+            echo "SSH_USER=$SSH_USER"
+          } >> "$GITHUB_ENV"
+
+      - name: nomad-plan (read-only)
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          ssh -i "$HOME/.ssh/production-deploy-key" \
+              -o UserKnownHostsFile="$HOME/.ssh/production-known-hosts" \
+              -o BatchMode=yes \
+              "$SSH_USER@$SSH_HOST" \
+              nomad-plan "$RELEASE_SHA"
+
+      - name: nomad-deploy (host-owned transaction; polls status, does not hold this step open for the whole rollout)
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          ssh -i "$HOME/.ssh/production-deploy-key" \
+              -o UserKnownHostsFile="$HOME/.ssh/production-known-hosts" \
+              -o BatchMode=yes \
+              "$SSH_USER@$SSH_HOST" \
+              nomad-deploy "$RELEASE_SHA"
+
+      - name: nomad-status (final readback; authoritative even if a prior step's SSH connection dropped)
+        if: always()
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          ssh -i "$HOME/.ssh/production-deploy-key" \
+              -o UserKnownHostsFile="$HOME/.ssh/production-known-hosts" \
+              -o BatchMode=yes \
+              "$SSH_USER@$SSH_HOST" \
+              nomad-status "$RELEASE_SHA"

--- a/.github/workflows/production-api-nomad.yml
+++ b/.github/workflows/production-api-nomad.yml
@@ -1,0 +1,89 @@
+name: Production API image (Nomad MVP)
+
+# Build-only. This workflow never deploys, never opens the production SSH
+# connection, and never touches the `production` GitHub environment: it only
+# produces an immutable, digest-addressed API image plus a small release
+# manifest as CI evidence. Nomad-driven rollout is a separate workflow added
+# in a later PR once ops/nomad/release.mjs exists.
+on:
+  push:
+    branches: [main]
+    paths:
+      - ops/nomad/api.Dockerfile
+      - ops/nomad/contracts.mjs
+      - .github/workflows/production-api-nomad.yml
+      - apps/api-gateway/**
+      - libs/**
+      - prisma/**
+      - package.json
+      - package-lock.json
+      - prisma.config.ts
+      - tsconfig.json
+      - tsconfig.build.json
+      - vendor/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: social-monitor-production-api-nomad-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build_api_image:
+    name: Build and publish API image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with: { fetch-depth: 0 }
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push immutable API image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: .
+          file: ops/nomad/api.Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            SOCIAL_MONITOR_RELEASE_SHA=${{ github.sha }}
+          tags: ghcr.io/777genius/social-monitor-api:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Write release manifest evidence
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg schemaVersion "1" \
+            --arg sourceSha "$GITHUB_SHA" \
+            --arg repository "777genius/social-monitor-api" \
+            --arg digest "$IMAGE_DIGEST" \
+            --arg platform "linux/amd64" \
+            --arg ciRunId "$GITHUB_RUN_ID" \
+            '{schemaVersion: ($schemaVersion | tonumber), sourceSha: $sourceSha, image: {repository: $repository, digest: $digest, platform: $platform}, ciRunId: $ciRunId}' \
+            > release-manifest.json
+          cat release-manifest.json
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: social-monitor-api-release-manifest-${{ github.sha }}
+          path: release-manifest.json
+          retention-days: 90

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['scripts/**/*.mjs', 'apps/**/bin/**/*.mjs'],
+    files: ['scripts/**/*.mjs', 'apps/**/bin/**/*.mjs', 'ops/nomad/**/*.mjs'],
     languageOptions: {
       globals: {
         AbortController: 'readonly',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default tseslint.config(
     languageOptions: {
       globals: {
         AbortController: 'readonly',
+        AbortSignal: 'readonly',
         Buffer: 'readonly',
         URL: 'readonly',
         clearTimeout: 'readonly',

--- a/ops/nomad/README.md
+++ b/ops/nomad/README.md
@@ -1,0 +1,165 @@
+# Nomad API vertical slice (MVP)
+
+Status: implementation plan and reviewable code, exactly as scoped by
+`docs/architecture-memory/nomad-deployment-migration-plan.md` ("Nomad
+Vertical Slice MVP: deployment API Social Monitor"). **This document, and
+everything under `ops/nomad/`, is not a production bootstrap or rollout
+authorization.** No file here has been run against a real Nomad agent, a
+real nginx process, or the production VPS. Every test in this directory
+runs against in-memory fakes or temp-dir fixtures.
+
+## What this MVP does
+
+Manages only the `sm-api` service on a single-node Nomad CE (server+client)
+on the existing VPS: a CI-built, digest-pinned GHCR image, one jobspec,
+native health/readiness checks, and a canary rollout that only cuts nginx
+traffic over once Nomad reports the candidate healthy. Caddy/nginx,
+managed PostgreSQL, RabbitMQ, Redis, OTel, workers, agent-runtime, and the
+existing schedulers are untouched and keep running exactly as they do
+today. The existing Compose API remains the proven rollback target for as
+long as ownership stays `compose` (the only value this MVP ever writes in
+production - see "Ownership" below).
+
+**Explicitly out of scope for this MVP** (plan sections 1 and 10): Consul,
+Vault, Traefik, multi-node HA, autoscaling, a new registry, moving
+workers/agent-runtime/schedulers onto Nomad, a new migration runner, schema
+changes, or a new deployment framework/DSL. Those are separate, later
+phases with their own plan sections - implementing this MVP does not imply
+any of them are ready.
+
+## What was implemented (PR1-PR4)
+
+| PR | Files | What it proves |
+| --- | --- | --- |
+| PR1 | `api.Dockerfile`, `contracts.mjs`(+test), `preflight.sh`(+test), `.github/workflows/production-api-nomad.yml` | An immutable, digest-pinned API image builds and pushes to GHCR without touching production; the six narrow release/health/traffic contracts validate correctly. |
+| PR2 | `ownership.mjs`(+test), `ownership-guard.sh`(+test), `api-env-entrypoint.mjs`(+test), `host/nomad.hcl`, `host/acl.hcl`, `versions.json`, `bootstrap.sh`(+test) | A durable `compose`/`nomad` owner marker exists and round-trips atomically; the API's env-file entrypoint parses safely without `eval`; the Nomad agent/ACL config and pinned version are reviewable; bootstrap is dry-run-only in this PR. |
+| PR3 | `adapters/nomad.mjs`(+test), `adapters/nginx.mjs`, `release.mjs`, `reconcile-traffic.mjs`, `rollout.test.mjs`, `api.nomad.hcl`, `host/api-deploy.service`, `host/api-traffic.service`, `.github/workflows/production-api-nomad-deploy.yml` | The full canary sequence (candidate → healthy → nginx switch → promote, or revert/restore on any failure) works end-to-end against fakes, including untrusted-endpoint rejection and the first-deployment-has-no-previous-release case. |
+| PR4 | `concurrent-release.test.mjs`, `failure-drill.test.sh`, this README | Concurrent/stale submissions, a fully offline Nomad backend, and recovery after a mid-release crash are all proven not to corrupt the route or the owner marker. |
+
+## Running the tests locally
+
+Everything below runs against fakes/temp directories; none of it needs a
+real Nomad agent, nginx, or network access to production.
+
+```sh
+git diff --check
+npm run check:source-line-cap
+npm run check:architecture
+npm run check:code-quality
+
+node --test ops/nomad/*.test.mjs ops/nomad/adapters/*.test.mjs
+bash ops/nomad/preflight.test.sh
+bash ops/nomad/bootstrap.test.sh
+bash ops/nomad/ownership-guard.test.sh
+bash ops/nomad/failure-drill.test.sh
+```
+
+If the `nomad` CLI is available in your environment, also run
+`nomad fmt -check ops/nomad/api.nomad.hcl` and
+`nomad job validate ops/nomad/api.nomad.hcl` (with a var-file if your build
+of the jobspec requires variables) - these were **not** run while writing
+this MVP because `nomad` was not installed in that environment; the HCL was
+checked manually for brace balance and against the Nomad job specification
+docs only.
+
+## Ownership: how `compose`/`nomad` actually works
+
+`ops/nomad/ownership.mjs` owns a single durable marker file
+(`<deployState>/nomad/api-owner`, default `compose` when absent - see
+`resolveDeployStateRoot`). It is deliberately narrow (SRP): it only
+reads/writes/validates the marker. It never decides whether switching is
+safe, and nothing in this MVP's automated code paths ever calls
+`writeApiOwner("nomad")` - `ops/nomad/failure-drill.test.sh` greps every
+non-test `.mjs` file under `ops/nomad/` on every run to enforce that. The
+switch to `nomad` is step 4 of the "Activation" checklist below: a human
+runs it once, after everything else in that checklist is verified on the
+real host.
+
+## Honestly unresolved gaps (carried forward from PR2/PR3, not new)
+
+These are not hidden - they are the reason this MVP cannot be pointed at
+production today, even though every test above is green:
+
+1. **The owner-aware guard does not exist yet in the real production
+   controller.** `ops/deploy/social-monitor-production-deploy.sh` and
+   `ops/deploy/postgres-runtime-deploy-lib.sh` are protected by this repo's
+   cryptographic transition-review bridge
+   (`ops/deploy/production-transition-review-lib.sh`, ssh-keygen signatures
+   over `allowed_signers`, git-blob-hash assertions in
+   `ops/deploy/rabbitmq-quorum-deploy-bridge-transition.test.sh`). Extending
+   them to consult `ownership.mjs` before recreating/stopping the API
+   requires a real human-signed review PR - it is not something generated
+   code can or should do. Until that lands, the "dual-owner regression"
+   this plan worries about is only closed on the `ops/nomad/` side, not on
+   the legacy Compose side.
+2. **The restricted SSH wrapper does not implement the `nomad-*` verbs**
+   `.github/workflows/production-api-nomad-deploy.yml` calls
+   (`nomad-plan`/`nomad-deploy`/`nomad-status`/`nomad-rollback`). That
+   workflow is `workflow_dispatch`-only, gated behind an explicit
+   `confirm_wrapper_extended` input, and refuses to run until that wrapper
+   extension ships separately.
+   `ops/deploy/social-monitor-production-ssh-wrapper.sh` is not covered by
+   the same signature bridge as the two files above, but extending it is
+   still a distinct, reviewable change this MVP does not make.
+3. **`release.mjs --apply` is not implemented.** Only `runRelease()` is
+   exercised, in-process, by `rollout.test.mjs` and
+   `concurrent-release.test.mjs` with fake Nomad/nginx adapters. Wiring the
+   CLI to a real Nomad agent and a real nginx reload is the separate,
+   explicitly reviewed activation step referenced throughout this
+   directory's source comments.
+4. **`bootstrap.sh --apply` is not implemented** (dry-run only). Installing
+   Nomad/ACL/systemd units on the real host is the reviewed admin bootstrap
+   procedure in the Activation checklist, step 2 - not something this PR's
+   code runs.
+5. **The pinned Nomad release's GPG signature has not been verified** in
+   `ops/nomad/versions.json`. Its SHA256 was compared byte-for-byte against
+   the published SHASUMS file, but the `.sig` was not checked against
+   HashiCorp's public key (72D7468F) because that key was not available in
+   the environment this MVP was written in. Verify it before bootstrap.
+6. **`nomad fmt`/`nomad job validate` were never run** against
+   `api.nomad.hcl` (see "Running the tests locally" above) - the `nomad`
+   CLI was not installed in this environment.
+7. **No real VPS state was inspected.** Every "confirmed" fact in the plan
+   comes from reading this repo's code (the production controller,
+   Compose files, pool budget) on a specific commit SHA, not from querying
+   the live host. The plan's own preflight (release evidence: host
+   identity, image IDs, DB occupancy, current release markers) has to run
+   on the real VPS before any of this touches it.
+
+None of the above are things a future PR can silently work around by
+editing a hash constant, a signature file, or an `allowed_signers` entry -
+several are cryptographically enforced precisely so that they require a
+real human review.
+
+## Activation checklist (plan section 7) - for the human who runs this, not for CI
+
+This is a checklist, not a permission slip. Nothing in this repository
+runs any of these steps automatically.
+
+1. **Preflight.** Collect the redacted release-evidence record (plan
+   section 2: host identity, image IDs, DB occupancy, no unfinished
+   deploy/rescue/hold in progress). Verify the candidate and fallback
+   images are both actually pullable.
+2. **Install.** Through a separately reviewed admin channel (not this
+   repo's CI, not the restricted deploy account): install the pinned Nomad
+   binary/systemd units/ACL/mTLS from `host/nomad.hcl` and `host/acl.hcl`,
+   with the dormant nginx adapter in place. The existing Compose API keeps
+   serving traffic throughout this step.
+3. **First candidate.** Under the existing deploy/admission locks, start
+   `sm-api` on Nomad. Verify native health checks, the exact image digest,
+   DB/RAM surge headroom, and direct candidate reachability - all before
+   any public traffic moves.
+4. **Cut over.** Switch nginx to the approved, healthy Nomad endpoint.
+   Verify both public origins and auth/session behavior. Only now commit
+   the owner marker to `nomad` (`ops/nomad/ownership.mjs set-owner nomad`)
+   and stop the old Compose API, keeping its image/config in place. Repeat
+   one controlled update afterward to prove native canary from an already
+   `nomad`-owned stable release, not just the from-Compose transition.
+5. **Soak.** Run the existing required 300s restart/proxy/log/queue soak
+   and record the release/route receipt before enabling routine automation.
+
+Rollback at any point before step 4 completes: nothing to undo, Compose
+was never stopped. Rollback after step 4: reverse the owner marker to
+`compose` and restore the pinned Compose image/config (plan section 8) -
+this is the `rollback-required` path this MVP's contracts and tests
+already model, not a new mechanism to invent at rollback time.

--- a/ops/nomad/README.md
+++ b/ops/nomad/README.md
@@ -180,8 +180,15 @@ runs any of these steps automatically.
 2. **Install.** Through a separately reviewed admin channel (not this
    repo's CI, not the restricted deploy account): install the pinned Nomad
    binary/systemd units/ACL/mTLS from `host/nomad.hcl` and `host/acl.hcl`,
-   with the dormant nginx adapter in place. The existing Compose API keeps
-   serving traffic throughout this step.
+   with the dormant nginx adapter in place. **Also materialize the API's
+   secret env file** at the exact path `api.nomad.hcl`'s `api-secrets`
+   volume mounts (`social-monitor-api-secrets` host volume ->
+   `.../api.env.d/api.env`), owned/readable by the container's runtime
+   user, and confirm `api-env-entrypoint.mjs` can actually read it - `job
+   run` alone does not create this file, and neither `bootstrap.sh` nor
+   `release.mjs` implement `--apply` yet, so nothing in this repo's code
+   does this for you. The existing Compose API keeps serving traffic
+   throughout this step.
 3. **First candidate.** Under the existing deploy/admission locks, start
    `sm-api` on Nomad. Verify native health checks, the exact image digest,
    DB/RAM surge headroom, and direct candidate reachability - all before

--- a/ops/nomad/README.md
+++ b/ops/nomad/README.md
@@ -134,6 +134,22 @@ production today, even though every test above is green:
    on each other) and because `release.mjs --apply` does not exist yet (gap
    3). Add real fencing before either of those two gaps closes, not after -
    a marker file is not a lock.
+9. **`adapters/nginx.mjs`'s `switch()` is not crash-atomic across its own two
+   durable writes.** The cross-process lock (gap 8's sibling concern) closes
+   the multi-process race, but a hard crash/SIGKILL/power loss between
+   `reload()` succeeding and the following `writeAtomic(statePath, ...)`
+   would leave nginx actually serving the new endpoint while `inspect()`/the
+   state file still claims the old one - the next `switch()`'s CAS check
+   would then trust that stale claim. Not reachable today (`--apply` doesn't
+   exist), but real crash-atomicity here needs a proper write-ahead
+   sequence, not just the mutex this PR adds.
+10. **The canary health-count check in `adapters/nomad.mjs`'s
+    `waitForHealthy`** (`TaskGroups[groupName].DesiredCanaries`/
+    `HealthyAllocs`) is written from the Nomad HTTP API documentation and
+    tested only against fakes - it has not been verified against a real
+    Nomad agent's actual deployment response during an in-flight canary.
+    Confirm this exact field behavior against a real cluster before relying
+    on it to gate traffic.
 
 None of the above are things a future PR can silently work around by
 editing a hash constant, a signature file, or an `allowed_signers` entry -

--- a/ops/nomad/README.md
+++ b/ops/nomad/README.md
@@ -151,6 +151,13 @@ production today, even though every test above is green:
     request fields, JSON job object response) that `planJob`/`runJob` now
     depend on. Both are tested only against fakes. Confirm both against a
     real cluster before relying on either.
+11. **The nginx traffic-reconciliation adapter has no ACL policy or token of
+    its own yet.** `ops/nomad/adapters/nginx.mjs`/`reconcile-traffic.mjs`
+    already exist and are fully tested, but `host/acl.hcl` only defines the
+    deploy token's policy - the separate, strictly read-only
+    ("read-job"/"list-jobs" only) policy this adapter needs, and a matching
+    token wired into `host/api-traffic.service`, do not exist yet. Add both
+    before wiring the reconciliation loop to a real Nomad agent.
 
 None of the above are things a future PR can silently work around by
 editing a hash constant, a signature file, or an `allowed_signers` entry -

--- a/ops/nomad/README.md
+++ b/ops/nomad/README.md
@@ -125,6 +125,14 @@ production today, even though every test above is green:
    the live host. The plan's own preflight (release evidence: host
    identity, image IDs, DB occupancy, current release markers) has to run
    on the real VPS before any of this touches it.
+8. **The owner marker itself has no fencing token, TTL, or compare-and-swap**
+   (`ops/nomad/ownership.mjs`). A read-decide-act sequence (read the marker,
+   then act on it) is not fenced against a concurrent writer. This is safe
+   today only because nothing automated ever writes `nomad` (gap 1 above is
+   what would actually let a legacy Compose path and a Nomad release step
+   on each other) and because `release.mjs --apply` does not exist yet (gap
+   3). Add real fencing before either of those two gaps closes, not after -
+   a marker file is not a lock.
 
 None of the above are things a future PR can silently work around by
 editing a hash constant, a signature file, or an `allowed_signers` entry -

--- a/ops/nomad/README.md
+++ b/ops/nomad/README.md
@@ -143,13 +143,14 @@ production today, even though every test above is green:
    would then trust that stale claim. Not reachable today (`--apply` doesn't
    exist), but real crash-atomicity here needs a proper write-ahead
    sequence, not just the mutex this PR adds.
-10. **The canary health-count check in `adapters/nomad.mjs`'s
-    `waitForHealthy`** (`TaskGroups[groupName].DesiredCanaries`/
-    `HealthyAllocs`) is written from the Nomad HTTP API documentation and
-    tested only against fakes - it has not been verified against a real
-    Nomad agent's actual deployment response during an in-flight canary.
-    Confirm this exact field behavior against a real cluster before relying
-    on it to gate traffic.
+10. **Two `adapters/nomad.mjs` request/response shapes are written from
+    Nomad's HTTP API documentation, not verified against a real agent:**
+    the canary health-count check in `waitForHealthy`
+    (`TaskGroups[groupName].DesiredCanaries`/`HealthyAllocs`), and
+    `parseJobSpec`'s use of `POST /v1/jobs/parse` (`JobHCL`/`Canonicalize`
+    request fields, JSON job object response) that `planJob`/`runJob` now
+    depend on. Both are tested only against fakes. Confirm both against a
+    real cluster before relying on either.
 
 None of the above are things a future PR can silently work around by
 editing a hash constant, a signature file, or an `allowed_signers` entry -

--- a/ops/nomad/README.md
+++ b/ops/nomad/README.md
@@ -33,7 +33,7 @@ any of them are ready.
 | --- | --- | --- |
 | PR1 | `api.Dockerfile`, `contracts.mjs`(+test), `preflight.sh`(+test), `.github/workflows/production-api-nomad.yml` | An immutable, digest-pinned API image builds and pushes to GHCR without touching production; the six narrow release/health/traffic contracts validate correctly. |
 | PR2 | `ownership.mjs`(+test), `ownership-guard.sh`(+test), `api-env-entrypoint.mjs`(+test), `host/nomad.hcl`, `host/acl.hcl`, `versions.json`, `bootstrap.sh`(+test) | A durable `compose`/`nomad` owner marker exists and round-trips atomically; the API's env-file entrypoint parses safely without `eval`; the Nomad agent/ACL config and pinned version are reviewable; bootstrap is dry-run-only in this PR. |
-| PR3 | `adapters/nomad.mjs`(+test), `adapters/nginx.mjs`, `release.mjs`, `reconcile-traffic.mjs`, `rollout.test.mjs`, `api.nomad.hcl`, `host/api-deploy.service`, `host/api-traffic.service`, `.github/workflows/production-api-nomad-deploy.yml` | The full canary sequence (candidate → healthy → nginx switch → promote, or revert/restore on any failure) works end-to-end against fakes, including untrusted-endpoint rejection and the first-deployment-has-no-previous-release case. |
+| PR3 | `adapters/nomad.mjs`(+test), `adapters/nginx.mjs`, `release.mjs`, `release-cli.test.mjs`, `reconcile-traffic.mjs`, `rollout.test.mjs`, `jobspec-contract.test.mjs`, `api.nomad.hcl`, `host/api-deploy.service`, `host/api-traffic.service`, `.github/workflows/production-api-nomad-deploy.yml` | The full canary sequence (candidate → healthy → nginx switch → promote, or revert/restore on any failure) works end-to-end against fakes, including untrusted-endpoint rejection and the first-deployment-has-no-previous-release case; `jobspec-contract.test.mjs` statically checks the Dockerfile's entrypoint env path stays consistent with the jobspec's volume mount. |
 | PR4 | `concurrent-release.test.mjs`, `failure-drill.test.sh`, this README | Concurrent/stale submissions, a fully offline Nomad backend, and recovery after a mid-release crash are all proven not to corrupt the route or the owner marker. |
 
 ## Running the tests locally
@@ -46,12 +46,16 @@ git diff --check
 npm run check:source-line-cap
 npm run check:architecture
 npm run check:code-quality
+npm run check:secrets
+npx eslint ops/nomad
+npx tsc --noEmit
 
 node --test ops/nomad/*.test.mjs ops/nomad/adapters/*.test.mjs
 bash ops/nomad/preflight.test.sh
 bash ops/nomad/bootstrap.test.sh
 bash ops/nomad/ownership-guard.test.sh
 bash ops/nomad/failure-drill.test.sh
+shellcheck -S warning ops/nomad/*.sh
 ```
 
 If the `nomad` CLI is available in your environment, also run
@@ -184,7 +188,8 @@ runs any of these steps automatically.
    any public traffic moves.
 4. **Cut over.** Switch nginx to the approved, healthy Nomad endpoint.
    Verify both public origins and auth/session behavior. Only now commit
-   the owner marker to `nomad` (`ops/nomad/ownership.mjs set-owner nomad`)
+   the owner marker to `nomad` (`node ops/nomad/ownership.mjs set-owner nomad`
+   - the file is not executable on its own, unlike the `.sh` scripts here)
    and stop the old Compose API, keeping its image/config in place. Repeat
    one controlled update afterward to prove native canary from an already
    `nomad`-owned stable release, not just the from-Compose transition.

--- a/ops/nomad/README.md
+++ b/ops/nomad/README.md
@@ -94,7 +94,8 @@ production today, even though every test above is green:
    the legacy Compose side.
 2. **The restricted SSH wrapper does not implement the `nomad-*` verbs**
    `.github/workflows/production-api-nomad-deploy.yml` calls
-   (`nomad-plan`/`nomad-deploy`/`nomad-status`/`nomad-rollback`). That
+   (`nomad-plan`/`nomad-deploy`/`nomad-status`; rollback is a separate,
+   explicit operator action, not wired into this workflow). That
    workflow is `workflow_dispatch`-only, gated behind an explicit
    `confirm_wrapper_extended` input, and refuses to run until that wrapper
    extension ships separately.

--- a/ops/nomad/adapters/nginx.mjs
+++ b/ops/nomad/adapters/nginx.mjs
@@ -154,6 +154,31 @@ export function createNginxAdapter({
   const lockPath = join(includeDir, LOCK_DIR_NAME);
   const withLock = () => acquireLock(lockPath, { timeoutMs: lockTimeoutMs, pollIntervalMs: lockPollIntervalMs });
 
+  /**
+   * Restores activePath to whatever it held before the failed attempt
+   * (or removes it, on a first-ever publish with nothing to go back to),
+   * then tries once to bring nginx's own runtime state back in line with
+   * that file via reload(). Shared by every failure branch below
+   * (validate, reload, and state-persistence failures in both switch() and
+   * restore()) so "roll the config back and report whether nginx actually
+   * picked it up" is one reviewable behavior, not three copies of it.
+   * @param {string|null} previousContent
+   * @returns {Promise<boolean>} whether the rollback reload itself succeeded
+   */
+  async function rollbackActiveConfig(previousContent) {
+    if (previousContent !== null) {
+      writeAtomic(activePath, previousContent, 0o644);
+    } else {
+      rmSync(activePath, { force: true });
+    }
+    try {
+      await reload();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   function assertAllowedEndpoint(endpoint) {
     if (!endpoint || typeof endpoint !== "object") {
       throw new EndpointNotAllowedError("nginx adapter: endpoint must be an object");
@@ -204,57 +229,40 @@ export function createNginxAdapter({
         try {
           await validate(activePath);
         } catch (error) {
-          if (previousContent !== null) {
-            writeAtomic(activePath, previousContent, 0o644);
-          } else {
-            // First-ever publish: there is no previous route to restore to.
-            // Remove the invalid candidate instead of leaving it behind -
-            // the include directory must never hold content nginx never
-            // actually validated.
-            rmSync(activePath, { force: true });
-          }
+          const restored = await rollbackActiveConfig(previousContent);
           throw new NginxReloadError(`nginx adapter: config validation failed, kept previous route: ${error.message}`, {
-            restored: true,
+            restored,
           });
         }
 
         try {
           await reload();
         } catch (error) {
-          if (previousContent !== null) {
-            writeAtomic(activePath, previousContent, 0o644);
-            let restored = true;
-            try {
-              await reload();
-            } catch {
-              restored = false;
-            }
-            throw new NginxReloadError(`nginx adapter: reload failed after switch, restored previous route: ${error.message}`, {
-              restored,
-            });
-          }
-          // First-ever publish and reload failed: remove the unreloaded
-          // candidate so the include directory matches "nothing configured"
-          // (what nginx actually has loaded), then try to bring nginx's own
-          // state back in line with that by reloading once more.
-          rmSync(activePath, { force: true });
-          let restored = true;
-          try {
-            await reload();
-          } catch {
-            restored = false;
-          }
+          const restored = await rollbackActiveConfig(previousContent);
+          throw new NginxReloadError(`nginx adapter: reload failed after switch, restored previous route: ${error.message}`, {
+            restored,
+          });
+        }
+
+        try {
+          writeAtomic(
+            statePath,
+            JSON.stringify({ currentEndpoint: endpoint, configPreimage: rendered }, null, 2),
+            0o644,
+          );
+        } catch (error) {
+          // nginx has already reloaded to serve `endpoint`, but recording
+          // that durably just failed (disk full, permissions): leaving this
+          // half-applied - config live, bookkeeping stale - would let the
+          // next switch()'s CAS check trust the wrong "current" value. Roll
+          // the live config back too so both agree again, rather than
+          // leaving a call that "half-succeeded" behind.
+          const restored = await rollbackActiveConfig(previousContent);
           throw new NginxReloadError(
-            `nginx adapter: reload failed on first publish, removed unreloaded candidate: ${error.message}`,
+            `nginx adapter: failed to persist switch state, rolled config back: ${error.message}`,
             { restored },
           );
         }
-
-        writeAtomic(
-          statePath,
-          JSON.stringify({ currentEndpoint: endpoint, configPreimage: rendered }, null, 2),
-          0o644,
-        );
         return { switched: true, previousEndpoint: state.currentEndpoint ?? null, configPreimage: rendered };
       } finally {
         releaseLock(lockPath);
@@ -288,14 +296,35 @@ export function createNginxAdapter({
       }
       await withLock();
       try {
+        const previousContent = existsSync(activePath) ? readFileSync(activePath, "utf8") : null;
         writeAtomic(activePath, token.configPreimage, 0o644);
-        await validate(activePath);
-        await reload();
-        writeAtomic(
-          statePath,
-          JSON.stringify({ currentEndpoint: token.currentEndpoint ?? null, configPreimage: token.configPreimage }, null, 2),
-          0o644,
-        );
+        try {
+          await validate(activePath);
+          await reload();
+        } catch (error) {
+          // An explicit rollback that itself fails must not leave the
+          // active config in an unreviewed, unreloaded state - restore
+          // whatever was actually running before this call, same as
+          // switch()'s own failure handling.
+          const restored = await rollbackActiveConfig(previousContent);
+          throw new NginxReloadError(`nginx adapter: restore failed, rolled back to the prior config: ${error.message}`, {
+            restored,
+          });
+        }
+
+        try {
+          writeAtomic(
+            statePath,
+            JSON.stringify({ currentEndpoint: token.currentEndpoint ?? null, configPreimage: token.configPreimage }, null, 2),
+            0o644,
+          );
+        } catch (error) {
+          const restored = await rollbackActiveConfig(previousContent);
+          throw new NginxReloadError(
+            `nginx adapter: failed to persist restore state, rolled config back: ${error.message}`,
+            { restored },
+          );
+        }
         return { restored: true };
       } finally {
         releaseLock(lockPath);

--- a/ops/nomad/adapters/nginx.mjs
+++ b/ops/nomad/adapters/nginx.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * nginx traffic adapter for the `sm-api` vertical slice (plan section 4).
+ *
+ * Native Nomad service discovery is not DNS and does not update nginx by
+ * itself, so this adapter is the only bridge: it renders a validated
+ * upstream include, atomically publishes it into an **include directory**
+ * (never a single mounted file - an atomic rename onto a bind-mounted file
+ * can leave the container holding the old inode), runs an injectable
+ * validate+reload step, and only then remembers the new endpoint as current.
+ * On any validate/reload failure it leaves the previously active file alone
+ * and reports failure - it never guesses a "probably fine" fallback.
+ *
+ * This module satisfies the `TrafficSwitch` port from `../contracts.mjs`
+ * (`inspect`/`switch`/`restore`) but is written as a plain adapter object;
+ * wrap it with `createTrafficSwitch` from contracts.mjs at the call site
+ * (ISP: callers should depend on that narrow port, not on this file).
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export class TrafficSwitchConflictError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "TrafficSwitchConflictError";
+  }
+}
+
+export class EndpointNotAllowedError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "EndpointNotAllowedError";
+  }
+}
+
+export class NginxReloadError extends Error {
+  constructor(message, { restored } = {}) {
+    super(message);
+    this.name = "NginxReloadError";
+    this.restored = Boolean(restored);
+  }
+}
+
+const ACTIVE_FILE_NAME = "api-upstream.conf";
+const STATE_FILE_NAME = "api-upstream.state.json";
+
+function ipToInt(ip) {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
+    return null;
+  }
+  return parts.reduce((acc, part) => acc * 256 + part, 0);
+}
+
+/**
+ * Minimal IPv4 CIDR membership check - no dependency pulled in for one
+ * allowlist comparison (plan section 4: only the trusted project subnet may
+ * ever become an nginx upstream).
+ * @param {string} address
+ * @param {string} cidr - e.g. "172.20.0.0/16"
+ */
+export function isAddressInCidr(address, cidr) {
+  const [rangeIp, prefixRaw] = cidr.split("/");
+  const prefix = Number(prefixRaw);
+  const addressInt = ipToInt(address);
+  const rangeInt = ipToInt(rangeIp);
+  if (addressInt === null || rangeInt === null || Number.isNaN(prefix) || prefix < 0 || prefix > 32) {
+    return false;
+  }
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (addressInt & mask) === (rangeInt & mask);
+}
+
+function renderUpstreamInclude({ address, port }) {
+  return `# Managed by ops/nomad/adapters/nginx.mjs. Do not edit by hand.\nupstream social_monitor_api_nomad {\n  server ${address}:${port};\n}\n`;
+}
+
+function readState(statePath) {
+  if (!existsSync(statePath)) {
+    return { currentEndpoint: null, configPreimage: null };
+  }
+  return JSON.parse(readFileSync(statePath, "utf8"));
+}
+
+function writeAtomic(path, content, mode) {
+  const tempPath = `${path}.next-${process.pid}-${Date.now()}`;
+  writeFileSync(tempPath, content, { mode });
+  renameSync(tempPath, path);
+}
+
+/**
+ * @param {{
+ *   includeDir: string,
+ *   allowedNamespace: string,
+ *   allowedJob: string,
+ *   allowedCidr: string,
+ *   validate?: (path: string) => Promise<void>,
+ *   reload?: () => Promise<void>,
+ * }} options
+ */
+export function createNginxAdapter({
+  includeDir,
+  allowedNamespace,
+  allowedJob,
+  allowedCidr,
+  validate = async () => {},
+  reload = async () => {},
+}) {
+  mkdirSync(includeDir, { recursive: true, mode: 0o755 });
+  const activePath = join(includeDir, ACTIVE_FILE_NAME);
+  const statePath = join(includeDir, STATE_FILE_NAME);
+
+  function assertAllowedEndpoint(endpoint) {
+    if (!endpoint || typeof endpoint !== "object") {
+      throw new EndpointNotAllowedError("nginx adapter: endpoint must be an object");
+    }
+    const { namespace, jobId, address, port } = endpoint;
+    if (namespace !== allowedNamespace || jobId !== allowedJob) {
+      throw new EndpointNotAllowedError(
+        `nginx adapter: endpoint namespace/job "${namespace}/${jobId}" is not the trusted target "${allowedNamespace}/${allowedJob}"`,
+      );
+    }
+    if (!isAddressInCidr(address, allowedCidr)) {
+      throw new EndpointNotAllowedError(`nginx adapter: address "${address}" is outside the trusted subnet ${allowedCidr}`);
+    }
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+      throw new EndpointNotAllowedError(`nginx adapter: invalid port "${port}"`);
+    }
+  }
+
+  return Object.freeze({
+    /** @returns {{currentEndpoint: object|null, configPreimage: string|null}} */
+    async inspect() {
+      return readState(statePath);
+    },
+
+    /**
+     * Compare-and-swap traffic switch. `expectedPrevious` must match the
+     * adapter's own last-known current endpoint (or `null` on first
+     * publish); mismatched callers get a conflict rather than silently
+     * clobbering a route someone else already changed.
+     */
+    async switch(expectedPrevious, endpoint) {
+      const state = readState(statePath);
+      const expectedKey = JSON.stringify(expectedPrevious ?? null);
+      const actualKey = JSON.stringify(state.currentEndpoint ?? null);
+      if (expectedKey !== actualKey) {
+        throw new TrafficSwitchConflictError(
+          "nginx adapter: expectedPrevious does not match the current route (concurrent switch?)",
+        );
+      }
+      assertAllowedEndpoint(endpoint);
+
+      const rendered = renderUpstreamInclude(endpoint);
+      const previousContent = existsSync(activePath) ? readFileSync(activePath, "utf8") : null;
+
+      writeAtomic(activePath, rendered, 0o644);
+      try {
+        await validate(activePath);
+      } catch (error) {
+        if (previousContent !== null) {
+          writeAtomic(activePath, previousContent, 0o644);
+        }
+        throw new NginxReloadError(`nginx adapter: config validation failed, kept previous route: ${error.message}`, {
+          restored: true,
+        });
+      }
+
+      try {
+        await reload();
+      } catch (error) {
+        if (previousContent !== null) {
+          writeAtomic(activePath, previousContent, 0o644);
+          let restored = true;
+          try {
+            await reload();
+          } catch {
+            restored = false;
+          }
+          throw new NginxReloadError(`nginx adapter: reload failed after switch, restored previous route: ${error.message}`, {
+            restored,
+          });
+        }
+        throw new NginxReloadError(`nginx adapter: reload failed on first publish, no previous route to restore: ${error.message}`, {
+          restored: false,
+        });
+      }
+
+      writeAtomic(
+        statePath,
+        JSON.stringify({ currentEndpoint: endpoint, configPreimage: rendered }, null, 2),
+        0o644,
+      );
+      return { switched: true, previousEndpoint: state.currentEndpoint ?? null, configPreimage: rendered };
+    },
+
+    /**
+     * Restores a previously recorded receipt's config verbatim (used on
+     * explicit rollback, not on the automatic validate/reload failure path
+     * above, which already restores inline).
+     */
+    async restore(receipt) {
+      if (!receipt || typeof receipt.configPreimage !== "string") {
+        throw new EndpointNotAllowedError("nginx adapter: restore requires a receipt with configPreimage");
+      }
+      writeAtomic(activePath, receipt.configPreimage, 0o644);
+      await validate(activePath);
+      await reload();
+      writeAtomic(
+        statePath,
+        JSON.stringify({ currentEndpoint: receipt.currentEndpoint ?? null, configPreimage: receipt.configPreimage }, null, 2),
+        0o644,
+      );
+      return { restored: true };
+    },
+  });
+}

--- a/ops/nomad/adapters/nginx.mjs
+++ b/ops/nomad/adapters/nginx.mjs
@@ -82,9 +82,21 @@ function releaseLock(lockPath) {
   rmSync(lockPath, { recursive: true, force: true });
 }
 
+const IPV4_OCTET_PATTERN = /^\d{1,3}$/u;
+
 function ipToInt(ip) {
-  const parts = ip.split(".").map(Number);
-  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
+  const rawParts = ip.split(".");
+  // `Number("5\n")` and `Number(" 5")` both trim whitespace per the
+  // ToNumber spec and parse as 5, so building on Number() directly here
+  // would let a stray newline/space embedded in an octet slip through this
+  // CIDR check - the one thing standing between an attacker-influenced
+  // endpoint and becoming a literal line in the rendered nginx upstream
+  // config below. Require every octet to be nothing but ASCII digits first.
+  if (rawParts.length !== 4 || rawParts.some((part) => !IPV4_OCTET_PATTERN.test(part))) {
+    return null;
+  }
+  const parts = rawParts.map(Number);
+  if (parts.some((part) => part > 255)) {
     return null;
   }
   return parts.reduce((acc, part) => acc * 256 + part, 0);

--- a/ops/nomad/adapters/nginx.mjs
+++ b/ops/nomad/adapters/nginx.mjs
@@ -166,15 +166,20 @@ export function createNginxAdapter({
    * @returns {Promise<boolean>} whether the rollback reload itself succeeded
    */
   async function rollbackActiveConfig(previousContent) {
-    if (previousContent !== null) {
-      writeAtomic(activePath, previousContent, 0o644);
-    } else {
-      rmSync(activePath, { force: true });
-    }
     try {
+      if (previousContent !== null) {
+        writeAtomic(activePath, previousContent, 0o644);
+      } else {
+        rmSync(activePath, { force: true });
+      }
       await reload();
       return true;
     } catch {
+      // Whatever caused the original failure (disk full, permissions) can
+      // just as easily break this rollback attempt too - report it the
+      // same as a reload-only failure (a plain `false`) rather than letting
+      // an unrelated fs exception escape and replace the caller's own
+      // NginxReloadError with a less informative one.
       return false;
     }
   }

--- a/ops/nomad/adapters/nginx.mjs
+++ b/ops/nomad/adapters/nginx.mjs
@@ -17,7 +17,7 @@
  * (ISP: callers should depend on that narrow port, not on this file).
  */
 
-import { mkdirSync, readFileSync, renameSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 export class TrafficSwitchConflictError extends Error {
@@ -44,6 +44,43 @@ export class NginxReloadError extends Error {
 
 const ACTIVE_FILE_NAME = "api-upstream.conf";
 const STATE_FILE_NAME = "api-upstream.state.json";
+const LOCK_DIR_NAME = "api-upstream.lock";
+
+/**
+ * Cross-process mutex for the read-decide-write sequence in `switch`/
+ * `restore`. `release.mjs` (occasional deploys) and reconcile-traffic.mjs's
+ * periodic loop (every ~5s, plan section 4) both call this adapter and are
+ * not otherwise serialized against each other - without a real lock here,
+ * two callers could both read the same "current" state and then both write,
+ * corrupting either the served config or the state file's own bookkeeping.
+ * `mkdirSync` is used as the atomic primitive (EEXIST is atomic and
+ * portable); a crashed holder fails loudly on the next attempt instead of
+ * silently racing, matching this repo's fail-closed conventions.
+ */
+async function acquireLock(lockPath, { timeoutMs = 5000, pollIntervalMs = 50 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      mkdirSync(lockPath);
+      return;
+    } catch (error) {
+      if (error.code !== "EEXIST") {
+        throw error;
+      }
+      if (Date.now() >= deadline) {
+        throw new TrafficSwitchConflictError(
+          `nginx adapter: could not acquire cross-process lock at ${lockPath} within ${timeoutMs}ms ` +
+            "(a concurrent switch/reconcile is in progress, or a prior holder crashed and left it behind)",
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+  }
+}
+
+function releaseLock(lockPath) {
+  rmSync(lockPath, { recursive: true, force: true });
+}
 
 function ipToInt(ip) {
   const parts = ip.split(".").map(Number);
@@ -97,6 +134,8 @@ function writeAtomic(path, content, mode) {
  *   allowedCidr: string,
  *   validate?: (path: string) => Promise<void>,
  *   reload?: () => Promise<void>,
+ *   lockTimeoutMs?: number,
+ *   lockPollIntervalMs?: number,
  * }} options
  */
 export function createNginxAdapter({
@@ -106,10 +145,14 @@ export function createNginxAdapter({
   allowedCidr,
   validate = async () => {},
   reload = async () => {},
+  lockTimeoutMs = 5000,
+  lockPollIntervalMs = 50,
 }) {
   mkdirSync(includeDir, { recursive: true, mode: 0o755 });
   const activePath = join(includeDir, ACTIVE_FILE_NAME);
   const statePath = join(includeDir, STATE_FILE_NAME);
+  const lockPath = join(includeDir, LOCK_DIR_NAME);
+  const withLock = () => acquireLock(lockPath, { timeoutMs: lockTimeoutMs, pollIntervalMs: lockPollIntervalMs });
 
   function assertAllowedEndpoint(endpoint) {
     if (!endpoint || typeof endpoint !== "object") {
@@ -142,77 +185,121 @@ export function createNginxAdapter({
      * clobbering a route someone else already changed.
      */
     async switch(expectedPrevious, endpoint) {
-      const state = readState(statePath);
-      const expectedKey = JSON.stringify(expectedPrevious ?? null);
-      const actualKey = JSON.stringify(state.currentEndpoint ?? null);
-      if (expectedKey !== actualKey) {
-        throw new TrafficSwitchConflictError(
-          "nginx adapter: expectedPrevious does not match the current route (concurrent switch?)",
-        );
-      }
-      assertAllowedEndpoint(endpoint);
-
-      const rendered = renderUpstreamInclude(endpoint);
-      const previousContent = existsSync(activePath) ? readFileSync(activePath, "utf8") : null;
-
-      writeAtomic(activePath, rendered, 0o644);
+      await withLock();
       try {
-        await validate(activePath);
-      } catch (error) {
-        if (previousContent !== null) {
-          writeAtomic(activePath, previousContent, 0o644);
+        const state = readState(statePath);
+        const expectedKey = JSON.stringify(expectedPrevious ?? null);
+        const actualKey = JSON.stringify(state.currentEndpoint ?? null);
+        if (expectedKey !== actualKey) {
+          throw new TrafficSwitchConflictError(
+            "nginx adapter: expectedPrevious does not match the current route (concurrent switch?)",
+          );
         }
-        throw new NginxReloadError(`nginx adapter: config validation failed, kept previous route: ${error.message}`, {
-          restored: true,
-        });
-      }
+        assertAllowedEndpoint(endpoint);
 
-      try {
-        await reload();
-      } catch (error) {
-        if (previousContent !== null) {
-          writeAtomic(activePath, previousContent, 0o644);
+        const rendered = renderUpstreamInclude(endpoint);
+        const previousContent = existsSync(activePath) ? readFileSync(activePath, "utf8") : null;
+
+        writeAtomic(activePath, rendered, 0o644);
+        try {
+          await validate(activePath);
+        } catch (error) {
+          if (previousContent !== null) {
+            writeAtomic(activePath, previousContent, 0o644);
+          } else {
+            // First-ever publish: there is no previous route to restore to.
+            // Remove the invalid candidate instead of leaving it behind -
+            // the include directory must never hold content nginx never
+            // actually validated.
+            rmSync(activePath, { force: true });
+          }
+          throw new NginxReloadError(`nginx adapter: config validation failed, kept previous route: ${error.message}`, {
+            restored: true,
+          });
+        }
+
+        try {
+          await reload();
+        } catch (error) {
+          if (previousContent !== null) {
+            writeAtomic(activePath, previousContent, 0o644);
+            let restored = true;
+            try {
+              await reload();
+            } catch {
+              restored = false;
+            }
+            throw new NginxReloadError(`nginx adapter: reload failed after switch, restored previous route: ${error.message}`, {
+              restored,
+            });
+          }
+          // First-ever publish and reload failed: remove the unreloaded
+          // candidate so the include directory matches "nothing configured"
+          // (what nginx actually has loaded), then try to bring nginx's own
+          // state back in line with that by reloading once more.
+          rmSync(activePath, { force: true });
           let restored = true;
           try {
             await reload();
           } catch {
             restored = false;
           }
-          throw new NginxReloadError(`nginx adapter: reload failed after switch, restored previous route: ${error.message}`, {
-            restored,
-          });
+          throw new NginxReloadError(
+            `nginx adapter: reload failed on first publish, removed unreloaded candidate: ${error.message}`,
+            { restored },
+          );
         }
-        throw new NginxReloadError(`nginx adapter: reload failed on first publish, no previous route to restore: ${error.message}`, {
-          restored: false,
-        });
-      }
 
-      writeAtomic(
-        statePath,
-        JSON.stringify({ currentEndpoint: endpoint, configPreimage: rendered }, null, 2),
-        0o644,
-      );
-      return { switched: true, previousEndpoint: state.currentEndpoint ?? null, configPreimage: rendered };
+        writeAtomic(
+          statePath,
+          JSON.stringify({ currentEndpoint: endpoint, configPreimage: rendered }, null, 2),
+          0o644,
+        );
+        return { switched: true, previousEndpoint: state.currentEndpoint ?? null, configPreimage: rendered };
+      } finally {
+        releaseLock(lockPath);
+      }
     },
 
     /**
-     * Restores a previously recorded receipt's config verbatim (used on
-     * explicit rollback, not on the automatic validate/reload failure path
-     * above, which already restores inline).
+     * @typedef {object} NginxRestoreToken
+     * @property {string} configPreimage - exact file content a prior `switch()` rendered, not a `contracts.mjs` RollbackReceipt's opaque reference/hash.
+     * @property {{namespace: string, jobId: string, address: string, port: number}|null} currentEndpoint - the endpoint that configPreimage actually serves, so `inspect()` stays accurate after this restore.
      */
-    async restore(receipt) {
-      if (!receipt || typeof receipt.configPreimage !== "string") {
-        throw new EndpointNotAllowedError("nginx adapter: restore requires a receipt with configPreimage");
+    /**
+     * Restores a previously recorded config verbatim (used on an explicit,
+     * operator-triggered rollback, not on the automatic validate/reload
+     * failure path above, which already restores inline).
+     *
+     * Takes an `NginxRestoreToken`, deliberately not a bare `contracts.mjs`
+     * RollbackReceipt: RollbackReceipt has no `currentEndpoint` field at
+     * all, and its `configPreimage` is documented as an opaque
+     * reference/hash, not literal file content. Passing a RollbackReceipt
+     * here directly would silently record `currentEndpoint: null`
+     * regardless of what was actually restored. Build the token from
+     * whichever store durably holds the real content+endpoint pair (e.g.
+     * this adapter's own prior successful `switch()` result) before calling
+     * this.
+     * @param {NginxRestoreToken} token
+     */
+    async restore(token) {
+      if (!token || typeof token.configPreimage !== "string") {
+        throw new EndpointNotAllowedError("nginx adapter: restore requires a token with configPreimage");
       }
-      writeAtomic(activePath, receipt.configPreimage, 0o644);
-      await validate(activePath);
-      await reload();
-      writeAtomic(
-        statePath,
-        JSON.stringify({ currentEndpoint: receipt.currentEndpoint ?? null, configPreimage: receipt.configPreimage }, null, 2),
-        0o644,
-      );
-      return { restored: true };
+      await withLock();
+      try {
+        writeAtomic(activePath, token.configPreimage, 0o644);
+        await validate(activePath);
+        await reload();
+        writeAtomic(
+          statePath,
+          JSON.stringify({ currentEndpoint: token.currentEndpoint ?? null, configPreimage: token.configPreimage }, null, 2),
+          0o644,
+        );
+        return { restored: true };
+      } finally {
+        releaseLock(lockPath);
+      }
     },
   });
 }

--- a/ops/nomad/adapters/nginx.mjs
+++ b/ops/nomad/adapters/nginx.mjs
@@ -111,10 +111,17 @@ function ipToInt(ip) {
  */
 export function isAddressInCidr(address, cidr) {
   const [rangeIp, prefixRaw] = cidr.split("/");
-  const prefix = Number(prefixRaw);
   const addressInt = ipToInt(address);
   const rangeInt = ipToInt(rangeIp);
-  if (addressInt === null || rangeInt === null || Number.isNaN(prefix) || prefix < 0 || prefix > 32) {
+  // Same ToNumber whitespace-trimming pitfall as the octets above
+  // (Number("16\n") === 16): `cidr` is caller-supplied trusted config
+  // today, not attacker input, but this function's only job is exact
+  // membership arithmetic, so it must not depend on that being true forever.
+  if (addressInt === null || rangeInt === null || prefixRaw === undefined || !IPV4_OCTET_PATTERN.test(prefixRaw)) {
+    return false;
+  }
+  const prefix = Number(prefixRaw);
+  if (prefix > 32) {
     return false;
   }
   const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;

--- a/ops/nomad/adapters/nomad.mjs
+++ b/ops/nomad/adapters/nomad.mjs
@@ -33,7 +33,7 @@ function defaultSleep(ms) {
 }
 
 /**
- * @param {{baseUrl?: string, token?: string|null, fetchImpl?: typeof fetch, sleep?: (ms: number) => Promise<void>}} [options]
+ * @param {{baseUrl?: string, token?: string|null, fetchImpl?: typeof fetch, sleep?: (ms: number) => Promise<void>, requestTimeoutMs?: number, now?: () => Date}} [options]
  */
 export function createNomadClient({
   baseUrl = DEFAULT_BASE_URL,
@@ -41,6 +41,7 @@ export function createNomadClient({
   fetchImpl = fetch,
   sleep = defaultSleep,
   requestTimeoutMs = 10_000,
+  now = () => new Date(),
 } = {}) {
   async function request(method, path, body) {
     const headers = { "content-type": "application/json" };
@@ -226,7 +227,7 @@ export function createNomadClient({
         if (lastStatus === "running" || lastStatus === "successful") {
           return createHealthResult({
             status: "healthy",
-            checkedAt: new Date(),
+            checkedAt: now(),
             reason: lastDescription,
             observedAllocation: deploymentId,
           });
@@ -234,7 +235,7 @@ export function createNomadClient({
         if (lastStatus === "failed" || lastStatus === "cancelled") {
           return createHealthResult({
             status: "unhealthy",
-            checkedAt: new Date(),
+            checkedAt: now(),
             reason: lastDescription || lastStatus,
             observedAllocation: deploymentId,
           });
@@ -242,7 +243,7 @@ export function createNomadClient({
         if (Date.now() >= deadline) {
           return createHealthResult({
             status: "unknown",
-            checkedAt: new Date(),
+            checkedAt: now(),
             reason: `timed out waiting for deployment status (last=${lastStatus})`,
             observedAllocation: deploymentId,
           });

--- a/ops/nomad/adapters/nomad.mjs
+++ b/ops/nomad/adapters/nomad.mjs
@@ -102,16 +102,29 @@ export function createNomadClient({
     return { allocId, address, port };
   }
 
+  /**
+   * Nomad's job register/plan endpoints require a JSON-encoded Job object
+   * in the `Job` field - never raw HCL text (confirmed against the Nomad
+   * HTTP API docs). `/v1/jobs/parse` is the only supported way to turn this
+   * repo's `.nomad.hcl` source into that shape; skipping this step would
+   * make every real planJob/runJob call fail against an actual Nomad agent
+   * despite passing against the fake fetchImpl this test suite uses.
+   */
+  async function parseJobSpec(jobHcl) {
+    return request("POST", "/v1/jobs/parse", { JobHCL: jobHcl, Canonicalize: true });
+  }
+
   return Object.freeze({
     /**
      * Read-only plan. Never mutates the job; a `jobModifyIndex` mismatch on
      * the later `runJob` call means a stale plan (plan section 7).
      */
     async planJob(namespace, jobId, jobHcl) {
+      const parsedJob = await parseJobSpec(jobHcl);
       const result = await request(
         "POST",
         `/v1/job/${encodeURIComponent(jobId)}/plan?namespace=${encodeURIComponent(namespace)}`,
-        { Job: jobHcl, Diff: true },
+        { Job: parsedJob, Diff: true },
       );
       return { jobModifyIndex: result?.JobModifyIndex ?? null, warnings: result?.Warnings ?? "" };
     },
@@ -123,8 +136,9 @@ export function createNomadClient({
      * section 7). Returns submission identifiers only - not health.
      */
     async runJob(namespace, jobId, jobHcl, { checkIndex } = {}) {
+      const parsedJob = await parseJobSpec(jobHcl);
       const result = await request("POST", `/v1/job/${encodeURIComponent(jobId)}?namespace=${encodeURIComponent(namespace)}`, {
-        Job: jobHcl,
+        Job: parsedJob,
         EnforceIndex: checkIndex !== undefined && checkIndex !== null,
         JobModifyIndex: checkIndex ?? undefined,
       });
@@ -224,15 +238,10 @@ export function createNomadClient({
         } catch (error) {
           lastDescription = error instanceof Error ? error.message : String(error);
         }
-        if (lastStatus === "running" || lastStatus === "successful") {
-          return createHealthResult({
-            status: "healthy",
-            checkedAt: now(),
-            reason: lastDescription,
-            observedAllocation: deploymentId,
-          });
-        }
         if (lastStatus === "failed" || lastStatus === "cancelled") {
+          // A definitive negative signal is trusted regardless of timing -
+          // there is no "late failure" ambiguity the way there is for
+          // "late success" below.
           return createHealthResult({
             status: "unhealthy",
             checkedAt: now(),
@@ -241,10 +250,23 @@ export function createNomadClient({
           });
         }
         if (Date.now() >= deadline) {
+          // Checked before accepting "running"/"successful" below on
+          // purpose: a status that only turned healthy after this
+          // deployment's own timeout budget already elapsed must not be
+          // treated as an on-time healthy result - runRelease has already
+          // moved on to whatever "unknown" implies for it (fail closed).
           return createHealthResult({
             status: "unknown",
             checkedAt: now(),
             reason: `timed out waiting for deployment status (last=${lastStatus})`,
+            observedAllocation: deploymentId,
+          });
+        }
+        if (lastStatus === "running" || lastStatus === "successful") {
+          return createHealthResult({
+            status: "healthy",
+            checkedAt: now(),
+            reason: lastDescription,
             observedAllocation: deploymentId,
           });
         }

--- a/ops/nomad/adapters/nomad.mjs
+++ b/ops/nomad/adapters/nomad.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * Thin Nomad HTTP API client for the `sm-api` vertical slice (plan sections
+ * 4 and 7). This module only translates release.mjs/reconcile-traffic.mjs
+ * calls into Nomad HTTP requests and Nomad's JSON responses back into small
+ * plain objects (DIP: those callers depend on this narrow shape, not on the
+ * Nomad wire format). It never decides whether a rollout is safe, never
+ * touches nginx, and never shells out to the `nomad` CLI.
+ *
+ * The Nomad HTTP API is reachable only on loopback (see host/nomad.hcl), so
+ * in production this client always talks to `http://127.0.0.1:4646`. Tests
+ * inject a fake `fetchImpl`/`sleep` instead of a real Nomad agent - this
+ * repository does not run a Nomad agent as part of its test suite.
+ */
+
+import { createHealthResult } from "../contracts.mjs";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:4646";
+
+export class NomadApiError extends Error {
+  constructor(message, { status, body } = {}) {
+    super(message);
+    this.name = "NomadApiError";
+    this.status = status ?? null;
+    this.body = body ?? null;
+  }
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * @param {{baseUrl?: string, token?: string|null, fetchImpl?: typeof fetch, sleep?: (ms: number) => Promise<void>}} [options]
+ */
+export function createNomadClient({
+  baseUrl = DEFAULT_BASE_URL,
+  token = null,
+  fetchImpl = fetch,
+  sleep = defaultSleep,
+} = {}) {
+  async function request(method, path, body) {
+    const headers = { "content-type": "application/json" };
+    if (token) {
+      headers["X-Nomad-Token"] = token;
+    }
+    const response = await fetchImpl(`${baseUrl}${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = typeof response.text === "function" ? await response.text() : "";
+    const parsed = text && text.length > 0 ? JSON.parse(text) : null;
+    if (!response.ok) {
+      throw new NomadApiError(`${method} ${path} failed with status ${response.status}`, {
+        status: response.status,
+        body: parsed,
+      });
+    }
+    return parsed;
+  }
+
+  async function getJobAllocations(namespace, jobId) {
+    const result = await request("GET", `/v1/job/${jobId}/allocations?namespace=${encodeURIComponent(namespace)}`);
+    return (result ?? []).map((alloc) => ({
+      allocId: alloc.ID,
+      clientStatus: alloc.ClientStatus,
+      isCanary: Boolean(alloc.DeploymentStatus?.Canary),
+      healthy: alloc.DeploymentStatus?.Healthy ?? null,
+    }));
+  }
+
+  async function getAllocationEndpoint(allocId, { port = 3000 } = {}) {
+    const alloc = await request("GET", `/v1/allocation/${allocId}`);
+    const address = alloc?.NetworkStatus?.Address ?? null;
+    if (!address) {
+      return null;
+    }
+    return { allocId, address, port };
+  }
+
+  return Object.freeze({
+    /**
+     * Read-only plan. Never mutates the job; a `jobModifyIndex` mismatch on
+     * the later `runJob` call means a stale plan (plan section 7).
+     */
+    async planJob(namespace, jobId, jobHcl) {
+      const result = await request(
+        "POST",
+        `/v1/job/${jobId}/plan?namespace=${encodeURIComponent(namespace)}`,
+        { Job: jobHcl, Diff: true },
+      );
+      return { jobModifyIndex: result?.JobModifyIndex ?? null, warnings: result?.Warnings ?? "" };
+    },
+
+    /**
+     * Submits the job with `-check-index` semantics (`EnforceIndex`): the
+     * write is rejected if the job changed since `planJob` observed
+     * `checkIndex`, protecting against a concurrent/stale deploy (plan
+     * section 7). Returns submission identifiers only - not health.
+     */
+    async runJob(namespace, jobId, jobHcl, { checkIndex } = {}) {
+      const result = await request("POST", `/v1/job/${jobId}?namespace=${encodeURIComponent(namespace)}`, {
+        Job: jobHcl,
+        EnforceIndex: checkIndex !== undefined && checkIndex !== null,
+        JobModifyIndex: checkIndex ?? undefined,
+      });
+      return {
+        evalId: result?.EvalID ?? null,
+        deploymentId: result?.DeploymentID ?? null,
+        jobModifyIndex: result?.JobModifyIndex ?? checkIndex ?? null,
+        warnings: result?.Warnings ?? "",
+      };
+    },
+
+    async getDeployment(deploymentId) {
+      const result = await request("GET", `/v1/deployment/${deploymentId}`);
+      return {
+        status: result?.Status ?? "unknown",
+        statusDescription: result?.StatusDescription ?? "",
+        taskGroups: result?.TaskGroups ?? {},
+      };
+    },
+
+    getJobAllocations,
+    getAllocationEndpoint,
+
+    /**
+     * Finds the current canary allocation for a job and resolves its
+     * driver-mode network address (plan section 4: `address_mode="driver"`,
+     * no new host ports). Returns `null` while no canary allocation is up
+     * yet, so callers can keep polling instead of switching traffic early.
+     */
+    async getCandidateEndpoint(namespace, jobId, { port = 3000 } = {}) {
+      const allocations = await getJobAllocations(namespace, jobId);
+      const candidate = allocations.find((alloc) => alloc.isCanary && alloc.clientStatus === "running");
+      if (!candidate) {
+        return null;
+      }
+      return getAllocationEndpoint(candidate.allocId, { port });
+    },
+
+    /**
+     * Finds the current promoted (non-canary) healthy allocation's endpoint,
+     * used by reconcile-traffic.mjs after a restart/reschedule changes the
+     * container IP.
+     */
+    async getStableEndpoint(namespace, jobId, { port = 3000 } = {}) {
+      const allocations = await getJobAllocations(namespace, jobId);
+      const stable = allocations.find(
+        (alloc) => !alloc.isCanary && alloc.clientStatus === "running" && alloc.healthy !== false,
+      );
+      if (!stable) {
+        return null;
+      }
+      return getAllocationEndpoint(stable.allocId, { port });
+    },
+
+    async promoteDeployment(deploymentId) {
+      await request("POST", `/v1/deployment/promote/${deploymentId}`, { All: true });
+      return { promoted: true };
+    },
+
+    async failDeployment(deploymentId) {
+      await request("POST", `/v1/deployment/fail/${deploymentId}`, {});
+      return { failed: true };
+    },
+
+    /**
+     * Polls deployment status until Nomad reports a terminal-enough state to
+     * act on. This never invents health: a request error or a timeout comes
+     * back as `unknown`, and `release.mjs` treats `unknown` the same as
+     * `unhealthy` for promotion purposes (fail closed).
+     * @param {string} deploymentId
+     * @param {{timeoutMs?: number, intervalMs?: number}} [options]
+     */
+    async waitForHealthy(deploymentId, { timeoutMs = 5 * 60 * 1000, intervalMs = 2000 } = {}) {
+      const deadline = Date.now() + timeoutMs;
+      let lastStatus = "unknown";
+      let lastDescription = "";
+      for (;;) {
+        try {
+          const deployment = await request("GET", `/v1/deployment/${deploymentId}`);
+          lastStatus = deployment?.Status ?? "unknown";
+          lastDescription = deployment?.StatusDescription ?? "";
+        } catch (error) {
+          lastDescription = error instanceof Error ? error.message : String(error);
+        }
+        if (lastStatus === "running" || lastStatus === "successful") {
+          return createHealthResult({
+            status: "healthy",
+            checkedAt: new Date(),
+            reason: lastDescription,
+            observedAllocation: deploymentId,
+          });
+        }
+        if (lastStatus === "failed" || lastStatus === "cancelled") {
+          return createHealthResult({
+            status: "unhealthy",
+            checkedAt: new Date(),
+            reason: lastDescription || lastStatus,
+            observedAllocation: deploymentId,
+          });
+        }
+        if (Date.now() >= deadline) {
+          return createHealthResult({
+            status: "unknown",
+            checkedAt: new Date(),
+            reason: `timed out waiting for deployment status (last=${lastStatus})`,
+            observedAllocation: deploymentId,
+          });
+        }
+        await sleep(intervalMs);
+      }
+    },
+  });
+}

--- a/ops/nomad/adapters/nomad.mjs
+++ b/ops/nomad/adapters/nomad.mjs
@@ -40,6 +40,7 @@ export function createNomadClient({
   token = null,
   fetchImpl = fetch,
   sleep = defaultSleep,
+  requestTimeoutMs = 10_000,
 } = {}) {
   async function request(method, path, body) {
     const headers = { "content-type": "application/json" };
@@ -50,9 +51,25 @@ export function createNomadClient({
       method,
       headers,
       body: body === undefined ? undefined : JSON.stringify(body),
+      // Without this, a stalled Nomad connection hangs the request forever,
+      // defeating waitForHealthy's own polling deadline (it never gets a
+      // chance to re-check Date.now() against that deadline mid-request).
+      signal: AbortSignal.timeout(requestTimeoutMs),
     });
     const text = typeof response.text === "function" ? await response.text() : "";
-    const parsed = text && text.length > 0 ? JSON.parse(text) : null;
+    let parsed = null;
+    if (text && text.length > 0) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        // Nomad (or a proxy in front of it) can return a non-JSON body, e.g.
+        // a plain-text error or an HTML error page. Fall back to the raw
+        // text instead of throwing here, so a 409 (stale plan) or any other
+        // error status still reaches the caller as a NomadApiError with its
+        // body intact, rather than as an unrelated SyntaxError.
+        parsed = text;
+      }
+    }
     if (!response.ok) {
       throw new NomadApiError(`${method} ${path} failed with status ${response.status}`, {
         status: response.status,
@@ -63,7 +80,10 @@ export function createNomadClient({
   }
 
   async function getJobAllocations(namespace, jobId) {
-    const result = await request("GET", `/v1/job/${jobId}/allocations?namespace=${encodeURIComponent(namespace)}`);
+    const result = await request(
+      "GET",
+      `/v1/job/${encodeURIComponent(jobId)}/allocations?namespace=${encodeURIComponent(namespace)}`,
+    );
     return (result ?? []).map((alloc) => ({
       allocId: alloc.ID,
       clientStatus: alloc.ClientStatus,
@@ -73,7 +93,7 @@ export function createNomadClient({
   }
 
   async function getAllocationEndpoint(allocId, { port = 3000 } = {}) {
-    const alloc = await request("GET", `/v1/allocation/${allocId}`);
+    const alloc = await request("GET", `/v1/allocation/${encodeURIComponent(allocId)}`);
     const address = alloc?.NetworkStatus?.Address ?? null;
     if (!address) {
       return null;
@@ -89,7 +109,7 @@ export function createNomadClient({
     async planJob(namespace, jobId, jobHcl) {
       const result = await request(
         "POST",
-        `/v1/job/${jobId}/plan?namespace=${encodeURIComponent(namespace)}`,
+        `/v1/job/${encodeURIComponent(jobId)}/plan?namespace=${encodeURIComponent(namespace)}`,
         { Job: jobHcl, Diff: true },
       );
       return { jobModifyIndex: result?.JobModifyIndex ?? null, warnings: result?.Warnings ?? "" };
@@ -102,7 +122,7 @@ export function createNomadClient({
      * section 7). Returns submission identifiers only - not health.
      */
     async runJob(namespace, jobId, jobHcl, { checkIndex } = {}) {
-      const result = await request("POST", `/v1/job/${jobId}?namespace=${encodeURIComponent(namespace)}`, {
+      const result = await request("POST", `/v1/job/${encodeURIComponent(jobId)}?namespace=${encodeURIComponent(namespace)}`, {
         Job: jobHcl,
         EnforceIndex: checkIndex !== undefined && checkIndex !== null,
         JobModifyIndex: checkIndex ?? undefined,
@@ -116,7 +136,7 @@ export function createNomadClient({
     },
 
     async getDeployment(deploymentId) {
-      const result = await request("GET", `/v1/deployment/${deploymentId}`);
+      const result = await request("GET", `/v1/deployment/${encodeURIComponent(deploymentId)}`);
       return {
         status: result?.Status ?? "unknown",
         statusDescription: result?.StatusDescription ?? "",
@@ -159,12 +179,12 @@ export function createNomadClient({
     },
 
     async promoteDeployment(deploymentId) {
-      await request("POST", `/v1/deployment/promote/${deploymentId}`, { All: true });
+      await request("POST", `/v1/deployment/promote/${encodeURIComponent(deploymentId)}`, { All: true });
       return { promoted: true };
     },
 
     async failDeployment(deploymentId) {
-      await request("POST", `/v1/deployment/fail/${deploymentId}`, {});
+      await request("POST", `/v1/deployment/fail/${encodeURIComponent(deploymentId)}`, {});
       return { failed: true };
     },
 
@@ -174,17 +194,32 @@ export function createNomadClient({
      * back as `unknown`, and `release.mjs` treats `unknown` the same as
      * `unhealthy` for promotion purposes (fail closed).
      * @param {string} deploymentId
-     * @param {{timeoutMs?: number, intervalMs?: number}} [options]
+     * @param {{timeoutMs?: number, intervalMs?: number, groupName?: string}} [options]
      */
-    async waitForHealthy(deploymentId, { timeoutMs = 5 * 60 * 1000, intervalMs = 2000 } = {}) {
+    async waitForHealthy(deploymentId, { timeoutMs = 5 * 60 * 1000, intervalMs = 2000, groupName = "api" } = {}) {
       const deadline = Date.now() + timeoutMs;
       let lastStatus = "unknown";
       let lastDescription = "";
       for (;;) {
         try {
-          const deployment = await request("GET", `/v1/deployment/${deploymentId}`);
+          const deployment = await request("GET", `/v1/deployment/${encodeURIComponent(deploymentId)}`);
           lastStatus = deployment?.Status ?? "unknown";
           lastDescription = deployment?.StatusDescription ?? "";
+          if (lastStatus === "running") {
+            // Nomad marks a deployment "running" as soon as the canary
+            // allocation is placed - well before its own health checks
+            // pass. Without also checking the task group's canary health
+            // counts, this would report "healthy" the moment a candidate
+            // exists, letting release.mjs switch traffic to an unverified
+            // allocation. Treat "running" as still-pending until the group's
+            // healthy count actually reaches its desired canary count.
+            const group = deployment?.TaskGroups?.[groupName];
+            const desiredCanaries = group?.DesiredCanaries ?? 0;
+            const healthyAllocs = group?.HealthyAllocs ?? 0;
+            if (desiredCanaries <= 0 || healthyAllocs < desiredCanaries) {
+              lastStatus = "pending";
+            }
+          }
         } catch (error) {
           lastDescription = error instanceof Error ? error.message : String(error);
         }

--- a/ops/nomad/adapters/nomad.test.mjs
+++ b/ops/nomad/adapters/nomad.test.mjs
@@ -27,29 +27,46 @@ function fakeFetch(handlers) {
   return fn;
 }
 
-test("planJob maps Nomad's plan response to jobModifyIndex/warnings", async () => {
-  const fetchImpl = fakeFetch([
+const FAKE_PARSED_JOB = Object.freeze({ ID: "sm-api", Name: "sm-api" });
+
+function expectParseThenRequest(assertSecondCall, secondResponse) {
+  return fakeFetch([
     async (url, init) => {
-      assert.match(url, /\/v1\/job\/sm-api\/plan\?namespace=social-monitor$/);
+      assert.match(url, /\/v1\/jobs\/parse$/);
       assert.equal(init.method, "POST");
-      return jsonResponse(200, { JobModifyIndex: 7, Warnings: "" });
+      const body = JSON.parse(init.body);
+      assert.equal(body.JobHCL, "job \"sm-api\" {}");
+      assert.equal(body.Canonicalize, true);
+      return jsonResponse(200, FAKE_PARSED_JOB);
+    },
+    async (url, init) => {
+      assertSecondCall(url, init);
+      return secondResponse;
     },
   ]);
+}
+
+test("planJob parses the HCL through /v1/jobs/parse before submitting it as the JSON Job field", async () => {
+  const fetchImpl = expectParseThenRequest((url, init) => {
+    assert.match(url, /\/v1\/job\/sm-api\/plan\?namespace=social-monitor$/);
+    assert.equal(init.method, "POST");
+    const body = JSON.parse(init.body);
+    assert.deepEqual(body.Job, FAKE_PARSED_JOB, "the plan endpoint must receive the parsed JSON job, not the raw HCL string");
+    assert.equal(body.Diff, true);
+  }, jsonResponse(200, { JobModifyIndex: 7, Warnings: "" }));
   const client = createNomadClient({ fetchImpl });
   const result = await client.planJob("social-monitor", "sm-api", "job \"sm-api\" {}");
   assert.deepEqual(result, { jobModifyIndex: 7, warnings: "" });
 });
 
-test("runJob sends EnforceIndex/JobModifyIndex from the supplied checkIndex", async () => {
-  const fetchImpl = fakeFetch([
-    async (url, init) => {
-      assert.match(url, /\/v1\/job\/sm-api\?namespace=social-monitor$/);
-      const body = JSON.parse(init.body);
-      assert.equal(body.EnforceIndex, true);
-      assert.equal(body.JobModifyIndex, 7);
-      return jsonResponse(200, { EvalID: "eval-1", DeploymentID: "deploy-1", JobModifyIndex: 8 });
-    },
-  ]);
+test("runJob parses the HCL through /v1/jobs/parse and sends EnforceIndex/JobModifyIndex from the supplied checkIndex", async () => {
+  const fetchImpl = expectParseThenRequest((url, init) => {
+    assert.match(url, /\/v1\/job\/sm-api\?namespace=social-monitor$/);
+    const body = JSON.parse(init.body);
+    assert.deepEqual(body.Job, FAKE_PARSED_JOB, "the register endpoint must receive the parsed JSON job, not the raw HCL string");
+    assert.equal(body.EnforceIndex, true);
+    assert.equal(body.JobModifyIndex, 7);
+  }, jsonResponse(200, { EvalID: "eval-1", DeploymentID: "deploy-1", JobModifyIndex: 8 }));
   const client = createNomadClient({ fetchImpl });
   const result = await client.runJob("social-monitor", "sm-api", "job \"sm-api\" {}", { checkIndex: 7 });
   assert.deepEqual(result, { evalId: "eval-1", deploymentId: "deploy-1", jobModifyIndex: 8, warnings: "" });
@@ -171,6 +188,34 @@ test("waitForHealthy keeps polling a 'running' deployment until the canary's own
   const health = await client.waitForHealthy("deploy-1", { intervalMs: 10, timeoutMs: 1000 });
   assert.equal(health.status, "healthy");
   assert.deepEqual(sleeps, [10]);
+});
+
+test("waitForHealthy does not report healthy for a 'running' status observed after its own deadline already elapsed", async () => {
+  const fetchImpl = fakeFetch([
+    async () =>
+      jsonResponse(200, {
+        Status: "running",
+        StatusDescription: "canary healthy, but arrived late",
+        TaskGroups: { api: { DesiredCanaries: 1, HealthyAllocs: 1 } },
+      }),
+  ]);
+  let now = 0;
+  const originalNow = Date.now;
+  // The deadline is computed once at entry (now=0, timeoutMs=10 -> deadline
+  // 10), then time "passes" during the request itself so it is already
+  // past that deadline by the time the response comes back.
+  Date.now = () => {
+    const value = now;
+    now = 20;
+    return value;
+  };
+  try {
+    const client = createNomadClient({ fetchImpl });
+    const health = await client.waitForHealthy("deploy-1", { intervalMs: 10, timeoutMs: 10 });
+    assert.equal(health.status, "unknown", "a late-arriving success must not be trusted as an on-time healthy result");
+  } finally {
+    Date.now = originalNow;
+  }
 });
 
 test("waitForHealthy reports unknown (not a crash) once the timeout elapses without a terminal status", async () => {

--- a/ops/nomad/adapters/nomad.test.mjs
+++ b/ops/nomad/adapters/nomad.test.mjs
@@ -116,6 +116,20 @@ test("getCandidateEndpoint returns null while no canary allocation is running ye
   assert.equal(await client.getCandidateEndpoint("social-monitor", "sm-api"), null);
 });
 
+test("waitForHealthy stamps checkedAt from the injected clock, not a hidden new Date()", async () => {
+  const fetchImpl = fakeFetch([
+    async () =>
+      jsonResponse(200, {
+        Status: "successful",
+        StatusDescription: "",
+      }),
+  ]);
+  const fixedNow = new Date("2026-01-01T00:00:00.000Z");
+  const client = createNomadClient({ fetchImpl, now: () => fixedNow });
+  const health = await client.waitForHealthy("deploy-1", { intervalMs: 10, timeoutMs: 1000 });
+  assert.equal(health.checkedAt, fixedNow.toISOString());
+});
+
 test("waitForHealthy polls until a terminal deployment status, sleeping between attempts", async () => {
   const statuses = ["pending", "running"];
   const fetchImpl = fakeFetch([

--- a/ops/nomad/adapters/nomad.test.mjs
+++ b/ops/nomad/adapters/nomad.test.mjs
@@ -72,10 +72,29 @@ test("runJob parses the HCL through /v1/jobs/parse and sends EnforceIndex/JobMod
   assert.deepEqual(result, { evalId: "eval-1", deploymentId: "deploy-1", jobModifyIndex: 8, warnings: "" });
 });
 
-test("a non-2xx response raises NomadApiError with the status and parsed body", async () => {
+test("a non-2xx response from /v1/jobs/parse raises NomadApiError with the status and parsed body", async () => {
   const fetchImpl = fakeFetch([
-    async () => jsonResponse(409, { Error: "index mismatch" }),
+    async () => jsonResponse(400, { Error: "invalid HCL" }),
   ]);
+  const client = createNomadClient({ fetchImpl });
+  await assert.rejects(
+    () => client.runJob("social-monitor", "sm-api", "job \"sm-api\" {}", { checkIndex: 1 }),
+    (error) => {
+      assert.ok(error instanceof NomadApiError);
+      assert.equal(error.status, 400);
+      assert.equal(error.body.Error, "invalid HCL");
+      return true;
+    },
+  );
+});
+
+test("a 409 from the register endpoint itself (stale plan) raises NomadApiError after a successful parse", async () => {
+  const fetchImpl = expectParseThenRequest((url, init) => {
+    assert.match(url, /\/v1\/job\/sm-api\?namespace=social-monitor$/);
+    const body = JSON.parse(init.body);
+    assert.equal(body.EnforceIndex, true);
+    assert.equal(body.JobModifyIndex, 1);
+  }, jsonResponse(409, { Error: "index mismatch" }));
   const client = createNomadClient({ fetchImpl });
   await assert.rejects(
     () => client.runJob("social-monitor", "sm-api", "job \"sm-api\" {}", { checkIndex: 1 }),

--- a/ops/nomad/adapters/nomad.test.mjs
+++ b/ops/nomad/adapters/nomad.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { NomadApiError, createNomadClient } from "./nomad.mjs";
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return body === undefined ? "" : JSON.stringify(body);
+    },
+  };
+}
+
+function fakeFetch(handlers) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    const handler = handlers.shift();
+    if (!handler) {
+      throw new Error(`unexpected extra request: ${url}`);
+    }
+    return handler(url, init);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+test("planJob maps Nomad's plan response to jobModifyIndex/warnings", async () => {
+  const fetchImpl = fakeFetch([
+    async (url, init) => {
+      assert.match(url, /\/v1\/job\/sm-api\/plan\?namespace=social-monitor$/);
+      assert.equal(init.method, "POST");
+      return jsonResponse(200, { JobModifyIndex: 7, Warnings: "" });
+    },
+  ]);
+  const client = createNomadClient({ fetchImpl });
+  const result = await client.planJob("social-monitor", "sm-api", "job \"sm-api\" {}");
+  assert.deepEqual(result, { jobModifyIndex: 7, warnings: "" });
+});
+
+test("runJob sends EnforceIndex/JobModifyIndex from the supplied checkIndex", async () => {
+  const fetchImpl = fakeFetch([
+    async (url, init) => {
+      assert.match(url, /\/v1\/job\/sm-api\?namespace=social-monitor$/);
+      const body = JSON.parse(init.body);
+      assert.equal(body.EnforceIndex, true);
+      assert.equal(body.JobModifyIndex, 7);
+      return jsonResponse(200, { EvalID: "eval-1", DeploymentID: "deploy-1", JobModifyIndex: 8 });
+    },
+  ]);
+  const client = createNomadClient({ fetchImpl });
+  const result = await client.runJob("social-monitor", "sm-api", "job \"sm-api\" {}", { checkIndex: 7 });
+  assert.deepEqual(result, { evalId: "eval-1", deploymentId: "deploy-1", jobModifyIndex: 8, warnings: "" });
+});
+
+test("a non-2xx response raises NomadApiError with the status and parsed body", async () => {
+  const fetchImpl = fakeFetch([
+    async () => jsonResponse(409, { Error: "index mismatch" }),
+  ]);
+  const client = createNomadClient({ fetchImpl });
+  await assert.rejects(
+    () => client.runJob("social-monitor", "sm-api", "job \"sm-api\" {}", { checkIndex: 1 }),
+    (error) => {
+      assert.ok(error instanceof NomadApiError);
+      assert.equal(error.status, 409);
+      assert.equal(error.body.Error, "index mismatch");
+      return true;
+    },
+  );
+});
+
+test("getCandidateEndpoint resolves the running canary allocation's driver-mode address", async () => {
+  const fetchImpl = fakeFetch([
+    async () =>
+      jsonResponse(200, [
+        { ID: "alloc-stable", ClientStatus: "running", DeploymentStatus: { Canary: false, Healthy: true } },
+        { ID: "alloc-canary", ClientStatus: "running", DeploymentStatus: { Canary: true, Healthy: true } },
+      ]),
+    async (url) => {
+      assert.match(url, /\/v1\/allocation\/alloc-canary$/);
+      return jsonResponse(200, { NetworkStatus: { Address: "172.20.0.5" } });
+    },
+  ]);
+  const client = createNomadClient({ fetchImpl });
+  const endpoint = await client.getCandidateEndpoint("social-monitor", "sm-api", { port: 3000 });
+  assert.deepEqual(endpoint, { allocId: "alloc-canary", address: "172.20.0.5", port: 3000 });
+});
+
+test("getCandidateEndpoint returns null while no canary allocation is running yet", async () => {
+  const fetchImpl = fakeFetch([async () => jsonResponse(200, [])]);
+  const client = createNomadClient({ fetchImpl });
+  assert.equal(await client.getCandidateEndpoint("social-monitor", "sm-api"), null);
+});
+
+test("waitForHealthy polls until a terminal deployment status, sleeping between attempts", async () => {
+  const statuses = ["pending", "running"];
+  const fetchImpl = fakeFetch([
+    async () => jsonResponse(200, { Status: statuses[0], StatusDescription: "" }),
+    async () => jsonResponse(200, { Status: statuses[1], StatusDescription: "canary healthy" }),
+  ]);
+  const sleeps = [];
+  const client = createNomadClient({ fetchImpl, sleep: async (ms) => sleeps.push(ms) });
+  const health = await client.waitForHealthy("deploy-1", { intervalMs: 10, timeoutMs: 1000 });
+  assert.equal(health.status, "healthy");
+  assert.deepEqual(sleeps, [10]);
+});
+
+test("waitForHealthy reports unknown (not a crash) once the timeout elapses without a terminal status", async () => {
+  const fetchImpl = fakeFetch([
+    async () => jsonResponse(200, { Status: "pending", StatusDescription: "" }),
+    async () => jsonResponse(200, { Status: "pending", StatusDescription: "" }),
+  ]);
+  let now = 0;
+  const originalNow = Date.now;
+  Date.now = () => now;
+  try {
+    const client = createNomadClient({
+      fetchImpl,
+      sleep: async () => {
+        now += 20;
+      },
+    });
+    const health = await client.waitForHealthy("deploy-1", { intervalMs: 10, timeoutMs: 15 });
+    assert.equal(health.status, "unknown");
+  } finally {
+    Date.now = originalNow;
+  }
+});

--- a/ops/nomad/adapters/nomad.test.mjs
+++ b/ops/nomad/adapters/nomad.test.mjs
@@ -71,6 +71,28 @@ test("a non-2xx response raises NomadApiError with the status and parsed body", 
   );
 });
 
+test("a non-JSON error body does not crash the client - it reaches NomadApiError as raw text", async () => {
+  const fetchImpl = fakeFetch([
+    async () => ({
+      ok: false,
+      status: 502,
+      async text() {
+        return "<html>502 Bad Gateway</html>";
+      },
+    }),
+  ]);
+  const client = createNomadClient({ fetchImpl });
+  await assert.rejects(
+    () => client.runJob("social-monitor", "sm-api", "job \"sm-api\" {}", { checkIndex: 1 }),
+    (error) => {
+      assert.ok(error instanceof NomadApiError);
+      assert.equal(error.status, 502);
+      assert.match(error.body, /502 Bad Gateway/);
+      return true;
+    },
+  );
+});
+
 test("getCandidateEndpoint resolves the running canary allocation's driver-mode address", async () => {
   const fetchImpl = fakeFetch([
     async () =>
@@ -98,7 +120,37 @@ test("waitForHealthy polls until a terminal deployment status, sleeping between 
   const statuses = ["pending", "running"];
   const fetchImpl = fakeFetch([
     async () => jsonResponse(200, { Status: statuses[0], StatusDescription: "" }),
-    async () => jsonResponse(200, { Status: statuses[1], StatusDescription: "canary healthy" }),
+    async () =>
+      jsonResponse(200, {
+        Status: statuses[1],
+        StatusDescription: "canary healthy",
+        TaskGroups: { api: { DesiredCanaries: 1, HealthyAllocs: 1 } },
+      }),
+  ]);
+  const sleeps = [];
+  const client = createNomadClient({ fetchImpl, sleep: async (ms) => sleeps.push(ms) });
+  const health = await client.waitForHealthy("deploy-1", { intervalMs: 10, timeoutMs: 1000 });
+  assert.equal(health.status, "healthy");
+  assert.deepEqual(sleeps, [10]);
+});
+
+test("waitForHealthy keeps polling a 'running' deployment until the canary's own health count catches up", async () => {
+  // Nomad flips Status to "running" the instant the canary is placed, long
+  // before its health checks pass - a deployment status of "running" alone
+  // must never be enough to call the candidate healthy.
+  const fetchImpl = fakeFetch([
+    async () =>
+      jsonResponse(200, {
+        Status: "running",
+        StatusDescription: "canary placed",
+        TaskGroups: { api: { DesiredCanaries: 1, HealthyAllocs: 0 } },
+      }),
+    async () =>
+      jsonResponse(200, {
+        Status: "running",
+        StatusDescription: "canary healthy",
+        TaskGroups: { api: { DesiredCanaries: 1, HealthyAllocs: 1 } },
+      }),
   ]);
   const sleeps = [];
   const client = createNomadClient({ fetchImpl, sleep: async (ms) => sleeps.push(ms) });

--- a/ops/nomad/api-env-entrypoint.mjs
+++ b/ops/nomad/api-env-entrypoint.mjs
@@ -70,16 +70,40 @@ function main(argv) {
     return;
   }
   const child = spawn(command, commandArgs, { env: mergedEnv, stdio: "inherit" });
+
+  child.on("error", (error) => {
+    // Without this listener, a launch failure (e.g. ENOENT because
+    // `command` is wrong, EACCES on the binary) is an unhandled 'error'
+    // event, which Node re-throws as an uncaught exception instead of a
+    // clear, actionable message.
+    process.stderr.write(`api-env-entrypoint: failed to launch "${command}": ${error.message}\n`);
+    process.exitCode = 1;
+  });
+
+  const signalHandlers = new Map();
+  for (const signal of ["SIGTERM", "SIGINT"]) {
+    const handler = () => child.kill(signal);
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
   child.on("exit", (code, signal) => {
     if (signal) {
+      // Remove our own forwarding listener for this exact signal before
+      // re-raising it on ourselves: as long as that listener stays
+      // registered, Node treats the signal as handled and never applies
+      // its default (terminating) action, so process.kill below would
+      // just re-invoke the handler against the now-dead child forever
+      // instead of actually letting this process exit.
+      const handler = signalHandlers.get(signal);
+      if (handler) {
+        process.removeListener(signal, handler);
+      }
       process.kill(process.pid, signal);
       return;
     }
     process.exitCode = code ?? 1;
   });
-  for (const signal of ["SIGTERM", "SIGINT"]) {
-    process.on(signal, () => child.kill(signal));
-  }
 }
 
 const isMainModule = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;

--- a/ops/nomad/api-env-entrypoint.mjs
+++ b/ops/nomad/api-env-entrypoint.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Thin container entrypoint: read a newline-delimited KEY=VALUE env file
+ * without `eval` or shell sourcing, then exec the real API process with
+ * that environment merged in. Parsing lives in `parseEnvFile` (SRP) so it
+ * can be unit-tested without ever spawning a process.
+ *
+ * The env file format matches a conservative dotenv subset: `KEY=value`
+ * lines, optional single/double-quoted values, `#` comment lines, and blank
+ * lines. No variable expansion, no command substitution, no multi-line
+ * values - anything else is a hard parse error rather than a silent guess.
+ */
+
+import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+/**
+ * @param {string} contents raw env file contents.
+ * @returns {Record<string, string>}
+ */
+export function parseEnvFile(contents) {
+  const env = {};
+  const lines = contents.split(/\r\n|\n|\r/u);
+  for (const [index, rawLine] of lines.entries()) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex <= 0) {
+      throw new SyntaxError(`api-env-entrypoint: malformed line ${index + 1}: expected KEY=VALUE`);
+    }
+    const key = line.slice(0, separatorIndex).trim();
+    let value = line.slice(separatorIndex + 1);
+    if (!KEY_PATTERN.test(key)) {
+      throw new SyntaxError(`api-env-entrypoint: invalid env key on line ${index + 1}: ${JSON.stringify(key)}`);
+    }
+    if (value.length >= 2) {
+      const first = value[0];
+      const last = value[value.length - 1];
+      if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+        value = value.slice(1, -1);
+      }
+    }
+    if (Object.hasOwn(env, key)) {
+      throw new SyntaxError(`api-env-entrypoint: duplicate env key on line ${index + 1}: ${JSON.stringify(key)}`);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+/**
+ * @param {string} path
+ * @returns {Record<string, string>}
+ */
+export function readEnvFile(path) {
+  return parseEnvFile(readFileSync(path, "utf8"));
+}
+
+function main(argv) {
+  const envFilePath = process.env.SOCIAL_MONITOR_API_ENV_FILE ?? "/run/social-monitor/api.env";
+  const fileEnv = readEnvFile(envFilePath);
+  const mergedEnv = { ...process.env, ...fileEnv };
+  const [command, ...commandArgs] = argv;
+  if (!command) {
+    process.stderr.write("api-env-entrypoint: no command supplied to exec\n");
+    process.exitCode = 64;
+    return;
+  }
+  const child = spawn(command, commandArgs, { env: mergedEnv, stdio: "inherit" });
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exitCode = code ?? 1;
+  });
+  for (const signal of ["SIGTERM", "SIGINT"]) {
+    process.on(signal, () => child.kill(signal));
+  }
+}
+
+const isMainModule = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMainModule) {
+  main(process.argv.slice(2));
+}

--- a/ops/nomad/api-env-entrypoint.test.mjs
+++ b/ops/nomad/api-env-entrypoint.test.mjs
@@ -1,0 +1,59 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseEnvFile, readEnvFile } from "./api-env-entrypoint.mjs";
+
+test("parseEnvFile parses simple KEY=VALUE lines", () => {
+  const env = parseEnvFile("PORT=3000\nNODE_ENV=production\n");
+  assert.deepEqual(env, { PORT: "3000", NODE_ENV: "production" });
+});
+
+test("parseEnvFile skips blank lines and comments", () => {
+  const env = parseEnvFile("\n# a comment\nPORT=3000\n\n#another\n");
+  assert.deepEqual(env, { PORT: "3000" });
+});
+
+test("parseEnvFile strips matching single or double quotes", () => {
+  const env = parseEnvFile('A="hello world"\nB=\'quoted value\'\nC=unquoted\n');
+  assert.deepEqual(env, { A: "hello world", B: "quoted value", C: "unquoted" });
+});
+
+test("parseEnvFile preserves an empty value", () => {
+  const env = parseEnvFile("EMPTY=\n");
+  assert.deepEqual(env, { EMPTY: "" });
+});
+
+test("parseEnvFile preserves embedded equals signs in the value", () => {
+  const env = parseEnvFile("DATABASE_URL=postgres://user:pass@host/db?sslmode=verify-full\n");
+  assert.equal(env.DATABASE_URL, "postgres://user:pass@host/db?sslmode=verify-full");
+});
+
+test("parseEnvFile rejects a line with no separator", () => {
+  assert.throws(() => parseEnvFile("NOT_KEY_VALUE\n"), SyntaxError);
+});
+
+test("parseEnvFile rejects an invalid key", () => {
+  assert.throws(() => parseEnvFile("1BAD=value\n"), SyntaxError);
+});
+
+test("parseEnvFile rejects a duplicate key", () => {
+  assert.throws(() => parseEnvFile("A=1\nA=2\n"), SyntaxError);
+});
+
+test("parseEnvFile never evaluates shell metacharacters in a value", () => {
+  const env = parseEnvFile("CMD=$(rm -rf /)\n");
+  assert.equal(env.CMD, "$(rm -rf /)");
+});
+
+test("readEnvFile reads and parses a real file from disk", () => {
+  const dir = mkdtempSync(join(tmpdir(), "sm-api-env-entrypoint-test-"));
+  try {
+    const path = join(dir, "api.env");
+    writeFileSync(path, "PORT=3000\n# comment\nNODE_ENV=production\n");
+    assert.deepEqual(readEnvFile(path), { PORT: "3000", NODE_ENV: "production" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/ops/nomad/api-env-entrypoint.test.mjs
+++ b/ops/nomad/api-env-entrypoint.test.mjs
@@ -88,14 +88,32 @@ test("main() forwards SIGTERM to the child and then actually terminates itself, 
     const envPath = join(dir, "api.env");
     writeFileSync(envPath, "PORT=3000\n");
     const childScript = join(dir, "sleep.mjs");
-    writeFileSync(childScript, "setInterval(() => {}, 1000);\n");
+    // No SIGTERM handler here on purpose: the child must actually be
+    // terminated by the signal itself (reported to the entrypoint as
+    // `(code=null, signal="SIGTERM")`), not catch it and exit with a code -
+    // that is the exact branch this test exercises.
+    writeFileSync(childScript, "console.log('child-ready');\nsetInterval(() => {}, 1000);\n");
 
     const proc = spawn(process.execPath, [entrypointPath, process.execPath, childScript], {
       env: { ...process.env, SOCIAL_MONITOR_API_ENV_FILE: envPath },
-      stdio: "ignore",
+      stdio: ["ignore", "pipe", "ignore"],
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    // Wait for the grandchild's own readiness marker instead of a fixed
+    // delay: a magic-number sleep here would be flaky under CI load (spawn
+    // and the SIGTERM-listener registration racing an arbitrary timeout).
+    await new Promise((resolve, reject) => {
+      let buffered = "";
+      const onData = (chunk) => {
+        buffered += chunk.toString();
+        if (buffered.includes("child-ready")) {
+          proc.stdout.off("data", onData);
+          resolve();
+        }
+      };
+      proc.stdout.on("data", onData);
+      proc.once("exit", (code, signal) => reject(new Error(`entrypoint exited early (code=${code}, signal=${signal}) before the child became ready`)));
+    });
     proc.kill("SIGTERM");
 
     const exited = await new Promise((resolve) => {

--- a/ops/nomad/api-env-entrypoint.test.mjs
+++ b/ops/nomad/api-env-entrypoint.test.mjs
@@ -1,9 +1,16 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { parseEnvFile, readEnvFile } from "./api-env-entrypoint.mjs";
+
+// main() sets this process's own process.exitCode and registers signal
+// handlers on it, so it can only be exercised safely as a real subprocess
+// (spawning it in-process would corrupt the test runner's own exit status).
+const entrypointPath = fileURLToPath(new URL("./api-env-entrypoint.mjs", import.meta.url));
 
 test("parseEnvFile parses simple KEY=VALUE lines", () => {
   const env = parseEnvFile("PORT=3000\nNODE_ENV=production\n");
@@ -53,6 +60,54 @@ test("readEnvFile reads and parses a real file from disk", () => {
     const path = join(dir, "api.env");
     writeFileSync(path, "PORT=3000\n# comment\nNODE_ENV=production\n");
     assert.deepEqual(readEnvFile(path), { PORT: "3000", NODE_ENV: "production" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("main() reports a clean error instead of an uncaught exception when the target command cannot be launched", () => {
+  const dir = mkdtempSync(join(tmpdir(), "sm-api-env-entrypoint-spawn-test-"));
+  try {
+    const envPath = join(dir, "api.env");
+    writeFileSync(envPath, "PORT=3000\n");
+    const result = spawnSync(process.execPath, [entrypointPath, "/definitely/does-not-exist-xyz"], {
+      env: { ...process.env, SOCIAL_MONITOR_API_ENV_FILE: envPath },
+      encoding: "utf8",
+    });
+    assert.equal(result.signal, null, "a launch failure must not crash the entrypoint itself");
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /failed to launch/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("main() forwards SIGTERM to the child and then actually terminates itself, instead of re-forwarding to a dead child forever", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "sm-api-env-entrypoint-signal-test-"));
+  try {
+    const envPath = join(dir, "api.env");
+    writeFileSync(envPath, "PORT=3000\n");
+    const childScript = join(dir, "sleep.mjs");
+    writeFileSync(childScript, "setInterval(() => {}, 1000);\n");
+
+    const proc = spawn(process.execPath, [entrypointPath, process.execPath, childScript], {
+      env: { ...process.env, SOCIAL_MONITOR_API_ENV_FILE: envPath },
+      stdio: "ignore",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    proc.kill("SIGTERM");
+
+    const exited = await new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(null), 5000);
+      proc.on("exit", (code, signal) => {
+        clearTimeout(timer);
+        resolve({ code, signal });
+      });
+    });
+
+    assert.notEqual(exited, null, "the entrypoint must actually exit after SIGTERM, not hang re-forwarding to the now-dead child");
+    assert.equal(exited.signal, "SIGTERM");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/ops/nomad/api-env-entrypoint.test.mjs
+++ b/ops/nomad/api-env-entrypoint.test.mjs
@@ -26,8 +26,8 @@ test("parseEnvFile preserves an empty value", () => {
 });
 
 test("parseEnvFile preserves embedded equals signs in the value", () => {
-  const env = parseEnvFile("DATABASE_URL=postgres://user:pass@host/db?sslmode=verify-full\n");
-  assert.equal(env.DATABASE_URL, "postgres://user:pass@host/db?sslmode=verify-full");
+  const env = parseEnvFile("DATABASE_URL=postgres://user:password@host/db?sslmode=verify-full\n");
+  assert.equal(env.DATABASE_URL, "postgres://user:password@host/db?sslmode=verify-full");
 });
 
 test("parseEnvFile rejects a line with no separator", () => {

--- a/ops/nomad/api.Dockerfile
+++ b/ops/nomad/api.Dockerfile
@@ -1,0 +1,46 @@
+# Standalone immutable image for the Nomad-managed API vertical slice.
+# `apps/api-gateway` has compile-time references into sibling apps (provider
+# tokens, module wiring for health reporting), so the full `apps` tree is
+# required at build time even though only the API entrypoint runs here; the
+# runtime image itself carries no other app's server code invoked at startup.
+FROM node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS app
+
+WORKDIR /app
+
+USER root
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates openssl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0644 package.json package-lock.json ./
+COPY vendor ./vendor
+RUN npm ci
+
+COPY tsconfig.json tsconfig.build.json ./
+COPY prisma.config.ts ./
+COPY prisma ./prisma
+COPY scripts/check-feed-promotion-index-recovery.ts ./scripts/
+COPY apps ./apps
+COPY libs ./libs
+
+ARG PRISMA_GENERATE_DATABASE_URL=postgresql://social_monitor:social_monitor_local_password@localhost:5432/social_monitor
+RUN DATABASE_URL="${PRISMA_GENERATE_DATABASE_URL}" npm run prisma:generate && npm run build
+
+# Host checkouts may use umask 077. Keep public image assets root-owned and
+# readable by node, preserving executable tools and directory traversal.
+RUN chmod -R u=rwX,go=rX \
+  apps libs prisma scripts vendor dist \
+  tsconfig.json tsconfig.build.json prisma.config.ts
+
+ARG SOCIAL_MONITOR_RELEASE_SHA
+LABEL org.opencontainers.image.revision="${SOCIAL_MONITOR_RELEASE_SHA}"
+LABEL org.opencontainers.image.title="social-monitor-api"
+LABEL org.opencontainers.image.source="https://github.com/777genius/social-monitor"
+
+EXPOSE 3000
+ENV NODE_ENV=production
+ENV SERVICE=api
+ENV PATH="/app/node_modules/.bin:${PATH}"
+USER node
+
+CMD ["node", "dist/apps/api-gateway/src/main.js"]

--- a/ops/nomad/api.Dockerfile
+++ b/ops/nomad/api.Dockerfile
@@ -22,6 +22,7 @@ COPY prisma ./prisma
 COPY scripts/check-feed-promotion-index-recovery.ts ./scripts/
 COPY apps ./apps
 COPY libs ./libs
+COPY ops/nomad/api-env-entrypoint.mjs ./ops/nomad/api-env-entrypoint.mjs
 
 ARG PRISMA_GENERATE_DATABASE_URL=postgresql://social_monitor:social_monitor_local_password@localhost:5432/social_monitor
 RUN DATABASE_URL="${PRISMA_GENERATE_DATABASE_URL}" npm run prisma:generate && npm run build
@@ -29,7 +30,7 @@ RUN DATABASE_URL="${PRISMA_GENERATE_DATABASE_URL}" npm run prisma:generate && np
 # Host checkouts may use umask 077. Keep public image assets root-owned and
 # readable by node, preserving executable tools and directory traversal.
 RUN chmod -R u=rwX,go=rX \
-  apps libs prisma scripts vendor dist \
+  apps libs prisma scripts vendor dist ops \
   tsconfig.json tsconfig.build.json prisma.config.ts
 
 ARG SOCIAL_MONITOR_RELEASE_SHA
@@ -41,6 +42,11 @@ EXPOSE 3000
 ENV NODE_ENV=production
 ENV SERVICE=api
 ENV PATH="/app/node_modules/.bin:${PATH}"
+ENV SOCIAL_MONITOR_API_ENV_FILE=/run/social-monitor/api.env
 USER node
 
+# The entrypoint reads SOCIAL_MONITOR_API_ENV_FILE (a read-only named host
+# volume mount, plan section 6) without eval/shell sourcing, then execs the
+# real API process. See ops/nomad/api-env-entrypoint.mjs.
+ENTRYPOINT ["node", "ops/nomad/api-env-entrypoint.mjs"]
 CMD ["node", "dist/apps/api-gateway/src/main.js"]

--- a/ops/nomad/api.nomad.hcl
+++ b/ops/nomad/api.nomad.hcl
@@ -1,0 +1,113 @@
+# Nomad jobspec for the `sm-api` vertical slice (plan sections 4 and 7).
+# Submitted only by the host-owned release transaction in
+# `ops/nomad/release.mjs` via `host/api-deploy.service` - never applied
+# directly with the bare `nomad` CLI in production. `nomad job plan` against
+# this file must be run with `-check-index` semantics before every submit.
+#
+# No `network` stanza on the group: this task joins the existing project
+# Docker network directly via the driver's own `network_mode` (plan section
+# 4), and the plan is explicit that Nomad-managed `network.mode = "bridge"`
+# (CNI) must never be combined with that - so this jobspec intentionally
+# declares neither.
+#
+# NOTE: `nomad fmt`/`nomad job validate` were not run against this file -
+# the `nomad` CLI is not available in this environment. It has only been
+# reviewed manually against the HCL2 job specification docs referenced in
+# the plan. Run both before the first real submit.
+
+variable "image" {
+  type        = string
+  description = "Immutable digest reference, e.g. ghcr.io/777genius/social-monitor-api@sha256:..."
+}
+
+variable "release_sha" {
+  type        = string
+  description = "Full 40-hex source commit SHA this image was built from."
+}
+
+variable "network_mode" {
+  type        = string
+  description = "Existing project Docker network name, passed straight to the Docker driver's network_mode (from preflight inventory)."
+}
+
+job "sm-api" {
+  region      = "global"
+  datacenters = ["dc1"]
+  namespace   = "social-monitor"
+  type        = "service"
+
+  update {
+    max_parallel      = 1
+    canary            = 1
+    min_healthy_time  = "30s"
+    healthy_deadline  = "5m"
+    progress_deadline = "10m"
+    auto_revert       = true
+    auto_promote      = false
+    health_check      = "checks"
+  }
+
+  group "api" {
+    count = 1
+
+    volume "api-secrets" {
+      type      = "host"
+      source    = "social-monitor-api-secrets"
+      read_only = true
+    }
+
+    task "api" {
+      driver = "docker"
+
+      volume_mount {
+        volume      = "api-secrets"
+        destination = "/var/run/social-monitor/secrets/nomad/api.env.d"
+        read_only   = true
+      }
+
+      config {
+        image        = var.image
+        network_mode = var.network_mode
+        # No privileged/raw_exec-equivalent flags, no extra host mounts, no
+        # host PID/IPC (plan section 5). The entrypoint baked into the image
+        # (ops/nomad/api-env-entrypoint.mjs) reads its env file from the
+        # read-only volume mounted above before exec'ing the real process.
+      }
+
+      env {
+        NODE_ENV = "production"
+        SERVICE  = "api"
+      }
+
+      # address_mode = "driver" resolves the container's own IP on the
+      # existing project network (assigned above via network_mode), so no
+      # Nomad-declared port label or new host port is needed - port 3000 is
+      # the container's own EXPOSE'd port from ops/nomad/api.Dockerfile.
+      service {
+        name         = "sm-api"
+        port         = "3000"
+        provider     = "nomad"
+        address_mode = "driver"
+
+        check {
+          type     = "http"
+          path     = "/ready"
+          interval = "10s"
+          timeout  = "5s"
+        }
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+
+      kill_timeout   = "45s"
+      shutdown_delay = "10s"
+
+      meta {
+        release_sha = var.release_sha
+      }
+    }
+  }
+}

--- a/ops/nomad/api.nomad.hcl
+++ b/ops/nomad/api.nomad.hcl
@@ -96,10 +96,15 @@ job "sm-api" {
         address_mode = "driver"
 
         check {
-          type     = "http"
-          path     = "/ready"
-          interval = "10s"
-          timeout  = "5s"
+          type         = "http"
+          path         = "/ready"
+          interval     = "10s"
+          timeout      = "5s"
+          # Explicit, not inherited: this task has no host port at all (see
+          # the network_mode comment above), so the check must resolve the
+          # container's own driver-mode IP:port, matching the service block
+          # above, not fall back to a host address that does not serve /ready.
+          address_mode = "driver"
         }
       }
 

--- a/ops/nomad/api.nomad.hcl
+++ b/ops/nomad/api.nomad.hcl
@@ -77,6 +77,12 @@ job "sm-api" {
       env {
         NODE_ENV = "production"
         SERVICE  = "api"
+        # Overrides the image's baked-in default (ops/nomad/api.Dockerfile),
+        # which points at a local-testing path that does not exist inside
+        # this task: the actual secret lives inside the read-only volume
+        # mounted above, materialized by the host bootstrap as
+        # <api-secrets volume>/api.env (plan section 6).
+        SOCIAL_MONITOR_API_ENV_FILE = "/var/run/social-monitor/secrets/nomad/api.env.d/api.env"
       }
 
       # address_mode = "driver" resolves the container's own IP on the

--- a/ops/nomad/bootstrap.sh
+++ b/ops/nomad/bootstrap.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Idempotent host bootstrap for the Nomad API vertical slice (plan section
+# 5). This script never performs a destructive action without --apply: its
+# default (and only fully tested-here) mode is --dry-run/--check, which
+# reports what it would do without touching the host. Real root bootstrap on
+# a production VPS is a separate, explicitly reviewed admin action; this
+# script is the shared logic both that action and this PR's tests exercise.
+#
+# Usage:
+#   bootstrap.sh --dry-run [--root PATH]
+#   bootstrap.sh --apply   [--root PATH]     # not exercised by this PR's tests
+#
+# --root overrides the host root (default /var/data/social-monitor), so
+# tests can point every path check at a disposable temp directory instead of
+# the real filesystem.
+
+SELF_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+usage() {
+  printf 'Usage: %s (--dry-run|--apply) [--root PATH]\n' "$(basename "$0")" >&2
+}
+
+main() {
+  local mode='' root=/var/data/social-monitor
+  while (($# > 0)); do
+    case $1 in
+      --dry-run) mode=dry-run; shift ;;
+      --apply) mode=apply; shift ;;
+      --root)
+        [[ ${2:-} ]] || { usage; return 64; }
+        root=$2
+        shift 2
+        ;;
+      *)
+        usage
+        return 64
+        ;;
+    esac
+  done
+  [[ -n $mode ]] || { usage; return 64; }
+
+  local versions_file=$SELF_DIR/versions.json
+  [[ -f $versions_file ]] || {
+    printf 'bootstrap: %s is missing\n' "$versions_file" >&2
+    return 1
+  }
+  local nomad_version
+  nomad_version=$(node -e '
+    const versions = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+    if (!versions.nomad || !versions.nomad.version) {
+      process.exit(1);
+    }
+    process.stdout.write(versions.nomad.version);
+  ' "$versions_file") || {
+    printf 'bootstrap: %s does not declare a pinned Nomad version\n' "$versions_file" >&2
+    return 1
+  }
+
+  local -a planned_actions=(
+    "verify pinned Nomad ${nomad_version} binary checksum from ${versions_file}"
+    "install ${root}/../etc-equivalent nomad.d config from ${SELF_DIR}/host/nomad.hcl"
+    "install systemd unit for the Nomad agent (server+client, not dev mode)"
+    "apply ACL policy from ${SELF_DIR}/host/acl.hcl to the social-monitor namespace"
+    "create named read-only host volume for the API secret env file"
+  )
+
+  if [[ $mode == dry-run ]]; then
+    printf 'bootstrap dry-run: root=%s nomad_version=%s\n' "$root" "$nomad_version"
+    local action
+    for action in "${planned_actions[@]}"; do
+      printf 'bootstrap dry-run: would %s\n' "$action"
+    done
+    return 0
+  fi
+
+  printf 'bootstrap: --apply is not implemented by this PR; run the reviewed admin bootstrap procedure instead\n' >&2
+  return 1
+}
+
+main "$@"

--- a/ops/nomad/bootstrap.test.sh
+++ b/ops/nomad/bootstrap.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BOOTSTRAP=$SCRIPT_DIR/bootstrap.sh
+
+fail_test() {
+  printf 'bootstrap.test: %s\n' "$1" >&2
+  exit 1
+}
+
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/sm-nomad-bootstrap-test.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# --dry-run reports the pinned version and never touches the filesystem
+# outside of stdout.
+output=$(bash "$BOOTSTRAP" --dry-run --root "$FIXTURE/root")
+printf '%s\n' "$output" | grep -q 'nomad_version=2.0.6' || \
+  fail_test 'dry-run must report the pinned Nomad version'
+printf '%s\n' "$output" | grep -q 'would verify pinned Nomad' || \
+  fail_test 'dry-run must list its planned actions'
+[[ ! -e $FIXTURE/root ]] || fail_test 'dry-run must not create the root path'
+
+# --apply is an explicit, safe refusal in this PR: it must fail rather than
+# silently doing nothing or performing an untested mutation.
+set +e
+bash "$BOOTSTRAP" --apply --root "$FIXTURE/root" >/dev/null 2>/tmp/bootstrap-apply-stderr.$$
+status=$?
+set -e
+[[ $status -ne 0 ]] || fail_test '--apply must not report success in this PR'
+grep -q 'not implemented' /tmp/bootstrap-apply-stderr.$$ || \
+  fail_test '--apply must explain that it refuses to run'
+rm -f /tmp/bootstrap-apply-stderr.$$
+
+# Missing mode flag is rejected with the documented usage exit code.
+set +e
+bash "$BOOTSTRAP" --root "$FIXTURE/root" >/dev/null 2>&1
+status=$?
+set -e
+[[ $status == 64 ]] || fail_test 'missing mode flag must exit 64'
+
+# Unknown flag is rejected the same way.
+set +e
+bash "$BOOTSTRAP" --dry-run --bogus >/dev/null 2>&1
+status=$?
+set -e
+[[ $status == 64 ]] || fail_test 'unknown flag must exit 64'
+
+printf 'nomad bootstrap tests passed\n'

--- a/ops/nomad/bootstrap.test.sh
+++ b/ops/nomad/bootstrap.test.sh
@@ -23,13 +23,12 @@ printf '%s\n' "$output" | grep -q 'would verify pinned Nomad' || \
 # --apply is an explicit, safe refusal in this PR: it must fail rather than
 # silently doing nothing or performing an untested mutation.
 set +e
-bash "$BOOTSTRAP" --apply --root "$FIXTURE/root" >/dev/null 2>/tmp/bootstrap-apply-stderr.$$
+bash "$BOOTSTRAP" --apply --root "$FIXTURE/root" >/dev/null 2>"$FIXTURE/bootstrap-apply-stderr"
 status=$?
 set -e
 [[ $status -ne 0 ]] || fail_test '--apply must not report success in this PR'
-grep -q 'not implemented' /tmp/bootstrap-apply-stderr.$$ || \
+grep -q 'not implemented' "$FIXTURE/bootstrap-apply-stderr" || \
   fail_test '--apply must explain that it refuses to run'
-rm -f /tmp/bootstrap-apply-stderr.$$
 
 # Missing mode flag is rejected with the documented usage exit code.
 set +e

--- a/ops/nomad/concurrent-release.test.mjs
+++ b/ops/nomad/concurrent-release.test.mjs
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createDeployTarget, createReleaseManifest, createTrafficSwitch } from "./contracts.mjs";
+import { createNginxAdapter } from "./adapters/nginx.mjs";
+import { readApiOwner, writeApiOwner } from "./ownership.mjs";
+import { reconcileTick } from "./reconcile-traffic.mjs";
+import { COMPOSE_FALLBACK_MARKER, runRelease } from "./release.mjs";
+
+/**
+ * Failure-drill scenarios from plan section 9 acceptance that are not
+ * already exercised by rollout.test.mjs (candidate health, nginx
+ * validate/reload failure, allocation IP change, untrusted endpoint,
+ * first-ever deployment failure): concurrent/stale submissions, a fully
+ * offline Nomad backend, and recovery after a mid-release crash. Every
+ * scenario here uses in-memory/temp-dir fakes - no real Nomad agent,
+ * nginx process, or production host.
+ */
+
+const VALID_SHA = "a".repeat(40);
+const VALID_DIGEST = `sha256:${"c".repeat(64)}`;
+const ALLOWED_NAMESPACE = "social-monitor";
+const ALLOWED_JOB = "sm-api";
+const ALLOWED_CIDR = "172.20.0.0/16";
+const JOB_HCL = "job \"sm-api\" {}";
+
+function manifest(overrides = {}) {
+  return createReleaseManifest({
+    sourceSha: VALID_SHA,
+    image: {
+      registry: "ghcr.io",
+      repository: "777genius/social-monitor-api",
+      digest: VALID_DIGEST,
+      platform: "linux/amd64",
+    },
+    targetConfigHash: "config-hash-1",
+    previousReleaseId: "release-0",
+    ...overrides,
+  });
+}
+
+function target() {
+  return createDeployTarget({
+    namespace: ALLOWED_NAMESPACE,
+    jobId: ALLOWED_JOB,
+    hostBinding: { address: "127.0.0.1", port: 4646 },
+  });
+}
+
+async function withTempDir(run) {
+  const dir = mkdtempSync(join(tmpdir(), "sm-failure-drill-"));
+  try {
+    return await run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function nginxSwitch(dir) {
+  return createTrafficSwitch(
+    createNginxAdapter({
+      includeDir: dir,
+      allowedNamespace: ALLOWED_NAMESPACE,
+      allowedJob: ALLOWED_JOB,
+      allowedCidr: ALLOWED_CIDR,
+    }),
+  );
+}
+
+/**
+ * Models Nomad's own EnforceIndex/JobModifyIndex protection (plan section
+ * 7: "-check-index protects against a stale plan"). `planJob` always
+ * reports the index as of the moment it is called; `runJob` rejects unless
+ * the caller's checkIndex still matches - exactly like the real Nomad HTTP
+ * API rejecting a submission whose plan was observed before someone else's
+ * release already advanced the job.
+ */
+function createIndexTrackingNomad() {
+  let currentIndex = 1;
+  let deploymentSeq = 0;
+  const deployments = new Map();
+  return {
+    async planJob() {
+      return { jobModifyIndex: currentIndex, warnings: "" };
+    },
+    async runJob(_namespace, _jobId, _jobHcl, { checkIndex } = {}) {
+      if (checkIndex !== currentIndex) {
+        throw new Error(`stale plan: checkIndex ${checkIndex} does not match current jobModifyIndex ${currentIndex}`);
+      }
+      deploymentSeq += 1;
+      currentIndex += 1;
+      const deploymentId = `deployment-${deploymentSeq}`;
+      deployments.set(deploymentId, { address: `172.20.0.${10 + deploymentSeq}`, port: 3000 });
+      return { evalId: `eval-${deploymentSeq}`, deploymentId, jobModifyIndex: currentIndex };
+    },
+    async waitForHealthy(deploymentId) {
+      return { status: "healthy", checkedAt: new Date().toISOString(), reason: "", observedAllocation: deploymentId };
+    },
+    async getCandidateEndpoint(_namespace, _jobId) {
+      const last = [...deployments.values()].at(-1);
+      return last ? { allocId: "alloc", ...last } : null;
+    },
+    async getStableEndpoint() {
+      // Nothing has been promoted in this fake yet: a canary allocation
+      // existing is not the same as a promoted/stable one (plan section 4 -
+      // reconcile only ever re-points nginx at a *stable* allocation).
+      return null;
+    },
+    async promoteDeployment() {
+      return { promoted: true };
+    },
+  };
+}
+
+test("concurrent releases: a stale checkIndex is rejected, the winner's route is not clobbered", async () => {
+  await withTempDir(async (dir) => {
+    const trafficSwitch = nginxSwitch(dir);
+    const nomad = createIndexTrackingNomad();
+
+    // Both callers observe the job at the same index before either submits -
+    // this is the actual race the plan's "-check-index" contract guards
+    // against, not a timing coincidence this test has to force.
+    const [resultA, resultB] = await Promise.all([
+      runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL }),
+      runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL }),
+    ]);
+
+    const outcomes = [resultA.outcome, resultB.outcome].sort();
+    assert.deepEqual(outcomes, ["failed", "promoted"], "exactly one concurrent submission may win");
+
+    const loser = resultA.outcome === "failed" ? resultA : resultB;
+    assert.match(loser.error, /stale plan|checkIndex/i);
+    assert.equal(loser.receipt.outcome, "failed");
+
+    // The route reflects exactly one release, never an undefined/mixed state.
+    const route = await trafficSwitch.inspect();
+    assert.ok(route.currentEndpoint, "the winning release must have published a route");
+  });
+});
+
+test("nomad unreachable (registry/backend offline): explicit failed outcome, route and promotion untouched", async () => {
+  await withTempDir(async (dir) => {
+    const trafficSwitch = nginxSwitch(dir);
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.9", port: 3000 });
+
+    let promoteCalls = 0;
+    const offlineNomad = {
+      async planJob() {
+        throw new Error("connect ECONNREFUSED 127.0.0.1:4646");
+      },
+      async runJob() {
+        throw new Error("unreachable");
+      },
+      async waitForHealthy() {
+        throw new Error("unreachable");
+      },
+      async getCandidateEndpoint() {
+        throw new Error("unreachable");
+      },
+      async promoteDeployment() {
+        promoteCalls += 1;
+      },
+    };
+
+    const result = await runRelease({ nomad: offlineNomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL });
+
+    assert.equal(result.outcome, "failed");
+    assert.equal(result.receipt.outcome, "failed");
+    assert.match(result.error, /ECONNREFUSED|offline|nomad plan\/run\/health-poll failed/i);
+    assert.equal(promoteCalls, 0, "an offline backend must never be told to promote");
+
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint.address, "172.20.0.9", "the existing route must survive a Nomad outage untouched");
+  });
+});
+
+test("nomad unreachable on a first-ever deployment: explicit fallback target is Compose, not an invented Nomad release", async () => {
+  await withTempDir(async (dir) => {
+    const trafficSwitch = nginxSwitch(dir);
+    const offlineNomad = {
+      async planJob() {
+        throw new Error("connect ETIMEDOUT 127.0.0.1:4646");
+      },
+    };
+
+    const result = await runRelease({
+      nomad: offlineNomad,
+      trafficSwitch,
+      manifest: manifest({ previousReleaseId: null }),
+      target: target(),
+      jobHcl: JOB_HCL,
+    });
+
+    assert.equal(result.outcome, "failed");
+    assert.equal(result.receipt.previousReleaseId, null);
+    assert.equal(result.receipt.configPreimage, COMPOSE_FALLBACK_MARKER, "no prior Nomad release exists to fall back to");
+
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint, null, "no route was ever published");
+  });
+});
+
+test("recovery after a mid-release crash: no duplicate owner, reconcile stays a no-op until a real stable allocation exists", async () => {
+  await withTempDir(async (dir) => {
+    await withTempDir(async (deployState) => {
+      const trafficSwitch = nginxSwitch(dir);
+      const nomad = createIndexTrackingNomad();
+
+      // Simulate the process dying right after Nomad accepted the submission
+      // (candidate exists) but before this release ever reached the traffic
+      // switch - call the adapter directly instead of runRelease() to model
+      // "runRelease never returned".
+      const plan = await nomad.planJob();
+      await nomad.runJob(ALLOWED_NAMESPACE, ALLOWED_JOB, JOB_HCL, { checkIndex: plan.jobModifyIndex });
+
+      // Ownership is a durable marker, not something this in-flight release
+      // ever wrote to: a crash here must not leave the API with an
+      // undefined or duplicate owner, and the MVP must never have flipped it
+      // to "nomad" on its own (that switch is an explicit human step, plan
+      // section 7 activation, outside this repo's automated paths).
+      assert.equal(readApiOwner({ deployState }), "compose", "absence of a marker means compose, exactly as before this PR existed");
+
+      // A reconcile tick running right after the "crash" must not invent a
+      // route from the still-canary allocation: getStableEndpoint correctly
+      // reports nothing promoted yet, so reconcile is a safe no-op.
+      const tick = await reconcileTick({ nomad, trafficSwitch, target: target() });
+      assert.equal(tick.changed, false);
+      const route = await trafficSwitch.inspect();
+      assert.equal(route.currentEndpoint, null, "reconcile must never publish a canary as if it were promoted");
+
+      // A fresh retry after the "reboot" (same manifest, same job) completes
+      // normally - the earlier half-finished attempt did not corrupt state.
+      const retry = await runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL });
+      assert.equal(retry.outcome, "promoted");
+      assert.equal(readApiOwner({ deployState }), "compose", "MVP never auto-switches ownership, even after a successful Nomad release");
+    });
+  });
+});
+
+test("writeApiOwner rejects a malformed owner value instead of silently writing it", () => {
+  // Defense in depth alongside ownership.test.mjs: a typo like
+  // "nomad-canary" must never reach the durable marker file. The repo-wide
+  // check that no *non-test source file* automates writeApiOwner("nomad")
+  // lives in failure-drill.test.sh, which can grep every file at once.
+  assert.throws(() => writeApiOwner("nomad-canary", { deployState: "/nonexistent" }), TypeError);
+});

--- a/ops/nomad/concurrent-release.test.mjs
+++ b/ops/nomad/concurrent-release.test.mjs
@@ -99,7 +99,7 @@ function createIndexTrackingNomad() {
     async waitForHealthy(deploymentId) {
       return { status: "healthy", checkedAt: new Date().toISOString(), reason: "", observedAllocation: deploymentId };
     },
-    async getCandidateEndpoint(_namespace, _jobId) {
+    async getCandidateEndpoint() {
       const last = [...deployments.values()].at(-1);
       return last ? { allocId: "alloc", ...last } : null;
     },

--- a/ops/nomad/contracts.mjs
+++ b/ops/nomad/contracts.mjs
@@ -1,0 +1,260 @@
+/**
+ * Narrow deployment contracts for the Nomad API vertical slice.
+ *
+ * This module owns only the small value/port shapes described in the MVP
+ * plan (release identity, health, traffic switching, rollback evidence). It
+ * must never import from `apps/` or `libs/`: deployment code stays isolated
+ * from application/domain code (Clean Architecture boundary), and adapters
+ * (Nomad, nginx, GitHub, GHCR, filesystem) depend on these contracts, not the
+ * other way around (DIP).
+ */
+
+const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const IMAGE_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const IMAGE_TAG_PATTERN = /^sha-[0-9a-f]{40}$/u;
+const REPOSITORY_PATTERN = /^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\/[a-z0-9]+(?:[._-][a-z0-9]+)*)+$/u;
+const REGISTRY_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9.-]*(?::\d+)?$/u;
+const SECRET_LIKE_KEY_PATTERN = /secret|token|password|credential|private[-_]?key/iu;
+const HEALTH_STATUSES = new Set(["healthy", "unhealthy", "unknown"]);
+const ROLLBACK_OUTCOMES = new Set(["succeeded", "failed", "rolled-back", "unknown"]);
+const REQUIRED_TRAFFIC_SWITCH_METHODS = ["inspect", "switch", "restore"];
+
+function fail(contractName, message) {
+  throw new TypeError(`ops/nomad/contracts: ${contractName} ${message}`);
+}
+
+function requireNonEmptyString(contractName, field, value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(contractName, `requires a non-empty string "${field}"`);
+  }
+  return value;
+}
+
+function requireMatch(contractName, field, value, pattern) {
+  requireNonEmptyString(contractName, field, value);
+  if (!pattern.test(value)) {
+    fail(contractName, `field "${field}" does not match the required format`);
+  }
+  return value;
+}
+
+function requireIsoTimestamp(contractName, field, value) {
+  const parsed = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(parsed.getTime())) {
+    fail(contractName, `requires a valid timestamp for "${field}"`);
+  }
+  return parsed.toISOString();
+}
+
+function requireNoSecretLikeKeys(contractName, field, value) {
+  if (value === null || typeof value !== "object") {
+    fail(contractName, `requires an object for "${field}"`);
+  }
+  for (const key of Object.keys(value)) {
+    if (SECRET_LIKE_KEY_PATTERN.test(key)) {
+      fail(contractName, `field "${field}" must not carry credential-shaped key "${key}"`);
+    }
+  }
+  return value;
+}
+
+/**
+ * @typedef {object} ImageReference
+ * @property {string} registry
+ * @property {string} repository
+ * @property {string} digest - `sha256:<64 hex>`; the only deployment identity.
+ * @property {string} platform - e.g. `linux/amd64`.
+ * @property {string|null} tag - optional `sha-<40 hex>` search aid, never identity.
+ * @property {string} reference - fully qualified `registry/repository@digest`.
+ */
+
+/**
+ * @param {{registry: string, repository: string, digest: string, platform: string, tag?: string|null}} fields
+ * @returns {ImageReference}
+ */
+export function createImageReference({ registry, repository, digest, platform, tag = null }) {
+  const name = "ImageReference";
+  requireMatch(name, "registry", registry, REGISTRY_PATTERN);
+  requireMatch(name, "repository", repository, REPOSITORY_PATTERN);
+  requireMatch(name, "digest", digest, IMAGE_DIGEST_PATTERN);
+  requireNonEmptyString(name, "platform", platform);
+  if (tag !== null && tag !== undefined) {
+    requireMatch(name, "tag", tag, IMAGE_TAG_PATTERN);
+  }
+  return Object.freeze({
+    registry,
+    repository,
+    digest,
+    platform,
+    tag: tag ?? null,
+    reference: `${registry}/${repository}@${digest}`,
+  });
+}
+
+/**
+ * @typedef {object} ReleaseManifest
+ * @property {string} sourceSha - full 40-hex commit SHA the image was built from.
+ * @property {ImageReference} image
+ * @property {string} targetConfigHash - hash identifying the rendered deploy target/config.
+ * @property {string|null} previousReleaseId - null only for the first release.
+ */
+
+/**
+ * @param {{sourceSha: string, image: ImageReference, targetConfigHash: string, previousReleaseId?: string|null}} fields
+ * @returns {ReleaseManifest}
+ */
+export function createReleaseManifest({ sourceSha, image, targetConfigHash, previousReleaseId = null }) {
+  const name = "ReleaseManifest";
+  requireMatch(name, "sourceSha", sourceSha, GIT_SHA_PATTERN);
+  requireNonEmptyString(name, "targetConfigHash", targetConfigHash);
+  const validatedImage = createImageReference(image ?? {});
+  if (previousReleaseId !== null && previousReleaseId !== undefined) {
+    requireNonEmptyString(name, "previousReleaseId", previousReleaseId);
+  }
+  return Object.freeze({
+    sourceSha,
+    image: validatedImage,
+    targetConfigHash,
+    previousReleaseId: previousReleaseId ?? null,
+  });
+}
+
+/**
+ * @typedef {object} DeployTarget
+ * @property {string} namespace
+ * @property {string} jobId
+ * @property {{address: string, port: number}} hostBinding - no credentials.
+ */
+
+/**
+ * @param {{namespace: string, jobId: string, hostBinding: {address: string, port: number}}} fields
+ * @returns {DeployTarget}
+ */
+export function createDeployTarget({ namespace, jobId, hostBinding }) {
+  const name = "DeployTarget";
+  requireNonEmptyString(name, "namespace", namespace);
+  requireNonEmptyString(name, "jobId", jobId);
+  requireNoSecretLikeKeys(name, "hostBinding", hostBinding);
+  requireNonEmptyString(name, "hostBinding.address", hostBinding.address);
+  if (!Number.isInteger(hostBinding.port) || hostBinding.port <= 0 || hostBinding.port > 65535) {
+    fail(name, 'requires an integer "hostBinding.port" in the 1-65535 range');
+  }
+  return Object.freeze({
+    namespace,
+    jobId,
+    hostBinding: Object.freeze({ address: hostBinding.address, port: hostBinding.port }),
+  });
+}
+
+/**
+ * @typedef {object} HealthResult
+ * @property {"healthy"|"unhealthy"|"unknown"} status
+ * @property {string} checkedAt - ISO 8601 timestamp.
+ * @property {string} reason - sanitized, human-readable; never a raw provider payload.
+ * @property {string|null} observedAllocation - allocation ID the check ran against, if any.
+ */
+
+/**
+ * @param {{status: string, checkedAt: string|Date, reason?: string, observedAllocation?: string|null}} fields
+ * @returns {HealthResult}
+ */
+export function createHealthResult({ status, checkedAt, reason = "", observedAllocation = null }) {
+  const name = "HealthResult";
+  if (!HEALTH_STATUSES.has(status)) {
+    fail(name, 'requires "status" to be one of healthy, unhealthy, unknown');
+  }
+  const isoCheckedAt = requireIsoTimestamp(name, "checkedAt", checkedAt);
+  if (typeof reason !== "string") {
+    fail(name, 'requires "reason" to be a string');
+  }
+  if (SECRET_LIKE_KEY_PATTERN.test(reason)) {
+    fail(name, 'field "reason" must not reference credential-shaped content');
+  }
+  if (observedAllocation !== null && observedAllocation !== undefined) {
+    requireNonEmptyString(name, "observedAllocation", observedAllocation);
+  }
+  return Object.freeze({
+    status,
+    checkedAt: isoCheckedAt,
+    reason,
+    observedAllocation: observedAllocation ?? null,
+  });
+}
+
+/**
+ * @typedef {object} TrafficSwitch
+ * @property {() => Promise<unknown>} inspect
+ * @property {(expectedPrevious: unknown, endpoint: unknown) => Promise<unknown>} switch
+ * @property {(receipt: unknown) => Promise<unknown>} restore
+ */
+
+/**
+ * Validates that an adapter satisfies the TrafficSwitch port and returns a
+ * facade exposing exactly those three methods (ISP: callers cannot reach
+ * adapter-specific internals through this contract).
+ * @param {Record<string, unknown>} adapter
+ * @returns {TrafficSwitch}
+ */
+export function createTrafficSwitch(adapter) {
+  const name = "TrafficSwitch";
+  if (adapter === null || typeof adapter !== "object") {
+    fail(name, "requires an adapter object");
+  }
+  for (const method of REQUIRED_TRAFFIC_SWITCH_METHODS) {
+    if (typeof adapter[method] !== "function") {
+      fail(name, `requires adapter method "${method}"`);
+    }
+  }
+  return Object.freeze({
+    inspect: (...args) => adapter.inspect(...args),
+    switch: (...args) => adapter.switch(...args),
+    restore: (...args) => adapter.restore(...args),
+  });
+}
+
+/**
+ * @typedef {object} RollbackReceipt
+ * @property {string|null} previousReleaseId - null only for the first release.
+ * @property {string} newReleaseId
+ * @property {string} jobId
+ * @property {string} deploymentId
+ * @property {string} configPreimage - reference/hash of config restored on rollback.
+ * @property {"succeeded"|"failed"|"rolled-back"|"unknown"} outcome
+ */
+
+/**
+ * @param {{previousReleaseId?: string|null, newReleaseId: string, jobId: string, deploymentId: string, configPreimage: string, outcome: string}} fields
+ * @returns {RollbackReceipt}
+ */
+export function createRollbackReceipt({
+  previousReleaseId = null,
+  newReleaseId,
+  jobId,
+  deploymentId,
+  configPreimage,
+  outcome,
+}) {
+  const name = "RollbackReceipt";
+  if (previousReleaseId !== null && previousReleaseId !== undefined) {
+    requireNonEmptyString(name, "previousReleaseId", previousReleaseId);
+  }
+  requireNonEmptyString(name, "newReleaseId", newReleaseId);
+  requireNonEmptyString(name, "jobId", jobId);
+  requireNonEmptyString(name, "deploymentId", deploymentId);
+  requireNonEmptyString(name, "configPreimage", configPreimage);
+  if (!ROLLBACK_OUTCOMES.has(outcome)) {
+    fail(name, 'requires "outcome" to be one of succeeded, failed, rolled-back, unknown');
+  }
+  return Object.freeze({
+    previousReleaseId: previousReleaseId ?? null,
+    newReleaseId,
+    jobId,
+    deploymentId,
+    configPreimage,
+    outcome,
+  });
+}
+
+export const GIT_SHA_FORMAT = GIT_SHA_PATTERN;
+export const IMAGE_DIGEST_FORMAT = IMAGE_DIGEST_PATTERN;
+export const IMAGE_TAG_FORMAT = IMAGE_TAG_PATTERN;

--- a/ops/nomad/contracts.mjs
+++ b/ops/nomad/contracts.mjs
@@ -264,7 +264,3 @@ export function createRollbackReceipt({
     outcome,
   });
 }
-
-export const GIT_SHA_FORMAT = GIT_SHA_PATTERN;
-export const IMAGE_DIGEST_FORMAT = IMAGE_DIGEST_PATTERN;
-export const IMAGE_TAG_FORMAT = IMAGE_TAG_PATTERN;

--- a/ops/nomad/contracts.mjs
+++ b/ops/nomad/contracts.mjs
@@ -14,6 +14,16 @@ const IMAGE_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/u;
 const IMAGE_TAG_PATTERN = /^sha-[0-9a-f]{40}$/u;
 const REPOSITORY_PATTERN = /^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\/[a-z0-9]+(?:[._-][a-z0-9]+)*)+$/u;
 const REGISTRY_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9.-]*(?::\d+)?$/u;
+// Intentionally not libs/shared-kernel/src/redaction.ts's isSensitiveKey,
+// despite covering the same idea: this file's own module contract above
+// forbids importing from libs/, and libs/shared-kernel is TypeScript run
+// through the app's build - importing it from a plain, buildless .mjs run
+// directly by `node --test` would only work by accident of the local Node
+// version's TS support (CI pins Node 22, which does not strip types by
+// default), matching the same standalone-pattern precedent already used by
+// scripts/check-secrets.mjs. This pattern is deliberately narrower in scope
+// than shared-kernel's (DeployTarget.hostBinding and HealthResult.reason
+// only) - it is not a substitute for the app-wide redaction policy.
 const SECRET_LIKE_KEY_PATTERN = /secret|token|password|credential|private[-_]?key/iu;
 const HEALTH_STATUSES = new Set(["healthy", "unhealthy", "unknown"]);
 const ROLLBACK_OUTCOMES = new Set(["succeeded", "failed", "rolled-back", "unknown"]);

--- a/ops/nomad/contracts.test.mjs
+++ b/ops/nomad/contracts.test.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createDeployTarget,
+  createHealthResult,
+  createImageReference,
+  createReleaseManifest,
+  createRollbackReceipt,
+  createTrafficSwitch,
+} from "./contracts.mjs";
+
+const VALID_SHA = "a".repeat(40);
+const VALID_DIGEST = `sha256:${"b".repeat(64)}`;
+
+function validImage(overrides = {}) {
+  return {
+    registry: "ghcr.io",
+    repository: "777genius/social-monitor-api",
+    digest: VALID_DIGEST,
+    platform: "linux/amd64",
+    ...overrides,
+  };
+}
+
+test("ImageReference accepts a valid digest reference and rejects a tag as identity", () => {
+  const image = createImageReference(validImage({ tag: `sha-${VALID_SHA}` }));
+  assert.equal(image.reference, `ghcr.io/777genius/social-monitor-api@${VALID_DIGEST}`);
+  assert.equal(image.tag, `sha-${VALID_SHA}`);
+  assert.throws(() => createImageReference(validImage({ digest: "latest" })), TypeError);
+  assert.throws(() => createImageReference(validImage({ repository: "UPPERCASE" })), TypeError);
+  assert.throws(() => createImageReference(validImage({ tag: "v1.0.0" })), TypeError);
+});
+
+test("ImageReference rejects missing required fields", () => {
+  assert.throws(() => createImageReference(validImage({ registry: "" })), TypeError);
+  assert.throws(() => createImageReference(validImage({ platform: undefined })), TypeError);
+});
+
+test("ImageReference is immutable", () => {
+  const image = createImageReference(validImage());
+  assert.throws(() => {
+    image.digest = "sha256:" + "0".repeat(64);
+  });
+});
+
+test("ReleaseManifest requires a full 40-hex source SHA and a valid image", () => {
+  const manifest = createReleaseManifest({
+    sourceSha: VALID_SHA,
+    image: validImage(),
+    targetConfigHash: "config-hash-1",
+  });
+  assert.equal(manifest.sourceSha, VALID_SHA);
+  assert.equal(manifest.previousReleaseId, null);
+  assert.throws(
+    () =>
+      createReleaseManifest({
+        sourceSha: "short-sha",
+        image: validImage(),
+        targetConfigHash: "config-hash-1",
+      }),
+    TypeError,
+  );
+  assert.throws(
+    () =>
+      createReleaseManifest({
+        sourceSha: VALID_SHA,
+        image: validImage({ digest: "not-a-digest" }),
+        targetConfigHash: "config-hash-1",
+      }),
+    TypeError,
+  );
+});
+
+test("ReleaseManifest carries an explicit previous release id when supplied", () => {
+  const manifest = createReleaseManifest({
+    sourceSha: VALID_SHA,
+    image: validImage(),
+    targetConfigHash: "config-hash-1",
+    previousReleaseId: "release-0",
+  });
+  assert.equal(manifest.previousReleaseId, "release-0");
+});
+
+test("DeployTarget rejects credential-shaped keys on hostBinding", () => {
+  assert.throws(
+    () =>
+      createDeployTarget({
+        namespace: "social-monitor",
+        jobId: "sm-api",
+        hostBinding: { address: "10.0.0.5", port: 3000, apiToken: "x" },
+      }),
+    TypeError,
+  );
+});
+
+test("DeployTarget accepts a bounded host binding without credentials", () => {
+  const target = createDeployTarget({
+    namespace: "social-monitor",
+    jobId: "sm-api",
+    hostBinding: { address: "10.0.0.5", port: 3000 },
+  });
+  assert.deepEqual(target.hostBinding, { address: "10.0.0.5", port: 3000 });
+});
+
+test("DeployTarget rejects an out-of-range port", () => {
+  assert.throws(
+    () =>
+      createDeployTarget({
+        namespace: "social-monitor",
+        jobId: "sm-api",
+        hostBinding: { address: "10.0.0.5", port: 70000 },
+      }),
+    TypeError,
+  );
+});
+
+test("HealthResult normalizes timestamps and rejects unknown status values", () => {
+  const checkedAt = new Date("2026-09-11T00:00:00.000Z");
+  const result = createHealthResult({ status: "healthy", checkedAt, observedAllocation: "alloc-1" });
+  assert.equal(result.checkedAt, "2026-09-11T00:00:00.000Z");
+  assert.equal(result.reason, "");
+  assert.throws(() => createHealthResult({ status: "degraded", checkedAt }), TypeError);
+  assert.throws(() => createHealthResult({ status: "healthy", checkedAt: "not-a-date" }), TypeError);
+});
+
+test("HealthResult rejects a reason that looks like a leaked credential", () => {
+  assert.throws(
+    () =>
+      createHealthResult({
+        status: "unhealthy",
+        checkedAt: new Date(),
+        reason: "db password=hunter2 rejected",
+      }),
+    TypeError,
+  );
+});
+
+test("TrafficSwitch requires inspect/switch/restore and exposes only those methods", () => {
+  const calls = [];
+  const adapter = {
+    inspect: async () => "current",
+    switch: async (expectedPrevious, endpoint) => calls.push(["switch", expectedPrevious, endpoint]),
+    restore: async (receipt) => calls.push(["restore", receipt]),
+    dangerousInternal: () => "should not be reachable",
+  };
+  const port = createTrafficSwitch(adapter);
+  assert.deepEqual(Object.keys(port).sort(), ["inspect", "restore", "switch"]);
+  assert.equal(typeof port.dangerousInternal, "undefined");
+});
+
+test("TrafficSwitch rejects an adapter missing a required method", () => {
+  assert.throws(
+    () =>
+      createTrafficSwitch({
+        inspect: async () => "current",
+        switch: async () => {},
+      }),
+    TypeError,
+  );
+});
+
+test("RollbackReceipt requires a known outcome and non-empty identifiers", () => {
+  const receipt = createRollbackReceipt({
+    newReleaseId: "release-1",
+    jobId: "sm-api",
+    deploymentId: "deploy-1",
+    configPreimage: "config-hash-0",
+    outcome: "rolled-back",
+  });
+  assert.equal(receipt.previousReleaseId, null);
+  assert.throws(
+    () =>
+      createRollbackReceipt({
+        newReleaseId: "release-1",
+        jobId: "sm-api",
+        deploymentId: "deploy-1",
+        configPreimage: "config-hash-0",
+        outcome: "maybe",
+      }),
+    TypeError,
+  );
+});

--- a/ops/nomad/failure-drill.test.sh
+++ b/ops/nomad/failure-drill.test.sh
@@ -60,10 +60,9 @@ owner=$(SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ow
 mkdir -p "$FIXTURE/deploy-state/nomad"
 printf 'not-a-real-owner\n' > "$FIXTURE/deploy-state/nomad/api-owner"
 set +e
-SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ownership.mjs" get-owner >/dev/null 2>/tmp/failure-drill-corrupt-marker.$$
+SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ownership.mjs" get-owner >/dev/null 2>"$FIXTURE/corrupt-marker-stderr"
 status=$?
 set -e
 [[ $status -ne 0 ]] || fail_test 'a corrupt marker file must not be silently treated as a valid owner'
-rm -f /tmp/failure-drill-corrupt-marker.$$
 
 printf 'nomad failure-drill tests passed\n'

--- a/ops/nomad/failure-drill.test.sh
+++ b/ops/nomad/failure-drill.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Acceptance-level failure drill for the Nomad API MVP (plan section 9/12
+# checkpoint). This does not stand up a real Nomad agent, nginx process, or
+# production host - every scenario below runs against the fakes/temp-dir
+# adapters already used by the unit suite. Its job is to be the single named
+# entrypoint the plan's acceptance checklist points at, not to duplicate
+# rollout.test.mjs's per-adapter coverage.
+
+fail_test() {
+  printf 'failure-drill: %s\n' "$1" >&2
+  exit 1
+}
+
+# 1) The concurrent/stale-plan/offline/mid-crash-recovery scenarios that are
+#    NOT already covered by rollout.test.mjs.
+node --test "$SCRIPT_DIR/concurrent-release.test.mjs"
+
+# 2) Static invariant: no *production code path* automates the owner switch
+#    to "nomad" - ownership.test.mjs legitimately calls writeApiOwner("nomad")
+#    to unit-test the marker mechanism itself, so this only scans non-test
+#    source files (release.mjs, reconcile-traffic.mjs, the CLIs, adapters)
+#    for a call a future PR might quietly wire into an automated path. The
+#    switch must stay an explicit human step (plan section 7 activation).
+non_test_source_files=()
+while IFS= read -r -d '' file; do
+  non_test_source_files+=("$file")
+done < <(find "$SCRIPT_DIR" -name '*.mjs' ! -name '*.test.mjs' -print0)
+if grep -lEn 'writeApiOwner\(\s*["'"'"']nomad["'"'"']' "${non_test_source_files[@]}" 2>/dev/null; then
+  fail_test 'no non-test file in ops/nomad may call writeApiOwner("nomad") - owner switch is an explicit human step, not an automated one (plan section 7)'
+fi
+
+# 3) Fresh-state / "host reboot" default: with no marker file at all (the
+#    state of every host before this PR's ownership.mjs existed), the CLI
+#    must report "compose", not crash or invent a value.
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/sm-nomad-failure-drill.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+
+owner=$(SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ownership.mjs" get-owner)
+[[ $owner == "compose" ]] || fail_test "fresh host with no marker must report owner=compose, got: $owner"
+
+# 4) Explicit rollback returns ownership to the prior value: writing "nomad"
+#    then rolling back to "compose" must round-trip cleanly through the same
+#    CLI a real rollback runbook step would call (plan section 7/10 -
+#    "explicit rollback returns the previous owner").
+SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ownership.mjs" set-owner nomad >/dev/null
+owner=$(SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ownership.mjs" get-owner)
+[[ $owner == "nomad" ]] || fail_test "set-owner nomad must round-trip, got: $owner"
+
+SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ownership.mjs" set-owner compose >/dev/null
+owner=$(SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ownership.mjs" get-owner)
+[[ $owner == "compose" ]] || fail_test "explicit rollback to compose must round-trip, got: $owner"
+
+# 5) A malformed marker on disk (corrupt state after an interrupted write,
+#    or a stray/tampered file) must fail loudly instead of silently
+#    defaulting - a crash-during-write must never be interpreted as a quiet
+#    "compose" default once a file actually exists.
+mkdir -p "$FIXTURE/deploy-state/nomad"
+printf 'not-a-real-owner\n' > "$FIXTURE/deploy-state/nomad/api-owner"
+set +e
+SOCIAL_MONITOR_DEPLOY_STATE="$FIXTURE/deploy-state" node "$SCRIPT_DIR/ownership.mjs" get-owner >/dev/null 2>/tmp/failure-drill-corrupt-marker.$$
+status=$?
+set -e
+[[ $status -ne 0 ]] || fail_test 'a corrupt marker file must not be silently treated as a valid owner'
+rm -f /tmp/failure-drill-corrupt-marker.$$
+
+printf 'nomad failure-drill tests passed\n'

--- a/ops/nomad/host/acl.hcl
+++ b/ops/nomad/host/acl.hcl
@@ -24,8 +24,12 @@ namespace "social-monitor" {
     "read-job",
     "list-jobs",
     "read-logs",
-    "dispatch-job",
   ]
+  # No "dispatch-job": sm-api is not (and is not planned to become) a
+  # parameterized job. Granting it now would let this token dispatch any
+  # future parameterized job in this namespace without a deliberate policy
+  # review at the time that job is actually added - least privilege means
+  # adding this back only when a real dispatch consumer exists.
 }
 
 agent {

--- a/ops/nomad/host/acl.hcl
+++ b/ops/nomad/host/acl.hcl
@@ -11,8 +11,14 @@
 # rather than being a second, unused namespace stanza here.
 
 namespace "social-monitor" {
-  policy = "deny"
-
+  # No `policy` shorthand here on purpose: Nomad merges a namespace block's
+  # `policy` shorthand into the same capabilities list as any explicit
+  # `capabilities` entries, and "deny" itself expands to a "deny" capability
+  # that takes precedence over every other capability once merged in. Adding
+  # `policy = "deny"` alongside the explicit list below would silently deny
+  # everything in this namespace regardless of the capabilities named here -
+  # the explicit list is already the complete, minimal grant; it does not
+  # need (and must not get) a coarse-grained policy shorthand layered on top.
   capabilities = [
     "submit-job",
     "read-job",

--- a/ops/nomad/host/acl.hcl
+++ b/ops/nomad/host/acl.hcl
@@ -1,0 +1,39 @@
+# Minimal deploy ACL policy for the `sm-api` job (plan section 5). Bound to
+# namespace "social-monitor" only: no management capability, no access to
+# any other namespace or global Nomad state. The CI-facing restricted
+# wrapper authenticates with a token tied to this policy, never the
+# bootstrap management token.
+#
+# The nginx traffic-reconciliation adapter (plan section 4) needs its own,
+# separate, strictly read-only policy ("read-job"/"list-jobs" only, no
+# submit-job/dispatch-job). That adapter does not exist until the rollout PR
+# ships its `ops/nomad/adapters/nginx.mjs`, so its policy file is added then
+# rather than being a second, unused namespace stanza here.
+
+namespace "social-monitor" {
+  policy = "deny"
+
+  capabilities = [
+    "submit-job",
+    "read-job",
+    "list-jobs",
+    "read-logs",
+    "dispatch-job",
+  ]
+}
+
+agent {
+  policy = "deny"
+}
+
+node {
+  policy = "deny"
+}
+
+operator {
+  policy = "deny"
+}
+
+quota {
+  policy = "deny"
+}

--- a/ops/nomad/host/acl.hcl
+++ b/ops/nomad/host/acl.hcl
@@ -4,11 +4,15 @@
 # wrapper authenticates with a token tied to this policy, never the
 # bootstrap management token.
 #
-# The nginx traffic-reconciliation adapter (plan section 4) needs its own,
-# separate, strictly read-only policy ("read-job"/"list-jobs" only, no
-# submit-job/dispatch-job). That adapter does not exist until the rollout PR
-# ships its `ops/nomad/adapters/nginx.mjs`, so its policy file is added then
-# rather than being a second, unused namespace stanza here.
+# The nginx traffic-reconciliation adapter (plan section 4;
+# `ops/nomad/adapters/nginx.mjs` and `reconcile-traffic.mjs` already exist in
+# this repo) still needs its own, separate, strictly read-only policy
+# ("read-job"/"list-jobs" only, no submit-job/dispatch-job) and a matching
+# token wired into `host/api-traffic.service`. Neither exists yet - this is
+# tracked as an open gap in ops/nomad/README.md, not a "future PR" this
+# comment can describe as not-yet-relevant: the code that will need it is
+# already shipped, only the policy/token plumbing for real activation is
+# missing.
 
 namespace "social-monitor" {
   # No `policy` shorthand here on purpose: Nomad merges a namespace block's

--- a/ops/nomad/host/api-deploy.service
+++ b/ops/nomad/host/api-deploy.service
@@ -13,6 +13,12 @@
 # own error message): this unit is real, reviewable shape, but wiring it to
 # a live Nomad agent/nginx host is a separate, explicitly reviewed
 # activation step (plan section 7), not something this PR turns on.
+#
+# NOMAD_ADDR below is set to https:// to match host/nomad.hcl's `tls { http
+# = true }` requirement, but nothing consumes it yet: ops/nomad/adapters/
+# nomad.mjs does not read this env var or support TLS/mTLS today - that is
+# part of the same future --apply implementation work, not a gap this
+# comment is hiding.
 
 [Unit]
 Description=Social Monitor sm-api Nomad release transaction
@@ -25,7 +31,7 @@ Type=oneshot
 User=root
 Group=root
 WorkingDirectory=/var/data/social-monitor/control/nomad
-Environment=NOMAD_ADDR=http://127.0.0.1:4646
+Environment=NOMAD_ADDR=https://127.0.0.1:4646
 ExecStart=/usr/bin/node /var/data/social-monitor/integration/ops/nomad/release.mjs --apply --manifest /var/data/social-monitor/control/deploy-state/nomad/pending-manifest.json
 TimeoutStartSec=900
 # A partially-applied release must not silently vanish: journald keeps the

--- a/ops/nomad/host/api-deploy.service
+++ b/ops/nomad/host/api-deploy.service
@@ -1,0 +1,38 @@
+# Host-owned deploy transaction service for `sm-api` (plan section 7).
+# The restricted GitHub deploy client starts this unit (via the existing
+# restricted SSH wrapper's `nomad-deploy` action) and then polls its status
+# instead of holding the SSH connection open for the whole rollout - a
+# dropped SSH session or a cancelled workflow must not abort a release
+# already past the point of no return. This unit does not run in CI: it
+# only exists on the production host after `ops/nomad/bootstrap.sh`.
+#
+# ExecStart intentionally does not accept shell/HCL/stdin from the caller:
+# it reads a single, already-validated, root-owned release manifest path.
+#
+# `release.mjs --apply` is deliberately not implemented yet (see the CLI's
+# own error message): this unit is real, reviewable shape, but wiring it to
+# a live Nomad agent/nginx host is a separate, explicitly reviewed
+# activation step (plan section 7), not something this PR turns on.
+
+[Unit]
+Description=Social Monitor sm-api Nomad release transaction
+Requires=nomad.service
+After=nomad.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+WorkingDirectory=/var/data/social-monitor/control/nomad
+Environment=NOMAD_ADDR=http://127.0.0.1:4646
+ExecStart=/usr/bin/node /var/data/social-monitor/integration/ops/nomad/release.mjs --apply --manifest /var/data/social-monitor/control/deploy-state/nomad/pending-manifest.json
+TimeoutStartSec=900
+# A partially-applied release must not silently vanish: journald keeps the
+# phase transitions (plan section 7's prepared/submitted/switched/committed
+# journal) for the next reconnect to read back.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/nomad/host/api-traffic.service
+++ b/ops/nomad/host/api-traffic.service
@@ -1,0 +1,27 @@
+# Host-owned nginx traffic reconciliation loop for `sm-api` (plan section
+# 4): keeps the nginx upstream pointed at whatever allocation Nomad reports
+# as the current stable/promoted one, so a restart/reschedule/auto-revert
+# doesn't leave nginx routing to a container IP that no longer exists.
+# Runs continuously; the tested logic is ops/nomad/reconcile-traffic.mjs's
+# `reconcileTick` (see rollout.test.mjs) - this unit just calls it on an
+# interval and is not itself exercised by any test in this PR.
+
+[Unit]
+Description=Social Monitor sm-api nginx traffic reconciliation
+Requires=nomad.service
+After=nomad.service network-online.target social-monitor-prod.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+Environment=NOMAD_ADDR=http://127.0.0.1:4646
+ExecStart=/usr/bin/node /var/data/social-monitor/integration/ops/nomad/reconcile-traffic.mjs
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/nomad/host/api-traffic.service
+++ b/ops/nomad/host/api-traffic.service
@@ -5,6 +5,10 @@
 # Runs continuously; the tested logic is ops/nomad/reconcile-traffic.mjs's
 # `reconcileTick` (see rollout.test.mjs) - this unit just calls it on an
 # interval and is not itself exercised by any test in this PR.
+#
+# NOMAD_ADDR is https:// to match host/nomad.hcl's TLS requirement, but
+# ops/nomad/adapters/nomad.mjs does not consume it or support TLS/mTLS yet -
+# see api-deploy.service's comment for the same, not-yet-implemented gap.
 
 [Unit]
 Description=Social Monitor sm-api nginx traffic reconciliation
@@ -16,7 +20,7 @@ Wants=network-online.target
 Type=simple
 User=root
 Group=root
-Environment=NOMAD_ADDR=http://127.0.0.1:4646
+Environment=NOMAD_ADDR=https://127.0.0.1:4646
 ExecStart=/usr/bin/node /var/data/social-monitor/integration/ops/nomad/reconcile-traffic.mjs
 Restart=on-failure
 RestartSec=5s

--- a/ops/nomad/host/nomad.hcl
+++ b/ops/nomad/host/nomad.hcl
@@ -1,0 +1,76 @@
+# Single server+client Nomad agent for the API vertical slice MVP (plan
+# section 5). Not dev mode: ACL and mTLS are enabled, and only the loopback
+# HTTP API is reachable from this host. `bootstrap_expect = 1` is a
+# deliberate single-VPS limitation (no host-level HA); see the plan's
+# section 1 for the explicit trade-off this accepts.
+#
+# Pin: ops/nomad/versions.json records the exact verified binary
+# version/checksum this config is meant to run.
+
+data_dir  = "/var/lib/nomad"
+log_level = "INFO"
+name      = "social-monitor-vps"
+region    = "global"
+datacenter = "dc1"
+
+# Loopback only: nothing outside this host can reach the Nomad API, RPC, or
+# gossip ports. The restricted deploy wrapper is the only external caller,
+# and it runs on the same host via SSH.
+bind_addr = "127.0.0.1"
+
+advertise {
+  http = "127.0.0.1"
+  rpc  = "127.0.0.1"
+  serf = "127.0.0.1"
+}
+
+ports {
+  http = 4646
+  rpc  = 4647
+  serf = 4648
+}
+
+server {
+  enabled          = true
+  bootstrap_expect = 1
+}
+
+client {
+  enabled = true
+
+  # No arbitrary host mounts: only the named volume the API entrypoint reads
+  # its env file from is allowed, and it is read-only.
+  host_volume "social-monitor-api-secrets" {
+    path      = "/var/data/social-monitor/secrets/nomad/api.env.d"
+    read_only = true
+  }
+}
+
+acl {
+  enabled = true
+}
+
+tls {
+  http = true
+  rpc  = true
+
+  ca_file   = "/var/data/social-monitor/secrets/nomad/tls/ca.pem"
+  cert_file = "/var/data/social-monitor/secrets/nomad/tls/agent.pem"
+  key_file  = "/var/data/social-monitor/secrets/nomad/tls/agent-key.pem"
+
+  verify_server_hostname = true
+  verify_https_client    = true
+}
+
+plugin "docker" {
+  config {
+    # No privileged containers, no raw_exec-equivalent capability escape,
+    # and no host PID/IPC sharing: the API task only needs its own network
+    # namespace on the existing project Docker network (plan section 4).
+    allow_privileged        = false
+    allow_caps              = ["CHOWN", "SETUID", "SETGID"]
+    volumes {
+      enabled = true
+    }
+  }
+}

--- a/ops/nomad/host/nomad.hcl
+++ b/ops/nomad/host/nomad.hcl
@@ -73,8 +73,16 @@ plugin "docker" {
     # UID/GID at runtime, so CHOWN/SETUID/SETGID have no real consumer here -
     # granting them would only widen what a compromised container could do.
     allow_caps              = []
+    # false (the default, spelled out here so it can never be flipped by a
+    # careless future edit without touching this exact line): `true` would
+    # let any job with submit-job capability (the restricted deploy token
+    # in acl.hcl has exactly that) bind-mount arbitrary host paths via its
+    # own task config `volumes` list, regardless of privileged mode -
+    # directly contradicting this repo's "no arbitrary host mounts" ACL
+    # boundary. The named `host_volume` above does not need this: Nomad
+    # resolves `host_volume`/`volume_mount` independently of this setting.
     volumes {
-      enabled = true
+      enabled = false
     }
   }
 }

--- a/ops/nomad/host/nomad.hcl
+++ b/ops/nomad/host/nomad.hcl
@@ -68,7 +68,11 @@ plugin "docker" {
     # and no host PID/IPC sharing: the API task only needs its own network
     # namespace on the existing project Docker network (plan section 4).
     allow_privileged        = false
-    allow_caps              = ["CHOWN", "SETUID", "SETGID"]
+    # Empty, not a default capability set: api.Dockerfile already switches to
+    # `USER node` at build time and the entrypoint never chowns or changes
+    # UID/GID at runtime, so CHOWN/SETUID/SETGID have no real consumer here -
+    # granting them would only widen what a compromised container could do.
+    allow_caps              = []
     volumes {
       enabled = true
     }

--- a/ops/nomad/jobspec-contract.test.mjs
+++ b/ops/nomad/jobspec-contract.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+/**
+ * Static consistency checks between api.nomad.hcl and api.Dockerfile.
+ * Neither rollout.test.mjs nor api-env-entrypoint.test.mjs exercises the
+ * real files together (both use in-memory fakes for the entrypoint's env
+ * path), so a mismatch between the image's baked-in default and the
+ * jobspec's volume mount would previously reach production undetected and
+ * crash-loop the task on every start with ENOENT.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const jobspec = readFileSync(join(here, "api.nomad.hcl"), "utf8");
+const dockerfile = readFileSync(join(here, "api.Dockerfile"), "utf8");
+
+test("api.nomad.hcl overrides SOCIAL_MONITOR_API_ENV_FILE to a path inside its own volume mount", () => {
+  const mountMatch = jobspec.match(/destination\s*=\s*"([^"]+)"/);
+  assert.ok(mountMatch, "expected a volume_mount destination in api.nomad.hcl");
+  const mountDestination = mountMatch[1];
+
+  const envOverrideMatch = jobspec.match(/SOCIAL_MONITOR_API_ENV_FILE\s*=\s*"([^"]+)"/);
+  assert.ok(envOverrideMatch, "api.nomad.hcl must override SOCIAL_MONITOR_API_ENV_FILE explicitly");
+  const envOverridePath = envOverrideMatch[1];
+
+  assert.ok(
+    envOverridePath.startsWith(`${mountDestination}/`),
+    `SOCIAL_MONITOR_API_ENV_FILE (${envOverridePath}) must live inside the mounted volume (${mountDestination}), ` +
+      "or the entrypoint will read a path nothing ever wrote to",
+  );
+});
+
+test("the Dockerfile's baked-in default path is never the one actually used under Nomad", () => {
+  const dockerfileDefaultMatch = dockerfile.match(/ENV SOCIAL_MONITOR_API_ENV_FILE=(\S+)/);
+  assert.ok(dockerfileDefaultMatch, "api.Dockerfile must set a default SOCIAL_MONITOR_API_ENV_FILE");
+  const dockerfileDefault = dockerfileDefaultMatch[1];
+
+  const envOverrideMatch = jobspec.match(/SOCIAL_MONITOR_API_ENV_FILE\s*=\s*"([^"]+)"/);
+  assert.ok(envOverrideMatch);
+
+  assert.notEqual(
+    envOverrideMatch[1],
+    dockerfileDefault,
+    "api.nomad.hcl must override the image's local-testing default, not silently rely on it matching a real mount",
+  );
+});

--- a/ops/nomad/ownership-guard.sh
+++ b/ops/nomad/ownership-guard.sh
@@ -8,10 +8,14 @@ set -euo pipefail
 # know anything about Nomad itself (SRP/DIP: callers depend on this narrow
 # contract, not on ownership.mjs's storage format).
 #
-# Fails open to the unfiltered list on any ownership-check error: this PR
-# only ever writes the "compose" marker in production, so a checker that
-# cannot run must not silently drop services from a deploy that predates
-# Nomad adoption.
+# Fails closed on any ownership-check error: this script only ever runs on
+# a host where ops/nomad has already been bootstrapped (a legacy deploy that
+# predates Nomad adoption entirely does not have this file to call in the
+# first place), so a broken check here means something is wrong with that
+# install, not "Nomad was never adopted". Defaulting to "compose" on error
+# would risk letting a legacy Compose path mutate a service Nomad has
+# already taken ownership of - exactly the dual-owner regression this guard
+# exists to prevent. Refuse instead, and require a human to look.
 #
 # Usage: ownership-guard.sh filter <service> < services.txt
 
@@ -24,7 +28,8 @@ main() {
   local self_dir owner
   self_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
   if ! owner=$(node "$self_dir/ownership.mjs" get-owner 2>/dev/null); then
-    owner=compose
+    printf 'ownership-guard: could not determine the API owner (node/ownership.mjs unavailable or failing) - refusing rather than assuming "compose"\n' >&2
+    return 1
   fi
   if [[ $owner == nomad ]]; then
     grep -vFx "$service" || true

--- a/ops/nomad/ownership-guard.sh
+++ b/ops/nomad/ownership-guard.sh
@@ -27,7 +27,7 @@ main() {
     owner=compose
   fi
   if [[ $owner == nomad ]]; then
-    grep -vx "$service" || true
+    grep -vFx "$service" || true
   else
     cat
   fi

--- a/ops/nomad/ownership-guard.sh
+++ b/ops/nomad/ownership-guard.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Filters a newline-delimited service list on stdin, dropping one service
+# name when the Nomad API ownership marker (ops/nomad/ownership.mjs) reports
+# that service as nomad-owned. Legacy Compose deploy/backup/rescue code calls
+# this so it stops mutating a service once Nomad owns it, without needing to
+# know anything about Nomad itself (SRP/DIP: callers depend on this narrow
+# contract, not on ownership.mjs's storage format).
+#
+# Fails open to the unfiltered list on any ownership-check error: this PR
+# only ever writes the "compose" marker in production, so a checker that
+# cannot run must not silently drop services from a deploy that predates
+# Nomad adoption.
+#
+# Usage: ownership-guard.sh filter <service> < services.txt
+
+main() {
+  local mode=${1:-} service=${2:-}
+  [[ $mode == filter && -n $service ]] || {
+    printf 'ownership-guard: usage: ownership-guard.sh filter <service>\n' >&2
+    return 64
+  }
+  local self_dir owner
+  self_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  if ! owner=$(node "$self_dir/ownership.mjs" get-owner 2>/dev/null); then
+    owner=compose
+  fi
+  if [[ $owner == nomad ]]; then
+    grep -vx "$service" || true
+  else
+    cat
+  fi
+}
+
+main "$@"

--- a/ops/nomad/ownership-guard.test.sh
+++ b/ops/nomad/ownership-guard.test.sh
@@ -32,11 +32,33 @@ actual=$(SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api <<< $'api
 [[ $actual == $'api\ningestion-worker' ]] || \
   fail_test 'reverting to compose must restore the unfiltered list'
 
-# Missing ownership.mjs (node unavailable) fails open: no filtering happens.
-node_dir=$(dirname "$(command -v node)")
-safe_path=$(printf '%s' "$PATH" | tr ':' '\n' | grep -vFx "$node_dir" | paste -sd: -)
-actual=$(PATH="$safe_path" SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api <<< $'api\ningestion-worker')
-[[ $actual == $'api\ningestion-worker' ]] || fail_test 'a missing node must fail open, not drop services'
+# Missing node (ownership check cannot run) fails closed: refuse rather
+# than silently assuming "compose" and letting a caller mutate a service
+# Nomad might actually already own.
+#
+# `command -v` only reports the first PATH hit, but a dev machine can have
+# node resolvable from more than one directory (e.g. both Homebrew and a
+# stray /usr/local/bin) - stripping only the first would leave node
+# reachable via the other and silently exercise the wrong code path.
+safe_path=""
+IFS=':' read -ra path_dirs <<< "$PATH"
+for path_dir in "${path_dirs[@]}"; do
+  [[ -x "$path_dir/node" ]] && continue
+  safe_path+="${safe_path:+:}$path_dir"
+done
+# Earlier lines in this script already ran `node ...` at its real location,
+# so bash has that resolved path cached in its command hash table. A
+# temporary `PATH=... command` prefix does not itself invalidate that cache,
+# so `command -v node` would keep reporting the stale, real path here
+# without this - silently testing nothing.
+hash -r
+PATH="$safe_path" command -v node >/dev/null 2>&1 && fail_test 'test setup bug: node is still reachable after PATH scrubbing'
+set +e
+PATH="$safe_path" SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api \
+  <<< $'api\ningestion-worker' >"$STATE/missing-node-stdout" 2>"$STATE/missing-node-stderr"
+status=$?
+set -e
+[[ $status -ne 0 ]] || fail_test 'a missing node must refuse (fail closed), not silently pass services through'
 
 # A service name containing a regex metacharacter is matched literally, not
 # as a pattern (grep -Fx, not -x): a stray "." must not make this match more

--- a/ops/nomad/ownership-guard.test.sh
+++ b/ops/nomad/ownership-guard.test.sh
@@ -54,11 +54,19 @@ done
 hash -r
 PATH="$safe_path" command -v node >/dev/null 2>&1 && fail_test 'test setup bug: node is still reachable after PATH scrubbing'
 set +e
-PATH="$safe_path" SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api \
+# $BASH (this interpreter's own absolute path), not a bare `bash` that
+# would itself need to resolve through the just-scrubbed $safe_path - if
+# bash's own directory were ever removed by that scrub, a bare `bash` here
+# would fail with "command not found" (also non-zero) and the assertion
+# below would pass for the wrong reason, without ownership-guard.sh having
+# run at all.
+PATH="$safe_path" SOCIAL_MONITOR_DEPLOY_STATE="$STATE" "$BASH" "$GUARD" filter api \
   <<< $'api\ningestion-worker' >"$STATE/missing-node-stdout" 2>"$STATE/missing-node-stderr"
 status=$?
 set -e
 [[ $status -ne 0 ]] || fail_test 'a missing node must refuse (fail closed), not silently pass services through'
+grep -q 'could not determine the API owner' "$STATE/missing-node-stderr" || \
+  fail_test 'the refusal must come from ownership-guard.sh itself, not an unrelated failure'
 
 # A service name containing a regex metacharacter is matched literally, not
 # as a pattern (grep -Fx, not -x): a stray "." must not make this match more

--- a/ops/nomad/ownership-guard.test.sh
+++ b/ops/nomad/ownership-guard.test.sh
@@ -38,6 +38,15 @@ safe_path=$(printf '%s' "$PATH" | tr ':' '\n' | grep -vFx "$node_dir" | paste -s
 actual=$(PATH="$safe_path" SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api <<< $'api\ningestion-worker')
 [[ $actual == $'api\ningestion-worker' ]] || fail_test 'a missing node must fail open, not drop services'
 
+# A service name containing a regex metacharacter is matched literally, not
+# as a pattern (grep -Fx, not -x): a stray "." must not make this match more
+# or fewer lines than the exact literal service name would.
+SOCIAL_MONITOR_DEPLOY_STATE="$STATE" node "$SCRIPT_DIR/ownership.mjs" set-owner nomad
+actual=$(SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter 'x.collector' <<< $'x.collector\nxacollector\napi')
+expected=$'xacollector\napi'
+[[ $actual == "$expected" ]] || fail_test 'a regex metacharacter in the service name must be matched literally'
+SOCIAL_MONITOR_DEPLOY_STATE="$STATE" node "$SCRIPT_DIR/ownership.mjs" set-owner compose
+
 # Missing arguments are rejected with the documented usage exit code.
 set +e
 bash "$GUARD" filter >/dev/null 2>&1

--- a/ops/nomad/ownership-guard.test.sh
+++ b/ops/nomad/ownership-guard.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+GUARD=$SCRIPT_DIR/ownership-guard.sh
+
+fail_test() {
+  printf 'ownership-guard.test: %s\n' "$1" >&2
+  exit 1
+}
+
+STATE=$(mktemp -d "${TMPDIR:-/tmp}/sm-ownership-guard-test.XXXXXX")
+trap 'rm -rf "$STATE"' EXIT
+
+# Default (no marker written) is compose: nothing is filtered out.
+actual=$(SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api <<< $'api\ningestion-worker')
+expected=$'api\ningestion-worker'
+[[ $actual == "$expected" ]] || fail_test 'default compose owner must not filter services'
+
+# Explicit nomad owner drops exactly the named service.
+SOCIAL_MONITOR_DEPLOY_STATE="$STATE" node "$SCRIPT_DIR/ownership.mjs" set-owner nomad
+actual=$(SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api <<< $'api\ningestion-worker')
+expected='ingestion-worker'
+[[ $actual == "$expected" ]] || fail_test 'nomad owner must filter out the named service'
+
+# nomad owner with the named service absent leaves the rest untouched.
+actual=$(SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api <<< 'ingestion-worker')
+[[ $actual == 'ingestion-worker' ]] || fail_test 'nomad owner must not touch unrelated services'
+
+# Switching back to compose restores the unfiltered list.
+SOCIAL_MONITOR_DEPLOY_STATE="$STATE" node "$SCRIPT_DIR/ownership.mjs" set-owner compose
+actual=$(SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api <<< $'api\ningestion-worker')
+[[ $actual == $'api\ningestion-worker' ]] || \
+  fail_test 'reverting to compose must restore the unfiltered list'
+
+# Missing ownership.mjs (node unavailable) fails open: no filtering happens.
+node_dir=$(dirname "$(command -v node)")
+safe_path=$(printf '%s' "$PATH" | tr ':' '\n' | grep -vFx "$node_dir" | paste -sd: -)
+actual=$(PATH="$safe_path" SOCIAL_MONITOR_DEPLOY_STATE="$STATE" bash "$GUARD" filter api <<< $'api\ningestion-worker')
+[[ $actual == $'api\ningestion-worker' ]] || fail_test 'a missing node must fail open, not drop services'
+
+# Missing arguments are rejected with the documented usage exit code.
+set +e
+bash "$GUARD" filter >/dev/null 2>&1
+status=$?
+set -e
+[[ $status == 64 ]] || fail_test 'missing service argument must exit 64'
+
+printf 'ownership-guard tests passed\n'

--- a/ops/nomad/ownership.mjs
+++ b/ops/nomad/ownership.mjs
@@ -10,6 +10,11 @@
  * `ops/deploy/social-monitor-production-deploy.sh` (`$CONTROL/deploy-state`):
  * `<deployState>/nomad/api-owner`. Absence of the marker means `compose`,
  * since production never wrote one before this PR existed.
+ *
+ * NOT a lock: this file has no fencing token, TTL, or compare-and-swap, so a
+ * read-decide-act sequence across two callers is not fenced against a
+ * concurrent writer. See ops/nomad/README.md gap 8 for why that is still
+ * safe today and what has to land before it stops being safe.
  */
 
 import { mkdirSync, readFileSync, renameSync, writeFileSync, unlinkSync } from "node:fs";

--- a/ops/nomad/ownership.mjs
+++ b/ops/nomad/ownership.mjs
@@ -19,7 +19,7 @@
 
 import { mkdirSync, readFileSync, renameSync, writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 
 export const API_OWNERS = Object.freeze(["compose", "nomad"]);
 export const DEFAULT_API_OWNER = "compose";
@@ -123,7 +123,3 @@ if (isMainModule) {
     process.exitCode = 1;
   }
 }
-
-// Re-exported so a caller can locate this file's own directory without
-// hardcoding a relative path (used by ownership-guard.sh's self-location).
-export const SELF_PATH = fileURLToPath(import.meta.url);

--- a/ops/nomad/ownership.mjs
+++ b/ops/nomad/ownership.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Durable owner marker for the API service: `compose` (legacy Docker Compose,
+ * the only value ever set in production by this PR) or `nomad` (later PR
+ * activation). This module owns only reading/writing/validating the marker
+ * itself (SRP) - it never decides whether switching owner is safe, and it
+ * never touches Docker/Nomad/nginx.
+ *
+ * Marker path mirrors the existing durable `deploy-state` convention used by
+ * `ops/deploy/social-monitor-production-deploy.sh` (`$CONTROL/deploy-state`):
+ * `<deployState>/nomad/api-owner`. Absence of the marker means `compose`,
+ * since production never wrote one before this PR existed.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const API_OWNERS = Object.freeze(["compose", "nomad"]);
+export const DEFAULT_API_OWNER = "compose";
+
+/**
+ * @param {{deployState?: string}} [options]
+ * @returns {string} absolute path to the durable deploy-state directory.
+ */
+export function resolveDeployStateRoot(options = {}) {
+  const deployState = options.deployState ?? process.env.SOCIAL_MONITOR_DEPLOY_STATE;
+  if (typeof deployState === "string" && deployState.trim().length > 0) {
+    return deployState;
+  }
+  return "/var/data/social-monitor/control/deploy-state";
+}
+
+/**
+ * @param {{deployState?: string}} [options]
+ * @returns {string} absolute path to the API owner marker file.
+ */
+export function apiOwnerMarkerPath(options = {}) {
+  return join(resolveDeployStateRoot(options), "nomad", "api-owner");
+}
+
+function assertValidOwner(owner) {
+  if (!API_OWNERS.includes(owner)) {
+    throw new TypeError(`ops/nomad/ownership: owner must be one of ${API_OWNERS.join(", ")}, got ${JSON.stringify(owner)}`);
+  }
+}
+
+/**
+ * @param {{deployState?: string}} [options]
+ * @returns {"compose"|"nomad"}
+ */
+export function readApiOwner(options = {}) {
+  const markerPath = apiOwnerMarkerPath(options);
+  let raw;
+  try {
+    raw = readFileSync(markerPath, "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return DEFAULT_API_OWNER;
+    }
+    throw error;
+  }
+  const owner = raw.trim();
+  assertValidOwner(owner);
+  return owner;
+}
+
+/**
+ * Atomically writes the marker: write to a sibling temp file, then rename
+ * over the destination, so a crash mid-write never leaves a partial marker
+ * that a subsequent read could misinterpret.
+ * @param {"compose"|"nomad"} owner
+ * @param {{deployState?: string}} [options]
+ */
+export function writeApiOwner(owner, options = {}) {
+  assertValidOwner(owner);
+  const markerPath = apiOwnerMarkerPath(options);
+  const markerDir = join(resolveDeployStateRoot(options), "nomad");
+  mkdirSync(markerDir, { recursive: true, mode: 0o755 });
+  const tempPath = `${markerPath}.next-${process.pid}-${Date.now()}`;
+  writeFileSync(tempPath, `${owner}\n`, { mode: 0o644 });
+  try {
+    renameSync(tempPath, markerPath);
+  } catch (error) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Best-effort cleanup; the original rename error is what matters.
+    }
+    throw error;
+  }
+}
+
+function runCli(argv) {
+  const [command, value] = argv;
+  if (command === "get-owner") {
+    process.stdout.write(`${readApiOwner()}\n`);
+    return 0;
+  }
+  if (command === "set-owner") {
+    if (!value) {
+      process.stderr.write("ownership: set-owner requires an owner value\n");
+      return 64;
+    }
+    writeApiOwner(value);
+    return 0;
+  }
+  process.stderr.write("ownership: usage: ownership.mjs get-owner|set-owner <compose|nomad>\n");
+  return 64;
+}
+
+const isMainModule = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMainModule) {
+  try {
+    process.exitCode = runCli(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`ownership: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+// Re-exported so a caller can locate this file's own directory without
+// hardcoding a relative path (used by ownership-guard.sh's self-location).
+export const SELF_PATH = fileURLToPath(import.meta.url);

--- a/ops/nomad/ownership.test.mjs
+++ b/ops/nomad/ownership.test.mjs
@@ -1,0 +1,81 @@
+import { mkdtempSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readApiOwner, writeApiOwner, apiOwnerMarkerPath, resolveDeployStateRoot } from "./ownership.mjs";
+
+function withTempDeployState(run) {
+  const deployState = mkdtempSync(join(tmpdir(), "sm-nomad-ownership-test-"));
+  try {
+    return run(deployState);
+  } finally {
+    rmSync(deployState, { recursive: true, force: true });
+  }
+}
+
+test("readApiOwner defaults to compose when the marker is absent", () => {
+  withTempDeployState((deployState) => {
+    assert.equal(readApiOwner({ deployState }), "compose");
+  });
+});
+
+test("writeApiOwner then readApiOwner round-trips nomad", () => {
+  withTempDeployState((deployState) => {
+    writeApiOwner("nomad", { deployState });
+    assert.equal(readApiOwner({ deployState }), "nomad");
+  });
+});
+
+test("writeApiOwner then readApiOwner round-trips compose after nomad", () => {
+  withTempDeployState((deployState) => {
+    writeApiOwner("nomad", { deployState });
+    writeApiOwner("compose", { deployState });
+    assert.equal(readApiOwner({ deployState }), "compose");
+  });
+});
+
+test("writeApiOwner rejects an invalid owner value and leaves no marker", () => {
+  withTempDeployState((deployState) => {
+    assert.throws(() => writeApiOwner("docker", { deployState }), TypeError);
+    assert.equal(readApiOwner({ deployState }), "compose");
+  });
+});
+
+test("readApiOwner rejects a corrupt marker instead of defaulting silently", () => {
+  withTempDeployState((deployState) => {
+    writeApiOwner("nomad", { deployState });
+    writeFileSync(apiOwnerMarkerPath({ deployState }), "not-an-owner\n");
+    assert.throws(() => readApiOwner({ deployState }), TypeError);
+  });
+});
+
+test("writeApiOwner does not leave a stray temp file behind on success", () => {
+  withTempDeployState((deployState) => {
+    writeApiOwner("nomad", { deployState });
+    const markerDir = join(deployState, "nomad");
+    const entries = readdirSync(markerDir);
+    assert.deepEqual(entries, ["api-owner"]);
+  });
+});
+
+test("resolveDeployStateRoot falls back to the production default", () => {
+  const previous = process.env.SOCIAL_MONITOR_DEPLOY_STATE;
+  delete process.env.SOCIAL_MONITOR_DEPLOY_STATE;
+  try {
+    assert.equal(resolveDeployStateRoot(), "/var/data/social-monitor/control/deploy-state");
+  } finally {
+    if (previous !== undefined) process.env.SOCIAL_MONITOR_DEPLOY_STATE = previous;
+  }
+});
+
+test("resolveDeployStateRoot prefers an explicit option over the environment", () => {
+  const previous = process.env.SOCIAL_MONITOR_DEPLOY_STATE;
+  process.env.SOCIAL_MONITOR_DEPLOY_STATE = "/tmp/should-not-be-used";
+  try {
+    assert.equal(resolveDeployStateRoot({ deployState: "/tmp/explicit" }), "/tmp/explicit");
+  } finally {
+    if (previous === undefined) delete process.env.SOCIAL_MONITOR_DEPLOY_STATE;
+    else process.env.SOCIAL_MONITOR_DEPLOY_STATE = previous;
+  }
+});

--- a/ops/nomad/preflight.sh
+++ b/ops/nomad/preflight.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only, allowlisted preflight evidence for the Nomad API MVP (plan
+# section 2). This is the "tiny preflight" bundled with PR1: it only reads
+# host/tooling identity available on the machine it runs on and never
+# executes `docker inspect`, dumps environment variables, or reads any file
+# under a secrets path. The full production inventory (disk inodes, cgroup
+# limits, swap, running container identities, nginx/DB state) is collected by
+# a separate admin-run preflight at bootstrap/activation time, not here.
+#
+# Usage: ops/nomad/preflight.sh [source-sha]
+# Prints a single line of JSON to stdout. A field that could not be collected
+# on this machine is reported as JSON null, never omitted, so a stale/broken
+# collector cannot look identical to a working one.
+
+preflight_json_string() {
+  local value=$1
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  printf '%s' "$value"
+}
+
+preflight_string_field() {
+  # Runs "$@", returns a quoted JSON string of the first output line, or the
+  # bare JSON literal null if the command is missing or fails.
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'null'
+    return 0
+  fi
+  local output=""
+  if output=$("$@" 2>/dev/null); then
+    output=$(printf '%s\n' "$output" | head -n1)
+    printf '"%s"' "$(preflight_json_string "$output")"
+  else
+    printf 'null'
+  fi
+}
+
+preflight_mem_total_kb() {
+  if [[ -r /proc/meminfo ]]; then
+    awk '/^MemTotal:/{print $2; found=1} END{exit !found}' /proc/meminfo && return 0
+  fi
+  if command -v sysctl >/dev/null 2>&1; then
+    local bytes
+    if bytes=$(sysctl -n hw.memsize 2>/dev/null) && [[ $bytes =~ ^[0-9]+$ ]]; then
+      printf '%d' $((bytes / 1024))
+      return 0
+    fi
+  fi
+  return 1
+}
+
+preflight_disk_free_kb() {
+  local target=${1:-/}
+  df -Pk "$target" 2>/dev/null | awk 'NR==2 && $4 ~ /^[0-9]+$/ {print $4; found=1} END{exit !found}'
+}
+
+preflight_number_field() {
+  local value
+  if value=$("$@" 2>/dev/null) && [[ $value =~ ^[0-9]+$ ]]; then
+    printf '%s' "$value"
+  else
+    printf 'null'
+  fi
+}
+
+preflight_source_sha_field() {
+  local candidate=${1:-${SOCIAL_MONITOR_PREFLIGHT_SOURCE_SHA:-}}
+  if [[ $candidate =~ ^[0-9a-f]{40}$ ]]; then
+    printf '"%s"' "$candidate"
+  else
+    if [[ -n $candidate ]]; then
+      printf 'nomad-preflight-error: ignoring malformed source SHA\n' >&2
+    fi
+    printf 'null'
+  fi
+}
+
+main() {
+  local collected_at
+  collected_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  local hostname_field kernel_field arch_field
+  hostname_field=$(preflight_string_field hostname)
+  kernel_field=$(preflight_string_field uname -srv)
+  arch_field=$(preflight_string_field uname -m)
+
+  local docker_version_field compose_version_field
+  docker_version_field=$(preflight_string_field docker version --format '{{.Server.Version}}')
+  compose_version_field=$(preflight_string_field docker compose version --short)
+
+  local mem_total_field disk_free_field
+  mem_total_field=$(preflight_number_field preflight_mem_total_kb)
+  disk_free_field=$(preflight_number_field preflight_disk_free_kb /)
+
+  local source_sha_field
+  source_sha_field=$(preflight_source_sha_field "${1:-}")
+
+  printf '{"collectedAt":"%s","sourceSha":%s,"host":{"hostname":%s,"kernel":%s,"architecture":%s},"docker":{"serverVersion":%s,"composeVersion":%s},"resources":{"memTotalKb":%s,"diskFreeKb":%s}}\n' \
+    "$collected_at" "$source_sha_field" \
+    "$hostname_field" "$kernel_field" "$arch_field" \
+    "$docker_version_field" "$compose_version_field" \
+    "$mem_total_field" "$disk_free_field"
+}
+
+main "$@"

--- a/ops/nomad/preflight.test.sh
+++ b/ops/nomad/preflight.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PREFLIGHT=$SCRIPT_DIR/preflight.sh
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/social-monitor-nomad-preflight.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+
+VALID_SHA=$(printf 'a%.0s' $(seq 1 40))
+
+fail() {
+  printf 'preflight-test-error: %s\n' "$1" >&2
+  exit 1
+}
+
+json_field() {
+  # json_field <json> <dotted.path>
+  node -e '
+    const data = JSON.parse(process.argv[1]);
+    const path = process.argv[2].split(".");
+    let value = data;
+    for (const key of path) {
+      value = value === null || value === undefined ? undefined : value[key];
+    }
+    process.stdout.write(JSON.stringify(value ?? null));
+  ' "$1" "$2"
+}
+
+assert_key_shape() {
+  local json=$1
+  node -e '
+    const data = JSON.parse(process.argv[1]);
+    const expected = ["collectedAt", "sourceSha", "host", "docker", "resources"].sort();
+    const actual = Object.keys(data).sort();
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      console.error("top-level keys mismatch", actual);
+      process.exit(1);
+    }
+    const expectedHost = ["hostname", "kernel", "architecture"].sort();
+    if (JSON.stringify(Object.keys(data.host).sort()) !== JSON.stringify(expectedHost)) {
+      console.error("host keys mismatch", data.host);
+      process.exit(1);
+    }
+    const expectedDocker = ["serverVersion", "composeVersion"].sort();
+    if (JSON.stringify(Object.keys(data.docker).sort()) !== JSON.stringify(expectedDocker)) {
+      console.error("docker keys mismatch", data.docker);
+      process.exit(1);
+    }
+    const expectedResources = ["memTotalKb", "diskFreeKb"].sort();
+    if (JSON.stringify(Object.keys(data.resources).sort()) !== JSON.stringify(expectedResources)) {
+      console.error("resources keys mismatch", data.resources);
+      process.exit(1);
+    }
+  ' "$json" || fail "unexpected JSON shape: $json"
+}
+
+# --- a valid source SHA is echoed back verbatim, output is one JSON line ---
+output=$("$PREFLIGHT" "$VALID_SHA")
+[[ $output != *$'\n'* ]] || fail "expected a single JSON line with no embedded newlines"
+assert_key_shape "$output"
+[[ $(json_field "$output" sourceSha) == "\"$VALID_SHA\"" ]] || fail "sourceSha was not echoed back: $output"
+[[ $(json_field "$output" collectedAt) =~ ^\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\"$ ]] \
+  || fail "collectedAt is not a UTC timestamp: $output"
+
+# --- a malformed source SHA degrades to null and warns on stderr, not stdout ---
+stdout_file=$FIXTURE/stdout
+stderr_file=$FIXTURE/stderr
+"$PREFLIGHT" "not-a-real-sha" >"$stdout_file" 2>"$stderr_file"
+assert_key_shape "$(cat "$stdout_file")"
+[[ $(json_field "$(cat "$stdout_file")" sourceSha) == "null" ]] || fail "malformed sourceSha should degrade to null"
+grep -q 'malformed source SHA' "$stderr_file" || fail "expected a stderr warning for a malformed source SHA"
+
+# --- missing optional tooling (docker, uname, hostname) degrades fields to
+# null instead of failing the whole collection ---
+minimal_bin=$FIXTURE/minimal-bin
+mkdir -p "$minimal_bin"
+for tool in date awk df head; do
+  tool_path=$(command -v "$tool") || fail "test setup needs $tool on PATH"
+  ln -s "$tool_path" "$minimal_bin/$tool"
+done
+bash_bin=$(command -v bash) || fail "test setup needs bash on PATH"
+degraded_output=$(env -i PATH="$minimal_bin" "$bash_bin" "$PREFLIGHT" "$VALID_SHA")
+assert_key_shape "$degraded_output"
+[[ $(json_field "$degraded_output" host.hostname) == "null" ]] || fail "hostname should be null without the hostname tool"
+[[ $(json_field "$degraded_output" host.kernel) == "null" ]] || fail "kernel should be null without uname"
+[[ $(json_field "$degraded_output" docker.serverVersion) == "null" ]] || fail "docker.serverVersion should be null without docker"
+[[ $(json_field "$degraded_output" sourceSha) == "\"$VALID_SHA\"" ]] || fail "a valid sourceSha must survive tool degradation"
+
+# --- output never contains secret-shaped content ---
+printf '%s' "$output" | grep -qiE 'password|secret|token|private[_-]?key' \
+  && fail "preflight output must never contain credential-shaped text" || true
+
+printf 'nomad preflight tests passed\n'

--- a/ops/nomad/reconcile-traffic.mjs
+++ b/ops/nomad/reconcile-traffic.mjs
@@ -22,12 +22,31 @@ import { pathToFileURL } from "node:url";
  * @returns {Promise<{changed: boolean, endpoint?: object, reason: string}>}
  */
 export async function reconcileTick({ nomad, trafficSwitch, target, port = 3000 }) {
-  const stable = await nomad.getStableEndpoint(target.namespace, target.jobId, { port });
+  let stable;
+  try {
+    stable = await nomad.getStableEndpoint(target.namespace, target.jobId, { port });
+  } catch (error) {
+    // The JSDoc above promises a result, never a rejection: runReconcileLoop
+    // also catches around this call as defense-in-depth, but reconcileTick
+    // itself must keep its own contract regardless of that outer safety net.
+    return {
+      changed: false,
+      reason: `nomad.getStableEndpoint failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
   if (!stable) {
     return { changed: false, reason: "no healthy stable allocation reported by nomad" };
   }
 
-  const current = await trafficSwitch.inspect();
+  let current;
+  try {
+    current = await trafficSwitch.inspect();
+  } catch (error) {
+    return {
+      changed: false,
+      reason: `trafficSwitch.inspect failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
   const desiredEndpoint = {
     namespace: target.namespace,
     jobId: target.jobId,

--- a/ops/nomad/reconcile-traffic.mjs
+++ b/ops/nomad/reconcile-traffic.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * One reconciliation tick for the nginx route (plan section 4). Native
+ * Nomad service registration is not DNS and does not push updates to
+ * nginx, so something has to notice when the promoted allocation's
+ * container IP changes (restart, reschedule, native `auto_revert`) and
+ * repoint the upstream. This file exports the pure, testable tick; the
+ * always-on ~5s loop lives in `host/api-traffic.service`, which just calls
+ * this function on an interval - keeping the interval itself untested here
+ * would hide the actual reconciliation logic behind a timer.
+ *
+ * This never promotes/demotes a Nomad deployment and never invents an
+ * endpoint: it only re-points nginx at whatever `nomad.getStableEndpoint`
+ * reports, and only if that endpoint passes the same allowlist the adapter
+ * already enforces on every switch.
+ */
+
+import { pathToFileURL } from "node:url";
+
+/**
+ * @param {{nomad: object, trafficSwitch: {inspect: Function, switch: Function}, target: import("./contracts.mjs").DeployTarget, port?: number}} params
+ * @returns {Promise<{changed: boolean, endpoint?: object, reason: string}>}
+ */
+export async function reconcileTick({ nomad, trafficSwitch, target, port = 3000 }) {
+  const stable = await nomad.getStableEndpoint(target.namespace, target.jobId, { port });
+  if (!stable) {
+    return { changed: false, reason: "no healthy stable allocation reported by nomad" };
+  }
+
+  const current = await trafficSwitch.inspect();
+  const desiredEndpoint = {
+    namespace: target.namespace,
+    jobId: target.jobId,
+    address: stable.address,
+    port: stable.port,
+  };
+
+  const currentEndpoint = current.currentEndpoint ?? null;
+  const isSameEndpoint =
+    currentEndpoint &&
+    currentEndpoint.address === desiredEndpoint.address &&
+    currentEndpoint.port === desiredEndpoint.port &&
+    currentEndpoint.namespace === desiredEndpoint.namespace &&
+    currentEndpoint.jobId === desiredEndpoint.jobId;
+
+  if (isSameEndpoint) {
+    return { changed: false, reason: "route already points at the current stable allocation" };
+  }
+
+  try {
+    await trafficSwitch.switch(currentEndpoint, desiredEndpoint);
+  } catch (error) {
+    return {
+      changed: false,
+      reason: `switch rejected: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  return { changed: true, endpoint: desiredEndpoint, reason: "route repointed at new stable allocation" };
+}
+
+/**
+ * Runs `reconcileTick` on a fixed interval until the process receives
+ * SIGTERM/SIGINT. This is the only part `host/api-traffic.service` actually
+ * executes; it is intentionally not covered by `rollout.test.mjs` (an
+ * infinite loop isn't a unit test) - `reconcileTick` above carries all the
+ * tested logic, this is just its untested timer shell.
+ * @param {{nomad: object, trafficSwitch: object, target: object, intervalMs?: number, port?: number, log?: (line: string) => void}} params
+ */
+export async function runReconcileLoop({ nomad, trafficSwitch, target, intervalMs = 5000, port = 3000, log = console.log }) {
+  let stopped = false;
+  const stop = () => {
+    stopped = true;
+  };
+  process.once("SIGTERM", stop);
+  process.once("SIGINT", stop);
+
+  while (!stopped) {
+    try {
+      const outcome = await reconcileTick({ nomad, trafficSwitch, target, port });
+      if (outcome.changed) {
+        log(`reconcile-traffic: ${outcome.reason}`);
+      }
+    } catch (error) {
+      log(`reconcile-traffic: tick failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+}
+
+const isMainModule = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMainModule) {
+  process.stderr.write(
+    "reconcile-traffic: standalone CLI wiring (real Nomad/nginx adapters) is a separate, explicitly " +
+      "reviewed activation step (plan section 7); this PR only ships the tested runReconcileLoop/reconcileTick " +
+      "functions for host/api-traffic.service to call once that wiring exists.\n",
+  );
+  process.exitCode = 1;
+}

--- a/ops/nomad/release-cli.test.mjs
+++ b/ops/nomad/release-cli.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { loadReleasePlan } from "./release.mjs";
+
+const RELEASE_CLI = fileURLToPath(new URL("./release.mjs", import.meta.url));
+const VALID_SHA = "b".repeat(40);
+const VALID_DIGEST = `sha256:${"d".repeat(64)}`;
+
+function withManifestFile(content, run) {
+  const dir = mkdtempSync(join(tmpdir(), "sm-release-manifest-"));
+  const manifestPath = join(dir, "manifest.json");
+  writeFileSync(manifestPath, JSON.stringify(content));
+  try {
+    return run(manifestPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function validManifestContent(overrides = {}) {
+  return {
+    sourceSha: VALID_SHA,
+    image: {
+      registry: "ghcr.io",
+      repository: "777genius/social-monitor-api",
+      digest: VALID_DIGEST,
+      platform: "linux/amd64",
+    },
+    targetConfigHash: "hash-1",
+    previousReleaseId: null,
+    target: { namespace: "social-monitor", jobId: "sm-api", hostBinding: { address: "127.0.0.1", port: 4646 } },
+    jobHcl: "job \"sm-api\" {}",
+    ...overrides,
+  };
+}
+
+test("loadReleasePlan validates the manifest through the existing contracts", () => {
+  withManifestFile(validManifestContent(), (manifestPath) => {
+    const plan = loadReleasePlan(manifestPath);
+    assert.equal(plan.manifest.sourceSha, VALID_SHA);
+    assert.equal(plan.target.jobId, "sm-api");
+    assert.equal(plan.jobHcl, "job \"sm-api\" {}");
+  });
+});
+
+test("loadReleasePlan rejects a manifest missing a rendered jobHcl", () => {
+  withManifestFile(validManifestContent({ jobHcl: "" }), (manifestPath) => {
+    assert.throws(() => loadReleasePlan(manifestPath), TypeError);
+  });
+});
+
+test("loadReleasePlan rejects an invalid image digest via the ImageReference contract", () => {
+  withManifestFile(
+    validManifestContent({ image: { registry: "ghcr.io", repository: "x/y", digest: "latest", platform: "linux/amd64" } }),
+    (manifestPath) => {
+      assert.throws(() => loadReleasePlan(manifestPath), TypeError);
+    },
+  );
+});
+
+test("CLI --dry-run prints the planned action and exits 0 without touching the network", () => {
+  withManifestFile(validManifestContent(), (manifestPath) => {
+    const output = execFileSync("node", [RELEASE_CLI, "--dry-run", "--manifest", manifestPath], { encoding: "utf8" });
+    assert.match(output, /release dry-run: would submit sm-api/);
+    assert.match(output, /compose-fallback/);
+  });
+});
+
+test("CLI --apply refuses with a clear, non-zero exit instead of silently doing nothing", () => {
+  withManifestFile(validManifestContent(), (manifestPath) => {
+    assert.throws(() => execFileSync("node", [RELEASE_CLI, "--apply", "--manifest", manifestPath], { encoding: "utf8" }));
+  });
+});
+
+test("CLI with no arguments prints usage and exits non-zero", () => {
+  assert.throws(() => execFileSync("node", [RELEASE_CLI], { encoding: "utf8" }));
+});

--- a/ops/nomad/release.mjs
+++ b/ops/nomad/release.mjs
@@ -118,7 +118,27 @@ export async function runRelease({
     };
   }
 
-  const previousRoute = await trafficSwitch.inspect();
+  let previousRoute;
+  try {
+    previousRoute = await trafficSwitch.inspect();
+  } catch (error) {
+    // Still before the one trafficSwitch.switch() call: the route is
+    // guaranteed untouched, so this is a clean "failed" outcome with the
+    // real health/deploymentId we already have, not an uncaught rejection.
+    return {
+      outcome: "failed",
+      health,
+      receipt: createRollbackReceipt({
+        previousReleaseId: manifest.previousReleaseId,
+        newReleaseId: manifest.sourceSha,
+        jobId: target.jobId,
+        deploymentId: run.deploymentId ?? "unknown",
+        configPreimage: rollbackTarget,
+        outcome: "failed",
+      }),
+      error: `nginx adapter inspect() failed before any switch was attempted: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
   const endpoint = {
     namespace: target.namespace,
     jobId: target.jobId,
@@ -128,7 +148,7 @@ export async function runRelease({
 
   let switchResult;
   try {
-    switchResult = await trafficSwitch.switch(previousRoute.currentEndpoint ?? null, endpoint);
+    switchResult = await trafficSwitch.switch(previousRoute?.currentEndpoint ?? null, endpoint);
   } catch (error) {
     // The candidate is healthy per Nomad but the switch itself failed
     // (validation/reload/conflict): the route is guaranteed unchanged by

--- a/ops/nomad/release.mjs
+++ b/ops/nomad/release.mjs
@@ -29,7 +29,7 @@ const COMPOSE_FALLBACK_MARKER = "compose-fallback";
  *   port?: number,
  *   healthTimeoutMs?: number,
  * }} params
- * @returns {Promise<{outcome: "promoted"|"failed"|"rolled-back", receipt: object, health: object}>}
+ * @returns {Promise<{outcome: "promoted"|"failed"|"rolled-back"|"promotion-ambiguous", receipt: object, health: object}>}
  */
 export async function runRelease({
   nomad,
@@ -149,7 +149,31 @@ export async function runRelease({
     };
   }
 
-  await nomad.promoteDeployment(run.deploymentId);
+  try {
+    await nomad.promoteDeployment(run.deploymentId);
+  } catch (error) {
+    // Traffic has already been cut over to the candidate by the nginx
+    // adapter above, but Nomad still considers the deployment an
+    // unpromoted canary: this is a genuinely ambiguous state, not a clean
+    // failure or a rollback. Do not claim "promoted" (Nomad disagrees) and
+    // do not claim "rolled-back" (traffic did not move back - retrying
+    // the nginx switch here would fight whatever caused promoteDeployment
+    // to fail). promoteDeployment is idempotent on the Nomad side, so a
+    // human or a retry can safely call it again once Nomad is reachable.
+    return {
+      outcome: "promotion-ambiguous",
+      health,
+      receipt: createRollbackReceipt({
+        previousReleaseId: manifest.previousReleaseId,
+        newReleaseId: manifest.sourceSha,
+        jobId: target.jobId,
+        deploymentId: run.deploymentId ?? "unknown",
+        configPreimage: switchResult.configPreimage,
+        outcome: "unknown",
+      }),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 
   return {
     outcome: "promoted",

--- a/ops/nomad/release.mjs
+++ b/ops/nomad/release.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * Orchestrates the canary release sequence for `sm-api` (plan sections 4 and
+ * 7): submit candidate -> wait for native health -> switch nginx traffic ->
+ * verify -> promote. It depends only on the small ports this repo already
+ * defines - `nomad` (adapters/nomad.mjs-shaped client) and `trafficSwitch`
+ * (contracts.mjs `TrafficSwitch`) - so tests can supply fakes without a real
+ * Nomad agent or nginx process (DIP).
+ *
+ * Hard invariant enforced here, not just documented: a candidate never
+ * receives the nginx switch before Nomad reports it healthy, and Nomad is
+ * never told to promote before the nginx switch actually succeeded.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { createDeployTarget, createReleaseManifest, createRollbackReceipt } from "./contracts.mjs";
+
+const COMPOSE_FALLBACK_MARKER = "compose-fallback";
+
+/**
+ * @param {{
+ *   nomad: object,
+ *   trafficSwitch: {inspect: Function, switch: Function, restore: Function},
+ *   manifest: import("./contracts.mjs").ReleaseManifest,
+ *   target: import("./contracts.mjs").DeployTarget,
+ *   jobHcl: string,
+ *   port?: number,
+ *   healthTimeoutMs?: number,
+ * }} params
+ * @returns {Promise<{outcome: "promoted"|"failed"|"rolled-back", receipt: object, health: object}>}
+ */
+export async function runRelease({
+  nomad,
+  trafficSwitch,
+  manifest,
+  target,
+  jobHcl,
+  port = 3000,
+  healthTimeoutMs = 5 * 60 * 1000,
+}) {
+  const rollbackTarget = manifest.previousReleaseId ?? COMPOSE_FALLBACK_MARKER;
+
+  function failedBeforeSwitch(reason, error) {
+    // Anything thrown here (stale `checkIndex`/EnforceIndex rejection,
+    // Nomad/registry unreachable, a plan/run/health-poll network error) is
+    // caught explicitly rather than left as an uncaught rejection: the
+    // nginx route is guaranteed untouched (this all happens before the one
+    // `trafficSwitch.switch()` call below), and the caller gets the same
+    // "failed" shape it already gets for an unhealthy candidate - including
+    // a concrete fallback target (previous release, or Compose on a
+    // first-ever deployment) instead of a crash with no receipt.
+    return {
+      outcome: "failed",
+      health: null,
+      receipt: createRollbackReceipt({
+        previousReleaseId: manifest.previousReleaseId,
+        newReleaseId: manifest.sourceSha,
+        jobId: target.jobId,
+        deploymentId: "unknown",
+        configPreimage: rollbackTarget,
+        outcome: "failed",
+      }),
+      error: `${reason}: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  let plan;
+  let run;
+  let health;
+  let candidateEndpoint;
+  try {
+    plan = await nomad.planJob(target.namespace, target.jobId, jobHcl);
+    run = await nomad.runJob(target.namespace, target.jobId, jobHcl, {
+      checkIndex: plan.jobModifyIndex,
+    });
+    health = await nomad.waitForHealthy(run.deploymentId, { timeoutMs: healthTimeoutMs });
+  } catch (error) {
+    return failedBeforeSwitch("nomad plan/run/health-poll failed (stale plan, offline, or rejected submission)", error);
+  }
+
+  if (health.status !== "healthy") {
+    // Candidate never reached the nginx switch: the previous route (or, on
+    // a first-ever deployment, the still-running Compose API) keeps serving
+    // traffic untouched. Native `auto_revert` is Nomad's own job, not ours.
+    return {
+      outcome: "failed",
+      health,
+      receipt: createRollbackReceipt({
+        previousReleaseId: manifest.previousReleaseId,
+        newReleaseId: manifest.sourceSha,
+        jobId: target.jobId,
+        deploymentId: run.deploymentId ?? "unknown",
+        configPreimage: rollbackTarget,
+        outcome: "failed",
+      }),
+    };
+  }
+
+  try {
+    candidateEndpoint = await nomad.getCandidateEndpoint(target.namespace, target.jobId, { port });
+  } catch (error) {
+    return failedBeforeSwitch("nomad getCandidateEndpoint failed (offline or rejected request)", error);
+  }
+  if (!candidateEndpoint) {
+    return {
+      outcome: "failed",
+      health,
+      receipt: createRollbackReceipt({
+        previousReleaseId: manifest.previousReleaseId,
+        newReleaseId: manifest.sourceSha,
+        jobId: target.jobId,
+        deploymentId: run.deploymentId ?? "unknown",
+        configPreimage: rollbackTarget,
+        outcome: "failed",
+      }),
+    };
+  }
+
+  const previousRoute = await trafficSwitch.inspect();
+  const endpoint = {
+    namespace: target.namespace,
+    jobId: target.jobId,
+    address: candidateEndpoint.address,
+    port: candidateEndpoint.port,
+  };
+
+  let switchResult;
+  try {
+    switchResult = await trafficSwitch.switch(previousRoute.currentEndpoint ?? null, endpoint);
+  } catch (error) {
+    // The candidate is healthy per Nomad but the switch itself failed
+    // (validation/reload/conflict): the route is guaranteed unchanged by
+    // the nginx adapter's own restore-on-failure behavior. Do not promote a
+    // job whose traffic was never actually cut over.
+    return {
+      outcome: "rolled-back",
+      health,
+      receipt: createRollbackReceipt({
+        previousReleaseId: manifest.previousReleaseId,
+        newReleaseId: manifest.sourceSha,
+        jobId: target.jobId,
+        deploymentId: run.deploymentId ?? "unknown",
+        configPreimage: previousRoute.configPreimage ?? rollbackTarget,
+        outcome: "rolled-back",
+      }),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  await nomad.promoteDeployment(run.deploymentId);
+
+  return {
+    outcome: "promoted",
+    health,
+    receipt: createRollbackReceipt({
+      previousReleaseId: manifest.previousReleaseId,
+      newReleaseId: manifest.sourceSha,
+      jobId: target.jobId,
+      deploymentId: run.deploymentId ?? "unknown",
+      configPreimage: switchResult.configPreimage,
+      outcome: "succeeded",
+    }),
+  };
+}
+
+export { COMPOSE_FALLBACK_MARKER };
+
+/**
+ * Loads and validates a release manifest file (`host/api-deploy.service`'s
+ * `--manifest` argument) into the `ReleaseManifest`/`DeployTarget` contracts
+ * this module needs, without touching Nomad/nginx. Exported so tests can
+ * exercise manifest validation without a live host.
+ * @param {string} manifestPath
+ */
+export function loadReleasePlan(manifestPath) {
+  const raw = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const manifest = createReleaseManifest({
+    sourceSha: raw.sourceSha,
+    image: raw.image,
+    targetConfigHash: raw.targetConfigHash,
+    previousReleaseId: raw.previousReleaseId ?? null,
+  });
+  const target = createDeployTarget({
+    namespace: raw.target?.namespace,
+    jobId: raw.target?.jobId,
+    hostBinding: raw.target?.hostBinding,
+  });
+  if (typeof raw.jobHcl !== "string" || raw.jobHcl.trim().length === 0) {
+    throw new TypeError("release manifest: \"jobHcl\" must be a non-empty rendered job spec string");
+  }
+  return { manifest, target, jobHcl: raw.jobHcl };
+}
+
+function usage() {
+  process.stderr.write("Usage: release.mjs (--dry-run|--apply) --manifest PATH\n");
+}
+
+async function runCli(argv) {
+  let mode = "";
+  let manifestPath = "";
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--dry-run" || arg === "--apply") {
+      mode = arg.slice(2);
+    } else if (arg === "--manifest") {
+      i += 1;
+      manifestPath = argv[i] ?? "";
+    } else {
+      usage();
+      return 64;
+    }
+  }
+  if (!mode || !manifestPath) {
+    usage();
+    return 64;
+  }
+
+  const plan = loadReleasePlan(manifestPath);
+
+  if (mode === "dry-run") {
+    process.stdout.write(
+      `release dry-run: would submit ${plan.target.jobId} in namespace ${plan.target.namespace} ` +
+        `at image ${plan.manifest.image.reference} (source ${plan.manifest.sourceSha}), ` +
+        `previous release ${plan.manifest.previousReleaseId ?? COMPOSE_FALLBACK_MARKER}\n`,
+    );
+    return 0;
+  }
+
+  process.stderr.write(
+    "release: --apply is not implemented by this PR; runRelease() is only exercised in-process via " +
+      "ops/nomad/rollout.test.mjs with fake adapters. Wiring this CLI to a real Nomad/nginx host is a " +
+      "separate, explicitly reviewed activation step (plan section 7).\n",
+  );
+  return 1;
+}
+
+const isMainModule = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMainModule) {
+  runCli(process.argv.slice(2)).then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      process.stderr.write(`release: ${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    },
+  );
+}
+
+export const SELF_PATH = fileURLToPath(import.meta.url);

--- a/ops/nomad/release.mjs
+++ b/ops/nomad/release.mjs
@@ -162,7 +162,7 @@ export async function runRelease({
         newReleaseId: manifest.sourceSha,
         jobId: target.jobId,
         deploymentId: run.deploymentId ?? "unknown",
-        configPreimage: previousRoute.configPreimage ?? rollbackTarget,
+        configPreimage: previousRoute?.configPreimage ?? rollbackTarget,
         outcome: "rolled-back",
       }),
       error: error instanceof Error ? error.message : String(error),

--- a/ops/nomad/release.mjs
+++ b/ops/nomad/release.mjs
@@ -13,7 +13,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 
 import { createDeployTarget, createReleaseManifest, createRollbackReceipt } from "./contracts.mjs";
 
@@ -292,5 +292,3 @@ if (isMainModule) {
     },
   );
 }
-
-export const SELF_PATH = fileURLToPath(import.meta.url);

--- a/ops/nomad/rollout.test.mjs
+++ b/ops/nomad/rollout.test.mjs
@@ -48,7 +48,7 @@ async function withTempIncludeDir(run) {
   }
 }
 
-function createTrafficSwitchOverTempDir(dir, { validate, reload } = {}) {
+function createTrafficSwitchOverTempDir(dir, { validate, reload, lockTimeoutMs, lockPollIntervalMs } = {}) {
   const adapter = createNginxAdapter({
     includeDir: dir,
     allowedNamespace: ALLOWED_NAMESPACE,
@@ -56,6 +56,8 @@ function createTrafficSwitchOverTempDir(dir, { validate, reload } = {}) {
     allowedCidr: ALLOWED_CIDR,
     validate: validate ?? (async () => {}),
     reload: reload ?? (async () => {}),
+    lockTimeoutMs,
+    lockPollIntervalMs,
   });
   return createTrafficSwitch(adapter);
 }
@@ -150,6 +152,29 @@ test("promoteDeployment failing after a successful traffic switch is reported as
     const route = await trafficSwitch.inspect();
     assert.equal(route.currentEndpoint.address, "172.20.0.8");
   });
+});
+
+test("trafficSwitch.inspect() failing before any switch is attempted is a clean failure, not a crash", async () => {
+  const trafficSwitch = createTrafficSwitch({
+    async inspect() {
+      throw new Error("state file is corrupt");
+    },
+    async switch() {
+      throw new Error("must not be called: inspect() already failed");
+    },
+    async restore() {
+      throw new Error("must not be called");
+    },
+  });
+  const nomad = createFakeNomad({
+    candidateEndpoint: { allocId: "alloc-9", address: "172.20.0.14", port: 3000 },
+  });
+
+  const result = await runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL });
+
+  assert.equal(result.outcome, "failed");
+  assert.match(result.error, /state file is corrupt/);
+  assert.equal(nomad.calls.promoteDeployment, 0);
 });
 
 test("unhealthy candidate: no traffic switch, no promotion, previous route untouched", async () => {
@@ -296,6 +321,64 @@ test("nginx adapter rejects a concurrent-modification switch (stale expectedPrev
       () => trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.10", port: 3000 }),
       /TrafficSwitchConflictError|conflict/i,
     );
+  });
+});
+
+test("nginx adapter serializes concurrent switch() calls across the shared lock instead of interleaving them", async () => {
+  await withTempIncludeDir(async (dir) => {
+    let validateCallCount = 0;
+    let releaseFirstValidate;
+    const gate = new Promise((resolve) => {
+      releaseFirstValidate = resolve;
+    });
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir, {
+      lockTimeoutMs: 2000,
+      lockPollIntervalMs: 10,
+      validate: async () => {
+        validateCallCount += 1;
+        if (validateCallCount === 1) {
+          await gate; // first switch() holds the lock here until released below
+        }
+      },
+    });
+
+    const first = trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.11", port: 3000 });
+    // Give the first call a chance to acquire the lock and enter validate().
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const second = trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.12", port: 3000 });
+    // The second call must be blocked acquiring the lock, not racing ahead:
+    // give it time to poll a few times, then prove it still has not written
+    // its own state while the first call holds the lock.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(existsSync(join(dir, "api-upstream.state.json")), false, "no switch has completed yet");
+
+    releaseFirstValidate();
+    await first;
+    // The second call was rejected by the CAS check (it still expected
+    // `null` as previous, but the first call already published) - proving
+    // it genuinely waited for the lock instead of racing past it.
+    await assert.rejects(() => second, /TrafficSwitchConflictError|conflict/i);
+
+    const finalState = JSON.parse(readFileSync(join(dir, "api-upstream.state.json"), "utf8"));
+    assert.equal(finalState.currentEndpoint.address, "172.20.0.11", "only the first call's write must have landed");
+  });
+});
+
+test("a first-ever publish that fails validation leaves no candidate file behind (nothing to restore to)", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir, {
+      validate: async () => {
+        throw new Error("nginx -t: [emerg] invalid directive");
+      },
+    });
+
+    await assert.rejects(
+      () => trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.13", port: 3000 }),
+      /invalid directive/,
+    );
+
+    assert.equal(existsSync(join(dir, "api-upstream.conf")), false, "an invalid, never-validated candidate must not be left on disk");
   });
 });
 

--- a/ops/nomad/rollout.test.mjs
+++ b/ops/nomad/rollout.test.mjs
@@ -389,6 +389,13 @@ test("isAddressInCidr rejects whitespace hidden inside an octet, not just non-nu
   assert.equal(isAddressInCidr("172.20.0.5", "172.20.0.0/16"), true, "a genuinely clean address must still pass");
 });
 
+test("isAddressInCidr rejects whitespace hidden inside the prefix length, same class of bug as the octets", async () => {
+  const { isAddressInCidr } = await import("./adapters/nginx.mjs");
+  assert.equal(isAddressInCidr("172.20.0.5", "172.20.0.0/16\n"), false);
+  assert.equal(isAddressInCidr("172.20.0.5", "172.20.0.0/ 16"), false);
+  assert.equal(isAddressInCidr("172.20.0.5", "172.20.0.0/16"), true, "a genuinely clean prefix must still pass");
+});
+
 test("nginx adapter rejects a concurrent-modification switch (stale expectedPrevious)", async () => {
   await withTempIncludeDir(async (dir) => {
     const trafficSwitch = createTrafficSwitchOverTempDir(dir);

--- a/ops/nomad/rollout.test.mjs
+++ b/ops/nomad/rollout.test.mjs
@@ -70,6 +70,7 @@ function createFakeNomad({
   candidateEndpoint,
   stableEndpoint,
   onPromote = () => {},
+  promoteDeploymentError = null,
 } = {}) {
   const calls = { planJob: 0, runJob: 0, waitForHealthy: 0, promoteDeployment: 0 };
   return {
@@ -101,6 +102,9 @@ function createFakeNomad({
     },
     async promoteDeployment(deploymentId) {
       calls.promoteDeployment += 1;
+      if (promoteDeploymentError) {
+        throw promoteDeploymentError;
+      }
       onPromote(deploymentId);
       return { promoted: true };
     },
@@ -123,6 +127,28 @@ test("happy path: healthy candidate switches traffic and promotes", async () => 
     const route = await trafficSwitch.inspect();
     assert.equal(route.currentEndpoint.address, "172.20.0.5");
     assert.match(readFileSync(join(dir, "api-upstream.conf"), "utf8"), /172\.20\.0\.5:3000/);
+  });
+});
+
+test("promoteDeployment failing after a successful traffic switch is reported as ambiguous, not silently promoted or rolled back", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    const nomad = createFakeNomad({
+      candidateEndpoint: { allocId: "alloc-7", address: "172.20.0.8", port: 3000 },
+      promoteDeploymentError: new Error("nomad unreachable: connect ECONNREFUSED"),
+    });
+
+    const result = await runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL });
+
+    assert.equal(result.outcome, "promotion-ambiguous");
+    assert.equal(result.receipt.outcome, "unknown");
+    assert.match(result.error, /ECONNREFUSED/);
+
+    // Traffic already moved: the candidate is what nginx actually serves,
+    // even though Nomad never confirmed the promotion. Silently reverting
+    // it here would be just as wrong as claiming success.
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint.address, "172.20.0.8");
   });
 });
 

--- a/ops/nomad/rollout.test.mjs
+++ b/ops/nomad/rollout.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -430,6 +430,50 @@ test("nginx adapter serializes concurrent switch() calls across the shared lock 
   });
 });
 
+test("restore() applies a known-good config and records its endpoint (not the unsupported RollbackReceipt shape)", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    const knownGoodEndpoint = { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.30", port: 3000 };
+    const knownGoodConfig = "# Managed by ops/nomad/adapters/nginx.mjs. Do not edit by hand.\nupstream social_monitor_api_nomad {\n  server 172.20.0.30:3000;\n}\n";
+
+    const result = await trafficSwitch.restore({ configPreimage: knownGoodConfig, currentEndpoint: knownGoodEndpoint });
+
+    assert.deepEqual(result, { restored: true });
+    assert.equal(readFileSync(join(dir, "api-upstream.conf"), "utf8"), knownGoodConfig);
+    const route = await trafficSwitch.inspect();
+    assert.deepEqual(route.currentEndpoint, knownGoodEndpoint);
+  });
+});
+
+test("restore() rolls back to whatever was active before, when the restore itself fails validation", async () => {
+  await withTempIncludeDir(async (dir) => {
+    let shouldFailValidate = false;
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir, {
+      validate: async () => {
+        if (shouldFailValidate) {
+          throw new Error("nginx -t: [emerg] bad restore target");
+        }
+      },
+    });
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.20", port: 3000 });
+    const contentBefore = readFileSync(join(dir, "api-upstream.conf"), "utf8");
+
+    shouldFailValidate = true;
+    await assert.rejects(
+      () => trafficSwitch.restore({ configPreimage: "upstream broken {}\n", currentEndpoint: null }),
+      /bad restore target/,
+    );
+
+    assert.equal(
+      readFileSync(join(dir, "api-upstream.conf"), "utf8"),
+      contentBefore,
+      "a failed restore must roll the active config back to what was there before the attempt",
+    );
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint.address, "172.20.0.20", "state must still reflect the pre-restore route, not the failed one");
+  });
+});
+
 test("a first-ever publish that fails validation leaves no candidate file behind (nothing to restore to)", async () => {
   await withTempIncludeDir(async (dir) => {
     const trafficSwitch = createTrafficSwitchOverTempDir(dir, {
@@ -444,6 +488,46 @@ test("a first-ever publish that fails validation leaves no candidate file behind
     );
 
     assert.equal(existsSync(join(dir, "api-upstream.conf")), false, "an invalid, never-validated candidate must not be left on disk");
+  });
+});
+
+test("switch() rolls the live config back if persisting the new state fails after a successful reload", async () => {
+  await withTempIncludeDir(async (dir) => {
+    let reloadCallCount = 0;
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir, {
+      reload: async () => {
+        reloadCallCount += 1;
+        if (reloadCallCount === 2) {
+          // Sabotage the state write that runRelease is about to attempt,
+          // *after* this reload (the one for the second switch()) has
+          // already succeeded: renaming a file onto an existing directory
+          // always fails (EISDIR/ENOTEMPTY), standing in for disk-full or
+          // permission failures without needing real disk exhaustion.
+          // activePath is untouched, so the rollback write below and this
+          // same reload() (called a third time, during that rollback) both
+          // still succeed normally.
+          rmSync(join(dir, "api-upstream.state.json"), { force: true });
+          mkdirSync(join(dir, "api-upstream.state.json"));
+        }
+      },
+    });
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.21", port: 3000 });
+    const contentBefore = readFileSync(join(dir, "api-upstream.conf"), "utf8");
+
+    await assert.rejects(
+      () =>
+        trafficSwitch.switch(
+          { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.21", port: 3000 },
+          { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.22", port: 3000 },
+        ),
+      /failed to persist switch state/,
+    );
+
+    assert.equal(
+      readFileSync(join(dir, "api-upstream.conf"), "utf8"),
+      contentBefore,
+      "nginx must be rolled back to the previous route when its own state bookkeeping cannot be persisted, not left serving an unrecorded route",
+    );
   });
 });
 

--- a/ops/nomad/rollout.test.mjs
+++ b/ops/nomad/rollout.test.mjs
@@ -377,6 +377,18 @@ test("isAddressInCidr rejects malformed input instead of throwing", async () => 
   assert.equal(isAddressInCidr("172.21.0.5", "172.20.0.0/16"), false);
 });
 
+test("isAddressInCidr rejects whitespace hidden inside an octet, not just non-numeric garbage", async () => {
+  const { isAddressInCidr } = await import("./adapters/nginx.mjs");
+  // Number("5\n") === 5 and Number(" 5") === 5 (ToNumber trims whitespace),
+  // so a naive Number(part) per octet would accept these and let a stray
+  // newline/space reach the rendered nginx upstream config verbatim.
+  assert.equal(isAddressInCidr("172.20.0.5\n", "172.20.0.0/16"), false);
+  assert.equal(isAddressInCidr("172.20.0.5\r\n", "172.20.0.0/16"), false);
+  assert.equal(isAddressInCidr("172.20. 0.5", "172.20.0.0/16"), false);
+  assert.equal(isAddressInCidr(" 172.20.0.5", "172.20.0.0/16"), false);
+  assert.equal(isAddressInCidr("172.20.0.5", "172.20.0.0/16"), true, "a genuinely clean address must still pass");
+});
+
 test("nginx adapter rejects a concurrent-modification switch (stale expectedPrevious)", async () => {
   await withTempIncludeDir(async (dir) => {
     const trafficSwitch = createTrafficSwitchOverTempDir(dir);

--- a/ops/nomad/rollout.test.mjs
+++ b/ops/nomad/rollout.test.mjs
@@ -73,6 +73,7 @@ function createFakeNomad({
   stableEndpoint,
   onPromote = () => {},
   promoteDeploymentError = null,
+  getStableEndpointError = null,
 } = {}) {
   const calls = { planJob: 0, runJob: 0, waitForHealthy: 0, promoteDeployment: 0 };
   return {
@@ -100,6 +101,9 @@ function createFakeNomad({
       return candidateEndpoint ?? null;
     },
     async getStableEndpoint() {
+      if (getStableEndpointError) {
+        throw getStableEndpointError;
+      }
       return stableEndpoint ?? null;
     },
     async promoteDeployment(deploymentId) {
@@ -232,6 +236,35 @@ test("nginx reload failure after a healthy candidate: route restored, no promoti
   });
 });
 
+test("a trafficSwitch.inspect() that resolves to undefined (not a throw) still yields a clean rolled-back outcome, not a crash", async () => {
+  const trafficSwitch = createTrafficSwitch({
+    async inspect() {
+      return undefined; // malformed adapter: resolves, but with garbage
+    },
+    async switch() {
+      throw new Error("nginx -t: [emerg] invalid directive");
+    },
+    async restore() {
+      throw new Error("must not be called");
+    },
+  });
+  const nomad = createFakeNomad({
+    candidateEndpoint: { allocId: "alloc-10", address: "172.20.0.15", port: 3000 },
+  });
+
+  const result = await runRelease({
+    nomad,
+    trafficSwitch,
+    manifest: manifest({ previousReleaseId: null }),
+    target: target(),
+    jobHcl: JOB_HCL,
+  });
+
+  assert.equal(result.outcome, "rolled-back");
+  assert.equal(result.receipt.outcome, "rolled-back");
+  assert.equal(result.receipt.configPreimage, COMPOSE_FALLBACK_MARKER, "must fall back to the rollback target, not crash on previousRoute.configPreimage");
+});
+
 test("reconcile tick repoints nginx after the stable allocation IP changes", async () => {
   await withTempIncludeDir(async (dir) => {
     const trafficSwitch = createTrafficSwitchOverTempDir(dir);
@@ -258,6 +291,38 @@ test("reconcile tick refuses an endpoint outside the trusted subnet", async () =
     const route = await trafficSwitch.inspect();
     assert.equal(route.currentEndpoint.address, "172.20.0.9", "an untrusted endpoint must never become the route");
   });
+});
+
+test("reconcile tick keeps its documented never-throws contract when nomad.getStableEndpoint fails", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    const nomad = createFakeNomad({ getStableEndpointError: new Error("nomad unreachable: ECONNREFUSED") });
+
+    const outcome = await reconcileTick({ nomad, trafficSwitch, target: target() });
+
+    assert.equal(outcome.changed, false);
+    assert.match(outcome.reason, /ECONNREFUSED/);
+  });
+});
+
+test("reconcile tick keeps its documented never-throws contract when trafficSwitch.inspect fails", async () => {
+  const trafficSwitch = createTrafficSwitch({
+    async inspect() {
+      throw new Error("state file is corrupt");
+    },
+    async switch() {
+      throw new Error("must not be called");
+    },
+    async restore() {
+      throw new Error("must not be called");
+    },
+  });
+  const nomad = createFakeNomad({ stableEndpoint: { allocId: "alloc-11", address: "172.20.0.16", port: 3000 } });
+
+  const outcome = await reconcileTick({ nomad, trafficSwitch, target: target() });
+
+  assert.equal(outcome.changed, false);
+  assert.match(outcome.reason, /state file is corrupt/);
 });
 
 test("reconcile tick is a no-op once nginx already points at the reported stable endpoint", async () => {

--- a/ops/nomad/rollout.test.mjs
+++ b/ops/nomad/rollout.test.mjs
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createDeployTarget, createReleaseManifest, createTrafficSwitch } from "./contracts.mjs";
+import { createNginxAdapter } from "./adapters/nginx.mjs";
+import { reconcileTick } from "./reconcile-traffic.mjs";
+import { COMPOSE_FALLBACK_MARKER, runRelease } from "./release.mjs";
+
+const VALID_SHA = "a".repeat(40);
+const VALID_DIGEST = `sha256:${"c".repeat(64)}`;
+const ALLOWED_NAMESPACE = "social-monitor";
+const ALLOWED_JOB = "sm-api";
+const ALLOWED_CIDR = "172.20.0.0/16";
+const JOB_HCL = "job \"sm-api\" {}"; // opaque to the fake nomad client below
+
+function manifest(overrides = {}) {
+  return createReleaseManifest({
+    sourceSha: VALID_SHA,
+    image: {
+      registry: "ghcr.io",
+      repository: "777genius/social-monitor-api",
+      digest: VALID_DIGEST,
+      platform: "linux/amd64",
+    },
+    targetConfigHash: "config-hash-1",
+    previousReleaseId: "release-0",
+    ...overrides,
+  });
+}
+
+function target() {
+  return createDeployTarget({
+    namespace: ALLOWED_NAMESPACE,
+    jobId: ALLOWED_JOB,
+    hostBinding: { address: "127.0.0.1", port: 4646 },
+  });
+}
+
+async function withTempIncludeDir(run) {
+  const dir = mkdtempSync(join(tmpdir(), "sm-nginx-adapter-"));
+  try {
+    return await run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function createTrafficSwitchOverTempDir(dir, { validate, reload } = {}) {
+  const adapter = createNginxAdapter({
+    includeDir: dir,
+    allowedNamespace: ALLOWED_NAMESPACE,
+    allowedJob: ALLOWED_JOB,
+    allowedCidr: ALLOWED_CIDR,
+    validate: validate ?? (async () => {}),
+    reload: reload ?? (async () => {}),
+  });
+  return createTrafficSwitch(adapter);
+}
+
+/**
+ * In-memory fake standing in for adapters/nomad.mjs's createNomadClient
+ * return shape. release.mjs/reconcile-traffic.mjs only depend on this
+ * shape (DIP), so no real Nomad agent is needed to test them.
+ */
+function createFakeNomad({
+  healthResult,
+  candidateEndpoint,
+  stableEndpoint,
+  onPromote = () => {},
+} = {}) {
+  const calls = { planJob: 0, runJob: 0, waitForHealthy: 0, promoteDeployment: 0 };
+  return {
+    calls,
+    async planJob() {
+      calls.planJob += 1;
+      return { jobModifyIndex: 42, warnings: "" };
+    },
+    async runJob() {
+      calls.runJob += 1;
+      return { evalId: "eval-1", deploymentId: "deployment-1", jobModifyIndex: 43 };
+    },
+    async waitForHealthy() {
+      calls.waitForHealthy += 1;
+      return (
+        healthResult ?? {
+          status: "healthy",
+          checkedAt: new Date().toISOString(),
+          reason: "",
+          observedAllocation: "deployment-1",
+        }
+      );
+    },
+    async getCandidateEndpoint() {
+      return candidateEndpoint ?? null;
+    },
+    async getStableEndpoint() {
+      return stableEndpoint ?? null;
+    },
+    async promoteDeployment(deploymentId) {
+      calls.promoteDeployment += 1;
+      onPromote(deploymentId);
+      return { promoted: true };
+    },
+  };
+}
+
+test("happy path: healthy candidate switches traffic and promotes", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    const nomad = createFakeNomad({
+      candidateEndpoint: { allocId: "alloc-1", address: "172.20.0.5", port: 3000 },
+    });
+
+    const result = await runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL });
+
+    assert.equal(result.outcome, "promoted");
+    assert.equal(result.receipt.outcome, "succeeded");
+    assert.equal(nomad.calls.promoteDeployment, 1);
+
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint.address, "172.20.0.5");
+    assert.match(readFileSync(join(dir, "api-upstream.conf"), "utf8"), /172\.20\.0\.5:3000/);
+  });
+});
+
+test("unhealthy candidate: no traffic switch, no promotion, previous route untouched", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    // Seed an existing route as if a previous release already promoted.
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.9", port: 3000 });
+
+    const nomad = createFakeNomad({
+      healthResult: { status: "unhealthy", checkedAt: new Date().toISOString(), reason: "OOM", observedAllocation: "deployment-1" },
+      candidateEndpoint: { allocId: "alloc-2", address: "172.20.0.6", port: 3000 },
+    });
+
+    const result = await runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL });
+
+    assert.equal(result.outcome, "failed");
+    assert.equal(result.receipt.outcome, "failed");
+    assert.equal(nomad.calls.promoteDeployment, 0);
+
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint.address, "172.20.0.9", "route must still point at the previous release");
+  });
+});
+
+test("nginx reload failure after a healthy candidate: route restored, no promotion", async () => {
+  await withTempIncludeDir(async (dir) => {
+    let reloadCallCount = 0;
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir, {
+      reload: async () => {
+        reloadCallCount += 1;
+        if (reloadCallCount === 1) {
+          // First reload: seeding the previous stable route below.
+          return;
+        }
+        throw new Error("nginx -s reload: [emerg] could not open socket");
+      },
+    });
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.9", port: 3000 });
+    const routeBefore = await trafficSwitch.inspect();
+    const contentBefore = readFileSync(join(dir, "api-upstream.conf"), "utf8");
+
+    const nomad = createFakeNomad({
+      candidateEndpoint: { allocId: "alloc-3", address: "172.20.0.7", port: 3000 },
+    });
+
+    const result = await runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL });
+
+    assert.equal(result.outcome, "rolled-back");
+    assert.equal(result.receipt.outcome, "rolled-back");
+    assert.equal(nomad.calls.promoteDeployment, 0, "must not promote a job whose traffic switch failed");
+
+    const routeAfter = await trafficSwitch.inspect();
+    assert.deepEqual(routeAfter.currentEndpoint, routeBefore.currentEndpoint);
+    assert.equal(readFileSync(join(dir, "api-upstream.conf"), "utf8"), contentBefore, "active include must be restored verbatim");
+  });
+});
+
+test("reconcile tick repoints nginx after the stable allocation IP changes", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.9", port: 3000 });
+
+    const nomad = createFakeNomad({ stableEndpoint: { allocId: "alloc-4", address: "172.20.0.42", port: 3000 } });
+    const outcome = await reconcileTick({ nomad, trafficSwitch, target: target() });
+
+    assert.equal(outcome.changed, true);
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint.address, "172.20.0.42");
+  });
+});
+
+test("reconcile tick refuses an endpoint outside the trusted subnet", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.9", port: 3000 });
+
+    const nomad = createFakeNomad({ stableEndpoint: { allocId: "alloc-5", address: "10.0.0.5", port: 3000 } });
+    const outcome = await reconcileTick({ nomad, trafficSwitch, target: target() });
+
+    assert.equal(outcome.changed, false);
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint.address, "172.20.0.9", "an untrusted endpoint must never become the route");
+  });
+});
+
+test("reconcile tick is a no-op once nginx already points at the reported stable endpoint", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.9", port: 3000 });
+
+    const nomad = createFakeNomad({ stableEndpoint: { allocId: "alloc-6", address: "172.20.0.9", port: 3000 } });
+    const outcome = await reconcileTick({ nomad, trafficSwitch, target: target() });
+
+    assert.equal(outcome.changed, false);
+  });
+});
+
+test("first-ever deployment failure rolls back to the Compose fallback marker, not an invented Nomad release", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    const nomad = createFakeNomad({
+      healthResult: { status: "unhealthy", checkedAt: new Date().toISOString(), reason: "crash loop", observedAllocation: "deployment-1" },
+      candidateEndpoint: null,
+    });
+
+    const firstManifest = manifest({ previousReleaseId: null });
+    const result = await runRelease({ nomad, trafficSwitch, manifest: firstManifest, target: target(), jobHcl: JOB_HCL });
+
+    assert.equal(result.outcome, "failed");
+    assert.equal(result.receipt.previousReleaseId, null);
+    assert.equal(result.receipt.configPreimage, COMPOSE_FALLBACK_MARKER);
+
+    const route = await trafficSwitch.inspect();
+    assert.equal(route.currentEndpoint, null, "no route was ever published on a first deployment that never went healthy");
+  });
+});
+
+test("candidate healthy but no resolvable network endpoint yet: treated as failed, not a crash", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    const nomad = createFakeNomad({ candidateEndpoint: null });
+
+    const result = await runRelease({ nomad, trafficSwitch, manifest: manifest(), target: target(), jobHcl: JOB_HCL });
+
+    assert.equal(result.outcome, "failed");
+    assert.equal(nomad.calls.promoteDeployment, 0);
+  });
+});
+
+test("isAddressInCidr rejects malformed input instead of throwing", async () => {
+  const { isAddressInCidr } = await import("./adapters/nginx.mjs");
+  assert.equal(isAddressInCidr("not-an-ip", "172.20.0.0/16"), false);
+  assert.equal(isAddressInCidr("172.20.0.5", "not-a-cidr"), false);
+  assert.equal(isAddressInCidr("172.20.0.5", "172.20.0.0/16"), true);
+  assert.equal(isAddressInCidr("172.21.0.5", "172.20.0.0/16"), false);
+});
+
+test("nginx adapter rejects a concurrent-modification switch (stale expectedPrevious)", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.9", port: 3000 });
+
+    await assert.rejects(
+      () => trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.10", port: 3000 }),
+      /TrafficSwitchConflictError|conflict/i,
+    );
+  });
+});
+
+test("existsSync sanity: adapter never mounts a single file, only writes inside includeDir", async () => {
+  await withTempIncludeDir(async (dir) => {
+    const trafficSwitch = createTrafficSwitchOverTempDir(dir);
+    await trafficSwitch.switch(null, { namespace: ALLOWED_NAMESPACE, jobId: ALLOWED_JOB, address: "172.20.0.9", port: 3000 });
+    assert.equal(existsSync(join(dir, "api-upstream.conf")), true);
+    assert.equal(existsSync(dir), true);
+  });
+});

--- a/ops/nomad/versions.json
+++ b/ops/nomad/versions.json
@@ -1,0 +1,19 @@
+{
+  "nomad": {
+    "version": "2.0.6",
+    "source": "https://api.releases.hashicorp.com/v1/releases/nomad/latest",
+    "verifiedAt": "2026-09-11T00:00:00Z",
+    "verificationMethod": "curl https://releases.hashicorp.com/nomad/<version>/nomad_<version>_SHA256SUMS, compared byte-for-byte against this file; GPG signature over that SHASUMS file not verified in this environment (no HashiCorp public key available here) - verify the .sig against key 72D7468F before production bootstrap",
+    "sha256": {
+      "linux_amd64": "c6da734081a41d51cadf15ec880d5eab0313093a29d2ee0984ca5ae1cdf867ec",
+      "linux_arm64": "6ccc4c25ec0b6b71c30af4df7ae3dfb3f7a0a05173555f94be452d072100cc52"
+    },
+    "downloadUrlTemplate": "https://releases.hashicorp.com/nomad/{version}/nomad_{version}_{os}_{arch}.zip",
+    "shasumsUrl": "https://releases.hashicorp.com/nomad/2.0.6/nomad_2.0.6_SHA256SUMS",
+    "shasumsSignatureUrls": [
+      "https://releases.hashicorp.com/nomad/2.0.6/nomad_2.0.6_SHA256SUMS.sig",
+      "https://releases.hashicorp.com/nomad/2.0.6/nomad_2.0.6_SHA256SUMS.72D7468F.sig"
+    ]
+  },
+  "traefik": null
+}


### PR DESCRIPTION
## Summary

Implements the four PRs from `docs/architecture-memory/nomad-deployment-migration-plan.md` ("Nomad Vertical Slice MVP: deployment API Social Monitor") as a single stack of commits, all scoped to `ops/nomad/` plus two new, isolated GitHub Actions workflows.

- **Image + contracts**: immutable, digest-pinned GHCR image for `sm-api`, build-only CI (no production mutation), and the six narrow release/health/traffic value contracts the rest of the slice depends on.
- **Ownership + host config**: a durable `compose`/`nomad` API owner marker (defaults to `compose`, atomic writes), a safe env-file entrypoint with no `eval`/shell sourcing, reviewable Nomad agent/ACL host config, and a checksum-verified pinned Nomad version. Bootstrap is dry-run only.
- **Canary rollout + nginx adapter**: the full candidate -> healthy -> nginx switch -> promote sequence against injectable Nomad/nginx adapters, with revert/route-restore on any failure. A candidate never receives public traffic before the switch. Includes a second, `workflow_dispatch`-only deploy workflow that intentionally refuses to run until the restricted SSH wrapper's `nomad-*` verbs ship separately.
- **Failure drill + acceptance checkpoint**: concurrent/stale-plan submissions, a fully offline Nomad backend, and recovery after a mid-release crash are all proven not to corrupt the route or the owner marker. `ops/nomad/README.md` documents scope, how to run everything locally, and every honestly unresolved gap.

## What this PR does NOT do

- No production deployment and no VPS bootstrap. Nomad is not installed anywhere; `bootstrap.sh` and `release.mjs` only support `--dry-run`.
- Does not touch `ops/deploy/social-monitor-production-deploy.sh` or `ops/deploy/postgres-runtime-deploy-lib.sh` - both are protected by this repo's cryptographic transition-review bridge and need a separate, human-signed follow-up PR to consult the new ownership marker.
- The new `production-api-nomad-deploy.yml` workflow cannot succeed today; it fails fast on a required confirmation input until the SSH wrapper is extended.

Every test in this PR runs against in-memory fakes or temp-directory fixtures - none of it talks to a real Nomad agent, nginx process, or the production host.

## Review history

This branch went through six independent review rounds after the initial four commits (two CodeRabbit passes plus four separately-scoped adversarial reviews) before settling. Real issues found and fixed along the way, most to least severe:

- **`host/nomad.hcl`'s Docker plugin had `volumes.enabled = true`**, letting any job with `submit-job` capability (the restricted deploy token has exactly that) bind-mount arbitrary host paths regardless of privileged mode - confirmed against Nomad's own docs. Now `false`.
- **`adapters/nomad.mjs` sent raw HCL text as the `Job` field** to Nomad's plan/register endpoints; the real API requires a JSON object there. Every real call would have failed against an actual agent despite passing this suite's fakes. Added the missing `/v1/jobs/parse` step.
- **`host/acl.hcl`'s namespace `policy = "deny"` merged into the same capabilities list** as its explicit grants; since `deny` takes precedence once merged, this silently denied everything regardless of the capabilities also listed.
- **`waitForHealthy` accepted `Status == "running"` as healthy** without checking the task group's own canary health counts - Nomad flips to "running" the instant the canary is placed, well before its health checks pass.
- No cross-process lock in `adapters/nginx.mjs` (release.mjs and the ~5s reconcile-traffic.mjs loop both call it), `restore()` had zero error handling, several `await` calls in `release.mjs`/`reconcile-traffic.mjs` could reject uncaught instead of returning the documented clean-failure shape, a `grep -vx` treated a service name as a regex instead of a literal string, and a few least-privilege tightenings (unused ACL capability, unused Docker caps).

79/79 `node --test` plus all four bash suites are green; nothing above required scope changes, only fixes and regression tests inside `ops/nomad/`.

## Test plan

- [x] `git diff --check`
- [x] `npm run check:source-line-cap`
- [x] `npm run check:architecture`
- [x] `npm run check:code-quality`
- [x] `npx eslint ops/nomad`
- [x] `npx tsc --noEmit`
- [x] `npm run check:secrets`
- [x] `npm run check:review-ci`
- [x] `node --test ops/nomad/*.test.mjs ops/nomad/adapters/*.test.mjs` (79/79)
- [x] `bash ops/nomad/preflight.test.sh`
- [x] `bash ops/nomad/bootstrap.test.sh`
- [x] `bash ops/nomad/ownership-guard.test.sh`
- [x] `bash ops/nomad/failure-drill.test.sh`
- [x] `shellcheck -S warning ops/nomad/*.sh`
- [x] Full CI pipeline (backend unit shards, e2e, RLS, Flutter, production container lifecycle) - all pass; the one unrelated red check (`scripts/lib/source-content-assessment-runtime.spec.ts`) is a pre-existing failure on `main` itself, outside this diff, confirmed independent of this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nomad-based API deployment foundations, immutable image publishing, canary rollouts, health checks, traffic switching, and rollback handling.
  * Added production preflight reporting, Compose/Nomad ownership tracking, and safer API environment-file startup and shutdown behavior.
  * Added manually triggered production deployment workflow scaffolding with release validation.

* **Documentation**
  * Added Nomad setup, testing, activation, rollback, and known-gap guidance.

* **Bug Fixes**
  * Prevented concurrent traffic updates from racing and improved recovery after failed nginx reloads.

* **Tests**
  * Expanded deployment, traffic switching, ownership, environment parsing, and failure-scenario coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
