### PR TITLE
fix(relevance): trust attested assessment request binding

### DIFF
--- a/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.spec.ts
+++ b/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.spec.ts
@@ -75,12 +75,33 @@ describe("AgentRuntimeSourceContentQualityReviewerAdapter failure stage classifi
     expect(stage).toBe("parse_schema");
   });
 
-  it("classifies a tampered bindingId as binding, distinct from a parse/schema failure", async () => {
+  // Legitimate model binding drift: the whole-batch execution attestation
+  // already proves the runtime executed exactly this candidate's content for
+  // a fresh requestId, so an imperfect bindingId echo (a model failing to
+  // reproduce the opaque 64-hex-char hash byte-for-byte) must not reject an
+  // otherwise-correct, correctly-identified assessment.
+  it("accepts a response with a mismatched bindingId once the request-level attestation is trusted", async () => {
     const input = request();
     const client = refreshTestRuntimeClient(async (r) => attestRefreshExecution(r,
-      { reviews: [{ ...validReview(input), bindingId: `${promotionWireCandidate(input).bindingId}-tampered` }] }));
+      { reviews: [{ ...validReview(input), bindingId: `${promotionWireCandidate(input).bindingId}-drifted` }] }));
+    const [result] = await adapterFor(client).reviewBatch([input]);
+    expect(result!.decision).toBe("promote");
+    expect(result!.assessment!.binding).toBe(input.promotion);
+  });
+
+  // Malicious candidate remap: a response can carry a valid candidateId and
+  // an attested batch, but the assessment for candidate A must still be
+  // rejected downstream if the caller ever accepted attention-content that
+  // does not actually belong to A. This adapter alone (unlike the caller's
+  // full verdict pipeline) does not itself verify evidence-quote content, so
+  // it cannot detect a same-request content swap; that boundary is proven in
+  // reader-summary-new-input-refresh-assessment-capture.spec.ts.
+  it("still rejects an unknown candidateId even when the request-level attestation is trusted", async () => {
+    const input = request();
+    const client = refreshTestRuntimeClient(async (r) => attestRefreshExecution(r,
+      { reviews: [{ ...validReview(input), candidateId: "not-a-real-candidate" }] }));
     const stage = await stageOf(adapterFor(client).reviewBatch([input]));
-    expect(stage).toBe("binding");
+    expect(stage).toBe("parse_schema");
   });
 
   it("accepts a fully valid attested completion without throwing", async () => {

--- a/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts
+++ b/libs/relevance/adapters/model/agent-runtime-source-content-quality-reviewer.adapter.ts
@@ -115,7 +115,14 @@ export class AgentRuntimeSourceContentQualityReviewerAdapter implements SourceCo
     if (output === undefined || Buffer.byteLength(output, "utf8") > 128_000) {
       throw new SourceContentAssessmentStageError("runtime_status", "Assessment output missing or too large");
     }
-    const reviews = parseReviews(output, requests);
+    // The attestation just verified above (requestId, canonicalRequestSha256,
+    // provider/model/reasoningEffort match) already proves the runtime
+    // executed exactly this batch's candidates/content for this fresh
+    // requestId - each candidate's bindingId is itself part of that attested
+    // prompt. That is a stronger, independently verified binding proof than
+    // an echoed bindingId string, so the parser can trust candidateId-matched
+    // requests here without also requiring a byte-exact echo.
+    const reviews = parseReviews(output, requests, { trustAttestedRequestBinding: true });
     if (signal.aborted) {
       throw new SourceContentAssessmentStageError("aborted", "Assessment validation deadline exhausted");
     }

--- a/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
+++ b/libs/relevance/adapters/model/assessment-schema-protocol.spec.ts
@@ -24,16 +24,18 @@ const compatible = {
   "observed batch one under reviews envelope": (o: { reviews: Wire[] }) => ({ reviews: o.reviews.map((r) => observed(r)) }),
   "observed batch two under reviews envelope": (o: { reviews: Wire[] }) => ({ reviews: o.reviews.map((r) => observed(r, true)) }),
   "results alias only": (o: { reviews: Wire[] }) => ({ results: o.reviews }),
+  // Legitimate model binding drift: the attested batch already proves the
+  // runtime executed exactly this candidate's content for a fresh request,
+  // so an imperfect bindingId echo must not reject an otherwise-correct,
+  // correctly-identified legacy-shaped assessment either.
+  "legacy dialect with drifted bindingId": (o: { reviews: Wire[] }) => ({ reviews: o.reviews.map((r) =>
+    observed({ ...r, bindingId: `${String(r.bindingId)}-drifted` })) }),
 } as const;
 const mutations: Record<string, (output: { reviews: Wire[] }) => Wire> = {
   // A single tampered field on an otherwise-complete canonical item is not a
   // legacy dialect and must stay rejected, not reinterpreted.
   "relevant decision": (o) => ({ reviews: o.reviews.map((r) => ({ ...r, decision: "relevant" })) }),
   "not_relevant decision": (o) => ({ reviews: o.reviews.map((r) => ({ ...r, decision: "not_relevant" })) }),
-  // A genuine legacy-shaped item with a tampered binding must still be
-  // rejected: item-dialect normalization cannot weaken the binding check.
-  "legacy dialect with tampered binding": (o) => ({ reviews: o.reviews.map((r) =>
-    observed({ ...r, bindingId: `${String(r.bindingId)}-tampered` })) }),
 };
 for (const field of ["confidence", "qualityScore", "interestRelevanceScore", "engagementIntegrityScore", "flags", "reason", "resolvedSoftFlags"]) {
   mutations[`missing ${field}`] = (o) => ({ reviews: o.reviews.map((r) => {
@@ -92,6 +94,30 @@ describe("assessment schema consumer protocol", () => {
     expect(result.ranking.orderedCandidateIds).toHaveLength(0);
     expect(result.items[0]!.contentQuality).toMatchObject({ qualityScore: 0,
       needsLlmReview: true, eligibleForTopRead: false });
+  });
+
+  // Malicious candidate remap: a correct candidateId and a trusted request
+  // attestation must not launder evidence that does not actually belong to
+  // this candidate's real text. Trusting the attestation only widens what
+  // identity proof is accepted (bindingId echo); it never widens what
+  // content is accepted as evidence - that stays enforced, unchanged, by
+  // the downstream verdict policy's evidence-quote check, so this never
+  // throws here (unlike a schema/shape violation) but still keeps the
+  // candidate pending and unpromoted.
+  it("keeps a remapped evidence quote pending and unpromoted, without laundering it through trusted attestation", async () => {
+    let calls = 0;
+    const adapter = new AgentRuntimeSourceContentQualityReviewerAdapter({
+      clock: new FixedClock(cutoff), ids: { generate: () => `sandbox-remap-${++calls}` },
+      batchTimeoutMs: 300_000, totalTimeoutMs: 600_000,
+      client: refreshTestRuntimeClient(async (request) => attestRefreshExecution(request,
+        { reviews: outputFor(request).reviews.map((r) => ({ ...r,
+          evidence: [{ field: "bodyPreview", start: 0, end: 40,
+            quote: "This sentence was never in the real body" }] })) })),
+    });
+    const result = await run([fixture("protocol")], adapter);
+    expect(calls).toBe(1);
+    expect(result.ranking.orderedCandidateIds).toHaveLength(0);
+    expect(result.items[0]!.contentQuality).toMatchObject({ needsLlmReview: true, eligibleForTopRead: false });
   });
 
   it.each([true, false])("preserves canonical=%s compatible siblings when the third batch times out without retry", async (canonical) => {

--- a/libs/relevance/adapters/model/promotion-review-wire.spec.ts
+++ b/libs/relevance/adapters/model/promotion-review-wire.spec.ts
@@ -1,5 +1,5 @@
 import { OpenAiSourceContentQualityReviewerAdapter } from "./openai-source-content-quality-reviewer.adapter";
-import { promotionReviewInstructions } from "./promotion-review-wire";
+import { bindPromotionAssessment, promotionReviewInstructions, promotionWireCandidate } from "./promotion-review-wire";
 import { SourceContentQualityPolicy } from "../../domain";
 import { assessedPromotionVerdict } from "../../features/rank-feed-items/promotion-assessment-verdict";
 import type { SourceContentQualityReviewRequest } from "../../ports";
@@ -45,6 +45,22 @@ describe("existing review adapter promotion wire contract", () => {
     const [review] = await adapter.reviewBatch([input]);
     expect(review!.assessment!.binding).toBe(input.promotion);
     expect(assessedPromotionVerdict(input, review, new SourceContentQualityPolicy()).qualityScore).toBe(0.7);
+  });
+
+  describe("bindPromotionAssessment trustAttestedRequestBinding opt-in", () => {
+    const input = request("reddit");
+    const raw = { bindingId: `${promotionWireCandidate(input).bindingId}-drifted`,
+      evidence: [{ field: "title", start: 0, end: input.title.length, quote: input.title }],
+      resolvedSoftFlags: [] };
+
+    it("still rejects a mismatched bindingId by default (unattested callers, e.g. the OpenAI adapter)", () => {
+      expect(() => bindPromotionAssessment(raw, input)).toThrow("Invalid promotion assessment binding");
+    });
+
+    it("accepts a mismatched bindingId only when the caller explicitly trusts request attestation", () => {
+      const assessment = bindPromotionAssessment(raw, input, { trustAttestedRequestBinding: true });
+      expect(assessment.binding).toBe(input.promotion);
+    });
   });
 
   it("rejects reuse after text or scope changes and honors cancellation", async () => {

--- a/libs/relevance/adapters/model/promotion-review-wire.ts
+++ b/libs/relevance/adapters/model/promotion-review-wire.ts
@@ -40,10 +40,27 @@ const bindingId = (request: SourceContentQualityReviewRequest): string =>
     providerKey: request.providerKey, context: request.promotion,
     title: request.title, body: request.bodyPreview ?? "" })).digest("hex");
 
+// The bindingId echo defends against a stale/replayed response bound to
+// different content or scope. Without an independent, caller-verified guard
+// against that, the echo stays mandatory (e.g. the OpenAI adapter, which has
+// no request-level attestation). When the caller has already verified a
+// whole-batch execution attestation (requestId + canonicalRequestSha256)
+// proving the runtime executed exactly the candidates/content this request
+// was built from - which already includes each candidate's bindingId as
+// prompt content - that attestation is a strictly stronger, independently
+// verified binding proof, and requiring the model to also echo the opaque
+// 64-hex-char hash byte-for-byte adds no further protection, only fragility:
+// legitimate models occasionally fail to reproduce it exactly, rejecting an
+// otherwise-correct assessment. Coverage (duplicate/missing/unknown
+// candidateId) and evidence-quote correctness are unaffected either way -
+// both are still enforced strictly, by the caller and by the downstream
+// verdict policy respectively.
 export const bindPromotionAssessment = (
   raw: JsonObject, request: SourceContentQualityReviewRequest,
+  options?: { readonly trustAttestedRequestBinding?: boolean },
 ): PromotionReviewAssessment => {
-  if (request.promotion === undefined || raw.bindingId !== bindingId(request) ||
+  if (request.promotion === undefined ||
+      (options?.trustAttestedRequestBinding !== true && raw.bindingId !== bindingId(request)) ||
       !Array.isArray(raw.evidence) || !Array.isArray(raw.resolvedSoftFlags)) {
     throw new Error("Invalid promotion assessment binding");
   }

--- a/libs/relevance/adapters/model/source-content-quality-review-wire.ts
+++ b/libs/relevance/adapters/model/source-content-quality-review-wire.ts
@@ -20,9 +20,10 @@ export const buildInstructions = (): string =>
 export const parseReviews = (
   outputText: string | undefined,
   requests?: readonly SourceContentQualityReviewRequest[],
+  options?: { readonly trustAttestedRequestBinding?: boolean },
 ): readonly SourceContentQualityReviewResult[] => {
   try {
-    return parseReviewsUnclassified(outputText, requests);
+    return parseReviewsUnclassified(outputText, requests, options);
   } catch (error) {
     // Any exception reaching here (JSON.parse syntax errors, shape checks,
     // the score/decision/flag validation below) is a parse/schema-contract
@@ -37,6 +38,7 @@ export const parseReviews = (
 const parseReviewsUnclassified = (
   outputText: string | undefined,
   requests?: readonly SourceContentQualityReviewRequest[],
+  options?: { readonly trustAttestedRequestBinding?: boolean },
 ): readonly SourceContentQualityReviewResult[] => {
   if (outputText === undefined) {
     throw new Error("OpenAI source content quality reviewer returned no text");
@@ -80,7 +82,7 @@ const parseReviewsUnclassified = (
     }
     let assessment: ReturnType<typeof bindPromotionAssessment> | undefined;
     if (request !== undefined) {
-      try { assessment = bindPromotionAssessment(record, request); }
+      try { assessment = bindPromotionAssessment(record, request, options); }
       catch (error) {
         // The only distinct failure class inside this map body: the model's
         // own bindingId/evidence/resolvedSoftFlags echo did not match this

--- a/scripts/lib/reader-summary-new-input-refresh-assessment-coverage.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment-coverage.spec.ts
@@ -97,13 +97,23 @@ describe("synthetic concrete assessment wire and parser capture binding", () => 
     expect(() => test.capture.validateAssessmentModel(test.command, 1)).not.toThrow();
     expect(() => test.capture.validateAssessmentParser(test.terminal)).not.toThrow();
   });
-  it.each(["prompt", "system", "schema", "binding", "parsed result"])("rejects changed %s bytes", (kind) => {
+  // "binding" (a drifted bindingId byte) is deliberately not in this table:
+  // validateAssessmentParser now replays the parse with
+  // trustAttestedRequestBinding, matching the live agent-runtime adapter, so
+  // a bindingId-only change no longer changes the parsed result and must not
+  // be reported as a mismatch - see the dedicated acceptance test below.
+  it.each(["prompt", "system", "schema", "parsed result"])("rejects changed %s bytes", (kind) => {
     const test = modelCoverage();
     if (kind === "prompt") test.command.prompt = "{}";
     if (kind === "system") test.command.systemPrompt = "Changed instructions";
     if (kind === "schema") Object.assign(test.command, { outputSchema: {} });
-    if (kind === "binding") test.output.reviews[0]!.bindingId = "changed";
     if (kind === "parsed result") test.terminal = { ...test.terminal, reviewsJson: "[]" };
     expect(() => test.capture.validateAssessmentParser(test.terminal)).toThrow();
+  });
+
+  it("does not report a drifted bindingId as a parser mismatch, matching the live trusted-attestation parse", () => {
+    const test = modelCoverage();
+    test.output.reviews[0]!.bindingId = "changed";
+    expect(() => test.capture.validateAssessmentParser(test.terminal)).not.toThrow();
   });
 });

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
@@ -69,9 +69,16 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
   });
 
   it.each([
-    ["missing", "binding"], ["one missing", "binding"], ["wrong binding", "binding"],
+    ["missing", "binding"], ["one missing", "binding"],
     ["wrong quote", "verdict"], ["duplicate", "binding"],
   ] as const)(
+    // "wrong binding" (a drifted bindingId echo) is deliberately not in this
+    // table anymore: the agent-runtime adapter now trusts the already-
+    // attested request binding over that echo, so it is accepted, not
+    // rejected - see "accepts a legitimate response ... bindingId echo is
+    // imperfect" in agent-runtime-source-content-quality-reviewer.adapter.spec.ts
+    // and the "legacy dialect with drifted bindingId" case in
+    // assessment-schema-protocol.spec.ts.
     "keeps %s assessment pending, prevents publication/subsequent spend, and journals failureStage=%s", async (kind, expectedStage) => {
       const test = await selectorWiring({ output: (command) => {
         const output = selectorOutput(command);
@@ -80,7 +87,6 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
         switch (kind) {
           case "missing": return { reviews: [] };
           case "one missing": return { reviews: reviews.slice(1) };
-          case "wrong binding": reviews[0]!.bindingId = "wrong"; break;
           case "wrong quote": reviews[0]!.evidence = [{ field: "title", start: 0, end: 5, quote: "wrong" }]; break;
           case "duplicate": return { reviews: [reviews[0], reviews[0]] };
         }

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.spec-support.ts
@@ -84,7 +84,7 @@ export function pairedFixture(options: { capture?: boolean; path?: string; suppl
     select: () => (capture?.selector(wiring.evidenceSelector) ?? wiring.evidenceSelector).select(query) };
 }
 
-function syntheticOutput(command: AgentRuntimeTaskCommand, relationCase = false): Record<string, unknown> {
+export function syntheticOutput(command: AgentRuntimeTaskCommand, relationCase = false): Record<string, unknown> {
   if (command.purpose === sourceContentAssessmentPurpose) {
     const { candidates } = JSON.parse(command.prompt) as { candidates: { candidateId: string; bindingId: string;
       untrustedSource: { bodyPreview: string } }[] };

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.spec.ts
@@ -5,9 +5,10 @@ import type { ReaderSummaryStoryRelationVerifierInput, AgentRuntimeTaskResult } 
 import { completedRefreshModelRequest, refreshModelCommand } from "./reader-summary-new-input-refresh-model.spec-support";
 import { existsSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { pairedFixture } from "./reader-summary-new-input-refresh-paired-export.spec-support";
+import { pairedFixture, syntheticOutput } from "./reader-summary-new-input-refresh-paired-export.spec-support";
 import { RefreshPairedExport } from "./reader-summary-new-input-refresh-paired-export";
 import { refreshManifest, refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import { sourceContentAssessmentPurpose } from "./reader-summary-new-input-refresh-assessment-runtime";
 
 const parents: string[] = [];
 const setup = (options: Parameters<typeof pairedFixture>[0] = {}) => {
@@ -55,6 +56,31 @@ describe("synthetic bounded refresh paired export", () => {
     expect(result.unresolvedCandidateCount).toBe(1);
     expect(json(on.path, "complete.json").experimentComplete).toBe(false);
     for (const name of readdirSync(on.path)) expect(statSync(join(on.path, name)).mode & 0o777).toBe(0o600);
+  });
+
+  // The paired-export validator replays the exact live agent-runtime parse
+  // for determinism verification. It must trust the same already-attested
+  // request binding the live parse did, so a legitimate drifted bindingId
+  // (a model failing to echo the opaque hash byte-for-byte) that the live
+  // path accepted does not make this replay throw instead of comparing
+  // output - live-accept must not diverge from capture-fail.
+  it("accepts a live response with a drifted bindingId without diverging live-accept from capture-fail", async () => {
+    const fixture = setup({ response: (command) => {
+      if (command.purpose !== sourceContentAssessmentPurpose) return syntheticOutput(command);
+      const { candidates } = JSON.parse(command.prompt) as { candidates: { candidateId: string; bindingId: string;
+        untrustedSource: { bodyPreview: string } }[] };
+      return { reviews: candidates.map((c) => ({ candidateId: c.candidateId, bindingId: `${c.bindingId}-drifted`,
+        decision: c.candidateId === "reject" ? "reject" : c.candidateId === "abstain" ? "needs_context" : "promote",
+        confidence: 0.96, qualityScore: 0.85, interestRelevanceScore: 0.95, engagementIntegrityScore: 0.95,
+        flags: [], reason: "Synthetic concrete parser result", resolvedSoftFlags: [],
+        evidence: [{ field: "bodyPreview", start: 0, end: c.untrustedSource.bodyPreview.length,
+          quote: c.untrustedSource.bodyPreview }] })) };
+    } });
+    await fixture.select();
+    const result = await fixture.capture!.finish(true);
+    expect(result.failures).toEqual([]);
+    const tape = readFileSync(join(fixture.path, "models.jsonl"), "utf8");
+    expect(tape).toContain('"envelope_verified"');
   });
 
   it("binds real rejected relation requests, validated responses and attestation bytes", async () => {

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.ts
@@ -424,7 +424,13 @@ export class RefreshPairedExport {
     const attempt = this.assessments.find((entry) => entry.phase === "attempt" && entry.batch === event.batch);
     if (attempt?.requestsJson !== event.requestsJson) throw new Error("Assessment parsed request mismatch");
     const requests = JSON.parse(event.requestsJson) as SourceContentQualityReviewRequest[];
-    const parsed = parseReviews(JSON.stringify(envelope.result.structuredOutput), requests);
+    // This replays the exact live agent-runtime parse for determinism
+    // verification, so it must trust the same already-attested request
+    // binding the live adapter did - otherwise a legitimate drifted
+    // bindingId the live parse accepted would make this replay throw
+    // instead of comparing output, diverging live-accept from capture-fail.
+    const parsed = parseReviews(JSON.stringify(envelope.result.structuredOutput), requests,
+      { trustAttestedRequestBinding: true });
     if (JSON.stringify(parsed) !== event.reviewsJson) throw new Error("Assessment concrete parser mismatch");
   }
 


### PR DESCRIPTION
Production refreshes reached a verified agent-runtime assessment but failed binding validation when the model did not reproduce an opaque SHA-256 binding byte-for-byte. The agent-runtime path now derives the binding from the exact candidate-matched request only after execution attestation is verified; non-attested adapters keep the strict echo check, and unknown/missing/duplicate candidates plus evidence remapping remain rejected.

Validation:
- focused relevance adapter, wire protocol, and assessment suites: 67 passed
- `npx tsc --noEmit -p tsconfig.build.json`
