### PR TITLE
test(relevance): align attested binding runtime coverage

### DIFF
--- a/scripts/lib/source-content-assessment-runtime.spec.ts
+++ b/scripts/lib/source-content-assessment-runtime.spec.ts
@@ -54,10 +54,9 @@ describe("pool-backed assessment through runtime transport and actual promotion"
     expect(result.ranking.orderedCandidateIds).toHaveLength(23);
   });
 
-  it.each(["binding", "identity", "range"])("rejects mismatched %s evidence", async (mutation) => {
+  it.each(["identity", "range"])("rejects mismatched %s evidence", async (mutation) => {
     const reviewer = runtimeReviewer(async (request) => {
       const output = outputFor(request);
-      if (mutation === "binding") output.reviews[0]!.bindingId = "other-workspace-binding";
       if (mutation === "range") output.reviews[0]!.evidence[0]!.start = 1;
       const result = await attestRefreshExecution(request, output);
       if (mutation === "identity") return { ...result, executionAttestation: {
@@ -65,6 +64,15 @@ describe("pool-backed assessment through runtime transport and actual promotion"
       return result;
     });
     expect((await run([fixture("bad-wire")], reviewer)).ranking.orderedCandidateIds).toHaveLength(0);
+  });
+
+  it("accepts bindingId echo drift when the exact request is attested", async () => {
+    const reviewer = runtimeReviewer(async (request) => {
+      const output = outputFor(request);
+      output.reviews[0]!.bindingId = "other-workspace-binding";
+      return attestRefreshExecution(request, output);
+    });
+    expect((await run([fixture("binding-drift")], reviewer)).ranking.orderedCandidateIds).toHaveLength(1);
   });
 
   it("allows pool latency beyond the former 60-second total within runtime bounds", async () => {


### PR DESCRIPTION
Production deploy for PR #394 was blocked by one stale runtime integration expectation: the attested path still expected an opaque `bindingId` echo mismatch to reject, although the merged contract now trusts exact request attestation for that field.

This updates the integration coverage to accept `bindingId` echo drift only with a valid request attestation. The same test continues to reject attestation identity mismatch and evidence-range mismatch.

Validation:
- `./node_modules/.bin/jest scripts/lib/source-content-assessment-runtime.spec.ts --runInBand` - 8 passed

Related #394
