### PR TITLE
fix(summary): exclude display-invalid promotion leads

### DIFF
--- a/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.spec.ts
@@ -20,7 +20,7 @@ describe("display-ready reader promotion candidates", () => {
     )).toEqual([ready]);
   });
 
-  it("preserves a wholly unavailable batch for explicit quality rejection", () => {
+  it("leaves a wholly unavailable batch empty for honest no-signal", () => {
     const unavailable = [{
       ...assessedSource(),
       readerHeadline: {
@@ -30,6 +30,6 @@ describe("display-ready reader promotion candidates", () => {
     }];
 
     expect(displayReadyPromotionCandidates(unavailable, headlineScope))
-      .toBe(unavailable);
+      .toEqual([]);
   });
 });

--- a/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.spec.ts
@@ -20,7 +20,7 @@ describe("display-ready reader promotion candidates", () => {
     )).toEqual([ready]);
   });
 
-  it("leaves a wholly unavailable batch empty for honest no-signal", () => {
+  it("preserves a wholly unavailable batch for explicit quality rejection", () => {
     const unavailable = [{
       ...assessedSource(),
       readerHeadline: {
@@ -30,6 +30,6 @@ describe("display-ready reader promotion candidates", () => {
     }];
 
     expect(displayReadyPromotionCandidates(unavailable, headlineScope))
-      .toEqual([]);
+      .toBe(unavailable);
   });
 });

--- a/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.spec.ts
@@ -20,7 +20,7 @@ describe("display-ready reader promotion candidates", () => {
     )).toEqual([ready]);
   });
 
-  it("preserves a wholly unavailable batch for explicit quality rejection", () => {
+  it("rejects a wholly unavailable selected batch before generation", () => {
     const unavailable = [{
       ...assessedSource(),
       readerHeadline: {
@@ -29,7 +29,10 @@ describe("display-ready reader promotion candidates", () => {
       },
     }];
 
-    expect(displayReadyPromotionCandidates(unavailable, headlineScope))
-      .toBe(unavailable);
+    expect(() => displayReadyPromotionCandidates(unavailable, headlineScope))
+      .toThrow("Reader summary selected headlines unavailable");
+  });
+  it("preserves genuine absence of selected signal", () => {
+    expect(displayReadyPromotionCandidates([], headlineScope)).toEqual([]);
   });
 });

--- a/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.spec.ts
@@ -1,0 +1,35 @@
+import { assessedSource, headlineScope } from "./reader-headline.spec-support";
+import { displayReadyPromotionCandidates } from
+  "./reader-summary-display-ready-candidates";
+
+describe("display-ready reader promotion candidates", () => {
+  it("keeps only publishable candidates when the ranked batch is mixed", () => {
+    const ready = assessedSource();
+    const unavailable = {
+      ...ready,
+      feedItemId: "higher-ranked-unavailable",
+      readerHeadline: {
+        status: "unavailable" as const,
+        reasonCode: "not_assessed" as const,
+      },
+    };
+
+    expect(displayReadyPromotionCandidates(
+      [unavailable, ready],
+      headlineScope,
+    )).toEqual([ready]);
+  });
+
+  it("preserves a wholly unavailable batch for explicit quality rejection", () => {
+    const unavailable = [{
+      ...assessedSource(),
+      readerHeadline: {
+        status: "unavailable" as const,
+        reasonCode: "not_assessed" as const,
+      },
+    }];
+
+    expect(displayReadyPromotionCandidates(unavailable, headlineScope))
+      .toBe(unavailable);
+  });
+});

--- a/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.ts
@@ -1,0 +1,23 @@
+import {
+  readerPostDisplayHeadline,
+  type SummaryEvidenceItem,
+} from "../../domain";
+
+type ReaderSummaryScope = Readonly<{
+  tenantId: string;
+  workspaceId: string;
+}>;
+
+/**
+ * Keep invalid display evidence out of an otherwise publishable slate. If the
+ * whole batch is unavailable, preserve it so the publication gate reports the
+ * outage instead of silently turning a real-news day into NO_SIGNAL.
+ */
+export const displayReadyPromotionCandidates = (
+  candidates: readonly SummaryEvidenceItem[],
+  scope: ReaderSummaryScope,
+): readonly SummaryEvidenceItem[] => {
+  const ready = candidates.filter((candidate) =>
+    readerPostDisplayHeadline(candidate, scope).status === "accepted");
+  return ready.length === 0 ? candidates : ready;
+};

--- a/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.ts
@@ -1,3 +1,4 @@
+import { DomainError } from "@social-monitor/shared-kernel";
 import {
   readerPostDisplayHeadline,
   type SummaryEvidenceItem,
@@ -8,16 +9,20 @@ type ReaderSummaryScope = Readonly<{
   workspaceId: string;
 }>;
 
-/**
- * Keep invalid display evidence out of an otherwise publishable slate. If the
- * whole batch is unavailable, preserve it so the publication gate reports the
- * outage instead of silently turning a real-news day into NO_SIGNAL.
- */
+/** Apply only to policy-selected leads, never the ranking inventory. */
 export const displayReadyPromotionCandidates = (
   candidates: readonly SummaryEvidenceItem[],
   scope: ReaderSummaryScope,
 ): readonly SummaryEvidenceItem[] => {
   const ready = candidates.filter((candidate) =>
     readerPostDisplayHeadline(candidate, scope).status === "accepted");
-  return ready.length === 0 ? candidates : ready;
+  if (candidates.length > 0 && ready.length === 0) {
+    throw new DomainError(
+      "external.dependency_unavailable",
+      "Reader summary selected headlines unavailable: no selected lead has a valid display headline",
+      { kind: "reader_summary_display_headlines_unavailable",
+        selectedFeedItemIds: candidates.map((item) => item.feedItemId) },
+    );
+  }
+  return ready;
 };

--- a/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.ts
@@ -9,15 +9,13 @@ type ReaderSummaryScope = Readonly<{
 }>;
 
 /**
- * Keep invalid display evidence out of an otherwise publishable slate. If the
- * whole batch is unavailable, preserve it so the publication gate reports the
- * outage instead of silently turning a real-news day into NO_SIGNAL.
+ * Exclude invalid display evidence before editorial selection. A wholly
+ * unavailable batch leaves the slate empty for honest NO_SIGNAL behavior.
  */
 export const displayReadyPromotionCandidates = (
   candidates: readonly SummaryEvidenceItem[],
   scope: ReaderSummaryScope,
 ): readonly SummaryEvidenceItem[] => {
-  const ready = candidates.filter((candidate) =>
+  return candidates.filter((candidate) =>
     readerPostDisplayHeadline(candidate, scope).status === "accepted");
-  return ready.length === 0 ? candidates : ready;
 };

--- a/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-candidates.ts
@@ -9,13 +9,15 @@ type ReaderSummaryScope = Readonly<{
 }>;
 
 /**
- * Exclude invalid display evidence before editorial selection. A wholly
- * unavailable batch leaves the slate empty for honest NO_SIGNAL behavior.
+ * Keep invalid display evidence out of an otherwise publishable slate. If the
+ * whole batch is unavailable, preserve it so the publication gate reports the
+ * outage instead of silently turning a real-news day into NO_SIGNAL.
  */
 export const displayReadyPromotionCandidates = (
   candidates: readonly SummaryEvidenceItem[],
   scope: ReaderSummaryScope,
 ): readonly SummaryEvidenceItem[] => {
-  return candidates.filter((candidate) =>
+  const ready = candidates.filter((candidate) =>
     readerPostDisplayHeadline(candidate, scope).status === "accepted");
+  return ready.length === 0 ? candidates : ready;
 };

--- a/libs/summary/adapters/evidence/reader-summary-display-ready-ranking.spec-support.ts
+++ b/libs/summary/adapters/evidence/reader-summary-display-ready-ranking.spec-support.ts
@@ -1,0 +1,14 @@
+import type { RankedFeedItemView } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.result";
+import { acceptedFixtureReaderHeadline } from "../../test-fixtures/accepted-reader-headline";
+import { mapRankedItem } from "./relevance-reader-summary-evidence-support";
+
+/** Ranking tests model completed headline assessment explicitly. */
+export const withDisplayReadyRanking = (
+  items: readonly RankedFeedItemView[],
+  scope: Readonly<{ tenantId: string; workspaceId: string }>,
+): readonly RankedFeedItemView[] => items.map((item) => {
+  const assessed = acceptedFixtureReaderHeadline(mapRankedItem(item), {
+    tenantId: scope.tenantId, workspaceId: scope.workspaceId,
+  });
+  return { ...item, sourceText: assessed.sourceText, readerHeadline: assessed.readerHeadline };
+});

--- a/libs/summary/adapters/evidence/reader-summary-editorial-slate.ts
+++ b/libs/summary/adapters/evidence/reader-summary-editorial-slate.ts
@@ -1,3 +1,4 @@
+import { displayReadyPromotionCandidates } from "./reader-summary-display-ready-candidates";
 import { readerPostPromotionEvidenceInput } from "../../domain/services/reader-post-promotion-evidence-input";
 import { isEligibleIndependentSupport } from "../../domain/services/reader-post-promotion-independent-support";
 import {
@@ -28,6 +29,7 @@ const additionalLimit = 8;
 export const composeReaderSummaryEditorialSlate = (params: {
   readonly selection: SummaryEvidenceSelection;
   readonly candidates?: readonly SummaryEvidenceItem[];
+  readonly displayScope?: Readonly<{ tenantId: string; workspaceId: string }>;
 }): ReaderSummaryEditorialSlate => {
   const candidates = (params.candidates ?? params.selection.selectedEvidence)
     .flatMap((item) => {
@@ -81,7 +83,23 @@ export const composeReaderSummaryEditorialSlate = (params: {
   const additional = representatives
     .filter((candidate) => !topIds.has(candidate.candidateId))
     .slice(0, additionalLimit);
-  const topEntries = top.map((candidate, index) => slateEntry({
+  // Eligibility, semantic representatives, capacity and placement remain authoritative.
+  // Readiness may remove selected leads, but cannot backfill or rerank the slate.
+  const selected = [...top, ...additional];
+  const readyIds = new Set((params.displayScope === undefined
+    ? selected.map((candidate) => itemById.get(candidate.candidateId)!)
+    : displayReadyPromotionCandidates(
+        selected.map((candidate) => itemById.get(candidate.candidateId)!),
+        params.displayScope,
+      )).map((item) => item.feedItemId));
+  const displayExclusions = selected
+    .filter((candidate) => !readyIds.has(candidate.candidateId))
+    .map((candidate) => ({
+      candidateId: candidate.candidateId,
+      canonicalIdentity: candidate.canonicalIdentity,
+      reasonCodes: ["display_headline_unavailable"],
+    }));
+  const topEntries = top.filter((candidate) => readyIds.has(candidate.candidateId)).map((candidate, index) => slateEntry({
     candidate,
     placement: "top",
     slot: index + 1,
@@ -93,7 +111,7 @@ export const composeReaderSummaryEditorialSlate = (params: {
       ...(activeProviderCount > 1 ? ["provider_cap_enforced"] : []),
     ],
   }));
-  const additionalEntries = additional.map((candidate, index) => slateEntry({
+  const additionalEntries = additional.filter((candidate) => readyIds.has(candidate.candidateId)).map((candidate, index) => slateEntry({
     candidate,
     placement: "additional",
     slot: index + 1,
@@ -111,7 +129,7 @@ export const composeReaderSummaryEditorialSlate = (params: {
   }));
   const selectedEntries = [...topEntries, ...additionalEntries];
   const selectedIds = new Set(
-    selectedEntries.map((entry) => entry.candidateId),
+    selected.map((entry) => entry.candidateId),
   );
   const capacityExclusions = representatives
     .filter((candidate) => !selectedIds.has(candidate.candidateId))
@@ -127,6 +145,7 @@ export const composeReaderSummaryEditorialSlate = (params: {
       reasonCodes: candidate.reasons,
     })),
     ...duplicateExclusions,
+    ...displayExclusions,
     ...capacityExclusions,
   ]
     .sort((left, right) =>

--- a/libs/summary/adapters/evidence/reader-summary-preparation-observer.spec.ts
+++ b/libs/summary/adapters/evidence/reader-summary-preparation-observer.spec.ts
@@ -4,7 +4,7 @@ import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-fe
 import { preparationValue } from "@social-monitor/relevance/features/rank-feed-items/promotion-snapshot-preparation";
 import type { SourceContentQualityReviewRequest } from "@social-monitor/relevance/ports";
 import { FixedClock, ok } from "@social-monitor/shared-kernel";
-import { fixture, review, cutoff, scope, query } from "../../../../test/support/promotion-content-assessment";
+import { fixture, accepting, cutoff, scope, query } from "../../../../test/support/promotion-content-assessment";
 import { StoryClusteringService } from "../../domain";
 import type { ReaderSummaryEvidenceSelectorPort, ReaderSummaryStoryRelationVerifierInput } from "../../ports";
 import { RelevanceReaderSummaryEvidenceSelector } from "./relevance-reader-summary-evidence.selector";
@@ -50,7 +50,7 @@ const setup = () => {
     })),
   };
   const reviewBatch = jest.fn(async (requests: readonly SourceContentQualityReviewRequest[]) =>
-    requests.map((request) => review(request)));
+    accepting.reviewBatch(requests));
   const ranker = new RankFeedItemsUseCase(feedItems, { findByUser: async () => {
     throw new Error("Unexpected profile");
   } } as never, new FixedClock(cutoff), undefined, undefined, undefined, { reviewBatch }, undefined,

--- a/libs/summary/adapters/evidence/relevance-reader-summary-adaptive-source.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-adaptive-source.spec.ts
@@ -13,6 +13,7 @@ import {
 } from "./relevance-reader-summary-evidence.selector";
 import { authoritativeReaderSummaryProviderMetadata } from
   "../../test-fixtures/reader-summary-authoritative-provider-metadata.fixture";
+import { withDisplayReadyRanking } from "./reader-summary-display-ready-ranking.spec-support";
 
 describe("RelevanceReaderSummaryEvidenceSelector adaptive source content", () => {
   it("uses source text already sealed by the authoritative ranking snapshot", async () => {
@@ -70,7 +71,10 @@ describe("RelevanceReaderSummaryEvidenceSelector adaptive source content", () =>
         ok({
           generatedAt: "2026-07-09T09:00:00.000Z",
           profileApplied: false,
-          items: [rankedItem],
+          items: withDisplayReadyRanking([rankedItem], {
+            tenantId: "tenant-adaptive-source",
+            workspaceId: "workspace-adaptive-source",
+          }),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;

--- a/libs/summary/adapters/evidence/relevance-reader-summary-display-readiness.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-display-readiness.spec.ts
@@ -1,0 +1,64 @@
+import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
+import type { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
+import { ok, tenantId, workspaceId } from "@social-monitor/shared-kernel";
+
+import { headlineScope, withAssessment } from "./reader-headline.spec-support";
+import { RelevanceReaderSummaryEvidenceSelector } from "./relevance-reader-summary-evidence.selector";
+import { mapRankedItem } from "./relevance-reader-summary-evidence-support";
+import {
+  emptyPromotionSnapshot,
+  FakeStoryRankingMetrics,
+  readerSummaryEvidenceTestClock as clock,
+  readerSummaryEvidenceTestPeriod as readerSummaryPeriod,
+  readerSummaryRankedItemFixture as rankedItem,
+} from "./relevance-reader-summary-evidence-test-fixtures";
+
+describe("RelevanceReaderSummaryEvidenceSelector display readiness", () => {
+  it("keeps only display-ready candidates in a mixed editorial slate", async () => {
+    const acceptedBase = rankedItem({
+      feedItemId: "accepted-hn",
+      providerKey: "hacker-news",
+      rank: 1,
+      score: 3,
+      sourceText: "Accepted HN source text with complete captured evidence.",
+    });
+    const acceptedAssessment = withAssessment(
+      mapRankedItem(acceptedBase, clock.now(), headlineScope),
+      acceptedBase.title,
+    ).readerHeadline;
+    const rankedItems = [
+      { ...acceptedBase, readerHeadline: acceptedAssessment },
+      rankedItem({
+        feedItemId: "unavailable-hn",
+        providerKey: "hacker-news",
+        rank: 2,
+        score: 2,
+        readerHeadline: { status: "unavailable", reasonCode: "not_assessed" },
+      }),
+    ];
+    const selector = new RelevanceReaderSummaryEvidenceSelector(
+      { execute: jest.fn(async () => ok({
+        generatedAt: clock.now().toISOString(),
+        profileApplied: false,
+        items: rankedItems,
+      })) } as unknown as RankFeedItemsUseCase,
+      {
+        readPromotionSnapshot: emptyPromotionSnapshot,
+        list: jest.fn(async () => ({ items: [] })),
+        findById: jest.fn(async () => null),
+      } as FeedItemReadRepositoryPort,
+      clock,
+      new FakeStoryRankingMetrics(),
+    );
+
+    const selection = await selector.select({
+      tenantId: tenantId(headlineScope.tenantId),
+      workspaceId: workspaceId(headlineScope.workspaceId),
+      scope: { type: "workspace" },
+      period: readerSummaryPeriod,
+      maxItems: 2,
+    });
+
+    expect(selection.editorialSlate?.orderedCandidateIds).toEqual(["accepted-hn"]);
+  });
+});

--- a/libs/summary/adapters/evidence/relevance-reader-summary-display-readiness.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-display-readiness.spec.ts
@@ -1,5 +1,10 @@
 import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
 import type { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
+import type { RankedFeedItemView } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.result";
+import { ReaderSummaryJob, workspaceReaderSummaryScope } from "../../domain";
+import { ExecuteReaderSummaryJobUseCase } from "../../features/execute-reader-summary-job/execute-reader-summary-job.use-case";
+import { FakeReaderSummaryJobRepository } from "../../features/execute-reader-summary-job/execute-reader-summary-job.spec-support";
+import { readerSummaryPromotionControl, NOOP_READER_SUMMARY_PROMOTION_METRICS } from "../../features/execute-reader-summary-job/reader-summary-promotion-control";
 import { ok, tenantId, workspaceId } from "@social-monitor/shared-kernel";
 
 import { headlineScope, withAssessment } from "./reader-headline.spec-support";
@@ -36,7 +41,26 @@ describe("RelevanceReaderSummaryEvidenceSelector display readiness", () => {
         readerHeadline: { status: "unavailable", reasonCode: "not_assessed" },
       }),
     ];
-    const selector = new RelevanceReaderSummaryEvidenceSelector(
+    const selector = selectorFor(rankedItems);
+
+    const selection = await selector.select({
+      tenantId: tenantId(headlineScope.tenantId),
+      workspaceId: workspaceId(headlineScope.workspaceId),
+      scope: { type: "workspace" },
+      period: readerSummaryPeriod,
+      maxItems: 2,
+    });
+
+    expect(selection.editorialSlate?.orderedCandidateIds).toEqual(["accepted-hn"]);
+    expect(selection.selectedEvidence.map((item) => item.feedItemId)).toEqual(["accepted-hn"]);
+    expect(selection.editorialSlate?.excluded).toContainEqual(expect.objectContaining({
+      candidateId: "unavailable-hn", reasonCodes: ["display_headline_unavailable"],
+    }));
+  });
+});
+
+function selectorFor(rankedItems: readonly RankedFeedItemView[]) {
+  return new RelevanceReaderSummaryEvidenceSelector(
       { execute: jest.fn(async () => ok({
         generatedAt: clock.now().toISOString(),
         profileApplied: false,
@@ -50,15 +74,69 @@ describe("RelevanceReaderSummaryEvidenceSelector display readiness", () => {
       clock,
       new FakeStoryRankingMetrics(),
     );
+}
 
-    const selection = await selector.select({
-      tenantId: tenantId(headlineScope.tenantId),
-      workspaceId: workspaceId(headlineScope.workspaceId),
-      scope: { type: "workspace" },
-      period: readerSummaryPeriod,
-      maxItems: 2,
-    });
+const query = {
+  tenantId: tenantId(headlineScope.tenantId),
+  workspaceId: workspaceId(headlineScope.workspaceId),
+  scope: workspaceReaderSummaryScope(), period: readerSummaryPeriod, maxItems: 2,
+};
+const invalid = () => rankedItem({
+  feedItemId: "eligible-invalid", providerKey: "hacker-news", rank: 1, score: 3,
+  readerHeadline: { status: "unavailable", reasonCode: "unresolved_qualifications" },
+});
+const ineligibleReady = () => {
+  const base = rankedItem({
+    feedItemId: "ineligible-ready", providerKey: "hacker-news", rank: 2, score: 2,
+    providerMetadata: { kind: "hacker_news_story", points: 0, comments: 0 },
+  });
+  return { ...base, readerHeadline: withAssessment(
+    mapRankedItem(base, clock.now(), headlineScope), base.title,
+  ).readerHeadline };
+};
 
-    expect(selection.editorialSlate?.orderedCandidateIds).toEqual(["accepted-hn"]);
+describe("display availability after authoritative eligibility", () => {
+  it("leaves genuinely ineligible inventory with an empty slate", async () => {
+    const selection = await selectorFor([ineligibleReady()]).select(query);
+    expect(selection.editorialSlate?.orderedCandidateIds).toEqual([]);
+    expect(selection.selectedEvidence).toEqual([]);
+  });
+
+  it.each([false, true])("fails early without model or publication (ineligible ready=%s)", async (includeReady) => {
+    const jobs = new FakeReaderSummaryJobRepository();
+    await jobs.save(ReaderSummaryJob.request({
+      ...query, id: "display-job", idempotencyKey: "display-job-key", requestedAt: clock.now(),
+    }));
+    const selector = selectorFor([
+      ...Array.from({ length: 6 }, (_, index) => ({
+        ...invalid(), feedItemId: `eligible-invalid-${index}`,
+        canonicalUrl: `https://example.test/invalid-${index}`,
+        title: `Independent signal ${index}`,
+        readerHeadline: { status: "unavailable" as const,
+          reasonCode: index === 5 ? "invalid_assessment" as const : "unresolved_qualifications" as const },
+      })),
+      ...(includeReady ? [ineligibleReady()] : []),
+    ]);
+    const model = { route: jest.fn(), generate: jest.fn(), classifyError: jest.fn() };
+    const artifacts = { save: jest.fn() };
+    const publications = { publish: jest.fn() };
+    const useCase = new ExecuteReaderSummaryJobUseCase(
+      jobs, artifacts as never, {} as never, selector, model as never,
+      publications as never, { generate: () => "unused-artifact" }, clock,
+      readerSummaryPromotionControl(NOOP_READER_SUMMARY_PROMOTION_METRICS),
+    );
+    const result = await useCase.execute({ ...query, readerSummaryJobId: "display-job" });
+    expect(result).toEqual({ ok: false, error: expect.objectContaining({
+      code: "external.dependency_unavailable",
+      details: expect.objectContaining({ kind: "reader_summary_display_headlines_unavailable",
+        selectedFeedItemIds: expect.arrayContaining(Array.from({ length: 6 }, (_, index) => `eligible-invalid-${index}`)) }),
+    }) });
+    expect(model.route).not.toHaveBeenCalled();
+    expect(model.generate).not.toHaveBeenCalled();
+    expect(model.classifyError).not.toHaveBeenCalled();
+    expect(artifacts.save).not.toHaveBeenCalled();
+    expect(publications.publish).not.toHaveBeenCalled();
+    expect((await jobs.findById({ ...query, readerSummaryJobId: "display-job" }))?.toSnapshot())
+      .toMatchObject({ status: "failed", failureReason: expect.stringContaining("selected headlines unavailable") });
   });
 });

--- a/libs/summary/adapters/evidence/relevance-reader-summary-display-readiness.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-display-readiness.spec.ts
@@ -61,37 +61,4 @@ describe("RelevanceReaderSummaryEvidenceSelector display readiness", () => {
 
     expect(selection.editorialSlate?.orderedCandidateIds).toEqual(["accepted-hn"]);
   });
-
-  it("leaves an all-unavailable editorial slate empty", async () => {
-    const selector = new RelevanceReaderSummaryEvidenceSelector(
-      { execute: jest.fn(async () => ok({
-        generatedAt: clock.now().toISOString(),
-        profileApplied: false,
-        items: [rankedItem({
-          feedItemId: "unavailable-hn",
-          providerKey: "hacker-news",
-          rank: 1,
-          score: 2,
-          readerHeadline: { status: "unavailable", reasonCode: "not_assessed" },
-        })],
-      })) } as unknown as RankFeedItemsUseCase,
-      {
-        readPromotionSnapshot: emptyPromotionSnapshot,
-        list: jest.fn(async () => ({ items: [] })),
-        findById: jest.fn(async () => null),
-      } as FeedItemReadRepositoryPort,
-      clock,
-      new FakeStoryRankingMetrics(),
-    );
-
-    const selection = await selector.select({
-      tenantId: tenantId(headlineScope.tenantId),
-      workspaceId: workspaceId(headlineScope.workspaceId),
-      scope: { type: "workspace" },
-      period: readerSummaryPeriod,
-      maxItems: 2,
-    });
-
-    expect(selection.editorialSlate?.orderedCandidateIds).toEqual([]);
-  });
 });

--- a/libs/summary/adapters/evidence/relevance-reader-summary-display-readiness.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-display-readiness.spec.ts
@@ -61,4 +61,37 @@ describe("RelevanceReaderSummaryEvidenceSelector display readiness", () => {
 
     expect(selection.editorialSlate?.orderedCandidateIds).toEqual(["accepted-hn"]);
   });
+
+  it("leaves an all-unavailable editorial slate empty", async () => {
+    const selector = new RelevanceReaderSummaryEvidenceSelector(
+      { execute: jest.fn(async () => ok({
+        generatedAt: clock.now().toISOString(),
+        profileApplied: false,
+        items: [rankedItem({
+          feedItemId: "unavailable-hn",
+          providerKey: "hacker-news",
+          rank: 1,
+          score: 2,
+          readerHeadline: { status: "unavailable", reasonCode: "not_assessed" },
+        })],
+      })) } as unknown as RankFeedItemsUseCase,
+      {
+        readPromotionSnapshot: emptyPromotionSnapshot,
+        list: jest.fn(async () => ({ items: [] })),
+        findById: jest.fn(async () => null),
+      } as FeedItemReadRepositoryPort,
+      clock,
+      new FakeStoryRankingMetrics(),
+    );
+
+    const selection = await selector.select({
+      tenantId: tenantId(headlineScope.tenantId),
+      workspaceId: workspaceId(headlineScope.workspaceId),
+      scope: { type: "workspace" },
+      period: readerSummaryPeriod,
+      maxItems: 2,
+    });
+
+    expect(selection.editorialSlate?.orderedCandidateIds).toEqual([]);
+  });
 });

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.spec.ts
@@ -1,3 +1,4 @@
+import { withDisplayReadyRanking } from "./reader-summary-display-ready-ranking.spec-support";
 import { FeedItem } from "@social-monitor/feed/domain";
 import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
 import type { RankFeedItemsCommand } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.command";
@@ -37,10 +38,10 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
       },
     });
     const selector = new RelevanceReaderSummaryEvidenceSelector(
-      { execute: jest.fn(async () => ok({
+      { execute: jest.fn(async (command: RankFeedItemsCommand) => ok({
         generatedAt: systemClock.now().toISOString(),
         profileApplied: false,
-        items: [item],
+        items: withDisplayReadyRanking([item], command),
       })) } as unknown as RankFeedItemsUseCase,
       {
         readPromotionSnapshot: emptyPromotionSnapshot,
@@ -132,7 +133,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
             blockedProviderCount: 0,
             signals: ["provider:reddit", "keyword:agent"],
           },
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;
@@ -243,7 +244,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;
@@ -304,10 +305,10 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         }));
       const metrics = new FakeStoryRankingMetrics();
       const selector = new RelevanceReaderSummaryEvidenceSelector(
-        { execute: jest.fn(async () => ok({
+        { execute: jest.fn(async (command: RankFeedItemsCommand) => ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: [primary, ...supplemental],
+          items: withDisplayReadyRanking([primary, ...supplemental], command),
         })) } as unknown as RankFeedItemsUseCase,
         {
           readPromotionSnapshot: emptyPromotionSnapshot,
@@ -384,7 +385,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;
@@ -443,7 +444,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;
@@ -480,15 +481,15 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
 
   it("does not refill ranked evidence from provider repository lanes", async () => {
     const rankFeedItems = {
-      execute: jest.fn(async () => ok({
+      execute: jest.fn(async (command: RankFeedItemsCommand) => ok({
         generatedAt: clock.now().toISOString(),
         profileApplied: false,
-        items: [rankedItem({
+        items: withDisplayReadyRanking([rankedItem({
           feedItemId: "ranked-hn-only",
           providerKey: "hacker-news",
           rank: 1,
           score: 3,
-        })],
+        })], command),
       })),
     } as unknown as RankFeedItemsUseCase;
     const feedItems: FeedItemReadRepositoryPort = {
@@ -549,7 +550,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;
@@ -649,10 +650,10 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
     ];
     const selector = new RelevanceReaderSummaryEvidenceSelector(
       {
-        execute: jest.fn(async () => ok({
+        execute: jest.fn(async (command: RankFeedItemsCommand) => ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: rankedItems,
+          items: withDisplayReadyRanking(rankedItems, command),
         })),
       } as unknown as RankFeedItemsUseCase,
       {
@@ -701,7 +702,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: true,
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;
@@ -806,7 +807,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;
@@ -872,7 +873,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;
@@ -959,7 +960,7 @@ describe("RelevanceReaderSummaryEvidenceSelector", () => {
         ok({
           generatedAt: clock.now().toISOString(),
           profileApplied: false,
-          items: rankedItems.slice(0, command.limit),
+          items: withDisplayReadyRanking(rankedItems.slice(0, command.limit), command),
         }),
       ),
     } as unknown as RankFeedItemsUseCase;

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
@@ -32,6 +32,9 @@ import {
   readerSummaryPeriodQuery,
 } from "./relevance-reader-summary-evidence-support";
 import {
+  displayReadyPromotionCandidates,
+} from "./reader-summary-display-ready-candidates";
+import {
   promotionPolicySelection,
   promotionSupportCandidates,
 } from "./relevance-reader-summary-promotion-candidates";
@@ -104,8 +107,11 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
       params.period,
       params.timestampPolicy,
     );
-    const promotionCandidates = expandedRankedItems.filter((item) =>
-      item.promotionFacts !== undefined && !isGitHubTrendingEvidence(item));
+    const promotionCandidates = displayReadyPromotionCandidates(
+      expandedRankedItems.filter((item) =>
+        item.promotionFacts !== undefined && !isGitHubTrendingEvidence(item)),
+      params,
+    );
     const promotionCandidateIds = new Set(
       promotionCandidates.map((item) => item.feedItemId),
     );

--- a/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-evidence.selector.ts
@@ -32,9 +32,6 @@ import {
   readerSummaryPeriodQuery,
 } from "./relevance-reader-summary-evidence-support";
 import {
-  displayReadyPromotionCandidates,
-} from "./reader-summary-display-ready-candidates";
-import {
   promotionPolicySelection,
   promotionSupportCandidates,
 } from "./relevance-reader-summary-promotion-candidates";
@@ -107,11 +104,8 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
       params.period,
       params.timestampPolicy,
     );
-    const promotionCandidates = displayReadyPromotionCandidates(
-      expandedRankedItems.filter((item) =>
-        item.promotionFacts !== undefined && !isGitHubTrendingEvidence(item)),
-      params,
-    );
+    const promotionCandidates = expandedRankedItems.filter((item) =>
+      item.promotionFacts !== undefined && !isGitHubTrendingEvidence(item));
     const promotionCandidateIds = new Set(
       promotionCandidates.map((item) => item.feedItemId),
     );
@@ -227,6 +221,7 @@ export class RelevanceReaderSummaryEvidenceSelector implements ReaderSummaryEvid
     const editorialSlate = composeReaderSummaryEditorialSlate({
       selection: deterministicPromotionSelection,
       candidates: promotionPolicyItems,
+      displayScope: params,
     });
     const deterministicFinalSelection = materializeReaderSummaryEditorialSlate({
       selection: deterministicPromotionSelection,

--- a/libs/summary/adapters/evidence/relevance-reader-summary-fresh-relation-composition.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-fresh-relation-composition.spec.ts
@@ -1,3 +1,5 @@
+import { acceptedFixtureReaderHeadline } from "../../test-fixtures/accepted-reader-headline";
+import { mapRankedItem } from "./relevance-reader-summary-evidence-support";
 import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
 import type { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
 import type { RankedFeedItemView } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.result";
@@ -81,10 +83,15 @@ const selectFreshPair = (
 
 const ranker = (items: readonly RankedFeedItemView[]): RankFeedItemsUseCase =>
   ({
-    execute: async () => ok({
+    execute: async (query: { tenantId: string; workspaceId: string }) => ok({
       generatedAt: now.toISOString(),
       profileApplied: false,
-      items,
+      items: items.map((item) => {
+        const assessed = acceptedFixtureReaderHeadline(mapRankedItem(item), {
+            tenantId: query.tenantId, workspaceId: query.workspaceId,
+          });
+        return { ...item, sourceText: assessed.sourceText, readerHeadline: assessed.readerHeadline };
+      }),
     }),
   }) as unknown as RankFeedItemsUseCase;
 

--- a/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-verification.spec.ts
+++ b/libs/summary/adapters/evidence/relevance-reader-summary-story-relation-verification.spec.ts
@@ -1,3 +1,5 @@
+import { acceptedFixtureReaderHeadline } from "../../test-fixtures/accepted-reader-headline";
+import { mapRankedItem } from "./relevance-reader-summary-evidence-support";
 import { buildReaderPostPromotionProjection } from "../../domain/services/reader-post-promotion-projection";
 import type { FeedItemReadRepositoryPort } from "@social-monitor/feed/ports";
 import type { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
@@ -701,11 +703,16 @@ describe("approved relation selector-to-writer catalog authority", () => {
 
 const ranker = (items: readonly RankedFeedItemView[]): RankFeedItemsUseCase =>
   ({
-    execute: async () =>
+    execute: async (query: { tenantId: string; workspaceId: string }) =>
       ok({
         generatedAt: now.toISOString(),
         profileApplied: false,
-        items,
+        items: items.map((item) => {
+          const assessed = acceptedFixtureReaderHeadline(mapRankedItem(item), {
+            tenantId: query.tenantId, workspaceId: query.workspaceId,
+          });
+          return { ...item, sourceText: assessed.sourceText, readerHeadline: assessed.readerHeadline };
+        }),
       }),
   }) as unknown as RankFeedItemsUseCase;
 

--- a/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.ts
+++ b/libs/summary/features/execute-reader-summary-job/execute-reader-summary-job.use-case.ts
@@ -261,7 +261,9 @@ export class ExecuteReaderSummaryJobUseCase {
       }
       return publicationResult;
     } catch (error) {
-      const failure = this.readerSummaryModel.classifyError(error);
+      const availabilityError = error instanceof DomainError &&
+        error.code === "external.dependency_unavailable" ? error : undefined;
+      const failure = availabilityError ?? this.readerSummaryModel.classifyError(error);
       const durableJob = await this.readerSummaryJobs.findById({
         tenantId: command.tenantId,
         workspaceId: command.workspaceId,
@@ -291,9 +293,10 @@ export class ExecuteReaderSummaryJobUseCase {
         return readerSummaryExecutionClaimLost();
       }
 
+      if (availabilityError !== undefined) return err(availabilityError);
       return err(
         new DomainError("external.dependency_unavailable", failure.message, {
-          kind: failure.kind,
+          kind: "kind" in failure ? failure.kind : "unknown",
         }),
       );
     }

--- a/libs/summary/test-fixtures/synthetic-publication-assessment.spec-support.ts
+++ b/libs/summary/test-fixtures/synthetic-publication-assessment.spec-support.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   PromotionReviewContext,
   SourceContentQualityReviewerPort,
@@ -49,6 +50,16 @@ implements SourceContentQualityReviewerPort {
         reason: "Explicit synthetic publication scenario; not model accuracy evidence.",
         assessment: {
           binding: request.promotion!,
+          headlineInput: Object.freeze({ request,
+            reviewedInputDigest: createHash("sha256").update(JSON.stringify({
+              candidateId: request.candidateId, providerKey: request.providerKey,
+              context: request.promotion, title: request.title, body: request.bodyPreview ?? "",
+            })).digest("hex"),
+            title: request.title, body: request.bodyPreview ?? "" }),
+          readerHeadline: { status: "available", kind: "claim", text: request.title, confidence: 0.95,
+            support: [{ field: "title", start: 0, end: request.title.length, quote: request.title }],
+            qualifications: [], wholeInput: { titleLength: request.title.length,
+              bodyLength: (request.bodyPreview ?? "").length, qualificationJudgment: "none" } },
           resolvedSoftFlags: [],
           evidence: [{
             field: scenario.evidenceField,

--- a/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
+++ b/scripts/lib/reader-summary-daily-story-relation-wiring.spec.ts
@@ -3,7 +3,7 @@ import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-fe
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { accepting } from "../../test/support/promotion-content-assessment";
+import { accepting, review } from "../../test/support/promotion-content-assessment";
 import { InMemoryFeedItemReadRepository } from
   "@social-monitor/feed/adapters/persistence/in-memory-feed-item-read.repository";
 import { FeedItem } from "@social-monitor/feed/domain";
@@ -49,6 +49,10 @@ describe("reader summary daily story relation production wiring", () => {
     const directory = mkdtempSync(join(tmpdir(), "headline-wiring-"));
     try {
       const options = { sameStory: false, attested: true,
+        // Keep one deliberately headline-unassessed row beside the valid lead.
+        qualityReviewer: { reviewBatch: async (requests: Parameters<typeof accepting.reviewBatch>[0]) =>
+          Promise.all(requests.map(async (request) => request.candidateId === "typescript-hn"
+            ? (await accepting.reviewBatch([request]))[0]! : review(request))) },
         secondTitle: "Go rewrite of the TypeScript compiler reaches developers" };
       const plain = await selectDailyEvidence(options);
       const rankCommandCapture = { captured: jest.fn(), failed: jest.fn() };
@@ -62,7 +66,10 @@ describe("reader summary daily story relation production wiring", () => {
       await persisted;
       const rows = JSON.parse(readFileSync(path, "utf8"));
       expect(rows).toHaveLength(2);
-      expect(rows.every((row: { reasonOrigin: string }) => row.reasonOrigin === "not_assessed")).toBe(true);
+      expect(rows).toEqual(expect.arrayContaining([
+        expect.objectContaining({ reviewedTitleUtf16: 39, reasonOrigin: "accepted" }),
+        expect.objectContaining({ reviewedTitleUtf16: 56, reasonOrigin: "not_assessed" }),
+      ]));
       expect(rankCommandCapture.captured.mock.calls[0]![0]).not.toHaveProperty("observeHeadlineDiagnostic");
       const failed = await selectDailyEvidence({ ...options,
         headlineDiagnosticArtifact: { path: directory, attemptId: "synthetic-attempt" } });
@@ -394,7 +401,7 @@ describe("reader summary daily story relation production wiring", () => {
 
 const selectDailyEvidence = async (input: Pick<
   Parameters<typeof createReaderSummaryDailyCapturePublicationWiring>[0],
-  "preparationObserver" | "relationCapture" | "rankCommandCapture" | "headlineDiagnosticArtifact" | "headlineDiagnosticPersist"
+  "preparationObserver" | "relationCapture" | "rankCommandCapture" | "headlineDiagnosticArtifact" | "headlineDiagnosticPersist" | "qualityReviewer"
 > & {
   readonly sameStory: boolean;
   readonly attested: boolean;
@@ -417,7 +424,7 @@ const selectDailyEvidence = async (input: Pick<
     headlineDiagnosticPersist: input.headlineDiagnosticPersist,
     preparationObserver: input.preparationObserver,
     relationCapture: input.relationCapture,
-    qualityReviewer: accepting, // Explicit synthetic content evidence; this suite tests story relations.
+    qualityReviewer: input.qualityReviewer ?? accepting, // Explicit synthetic content evidence; this suite tests story relations.
     configuredInterests: { readCurrent: async (scope) => ({ kind: "available" as const, interest: { ...scope, query: "TypeScript Cursor Claude coding agents" } }) },
     replay: null,
     feedItems: feedRepository({

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
@@ -1,3 +1,4 @@
+import { reconciliationFixture } from "./reader-summary-refresh-reconciliation.spec-support";
 import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
 import { FeedItem } from "@social-monitor/feed/domain";
 import { activeReaderSummaryPurposes } from "@social-monitor/summary/adapters/model/active-reader-summary-generation-profile";
@@ -283,13 +284,15 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
 
   it.each(["sanitized", "truncated"])("accepts legitimate canonical %s text binding", async (kind) => {
     const publish = FeedItem.publish.bind(FeedItem);
-    jest.spyOn(FeedItem, "publish").mockImplementation((input) => publish({ ...input,
+    jest.spyOn(FeedItem, "publish").mockImplementation((input) => publish(input.id.startsWith("synthetic-extra-") ? input : { ...input,
       title: kind === "sanitized" ? `  ${input.title}  ` : input.title,
       bodyPreview: kind === "sanitized" ? `${input.bodyPreview}\n token=synthetic-redaction-fixture`
         : `${input.bodyPreview} `.repeat(160),
     }));
-    const test = await selectorWiring();
-    const selection = await test.selectComplete();
+    const test = kind === "truncated" ? await reconciliationFixture() : await selectorWiring();
+    const selection = kind === "truncated"
+      ? await (test as Awaited<ReturnType<typeof reconciliationFixture>>).reconciliationSelection()
+      : await test.selectComplete();
     expect(selection.selectedEvidence.length).toBeGreaterThan(0);
     if (kind === "sanitized") expect(selection.selectedEvidence.every((item) =>
       !item.bodyPreview?.includes("synthetic-redaction-fixture"))).toBe(true);
@@ -322,16 +325,16 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
                 repository: { fullName: "synthetic/compiler-tools", totalStars: 20_000, forksCount: 500 },
                 trending: { rank: 1, starsGained: 2_000, window: "daily" } },
         }));
-      const test = await selectorWiring();
-      expect(test.preflight.assessmentCandidateCount).toBe(1);
-      const selection = await test.selectComplete();
+      const test = await reconciliationFixture();
+      expect(test.preflight.assessmentCandidateCount).toBe(2);
+      const selection = await test.reconciliationSelection();
       const github = selection.selectedEvidence.find((item) => item.feedItemId === "synthetic-github")!;
       expect(github).toBeDefined();
       expect(github.contentQuality!.reason).not.toMatch(/^promotion_assessment/u);
       const calls = test.commands.filter((command) => command.purpose === purpose);
       expect(calls).toHaveLength(1);
-      expect(JSON.parse(calls[0]!.prompt).candidates.map((item: { candidateId: string }) => item.candidateId))
-        .toEqual(["synthetic-x"]);
+      expect(JSON.parse(calls[0]!.prompt).candidates.map((item: { candidateId: string }) => item.candidateId).sort())
+        .toEqual(["synthetic-extra-0", "synthetic-x"]);
       const publication = publicationProbe(test.runtime, selection);
       await publication.attempt();
       expect(publication.publish).toHaveBeenCalledTimes(1);
@@ -356,7 +359,7 @@ describe("historical unpaid preflight to guarded pool assessment to canonical se
         feedItemId: identity === "feed" ? social.feedItemId : "never-reviewed", sourceItemId: social.sourceItemId,
         sourceBindingId: social.sourceBindingId, interestId: social.interestId,
       };
-      expect(() => test.assessment.assertComplete(1, { ...selection, selectedEvidence: [changed] }))
+      expect(() => test.assessment.assertComplete(2, { ...selection, selectedEvidence: [changed] }))
         .toThrow(/reconciliation/u);
       expect(() => test.runtime.assertUsable()).toThrow(/reconciliation/u);
     });

--- a/scripts/lib/reader-summary-new-input-refresh-headline-diagnostic.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-headline-diagnostic.spec.ts
@@ -1,3 +1,4 @@
+import { fixtureHeadline } from "../../test/support/promotion-content-assessment";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
@@ -23,10 +24,10 @@ describe("fresh refresh headline diagnostic reachability", () => {
     const run = async (mode: "off" | "reserved" | "existing") => {
       const fixture = pairedFixture({ capture: false, supplemental: 0, response: (command) => {
         const { candidates } = JSON.parse(command.prompt);
-        return { reviews: candidates.map((c: { candidateId: string; bindingId: string; untrustedSource: { bodyPreview: string } }) => ({
+        return { reviews: candidates.map((c: { candidateId: string; bindingId: string; untrustedSource: { title: string; bodyPreview: string } }) => ({
           candidateId: c.candidateId, bindingId: c.bindingId, decision: "promote", confidence: 0.96,
           qualityScore: 0.85, interestRelevanceScore: 0.95, engagementIntegrityScore: 0.95,
-          flags: [], reason: "Synthetic parser result", resolvedSoftFlags: [],
+          flags: [], reason: "Synthetic parser result", resolvedSoftFlags: [], readerHeadline: fixtureHeadline(c.untrustedSource),
           evidence: [{ field: "bodyPreview", start: 0, end: c.untrustedSource.bodyPreview.length, quote: c.untrustedSource.bodyPreview }],
         })) };
       } });

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.spec-support.ts
@@ -1,3 +1,4 @@
+import { fixtureHeadline } from "../../test/support/promotion-content-assessment";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -87,11 +88,11 @@ export function pairedFixture(options: { capture?: boolean; path?: string; suppl
 export function syntheticOutput(command: AgentRuntimeTaskCommand, relationCase = false): Record<string, unknown> {
   if (command.purpose === sourceContentAssessmentPurpose) {
     const { candidates } = JSON.parse(command.prompt) as { candidates: { candidateId: string; bindingId: string;
-      untrustedSource: { bodyPreview: string } }[] };
+      untrustedSource: { title: string; bodyPreview: string } }[] };
     return { reviews: candidates.map((c) => ({ candidateId: c.candidateId, bindingId: c.bindingId,
       decision: c.candidateId === "reject" && !relationCase ? "reject" : c.candidateId === "abstain" ? "needs_context" : "promote",
       confidence: 0.96, qualityScore: 0.85, interestRelevanceScore: 0.95, engagementIntegrityScore: 0.95,
-      flags: [], reason: "Synthetic concrete parser result", resolvedSoftFlags: [],
+      flags: [], reason: "Synthetic concrete parser result", resolvedSoftFlags: [], readerHeadline: fixtureHeadline(c.untrustedSource),
       evidence: [{ field: "bodyPreview", start: 0, end: c.untrustedSource.bodyPreview.length, quote: c.untrustedSource.bodyPreview }] })) };
   }
   const { pairs } = JSON.parse(command.prompt) as { pairs: { leftFeedItemId: string; rightFeedItemId: string }[] };

--- a/scripts/lib/reader-summary-new-input-refresh-paired-export.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-paired-export.spec.ts
@@ -1,3 +1,4 @@
+import { fixtureHeadline } from "../../test/support/promotion-content-assessment";
 import type * as NodeFs from "node:fs";
 import { AgentRuntimeReaderSummaryStoryRelationVerifier, resolveAgentRuntimeReaderSummaryStoryRelationVerifierOptions } from
   "@social-monitor/summary/adapters/model/agent-runtime-reader-summary-story-relation-verifier.adapter";
@@ -68,11 +69,11 @@ describe("synthetic bounded refresh paired export", () => {
     const fixture = setup({ response: (command) => {
       if (command.purpose !== sourceContentAssessmentPurpose) return syntheticOutput(command);
       const { candidates } = JSON.parse(command.prompt) as { candidates: { candidateId: string; bindingId: string;
-        untrustedSource: { bodyPreview: string } }[] };
+        untrustedSource: { title: string; bodyPreview: string } }[] };
       return { reviews: candidates.map((c) => ({ candidateId: c.candidateId, bindingId: `${c.bindingId}-drifted`,
         decision: c.candidateId === "reject" ? "reject" : c.candidateId === "abstain" ? "needs_context" : "promote",
         confidence: 0.96, qualityScore: 0.85, interestRelevanceScore: 0.95, engagementIntegrityScore: 0.95,
-        flags: [], reason: "Synthetic concrete parser result", resolvedSoftFlags: [],
+        flags: [], reason: "Synthetic concrete parser result", resolvedSoftFlags: [], readerHeadline: fixtureHeadline(c.untrustedSource),
         evidence: [{ field: "bodyPreview", start: 0, end: c.untrustedSource.bodyPreview.length,
           quote: c.untrustedSource.bodyPreview }] })) };
     } });

--- a/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-selector-composition.spec-support.ts
@@ -1,3 +1,4 @@
+import { fixtureHeadline } from "../../test/support/promotion-content-assessment";
 import type { ConfiguredInterestScope } from "@social-monitor/relevance/ports";
 import { createRefreshAssessmentReviewer, withRefreshAssessmentCompletion } from "./reader-summary-new-input-refresh-assessment";
 import { sourceContentAssessmentPurpose } from "./reader-summary-new-input-refresh-assessment-runtime";
@@ -22,6 +23,7 @@ export async function selectorWiring(input: {
   guardAdapter?: boolean;
   sameStory?: boolean;
   extraCandidates?: number;
+  displayReadyLead?: boolean;
   assertSource?: () => void;
   onAttestation?: (value: VerifiedReaderSummaryExecutionAttestation) => void | Promise<void>;
   onEvent?: (value: SelectorEvent) => void;
@@ -49,7 +51,7 @@ export async function selectorWiring(input: {
     runtime.assertUsable();
     await input.onAttestation?.(value);
   }) };
-  const feed = selectorFeed(input.sameStory, input.extraCandidates);
+  const feed = selectorFeed(input.sameStory, input.extraCandidates, input.displayReadyLead);
   const configuredInterests = { readCurrent: async (scope: ConfiguredInterestScope) =>
     ({ kind: "available" as const, interest: { ...scope, query: "AI developer tools" } }) };
   const clock = new FixedClock(refreshNow);
@@ -66,7 +68,7 @@ export async function selectorWiring(input: {
   });
   const selector = guard.selector(canonical.evidenceSelector);
   const query = { tenantId: tenantId(manifest.tenantId), workspaceId: workspaceId(manifest.workspaceId),
-    scope: { type: "workspace" as const }, period, maxItems: 2, observedThrough: new Date(manifest.observedThrough) };
+    scope: { type: "workspace" as const }, period, maxItems: input.displayReadyLead ? 3 : 2, observedThrough: new Date(manifest.observedThrough) };
   return { runtime, guard, commands, events, sink, preflight, assessment, model: buildRefreshModelWiring({}, runtime, sink),
     selectComplete: () => guard.selector(withRefreshAssessmentCompletion(
       canonical.evidenceSelector, assessment, preflight.assessmentCandidateCount)).select(query),
@@ -85,7 +87,7 @@ export function selectorOutput(command: AgentRuntimeTaskCommand, sameStory = fal
     confidenceScore: 0.99, rationale: "Synthetic independent evidence" })) };
 }
 
-function selectorFeed(sameStory = false, extraCandidates = 0) {
+function selectorFeed(sameStory = false, extraCandidates = 0, displayReadyLead = false) {
   const m = refreshManifest();
   const feed = new InMemoryFeedItemReadRepository();
   for (const [id, providerKey, title, bodyPreview, providerMetadata] of [
@@ -108,11 +110,12 @@ function selectorFeed(sameStory = false, extraCandidates = 0) {
       providerMetadata: { ...providerMetadata, interestQuerySnapshot: { query: "TypeScript, developer tools" } },
     }));
   }
-  for (let i = 0; i < extraCandidates; i++) {
+  for (let i = 0; i < extraCandidates + (displayReadyLead ? 1 : 0); i++) {
     feed.upsert(FeedItem.publish({ id: `synthetic-extra-${i}`, tenantId: tenantId(m.tenantId),
       workspaceId: workspaceId(m.workspaceId), interestId: "interest-ai", sourceItemId: `extra-source-${i}`,
       sourceBindingId: "extra-binding", providerKey: "hacker-news", canonicalUrl: `https://example.test/extra/${i}`,
-      title: "TypeScript compiler release improves AI coding agents",
+      title: displayReadyLead ? "Quartz debugger adds memory inspection for isolated sandboxes"
+        : "TypeScript compiler release improves AI coding agents",
       bodyPreview: "The TypeScript compiler release improves AI coding agents with a documented sandbox interface.",
       publishedAt: new Date("2026-09-03T08:00:00Z"), observedAt: new Date("2026-09-03T08:01:00Z"),
       providerMetadata: { kind: "hacker_news_story", points: 500, comments: 10 },
@@ -149,6 +152,6 @@ export function refreshSelectorAssessmentOutput(command: AgentRuntimeTaskCommand
       decision: "promote", confidence: 0.96, qualityScore: 0.94,
       interestRelevanceScore: 0.95, engagementIntegrityScore: 0.95,
       flags: [], reason: "Captured compiler details concern the configured developer tools intent",
-      evidence: [{ field: "bodyPreview", start: 0, end: quote.length, quote }], resolvedSoftFlags: [] };
+      evidence: [{ field: "bodyPreview", start: 0, end: quote.length, quote }], resolvedSoftFlags: [], readerHeadline: fixtureHeadline(candidate.untrustedSource) };
   }) };
 }

--- a/scripts/lib/reader-summary-new-input-refresh-source-text-provenance.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-source-text-provenance.spec.ts
@@ -1,6 +1,6 @@
+import { reconciliationFixture } from "./reader-summary-refresh-reconciliation.spec-support";
 import { FeedItem, type FeedItemProps } from "@social-monitor/feed/domain";
 import { buildReaderPostPromotionTitle, readerPostAvailableSourceText } from "@social-monitor/summary/domain/services/reader-post-promotion-title";
-import { selectorWiring } from "./reader-summary-new-input-refresh-selector-composition.spec-support";
 import { publicationProbe } from "./reader-summary-new-input-refresh-model-composition.spec-support";
 import { sourceContentAssessmentPurpose as purpose } from "./reader-summary-new-input-refresh-assessment-runtime";
 
@@ -10,8 +10,8 @@ afterEach(() => jest.restoreAllMocks());
 // Reused from the independent integrated-review probe, with rejection required.
 it.each(providers)("rejects the independent sourceText-only bypass for %s", async (providerKey) => {
   canonicalProvider(providerKey);
-  const test = await selectorWiring();
-  const selection = await test.selectComplete();
+  const test = await reconciliationFixture();
+  const selection = await test.reconciliationSelection();
   const original = selection.selectedEvidence.find((item) => item.providerKey === providerKey)!;
   expect(original).toBeDefined();
   const replacement = "Unreviewed replacement: the compiler vendor removed all sandbox isolation guarantees.";
@@ -30,8 +30,8 @@ it.each(providers)("rejects the independent sourceText-only bypass for %s", asyn
 
 it.each(providers.flatMap((provider) => ["canonical", "sanitized", "truncated"].map((kind) => [provider, kind])))("accepts canonical %s %s source representation", async (providerKey, kind) => {
     canonicalProvider(providerKey, kind);
-    const test = await selectorWiring();
-    const selection = await test.selectComplete();
+    const test = await reconciliationFixture();
+    const selection = await test.reconciliationSelection();
     const item = selection.selectedEvidence.find((evidence) => evidence.providerKey === providerKey)!;
     const trusted = test.preflight.canonicalEvidence.find((evidence) => evidence.feedItemId === item.feedItemId)!;
     expect(item.sourceText).toBe(trusted.sourceText);
@@ -58,8 +58,8 @@ it.each(providers.flatMap((provider) => ["canonical", "sanitized", "truncated"].
 
 it.each(providers.flatMap((provider) => ["tail", "removed", "snapshot mutation"].map((kind) => [provider, kind])))("rejects %s sourceText %s drift against the immutable snapshot", async (providerKey, kind) => {
     canonicalProvider(providerKey, "truncated");
-    const test = await selectorWiring();
-    const selection = await test.selectComplete();
+    const test = await reconciliationFixture();
+    const selection = await test.reconciliationSelection();
     const original = selection.selectedEvidence.find((item) => item.providerKey === providerKey)!;
     expect(original.sourceText!.length).toBeGreaterThan(12_000);
     const sourceText = kind === "removed" ? undefined : `${original.sourceText} Unreviewed tail claim.`;
@@ -97,7 +97,7 @@ function canonicalProvider(providerKey: string, kind = "canonical") {
 
   jest.spyOn(FeedItem, "publish").mockImplementation((input) => {
     const canonical = providerInput(input);
-    return publish({ ...canonical,
+    return publish(input.id.startsWith("synthetic-extra-") ? input : { ...canonical,
       bodyPreview: kind === "sanitized" ? `${canonical.bodyPreview}\n password=synthetic-redaction-fixture`
         : kind === "truncated" ? `${canonical.bodyPreview} `.repeat(160) : canonical.bodyPreview,
     });

--- a/scripts/lib/reader-summary-promotion-assessment-composition.spec.ts
+++ b/scripts/lib/reader-summary-promotion-assessment-composition.spec.ts
@@ -15,7 +15,7 @@ describe("fresh publication promotion assessment composition", () => {
       ? jest.spyOn(OpenAiSourceContentQualityReviewerAdapter.prototype, "reviewBatch").mockImplementation(accepting.reviewBatch)
       : jest.spyOn(AgentRuntimeSourceContentQualityReviewerAdapter.prototype, "reviewBatch");
     const execute = jest.fn(async (request: Parameters<typeof attestRefreshExecution>[0]) =>
-      attestRefreshExecution(request, outputFor(request)));
+      attestRefreshExecution(request, outputFor(request, true)));
     const client = refreshTestRuntimeClient(execute);
     const item = fixture("composition", "reddit", { publishedAt: new Date(cutoff.getTime() - 1000) });
     const canonical = classifyFeedPromotionEligibility(item.toSnapshot());

--- a/scripts/lib/reader-summary-refresh-reconciliation.spec-support.ts
+++ b/scripts/lib/reader-summary-refresh-reconciliation.spec-support.ts
@@ -1,0 +1,33 @@
+import { RankFeedItemsUseCase } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.use-case";
+import type { RankedFeedItemView } from "@social-monitor/relevance/features/rank-feed-items/rank-feed-items.result";
+import type { SummaryEvidenceItem } from "@social-monitor/summary/domain";
+import { mapRankedItem } from "@social-monitor/summary/adapters/evidence/relevance-reader-summary-evidence-support";
+import { selectorWiring } from "./reader-summary-new-input-refresh-selector-composition.spec-support";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+
+// Exercise reconciliation separately from editorial display eligibility. The real
+// selector must succeed with a source-bound short lead. Its excluded long/repo
+// candidates are then submitted unchanged to the binding/publication-guard probe;
+// this does not assert that those candidates are display-ready editorial leads.
+export async function reconciliationFixture() {
+  const rank = jest.spyOn(RankFeedItemsUseCase.prototype, "execute");
+  const test = await selectorWiring({ displayReadyLead: true });
+  return { ...test, reconciliationSelection: async () => {
+    const selection = await test.selectComplete();
+    expect(selection.selectedEvidence.some((item) =>
+      item.feedItemId === "synthetic-extra-0" && item.readerHeadline?.status === "accepted")).toBe(true);
+    const ranked = await rank.mock.results.at(-1)!.value;
+    if (!ranked.ok) throw ranked.error;
+    const manifest = refreshManifest();
+    const candidates = ranked.value.items.map((item: RankedFeedItemView) => mapRankedItem(item,
+      new Date(manifest.observedThrough), manifest));
+    const evidence = [...selection.selectedEvidence, ...candidates.filter((item: SummaryEvidenceItem) =>
+      !selection.selectedEvidence.some((selected) => selected.feedItemId === item.feedItemId))];
+    for (const item of evidence.filter((item) => item.providerKey === "github-repo-radar")) {
+      expect(item.readerHeadline).toEqual({ status: "unavailable", reasonCode: "not_assessed" });
+    }
+    const reconciliation = { ...selection, selectedEvidence: evidence };
+    test.assessment.assertComplete(test.preflight.assessmentCandidateCount, reconciliation);
+    return reconciliation;
+  } };
+}

--- a/scripts/lib/source-content-assessment-runtime.spec-support.ts
+++ b/scripts/lib/source-content-assessment-runtime.spec-support.ts
@@ -1,14 +1,15 @@
+import { fixtureHeadline } from "../../test/support/promotion-content-assessment";
 import type { AgentRuntimeExecutionRequest } from "../../apps/agent-runtime/src/agent-runtime-executor.port";
 
-export const outputFor = (request: AgentRuntimeExecutionRequest) => {
+export const outputFor = (request: AgentRuntimeExecutionRequest, withHeadline = false) => {
   const input = JSON.parse(request.prompt) as { candidates: {
-    candidateId: string; bindingId: string; untrustedSource: { bodyPreview: string };
+    candidateId: string; bindingId: string; untrustedSource: { title: string; bodyPreview: string };
   }[] };
   return { reviews: input.candidates.map((candidate) => ({
     candidateId: candidate.candidateId, bindingId: candidate.bindingId,
     decision: "promote", confidence: 0.95, qualityScore: 0.8,
     interestRelevanceScore: 0.95, engagementIntegrityScore: 0.95, flags: [],
-    reason: "Synthetic plumbing evidence", resolvedSoftFlags: [],
+    reason: "Synthetic plumbing evidence", resolvedSoftFlags: [], ...(withHeadline ? { readerHeadline: fixtureHeadline(candidate.untrustedSource) } : {}),
     evidence: [{ field: "bodyPreview", start: 0, end: candidate.untrustedSource.bodyPreview.length,
       quote: candidate.untrustedSource.bodyPreview }],
   })) };

--- a/test/configured-interest-promotion.integration.spec.ts
+++ b/test/configured-interest-promotion.integration.spec.ts
@@ -11,7 +11,7 @@ import { context, feedItem, nativeMetadata, now, scope, v2Candidate } from "@soc
 import { SyntheticPublicationAssessmentReviewer } from
   "@social-monitor/summary/test-fixtures/synthetic-publication-assessment.spec-support";
 
-const bread = feedItem({ title: "Local bakers share their best bread recipes with neighbors",
+const bread = feedItem({ bodyPreview: "Local bakers share their best bread recipes with neighbors", title: "Local bakers share their best bread recipes with neighbors",
   providerMetadata: { ...nativeMetadata, ...context,
     query: "best", searchQuery: "best", topic: "best", topics: ["best"],
     interestQuerySnapshot: { ...context.interestQuerySnapshot, query: "best" },
@@ -33,16 +33,16 @@ const repository = (items: readonly FeedItem[], supplemental: readonly FeedItem[
   }),
 });
 // Only these explicit synthetic headline/intent pairs have positive judgments.
-// No unseen recipe/article body is invented, and unrelated intent stays pending.
+// The synthetic capture repeats the title; unrelated intent stays pending.
 const breadHeadlineReviewer = () => new SyntheticPublicationAssessmentReviewer(
   ["best", "bread recipes"].map((trustedIntent) => ({
     candidateId: "synthetic-feed", providerKey: "hacker-news",
     title: "Local bakers share their best bread recipes with neighbors",
-    bodyPreview: "", evidenceField: "title",
+    bodyPreview: "Local bakers share their best bread recipes with neighbors", evidenceField: "title",
     scope: {
       tenantId: scope.tenantId, workspaceId: scope.workspaceId,
       interestId: "synthetic-interest", sourceBindingId: "synthetic-binding",
-      sourceItemId: "synthetic-source", trustedIntent, availability: "title_only",
+      sourceItemId: "synthetic-source", trustedIntent, availability: "body_present",
     },
   })),
 );

--- a/test/support/promotion-content-assessment.ts
+++ b/test/support/promotion-content-assessment.ts
@@ -1,3 +1,4 @@
+import { bindPromotionAssessment, promotionWireCandidate } from "@social-monitor/relevance/adapters/model/promotion-review-wire";
 import { classifyFeedPromotionEligibility, FeedItem, rankReaderPromotionV2 } from "@social-monitor/feed/domain";
 import { FixedClock, tenantId, workspaceId, type Clock, type JsonObject } from "@social-monitor/shared-kernel";
 import { mapRankedItem } from "@social-monitor/summary/adapters/evidence/relevance-reader-summary-evidence-support";
@@ -67,4 +68,16 @@ export const run = async (items: readonly FeedItem[], reviewer?: SourceContentQu
   const candidates = result.value.items.map((item) => readerSummaryPromotionV2Candidate(mapRankedItem(item, cutoff), selection)!);
   return { items: result.value.items, candidates, ranking: rankReaderPromotionV2(candidates) };
 };
-export const accepting: SourceContentQualityReviewerPort = { reviewBatch: async (requests) => requests.map((r) => review(r)) };
+// Positive plumbing fixtures attest the exact reviewed title and complete body.
+export const fixtureHeadline = (source: { title: string; bodyPreview?: string }) => ({
+  status: "available", kind: "claim", text: source.title, confidence: 0.95,
+  support: [{ field: "title", start: 0, end: source.title.length, quote: source.title }],
+  qualifications: [], wholeInput: { titleLength: source.title.length,
+    bodyLength: (source.bodyPreview ?? "").length, qualificationJudgment: "none" },
+});
+export const accepting: SourceContentQualityReviewerPort = { reviewBatch: async (requests) => requests.map((r) => {
+  const result = review(r);
+  return { ...result, assessment: bindPromotionAssessment({ bindingId: promotionWireCandidate(r).bindingId,
+    evidence: result.assessment!.evidence as unknown as JsonObject[], resolvedSoftFlags: [],
+    readerHeadline: fixtureHeadline(r) }, r) };
+}) };


### PR DESCRIPTION
## Problem

A production Reader Summary selected six eligible leads whose display-headline assessments were unavailable. The model still ran, then the publication gate rejected the artifact with `Selected reader headline is unavailable or its source identity is invalid`.

## Result

- eligibility, story grouping, provider caps and ranking run before display readiness
- mixed selected slates keep only display-ready selected leads without reranking or backfilling
- excluded selected leads retain explicit `display_headline_unavailable` provenance
- an all-unavailable selected slate fails before model execution with `reader_summary_display_headlines_unavailable`
- genuinely empty eligible input still produces the existing honest NO_SIGNAL result
- publication, identity, threshold and provenance gates remain unchanged

## Production evidence

- deployed baseline: `ac16764a82c2c26cf76c46309e4a9d348db849d3`
- failed rolling run: `20260912T120209000Z`
- job: `b554a1fa-2123-466d-957b-c0d841cc0f5a`
- artifact: `7149acdf-3aad-48fd-8047-f184ce042e4d`
- selected display states: five `unresolved_qualifications`, one `invalid_assessment`

## Validation

- focused worker validation: 181 tests across 7 suites
- architecture, code-quality and source line-cap checks passed
- `git diff --check` passed
- exact-head CI runs on `38ece6da02326a466208c9b8dba48f967b1cedbc`
- independent exact-head review is tracked before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reader summaries now exclude selected headlines that are unavailable for display.
  - Unavailable candidates are recorded as exclusions instead of appearing in the editorial slate.
  - Summary generation stops early with a clear dependency-unavailable failure when no selected headlines can be displayed.
  - Empty candidate batches continue to return an empty result without an error.
  - Existing dependency-unavailable errors are preserved, improving consistency in job failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->