### PR TITLE
fix(summary): skip supplemental-only refresh work

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.spec.ts
@@ -9,6 +9,30 @@ import type { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-m
 import { selectorOutput, selectorWiring } from "./reader-summary-new-input-refresh-selector-composition.spec-support";
 import { publicationProbe } from "./reader-summary-new-input-refresh-model-composition.spec-support";
 import { refreshNow } from "./reader-summary-new-input-refresh.spec-support";
+import { xEvidence } from "@social-monitor/summary/adapters/evidence/reader-summary-editorial-slate.spec-support";
+
+describe("refresh preflight persisted primary evidence", () => {
+  const source = xEvidence("synthetic-primary", 0);
+  const primary = { ...source, contentQuality: { ...source.contentQuality!,
+    decision: "promote", reason: "promotion_assessment:promote" } };
+  const supplemental = { ...primary, feedItemId: "synthetic-trending", providerKey: "github-trending-page",
+    promotionFacts: { ...primary.promotionFacts!, contentKind: "github_trending" as const } };
+  const hardGated = { ...primary, contentQuality: { ...primary.contentQuality!,
+    eligibleForSummary: false, needsLlmReview: false, decision: "reject",
+    reason: "promotion_assessment_not_requested:hard_gate" } };
+
+  it("rejects persisted selectable supplemental-only evidence", () => {
+    expect(supplemental.contentQuality).toMatchObject({ eligibleForSummary: true, needsLlmReview: false });
+    expect(hasRefreshSelectableEvidence([supplemental])).toBe(false);
+    expect(hasRefreshSelectableEvidence([...Array.from({ length: 430 }, () => hardGated),
+      ...Array.from({ length: 50 }, () => supplemental)])).toBe(false);
+    expect(hasRefreshSelectableEvidence([])).toBe(false);
+  });
+
+  it.each(["primary", "mixed"])("admits %s persisted selectable evidence", (kind) => {
+    expect(hasRefreshSelectableEvidence(kind === "primary" ? [primary] : [supplemental, primary])).toBe(true);
+  });
+});
 
 afterEach(() => jest.restoreAllMocks());
 

--- a/scripts/lib/reader-summary-new-input-refresh-assessment.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-assessment.ts
@@ -41,7 +41,7 @@ export type RefreshAssessmentCaptureEvent = Readonly<{
 }>;
 
 export function hasRefreshSelectableEvidence(items: readonly SummaryEvidenceItem[]): boolean {
-  return items.some((item) => isPersistedSelectableEvidence(item));
+  return items.some((item) => !isGitHubTrendingEvidence(item) && isPersistedSelectableEvidence(item));
 }
 
 // A caught error's own stage is the most specific, definitive signal of what


### PR DESCRIPTION
Supplemental GitHub Trending evidence could pass refresh preflight even when the persisted primary slate was empty. That created a job, invoked story-relation AI, and then failed publication as stale.

This change makes refresh admission require at least one persisted selectable primary item. Supplemental-only input now exits before job creation and model work, while primary-only and mixed input remain eligible.

Validation:
- 125 focused tests passed on the exact patch
- regression fails against the base commit
- independent hosted review: GO, no P0-P2 findings
- code-quality, source-line-cap, and diff checks passed

Refs #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved refresh assessment behavior so GitHub Trending content is not treated as selectable persisted evidence.
  - Refresh assessments now correctly reject supplemental-only evidence, including cases combined with hard-gated records.
  - Primary evidence, with or without supplemental evidence, continues to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->