### PR TITLE
fix(relevance): classify assessment failure stages

### DIFF
--- a/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.spec.ts
+++ b/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.spec.ts
@@ -1,0 +1,93 @@
+import { FixedClock } from "@social-monitor/shared-kernel";
+import { SourceContentAssessmentStageError } from "../../ports";
+import type { SourceContentQualityReviewRequest } from "../../ports";
+import { SourceContentQualityPolicy } from "../../domain";
+import { AgentRuntimeSourceContentQualityReviewerAdapter } from "./agent-runtime-source-content-quality-reviewer.adapter";
+import { promotionWireCandidate } from "./promotion-review-wire";
+import { attestRefreshExecution, refreshTestRuntimeClient } from "../../../../scripts/lib/reader-summary-new-input-refresh-model.spec-support";
+
+const cutoff = new Date("2026-09-11T12:00:00.000Z");
+
+const request = (id = "synthetic-wire"): SourceContentQualityReviewRequest => ({
+  candidateId: id, providerKey: "reddit", title: "Measured compiler diagnostics",
+  bodyPreview: "Concrete first-party benchmark numbers for the compiler release.",
+  deterministic: new SourceContentQualityPolicy().evaluate({ providerKey: "reddit",
+    title: "Measured compiler diagnostics", providerMetadata: { query: "compiler diagnostics" } }),
+  promotion: Object.freeze({ tenantId: "synthetic-tenant", workspaceId: "synthetic-workspace",
+    interestId: "synthetic-interest", sourceBindingId: "synthetic-binding", sourceItemId: `source-${id}`,
+    trustedIntent: "compiler diagnostics", availability: "body_present" }),
+});
+
+const validReview = (input: SourceContentQualityReviewRequest) => ({
+  candidateId: input.candidateId, bindingId: promotionWireCandidate(input).bindingId,
+  decision: "promote", confidence: 0.9, qualityScore: 0.7, interestRelevanceScore: 0.9,
+  engagementIntegrityScore: 0.9, flags: [], reason: "Synthetic review",
+  evidence: [{ field: "title", start: 0, end: input.title.length, quote: input.title }],
+  resolvedSoftFlags: [],
+});
+
+const adapterFor = (client: ReturnType<typeof refreshTestRuntimeClient>) =>
+  new AgentRuntimeSourceContentQualityReviewerAdapter({ clock: new FixedClock(cutoff),
+    ids: { generate: () => "sandbox-stage" }, batchTimeoutMs: 300_000, totalTimeoutMs: 600_000, client });
+
+const stageOf = async (promise: Promise<unknown>): Promise<string> => {
+  try { await promise; throw new Error("expected the adapter call to reject"); }
+  catch (error) {
+    if (!(error instanceof SourceContentAssessmentStageError)) throw error;
+    return error.stage;
+  }
+};
+
+describe("AgentRuntimeSourceContentQualityReviewerAdapter failure stage classification", () => {
+  it("classifies a transport call failure as runtime_status when the call itself throws", async () => {
+    const client = refreshTestRuntimeClient(async () => { throw new Error("synthetic transport outage"); });
+    const stage = await stageOf(adapterFor(client).reviewBatch([request()]));
+    expect(stage).toBe("runtime_status");
+  });
+
+  it("classifies a transport call failure as aborted when the caller signal was already aborted", async () => {
+    const client = refreshTestRuntimeClient(async () => { throw new Error("synthetic transport outage"); });
+    const controller = new AbortController();
+    controller.abort();
+    const stage = await stageOf(adapterFor(client).reviewBatch([request()], { signal: controller.signal }));
+    expect(stage).toBe("aborted");
+  });
+
+  it("classifies an attested-but-invalid completion (wrong status) as runtime_status", async () => {
+    const client = refreshTestRuntimeClient(async (r) => ({
+      ...(await attestRefreshExecution(r, { reviews: [] })), status: "failed",
+    }));
+    const stage = await stageOf(adapterFor(client).reviewBatch([request()]));
+    expect(stage).toBe("runtime_status");
+  });
+
+  it("classifies mismatched request scope as runtime_status before any call is made", async () => {
+    const client = refreshTestRuntimeClient(async () => { throw new Error("must not be reached"); });
+    const mismatched: SourceContentQualityReviewRequest = { ...request("other"),
+      promotion: { ...request("other").promotion!, workspaceId: "different-workspace" } };
+    const stage = await stageOf(adapterFor(client).reviewBatch([request(), mismatched]));
+    expect(stage).toBe("runtime_status");
+  });
+
+  it("classifies a JSON/schema-invalid structured output as parse_schema", async () => {
+    const client = refreshTestRuntimeClient(async (r) => attestRefreshExecution(r, { reviews: "not-an-array" }));
+    const stage = await stageOf(adapterFor(client).reviewBatch([request()]));
+    expect(stage).toBe("parse_schema");
+  });
+
+  it("classifies a tampered bindingId as binding, distinct from a parse/schema failure", async () => {
+    const input = request();
+    const client = refreshTestRuntimeClient(async (r) => attestRefreshExecution(r,
+      { reviews: [{ ...validReview(input), bindingId: `${promotionWireCandidate(input).bindingId}-tampered` }] }));
+    const stage = await stageOf(adapterFor(client).reviewBatch([input]));
+    expect(stage).toBe("binding");
+  });
+
+  it("accepts a fully valid attested completion without throwing", async () => {
+    const input = request();
+    const client = refreshTestRuntimeClient(async (r) =>
+      attestRefreshExecution(r, { reviews: [validReview(input)] }));
+    const [result] = await adapterFor(client).reviewBatch([input]);
+    expect(result!.decision).toBe("promote");
+  });
+});

--- a/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts
+++ b/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts
@@ -6,6 +6,7 @@ import {
   subscriptionRuntimeEngine,
 } from "@social-monitor/contracts/grpc/agent_runtime/v1/execution-attestation";
 import type { SourceContentQualityReviewerPort, SourceContentQualityReviewRequest } from "../../ports";
+import { SourceContentAssessmentStageError } from "../../ports";
 import { promotionReviewInstructions, promotionWireCandidate } from "./promotion-review-wire";
 import { parseReviews, promotionResponseSchema } from "./source-content-quality-review-wire";
 
@@ -44,16 +45,22 @@ export class AgentRuntimeSourceContentQualityReviewerAdapter implements SourceCo
         requests.length > 8 || requests.some((request) =>
           request.promotion?.tenantId !== scope.tenantId ||
           request.promotion?.workspaceId !== scope.workspaceId)) {
-      throw new Error("Assessment task requires a single tenant/workspace scope");
+      throw new SourceContentAssessmentStageError("runtime_status",
+        "Assessment task requires a single tenant/workspace scope");
     }
     const deadlineAtMs = options?.deadlineAtMs ?? (this.options.clock.now().getTime() + this.options.batchTimeoutMs);
     const timeoutMs = Math.min(this.options.batchTimeoutMs, deadlineAtMs - this.options.clock.now().getTime(),
       options?.timeoutMs ?? this.options.batchTimeoutMs);
-    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || options?.signal.aborted) {
-      throw new Error("Assessment task deadline exhausted");
+    if (options?.signal.aborted) {
+      throw new SourceContentAssessmentStageError("aborted", "Assessment task deadline exhausted");
+    }
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+      throw new SourceContentAssessmentStageError("deadline", "Assessment task deadline exhausted");
     }
     const prompt = JSON.stringify({ candidates: requests.map(promotionWireCandidate) });
-    if (Buffer.byteLength(prompt, "utf8") > 64_000) throw new Error("Assessment request too large");
+    if (Buffer.byteLength(prompt, "utf8") > 64_000) {
+      throw new SourceContentAssessmentStageError("runtime_status", "Assessment request too large");
+    }
     const requestId = `source-content-assessment:${this.options.ids.generate()}`;
     const command = {
       requestId, correlationId: requestId,
@@ -68,9 +75,31 @@ export class AgentRuntimeSourceContentQualityReviewerAdapter implements SourceCo
     };
     const signal = options === undefined ? AbortSignal.timeout(timeoutMs)
       : AbortSignal.any([options.signal, AbortSignal.timeout(timeoutMs)]);
-    const result = await this.options.client.runTask(command, { signal });
+    // The transport call itself (network/gRPC/runtime-pool failure before any
+    // completed attempt exists) is a distinct, earlier failure than an
+    // attested-but-invalid completion below. Classify it separately so
+    // telemetry can tell "never got a result" apart from "got one and it was
+    // malformed" without ever reading the underlying transport error text.
+    let result: Awaited<ReturnType<AgentRuntimeClientPort["runTask"]>>;
+    try {
+      result = await this.options.client.runTask(command, { signal });
+    } catch (error) {
+      if (error instanceof SourceContentAssessmentStageError) throw error;
+      // The message is kept on the error object itself (never written into
+      // telemetry, which only ever reads `.stage`) so existing transport-level
+      // validation detail stays visible to direct callers/tests.
+      const message = error instanceof Error ? error.message : "Assessment runtime call failed";
+      if (signal.aborted) throw new SourceContentAssessmentStageError("aborted", message);
+      throw new SourceContentAssessmentStageError("runtime_status", message);
+    }
     const attestation = result.executionAttestation;
-    if (signal.aborted || this.options.clock.now().getTime() >= deadlineAtMs || result.status !== "completed" || result.failure !== undefined ||
+    if (signal.aborted) {
+      throw new SourceContentAssessmentStageError("aborted", "Assessment task deadline exhausted after runtime call");
+    }
+    if (this.options.clock.now().getTime() >= deadlineAtMs) {
+      throw new SourceContentAssessmentStageError("deadline", "Assessment task deadline exhausted after runtime call");
+    }
+    if (result.status !== "completed" || result.failure !== undefined ||
         attestation === undefined || attestation.schemaVersion !== 1 ||
         attestation.requestId !== requestId || attestation.purpose !== command.purpose ||
         attestation.provider !== command.provider || attestation.model !== command.controls.model ||
@@ -80,15 +109,18 @@ export class AgentRuntimeSourceContentQualityReviewerAdapter implements SourceCo
         !isSha256Hex(attestation.canonicalRequestSha256) || !isSha256Hex(attestation.launcherSha256) ||
         attestation.selectedOutputKind !== "structured_output" ||
         !executionAttestationOutputMatches(attestation, result)) {
-      throw new Error("Invalid assessment runtime completion");
+      throw new SourceContentAssessmentStageError("runtime_status", "Invalid assessment runtime completion");
     }
     const output = JSON.stringify(result.structuredOutput);
     if (output === undefined || Buffer.byteLength(output, "utf8") > 128_000) {
-      throw new Error("Assessment output missing or too large");
+      throw new SourceContentAssessmentStageError("runtime_status", "Assessment output missing or too large");
     }
     const reviews = parseReviews(output, requests);
-    if (signal.aborted || this.options.clock.now().getTime() >= deadlineAtMs) {
-      throw new Error("Assessment validation deadline exhausted");
+    if (signal.aborted) {
+      throw new SourceContentAssessmentStageError("aborted", "Assessment validation deadline exhausted");
+    }
+    if (this.options.clock.now().getTime() >= deadlineAtMs) {
+      throw new SourceContentAssessmentStageError("deadline", "Assessment validation deadline exhausted");
     }
     return reviews;
   }

--- a/libs/relevance/adapters/model/source-content-quality-review-wire.ts
+++ b/libs/relevance/adapters/model/source-content-quality-review-wire.ts
@@ -1,6 +1,7 @@
 import type { JsonObject, JsonValue } from "@social-monitor/shared-kernel";
 import type { SourceContentQualityDecision, SourceContentQualityFlag } from "../../domain";
 import type { SourceContentQualityReviewRequest, SourceContentQualityReviewResult } from "../../ports";
+import { SourceContentAssessmentStageError } from "../../ports";
 import { bindPromotionAssessment, promotionReviewSchemaProperties } from "./promotion-review-wire";
 
 export const buildInstructions = (): string =>
@@ -17,6 +18,23 @@ export const buildInstructions = (): string =>
   ].join("\n");
 
 export const parseReviews = (
+  outputText: string | undefined,
+  requests?: readonly SourceContentQualityReviewRequest[],
+): readonly SourceContentQualityReviewResult[] => {
+  try {
+    return parseReviewsUnclassified(outputText, requests);
+  } catch (error) {
+    // Any exception reaching here (JSON.parse syntax errors, shape checks,
+    // the score/decision/flag validation below) is a parse/schema-contract
+    // failure by definition, except a binding failure already tagged inside
+    // the loop, which is rethrown unchanged.
+    if (error instanceof SourceContentAssessmentStageError) throw error;
+    throw new SourceContentAssessmentStageError("parse_schema",
+      error instanceof Error ? error.message : "Invalid quality review output");
+  }
+};
+
+const parseReviewsUnclassified = (
   outputText: string | undefined,
   requests?: readonly SourceContentQualityReviewRequest[],
 ): readonly SourceContentQualityReviewResult[] => {
@@ -60,9 +78,20 @@ export const parseReviews = (
           typeof flag !== "string" || !allowedFlags.has(flag as SourceContentQualityFlag)))) {
       throw new Error("Invalid promotion review result");
     }
+    let assessment: ReturnType<typeof bindPromotionAssessment> | undefined;
+    if (request !== undefined) {
+      try { assessment = bindPromotionAssessment(record, request); }
+      catch (error) {
+        // The only distinct failure class inside this map body: the model's
+        // own bindingId/evidence/resolvedSoftFlags echo did not match this
+        // exact request, as opposed to a schema/shape/enum mismatch above.
+        throw new SourceContentAssessmentStageError("binding",
+          error instanceof Error ? error.message : "Invalid promotion assessment binding");
+      }
+    }
     return {
       candidateId,
-      ...(request === undefined ? {} : { assessment: bindPromotionAssessment(record, request) }),
+      ...(assessment === undefined ? {} : { assessment }),
       decision: readDecision(record.decision),
       confidence: clampNumber(record.confidence, 0, 1),
       qualityScore: optionalScore(record.qualityScore),

--- a/libs/relevance/ports/source-content-quality-reviewer.port.ts
+++ b/libs/relevance/ports/source-content-quality-reviewer.port.ts
@@ -39,6 +39,28 @@ export const SOURCE_CONTENT_QUALITY_REVIEWER = Symbol(
   "SOURCE_CONTENT_QUALITY_REVIEWER",
 );
 
+// Fixed, whitelisted classification for a `reviewBatch` failure. Adapters
+// throw `SourceContentAssessmentStageError` so callers (refresh telemetry,
+// journals) can distinguish failure causes by `.stage` alone. Consumers must
+// never read `.message`: it can echo schema/shape context, and must never be
+// persisted — no exception text, payload, title/body, prompt or credential
+// ever belongs in a stage code.
+export type SourceContentAssessmentFailureStage =
+  | "runtime_status"
+  | "parse_schema"
+  | "binding"
+  | "verdict"
+  | "deadline"
+  | "aborted"
+  | "unknown";
+
+export class SourceContentAssessmentStageError extends Error {
+  constructor(readonly stage: SourceContentAssessmentFailureStage, message: string) {
+    super(message);
+    this.name = "SourceContentAssessmentStageError";
+  }
+}
+
 // A per-invocation frozen binding. Adapters must authenticate the wire response
 // against this exact request before returning its context object as the binding.
 export type PromotionReviewContext = Readonly<{

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-capture.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-capture.spec.ts
@@ -80,8 +80,20 @@ describe("synthetic assessment capture from the existing reviewer invocation", (
       ? { reviews: [] } : selectorOutput(command) });
     await expect(test.selectComplete()).rejects.toThrow(/reconciliation/u);
     expect(events.map((event) => event.phase)).toEqual(["attempt", "failed"]);
-    expect(events[1]).toMatchObject({ consumed: true, failure: "validation_or_runtime_failure" });
+    // An empty reviews array parses without error; the mismatch against the
+    // requested candidate count is a coverage/binding failure, not a
+    // parse/schema one.
+    expect(events[1]).toMatchObject({ consumed: true, failure: "binding" });
     expect(events[1]!.reviewsJson).toBeUndefined();
     expect(test.commands).toHaveLength(1);
+  });
+
+  it("classifies a schema-invalid review body as a parse/schema failure, not a generic one", async () => {
+    const events = captureEvents();
+    const test = await selectorWiring({ output: (command) => command.purpose === sourceContentAssessmentPurpose
+      ? { reviews: "not-an-array" } : selectorOutput(command) });
+    await expect(test.selectComplete()).rejects.toThrow(/reconciliation/u);
+    expect(events.map((event) => event.phase)).toEqual(["attempt", "failed"]);
+    expect(events[1]).toMatchObject({ consumed: true, failure: "parse_schema" });
   });
 });

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-failure-classification.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-failure-classification.spec.ts
@@ -1,0 +1,22 @@
+import { SourceContentAssessmentStageError } from "@social-monitor/relevance/ports";
+import { classifyAssessmentReviewBatchFailure } from "./reader-summary-new-input-refresh-assessment";
+
+describe("assessment reviewBatch failure classification precedence", () => {
+  it("prioritizes a binding stage over a coincidentally exceeded deadline", () => {
+    const error = new SourceContentAssessmentStageError("binding", "synthetic binding mismatch");
+    expect(classifyAssessmentReviewBatchFailure({ error, aborted: false, deadlineExceeded: true })).toBe("binding");
+    expect(classifyAssessmentReviewBatchFailure({ error, aborted: true, deadlineExceeded: true })).toBe("binding");
+  });
+
+  it("prioritizes a verdict stage the same way, never masked by an incidental abort", () => {
+    const error = new SourceContentAssessmentStageError("verdict", "synthetic verdict rejection");
+    expect(classifyAssessmentReviewBatchFailure({ error, aborted: true, deadlineExceeded: false })).toBe("verdict");
+  });
+
+  it("falls back to the documented aborted-then-deadline-then-unknown priority for an untyped error", () => {
+    const error = new Error("synthetic untyped failure");
+    expect(classifyAssessmentReviewBatchFailure({ error, aborted: true, deadlineExceeded: true })).toBe("aborted");
+    expect(classifyAssessmentReviewBatchFailure({ error, aborted: false, deadlineExceeded: true })).toBe("deadline");
+    expect(classifyAssessmentReviewBatchFailure({ error, aborted: false, deadlineExceeded: false })).toBe("unknown");
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.ts
@@ -44,6 +44,22 @@ export function hasRefreshSelectableEvidence(items: readonly SummaryEvidenceItem
   return items.some((item) => isPersistedSelectableEvidence(item));
 }
 
+// A caught error's own stage is the most specific, definitive signal of what
+// actually failed (binding, verdict, parse/schema, runtime status) and must
+// win even when the deadline/abort state happens to also be true by the time
+// the catch runs - otherwise an incidental deadline crossing during a slow
+// batch would mask a genuine binding/verdict failure behind "deadline". Live
+// abort/deadline state is the documented fallback only for an error that
+// never went through our own classification (a truly unknown exception).
+export function classifyAssessmentReviewBatchFailure(input: {
+  error: unknown; aborted: boolean; deadlineExceeded: boolean;
+}): SourceContentAssessmentFailureStage {
+  if (input.error instanceof SourceContentAssessmentStageError) return input.error.stage;
+  if (input.aborted) return "aborted";
+  if (input.deadlineExceeded) return "deadline";
+  return "unknown";
+}
+
 // This caller only authorizes the existing subscription pool. A direct provider
 // override cannot bypass its invocation journal, installation or date authority.
 export function createRefreshAssessmentReviewer(input: {
@@ -196,12 +212,9 @@ export function createRefreshAssessmentReviewer(input: {
         return reviews;
       } catch (error) {
         terminalBatches++;
-        // Deadline/abort classification is derived from state, not the caught
-        // error, so it stays correct even when the underlying exception is a
-        // generic timeout/cancellation type rather than our own stage error.
-        const stage: SourceContentAssessmentFailureStage = options?.signal.aborted ? "aborted"
-          : deadline !== undefined && input.clock.now().getTime() >= deadline ? "deadline"
-            : error instanceof SourceContentAssessmentStageError ? error.stage : "unknown";
+        const stage = classifyAssessmentReviewBatchFailure({ error,
+          aborted: options?.signal.aborted ?? false,
+          deadlineExceeded: deadline !== undefined && input.clock.now().getTime() >= deadline });
         capture(() => ({ ...event("failed"), failure: stage }));
         return fail(stage);
       }

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.ts
@@ -4,7 +4,10 @@ import type { ReaderSummaryEvidenceSelectorPort } from "@social-monitor/summary/
 import type { Clock } from "@social-monitor/shared-kernel";
 import { readerPromotionProviderFamily } from "@social-monitor/shared-kernel";
 import { SourceContentQualityPolicy } from "@social-monitor/relevance/domain";
-import type { SourceContentQualityReviewerPort, SourceContentQualityReviewRequest } from "@social-monitor/relevance/ports";
+import type {
+  SourceContentAssessmentFailureStage, SourceContentQualityReviewerPort, SourceContentQualityReviewRequest,
+} from "@social-monitor/relevance/ports";
+import { SourceContentAssessmentStageError } from "@social-monitor/relevance/ports";
 import { assessedPromotionVerdict } from "@social-monitor/relevance/features/rank-feed-items/promotion-assessment-verdict";
 import { PROMOTION_ASSESSMENT_BOUNDS } from "@social-monitor/relevance/features/rank-feed-items/promotion-content-assessment";
 import { createSourceContentAssessmentReviewer } from "@social-monitor/relevance/interfaces/rest/source-content-assessment-provider-tokens";
@@ -32,7 +35,9 @@ export type RefreshAssessmentCaptureEvent = Readonly<{
   options?: { timeoutMs?: number; deadlineAtMs?: number; aborted: boolean };
   reviewsJson?: string;
   verdictsJson?: string;
-  failure?: "deadline" | "aborted" | "validation_or_runtime_failure";
+  // A fixed, whitelisted stage code only. Never enrich this with the causing
+  // error's `.message`, payload, title/body, prompt or credential material.
+  failure?: SourceContentAssessmentFailureStage;
 }>;
 
 export function hasRefreshSelectableEvidence(items: readonly SummaryEvidenceItem[]): boolean {
@@ -83,9 +88,10 @@ export function createRefreshAssessmentReviewer(input: {
     if (!input.capture) return;
     try { input.capture(event()); } catch { captureFailures++; }
   };
-  const fail = (): never => {
+  const fail = (stage: SourceContentAssessmentFailureStage): never => {
     input.runtime.invalidateAdapter("source_content_assessment");
-    throw new Error("Refresh assessment is incomplete; original operation requires reconciliation");
+    throw new SourceContentAssessmentStageError(stage,
+      "Refresh assessment is incomplete; original operation requires reconciliation");
   };
   return {
     // Six workers put the evidenced eleven 8-item batches into two waves
@@ -102,19 +108,19 @@ export function createRefreshAssessmentReviewer(input: {
       // Historical refresh must assess the complete captured universe. Partial
       // UUID-ordered coverage would bias selection toward whichever batches ran first.
       const required = Math.min(expected, PROMOTION_ASSESSMENT_BOUNDS.candidates);
-      if (!Number.isSafeInteger(expected) || expected < 0 || required !== completed || completed !== seen.size) fail();
+      if (!Number.isSafeInteger(expected) || expected < 0 || required !== completed || completed !== seen.size) fail("binding");
       if (selection === undefined) return;
       // An empty bounded/uncertain result cannot support exhaustive no-signal.
       if (selection.selectedEvidence.length === 0 && (completed < expected || abstained > 0)) {
         throw new Error("Refresh assessment remains pending; cannot publish exhaustive no-signal");
       }
       for (const item of selection.selectedEvidence) {
-        if (!sourceTextBindings.has(sourceTextBinding(item))) fail();
+        if (!sourceTextBindings.has(sourceTextBinding(item))) fail("binding");
         const quality = item.contentQuality;
         if (!quality?.eligibleForSummary || quality.needsLlmReview ||
             !["promote", "keep", "downrank"].includes(quality.decision) ||
             quality.reason.startsWith("promotion_assessment_pending:") ||
-            quality.reason.startsWith("promotion_assessment_not_requested:")) return fail();
+            quality.reason.startsWith("promotion_assessment_not_requested:")) return fail("binding");
         // An attempted social identity cannot acquire an exemption by relabeling.
         const recorded = seen.has(item.feedItemId) || [...seen.values()].some((request) =>
           request.promotion?.sourceItemId === item.sourceItemId &&
@@ -123,7 +129,7 @@ export function createRefreshAssessmentReviewer(input: {
         if (!recorded && persistedAssessmentBindings.has(exemptionBinding(item))) continue;
         const canonicalExemption = !recorded && exemptBindings.has(exemptionBinding(item));
         if (canonicalExemption) {
-          if (quality.reason.startsWith("promotion_assessment:")) fail();
+          if (quality.reason.startsWith("promotion_assessment:")) fail("binding");
           continue;
         }
         const assessed = eligible.get(item.feedItemId);
@@ -134,7 +140,7 @@ export function createRefreshAssessmentReviewer(input: {
             request.promotion?.sourceItemId !== item.sourceItemId ||
             request.promotion?.sourceBindingId !== item.sourceBindingId ||
             assessed?.verdict.reason !== quality.reason ||
-            assessed?.verdict.decision !== quality.decision) fail();
+            assessed?.verdict.decision !== quality.decision) fail("binding");
       }
     },
     reviewBatch: async (requests, options) => {
@@ -152,18 +158,22 @@ export function createRefreshAssessmentReviewer(input: {
         const now = input.clock.now().getTime();
         deadline ??= now + reviewer.promotionTiming!.totalTimeoutMs;
         const size = Buffer.byteLength(JSON.stringify(requests), "utf8");
-        if (now >= deadline || options?.signal.aborted ||
-            requests.some((request) => seen.has(request.candidateId)) ||
+        // Deadline/abort is always the most informative classification when it
+        // applies, regardless of which coverage check would otherwise trigger.
+        if (now >= deadline) fail("deadline");
+        if (options?.signal.aborted) fail("aborted");
+        if (requests.some((request) => seen.has(request.candidateId)) ||
             seen.size + requests.length > PROMOTION_ASSESSMENT_BOUNDS.candidates ||
             size > PROMOTION_ASSESSMENT_BOUNDS.batchBytes ||
-            bytes + size > PROMOTION_ASSESSMENT_BOUNDS.totalBytes) fail();
+            bytes + size > PROMOTION_ASSESSMENT_BOUNDS.totalBytes) fail("binding");
         requests.forEach((request) => seen.set(request.candidateId, request));
         consumed = true;
         bytes += size; // Consumed before awaiting. Nothing refunds an attempt.
         const reviews = await reviewer.reviewBatch(requests, options);
-        if (input.clock.now().getTime() >= deadline || options?.signal.aborted ||
-            reviews.length !== requests.length || new Set(reviews.map((r) => r.candidateId)).size !== reviews.length ||
-            requests.some((request) => !reviews.some((review) => review.candidateId === request.candidateId))) fail();
+        if (input.clock.now().getTime() >= deadline) fail("deadline");
+        if (options?.signal.aborted) fail("aborted");
+        if (reviews.length !== requests.length || new Set(reviews.map((r) => r.candidateId)).size !== reviews.length ||
+            requests.some((request) => !reviews.some((review) => review.candidateId === request.candidateId))) fail("binding");
         const verdicts: { candidateId: string; verdict: ReturnType<typeof assessedPromotionVerdict> }[] = [];
         for (const request of requests) {
           const verdict = assessedPromotionVerdict(request,
@@ -174,7 +184,7 @@ export function createRefreshAssessmentReviewer(input: {
             // validation. All other pending outcomes remain authority failures.
             if (verdict.reason !== "promotion_assessment_pending:needs_context" &&
                 verdict.reason !== "promotion_assessment_pending:low_confidence" &&
-                verdict.reason !== "promotion_assessment_pending:invalid_assessment") fail();
+                verdict.reason !== "promotion_assessment_pending:invalid_assessment") fail("verdict");
             abstained++;
           } else if (verdict.eligibleForSummary) eligible.set(request.candidateId, { request, verdict });
         }
@@ -184,12 +194,16 @@ export function createRefreshAssessmentReviewer(input: {
         capture(() => ({ ...event("completed"), reviewsJson: JSON.stringify(reviews),
           verdictsJson: JSON.stringify(verdicts) }));
         return reviews;
-      } catch {
+      } catch (error) {
         terminalBatches++;
-        capture(() => ({ ...event("failed"), failure: options?.signal.aborted ? "aborted"
+        // Deadline/abort classification is derived from state, not the caught
+        // error, so it stays correct even when the underlying exception is a
+        // generic timeout/cancellation type rather than our own stage error.
+        const stage: SourceContentAssessmentFailureStage = options?.signal.aborted ? "aborted"
           : deadline !== undefined && input.clock.now().getTime() >= deadline ? "deadline"
-            : "validation_or_runtime_failure" }));
-        return fail();
+            : error instanceof SourceContentAssessmentStageError ? error.stage : "unknown";
+        capture(() => ({ ...event("failed"), failure: stage }));
+        return fail(stage);
       }
     },
   };


### PR DESCRIPTION
Production historical refreshes currently collapse every source-content-assessment failure into `adapter_validation`, which made repeated consumed operations impossible to diagnose safely. This change adds fixed failure-stage codes for runtime status, schema parsing, binding, verdict, deadline, abort, and unknown failures, and records only that whitelist in the refresh journal without persisting exception text or source payloads.

Validation:
- `npx jest libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.spec.ts scripts/lib/reader-summary-new-input-refresh-assessment-capture.spec.ts --runInBand` (15 passed)
- `npx tsc --noEmit -p tsconfig.build.json`
