### PR TITLE
fix(summary): render empty legacy executive fallback

### DIFF
--- a/libs/summary/adapters/model/openai-responses-reader-summary-draft-normalizer.spec.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-draft-normalizer.spec.ts
@@ -1,0 +1,65 @@
+import { tenantId, workspaceId } from "@social-monitor/shared-kernel";
+import { dailyEvidenceSelection } from
+  "../../domain/policies/reader-summary-publication-evidence-test-fixtures";
+import type { ReaderSummaryModelInput } from "../../ports";
+import { normalizeOpenAiReaderSummaryDraft } from
+  "./openai-responses-reader-summary-draft-normalizer";
+
+describe("normalizeOpenAiReaderSummaryDraft", () => {
+  it("uses normalized story copy when canonical and legacy narrative are empty", () => {
+    const evidence = dailyEvidenceSelection(0);
+    const input: ReaderSummaryModelInput = {
+      tenantId: tenantId("test-tenant"),
+      workspaceId: workspaceId("test-workspace"),
+      scope: { type: "workspace" },
+      period: {
+        cadence: "daily",
+        startedAt: evidence.sourceWindow.periodStartedAt!,
+        endedAt: evidence.sourceWindow.periodEndedAt!,
+        timezone: "UTC",
+        periodKey: "test-day",
+      },
+      evidence,
+      coveragePlan: { mode: "single_story", secondary: [] },
+      contextArtifacts: [],
+      policy: {
+        language: "en",
+        format: "executive_brief",
+        tone: "analytical",
+        maxStories: 8,
+        includeRisks: false,
+        includeInterestHighlights: false,
+        includeRepeatedSignals: false,
+        dedupeStrategy: "canonical_url_then_title",
+        rulesVersion: "test-no-signal-fallback",
+      },
+      requestedAt: evidence.sourceWindow.endedAt,
+    };
+
+    const draft = normalizeOpenAiReaderSummaryDraft({
+      headline: "A cited story remains publishable",
+      executiveSummary: "",
+      narrativeSections: [],
+      topStories: [],
+      qualityFlags: [],
+      confidence: {
+        level: "none",
+        score: 0,
+        rationale: "No evidence passed the publication slate.",
+      },
+      noSignalReason: null,
+    }, input, {
+      provider: "offline-test",
+      model: "fixture",
+      promptVersion: "test",
+      schemaVersion: "reader_summary.artifact.v1",
+    }, {
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+    }, "test");
+
+    expect(draft.executiveSummary).toBe(draft.topStories[0]?.summary);
+    expect(draft.executiveSummary.trim()).not.toBe("");
+  });
+});

--- a/libs/summary/adapters/model/openai-responses-reader-summary-draft-normalizer.ts
+++ b/libs/summary/adapters/model/openai-responses-reader-summary-draft-normalizer.ts
@@ -96,9 +96,17 @@ export const normalizeOpenAiReaderSummaryDraft = (
       ),
     ),
   });
+  const noSignalReason =
+    normalizedTopStories.length === 0
+      ? (optionalString(raw.noSignalReason) ??
+        "OpenAI reader summary returned no domain-safe cited stories.")
+      : undefined;
   const executiveSummary =
     narrativeSections.length === 0
-      ? legacyExecutiveSummary
+      ? (optionalString(legacyExecutiveSummary) ??
+        optionalString(normalizedTopStories[0]?.summary) ??
+        noSignalReason ??
+        "")
       : readerSummaryNarrativeMarkdown(narrativeSections);
   const interestHighlights = input.policy.includeInterestHighlights
     ? normalizeInterestHighlights(
@@ -129,11 +137,6 @@ export const normalizeOpenAiReaderSummaryDraft = (
           "limited_sources",
         ]) as readonly ReaderSummaryQualityFlag[])
       : rawQualityFlags.filter((flag) => flag !== "no_signal");
-  const noSignalReason =
-    normalizedTopStories.length === 0
-      ? (optionalString(raw.noSignalReason) ??
-        "OpenAI reader summary returned no domain-safe cited stories.")
-      : undefined;
   const confidence = normalizeConfidence(
     asRecord(raw.confidence) ?? {},
     normalizedTopStories.length,


### PR DESCRIPTION
## Summary
- derive executive copy from the first normalized cited story when both canonical narrative and the legacy duplicate summary are empty
- preserve fail-closed validation when no trustworthy fallback exists
- add the production-shape regression and align one stale runtime binding expectation from merged PR #394

## Verification
- focused Jest suites pass
- ESLint passes
- source line cap passes