### PR TITLE
fix(relevance): record assessment failure stage

### DIFF
--- a/scripts/lib/reader-summary-daily-story-relation-verifier.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-verifier.ts
@@ -8,6 +8,7 @@ import type { ReaderSummaryPreparationObserver } from "@social-monitor/summary/a
 import { StoryRankingMetricsRecorder } from "@social-monitor/summary/adapters/metrics/story-ranking-metrics.recorder";
 import { PrismaReaderSummaryGitHubProjectionReader } from "@social-monitor/summary/adapters/persistence/prisma/prisma-reader-summary-github-projection.reader";
 import { createSourceContentAssessmentReviewer } from "@social-monitor/relevance/interfaces/rest/source-content-assessment-provider-tokens";
+import type { SourceContentAssessmentFailureStage } from "@social-monitor/relevance/ports";
 import {
   AgentRuntimeReaderSummaryStoryRelationVerifier,
   resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions,
@@ -146,7 +147,8 @@ type StoryRelationCompositionInput = {
   readonly relationCapture?: ReaderSummaryDailyRelationCapture;
   readonly storyRelationVerifierGuard?: {
     assertUsable(): void;
-    invalidateAdapter(taskRole: "story_relation" | "related_topic_relation"): void;
+    invalidateAdapter(taskRole: "story_relation" | "related_topic_relation",
+      stage: SourceContentAssessmentFailureStage): void;
   };
 };
 
@@ -189,8 +191,10 @@ const buildReaderSummaryDailyStoryRelationVerifier = (
         // Refresh authority must be poisoned before selector fallback catches
         // adapter exceptions. Accepted decisions retain their normal reconciliation.
         observe(() => capture?.failed(query));
+        // No finer-grained stage classification exists for relation
+        // verification failures; "unknown" is the honest, whitelisted value.
         guard?.invalidateAdapter(query.verificationLane === "related_topic"
-          ? "related_topic_relation" : "story_relation");
+          ? "related_topic_relation" : "story_relation", "unknown");
         throw error;
       }
     },

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
@@ -68,8 +68,11 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
     expect(() => fixture.runtime.assertUsable()).toThrow(/reconciliation/u);
   });
 
-  it.each(["missing", "one missing", "wrong binding", "wrong quote", "duplicate"])(
-    "keeps %s assessment pending and prevents publication and subsequent spend", async (kind) => {
+  it.each([
+    ["missing", "binding"], ["one missing", "binding"], ["wrong binding", "binding"],
+    ["wrong quote", "verdict"], ["duplicate", "binding"],
+  ] as const)(
+    "keeps %s assessment pending, prevents publication/subsequent spend, and journals failureStage=%s", async (kind, expectedStage) => {
       const test = await selectorWiring({ output: (command) => {
         const output = selectorOutput(command);
         if (command.purpose !== purpose) return output;
@@ -87,6 +90,10 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
       await expect(test.selectComplete()).rejects.toThrow(/reconciliation/u);
       expect(() => test.assessment.assertComplete(2)).toThrow(/reconciliation/u);
       expect(test.commands.map((c) => c.purpose)).toEqual([purpose]);
+      // The mandatory (non-optional) journal record - not the optional paired
+      // capture - must carry the precise, whitelisted failure stage.
+      expect(test.events).toContainEqual(expect.objectContaining({ status: "requires_reconciliation",
+        phase: "adapter_validation", taskRole: "source_content_assessment", failureStage: expectedStage }));
       const publication = publicationProbe(test.runtime);
       await expect(publication.attempt()).rejects.toThrow(/reconciliation/u);
       expect(publication.publish).not.toHaveBeenCalled();

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.ts
@@ -105,7 +105,7 @@ export function createRefreshAssessmentReviewer(input: {
     try { input.capture(event()); } catch { captureFailures++; }
   };
   const fail = (stage: SourceContentAssessmentFailureStage): never => {
-    input.runtime.invalidateAdapter("source_content_assessment");
+    input.runtime.invalidateAdapter("source_content_assessment", stage);
     throw new SourceContentAssessmentStageError(stage,
       "Refresh assessment is incomplete; original operation requires reconciliation");
   };

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -15,6 +15,7 @@ import { BuildReaderSummaryTopicMapUseCase } from
 import type { AgentRuntimeClientPort, AgentRuntimeTaskCommand, AgentRuntimeTaskResult, ReaderSummaryModelPort } from "@social-monitor/summary/ports";
 import { verifyAndRecordReaderSummaryExecution, type ReaderSummaryAttestedTaskRole, type VerifiedReaderSummaryExecutionAttestationSink } from
   "@social-monitor/summary/adapters/model/reader-summary-execution-attestation";
+import type { SourceContentAssessmentFailureStage } from "@social-monitor/relevance/ports";
 import { refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
 import { assertRefreshEqual } from "./reader-summary-new-input-refresh-guard";
 
@@ -35,7 +36,11 @@ export function refreshGenerationSha256(env: NodeJS.ProcessEnv): string {
 }
 export type GuardedRefreshRuntime = AgentRuntimeClientPort & {
   assertUsable(): void;
-  invalidateAdapter(taskRole: ReaderSummaryAttestedTaskRole | "source_content_assessment"): void;
+  // stage is a fixed, whitelisted classification only (never a message or
+  // payload) so the mandatory requires_reconciliation journal entry below
+  // carries it even when no optional capture/journal is wired up.
+  invalidateAdapter(taskRole: ReaderSummaryAttestedTaskRole | "source_content_assessment",
+    stage: SourceContentAssessmentFailureStage): void;
 };
 
 export function buildRefreshModelWiring(env: NodeJS.ProcessEnv, client: GuardedRefreshRuntime,
@@ -59,7 +64,9 @@ export function buildRefreshModelWiring(env: NodeJS.ProcessEnv, client: GuardedR
       client.assertUsable();
       return result;
     } catch (error) {
-      client.invalidateAdapter(taskRole);
+      // Generation/labeling/relation adapters have no finer-grained stage
+      // classification; "unknown" is the honest, fail-closed whitelisted value.
+      client.invalidateAdapter(taskRole, "unknown");
       throw error;
     }
   };
@@ -70,7 +77,7 @@ export function buildRefreshModelWiring(env: NodeJS.ProcessEnv, client: GuardedR
       generate: (...args) => validated("summary", () => model.generate(...args)),
       validateRawProviderResponse: (attempt) => {
         const result = model.validateRawProviderResponse(attempt);
-        if (!result.ok) client.invalidateAdapter("summary");
+        if (!result.ok) client.invalidateAdapter("summary", "unknown");
         return result;
       },
       classifyError: (error) => model.classifyError(error),
@@ -130,10 +137,13 @@ export function guardedRefreshRuntime(input: {
     purpose === sourceContentAssessmentPurpose ? "low" : "high";
   return {
     assertUsable,
-    invalidateAdapter: (taskRole) => {
+    invalidateAdapter: (taskRole, stage) => {
       if (ambiguous) return;
       ambiguous = true; // Recording failure must not restore authority either.
-      input.record({ status: "requires_reconciliation", phase: "adapter_validation", taskRole,
+      // failureStage is a fixed whitelisted code only - never a message,
+      // payload, title/body, prompt or credential - and lands in this
+      // mandatory (non-optional) record, unlike the optional paired capture.
+      input.record({ status: "requires_reconciliation", phase: "adapter_validation", taskRole, failureStage: stage,
         operation: input.manifest.operation, observedThrough: input.manifest.observedThrough });
     },
     checkHealth: async (service) => {

--- a/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec.ts
@@ -30,8 +30,10 @@ describe("refresh canonical selector adapter exceptions", () => {
     expect(test.events.filter((event) => event.status === "completed")).toHaveLength(3);
     expect(test.sink.record.mock.calls.map(([value]) => value.taskRole)).toEqual(["story_relation"]);
     expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/u);
+    // Relation verification has no finer-grained stage classification; the
+    // mandatory journal record still carries the fixed, whitelisted fallback.
     expect(test.events).toContainEqual(expect.objectContaining({ status: "requires_reconciliation",
-      phase: "adapter_validation", taskRole: "related_topic_relation" }));
+      phase: "adapter_validation", taskRole: "related_topic_relation", failureStage: "unknown" }));
     await expectPermanentlyPoisoned(test);
   });
 
@@ -48,7 +50,7 @@ describe("refresh canonical selector adapter exceptions", () => {
     expect(test.commands.map((command) => command.purpose)).toEqual([assessmentPurpose, purposes.storyRelations]);
     expect(test.sink.record).not.toHaveBeenCalled();
     expect(test.events).toContainEqual(expect.objectContaining({ status: "requires_reconciliation",
-      phase: "adapter_validation", taskRole: "story_relation" }));
+      phase: "adapter_validation", taskRole: "story_relation", failureStage: "unknown" }));
     await expectPermanentlyPoisoned(test);
   });
 


### PR DESCRIPTION
The previous assessment failure taxonomy reached only optional paired capture, so production refresh journals still recorded a generic `adapter_validation` event. This follow-up carries the fixed whitelisted stage into the mandatory `requires_reconciliation` journal record while keeping exception messages and payloads out of telemetry.

Validation:
- focused reader-summary assessment and selector suites: 168 passed
- `npx tsc --noEmit -p tsconfig.build.json`
