### PR TITLE
fix(relevance): prioritize promotion assessment candidates

### DIFF
--- a/libs/relevance/features/rank-feed-items/promotion-assessment-failures.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-assessment-failures.spec.ts
@@ -79,6 +79,81 @@ describe("promotion assessment protocol and budgets through V2", () => {
     expect(oversized.items[0]!.contentQuality.reason).toContain("budget_exhausted");
   });
 
+  it("spends a saturated provider budget on stronger candidates before candidate id", async () => {
+    const reviewBatch = jest.fn(accepting.reviewBatch);
+    const items = Array.from({ length: 201 }, (_, index) => fixture(
+      `candidate-${String(index).padStart(3, "0")}`,
+      "reddit",
+      { providerMetadata: { kind: "reddit_post", score: index === 200 ? 9_000 : 25, upvoteRatio: 0.95 } },
+    ));
+
+    const result = await run(items, { reviewBatch });
+    const reviewedIds = reviewBatch.mock.calls.flatMap(([requests]) => requests.map(({ candidateId }) => candidateId));
+
+    expect(reviewedIds).toContain("candidate-200");
+    expect(reviewedIds).not.toContain("candidate-199");
+    expect(result.items.find(({ feedItemId }) => feedItemId === "candidate-199")!.contentQuality.reason)
+      .toContain("budget_exhausted");
+  });
+
+  it("deterministically round-robins providers without starving a late provider", async () => {
+    const items = [
+      ...Array.from({ length: 201 }, (_, index) => fixture(
+        `reddit-${String(index).padStart(3, "0")}`,
+        "reddit",
+        { providerMetadata: { kind: "reddit_post", score: index + 25, upvoteRatio: 0.95 } },
+      )),
+      fixture("x-late", "x-twitter", {
+        providerMetadata: { kind: "x_post", contentKind: "original_post", likes: 90, reposts: 10 },
+      }),
+    ];
+    const assessedOrder = async (population: typeof items) => {
+      const reviewBatch = jest.fn(accepting.reviewBatch);
+      await run(population, { reviewBatch });
+      return reviewBatch.mock.calls.flatMap(([requests]) => requests.map(({ candidateId }) => candidateId));
+    };
+
+    const forward = await assessedOrder(items);
+    const reversed = await assessedOrder([...items].reverse());
+
+    expect(forward).toContain("x-late");
+    expect(forward).toEqual(reversed);
+  });
+
+  it("groups provider aliases by canonical family before deterministic round-robin", async () => {
+    const xItems = ["x", "x-twitter", "twitter"].flatMap((providerKey, aliasIndex) =>
+      Array.from({ length: 100 }, (_, index) => fixture(
+        `${aliasIndex === 1 ? "z-strong" : "a-weak"}-${aliasIndex}-${String(index).padStart(3, "0")}`,
+        providerKey,
+        { providerMetadata: { kind: "x_post", contentKind: "original_post",
+          likes: aliasIndex === 1 ? 9_000 : 90, reposts: 10 } },
+      )));
+    const items = [...xItems, fixture("hacker-news-chance", "hacker-news")];
+    const assessedOrder = async (population: typeof items) => {
+      const reviewBatch = jest.fn(accepting.reviewBatch);
+      await run(population, { reviewBatch });
+      return reviewBatch.mock.calls.flatMap(([requests]) => requests.map(({ candidateId }) => candidateId));
+    };
+
+    const forward = await assessedOrder(items);
+    const reversed = await assessedOrder([...items].reverse());
+
+    expect(forward).toContain("hacker-news-chance");
+    expect(forward).toContain("z-strong-1-099");
+    expect(forward).not.toContain("a-weak-2-099");
+    expect(forward).toEqual(reversed);
+  });
+
+  it("keeps exact scheduling ties candidate-id stable", async () => {
+    const reviewBatch = jest.fn(accepting.reviewBatch);
+    const items = [fixture("tie-c"), fixture("tie-a"), fixture("tie-b")];
+
+    await run(items, { reviewBatch });
+
+    expect(reviewBatch.mock.calls.flatMap(([requests]) => requests.map(({ candidateId }) => candidateId)))
+      .toEqual(["tie-a", "tie-b", "tie-c"]);
+  });
+
   it("bounds total bytes and runs only one batch at a time", async () => {
     let active = 0;
     let peak = 0;

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.spec.ts
@@ -15,7 +15,7 @@ describe("promotion assessment through Summary candidate and V2 (synthetic revie
     expect(result.candidates[0]!.evidenceQualityScore).toBe(0.8);
   });
 
-  it("reviews eight candidates in one ordered batch and retains second-batch popularity", async () => {
+  it("reviews eight candidates in one popularity-prioritized batch", async () => {
     const ids = Array.from({ length: 8 }, (_, i) => `candidate-${i}`);
     let active = 0;
     let peak = 0;
@@ -31,7 +31,7 @@ describe("promotion assessment through Summary candidate and V2 (synthetic revie
     const result = await run(items, { reviewBatch });
     expect(reviewBatch).toHaveBeenCalledTimes(1);
     expect(reviewBatch.mock.calls.map(([requests]) => requests.map((r) => r.candidateId)))
-      .toEqual([ids]);
+      .toEqual([["candidate-7", ...ids.slice(0, 7)]]);
     expect(peak).toBe(1);
     expect(result.items.map((item) => item.feedItemId).sort()).toEqual(ids);
     for (const item of result.items) expect(item.contentQuality).toMatchObject({

--- a/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-content-assessment.ts
@@ -7,6 +7,11 @@ import { assessedPromotionVerdict, pendingPromotionAssessment } from "./promotio
 import { unavailablePromotionHeadline, type PromotionReaderHeadline } from "../../domain/promotion-reader-headline";
 import { assessPromotionReaderHeadline } from "./promotion-reader-headline-assessment";
 
+type PromotionAssessmentPriority = {
+  readonly providerFamily: string;
+  readonly engagementSalience: number;
+};
+
 export const PROMOTION_ASSESSMENT_BOUNDS = Object.freeze({
   candidates: 200, batchCandidates: 8, batchBytes: 64_000,
   totalBytes: 512_000, batchTimeoutMs: 15_000, deadlineMs: 60_000,
@@ -14,12 +19,14 @@ export const PROMOTION_ASSESSMENT_BOUNDS = Object.freeze({
 
 // All supplied requests have already passed immutable non-content gates.
 // Every candidate starts pending; budget, transport and protocol failures cannot
-// fall through to a heuristic pass. Batches are popularity-free; callers may
-// explicitly opt into bounded concurrency when their reviewer owns a safe pool.
+// fall through to a heuristic pass. Scheduling priority never enters the model
+// request; callers may explicitly opt into bounded concurrency when their
+// reviewer owns a safe pool.
 export const assessPromotionContent = async (input: {
   readonly observeHeadlineDiagnostic?: PromotionHeadlineDiagnosticObserver;
   readonly execution?: { readonly deadlineAtMs: number; readonly signal?: AbortSignal };
   readonly requests: readonly SourceContentQualityReviewRequest[];
+  readonly priorityByCandidateId?: ReadonlyMap<string, PromotionAssessmentPriority>;
   readonly reviewer?: SourceContentQualityReviewerPort;
   readonly policy: SourceContentQualityPolicy;
   readonly clock: Clock;
@@ -38,8 +45,7 @@ export const assessPromotionContent = async (input: {
     pendingPromotionAssessment(request.deterministic, "budget_exhausted")]));
   const readerHeadlines = new Map<string, PromotionReaderHeadline>(input.requests.map((request) =>
     [request.candidateId, unavailablePromotionHeadline("not_assessed")]));
-  const requests = [...input.requests].sort((a, b) =>
-    a.candidateId < b.candidateId ? -1 : a.candidateId > b.candidateId ? 1 : 0);
+  const requests = providerAwareAssessmentOrder(input.requests, input.priorityByCandidateId);
   if (new Set(requests.map(({ candidateId }) => candidateId)).size !== requests.length) {
     for (const request of requests) verdicts.set(request.candidateId,
       pendingPromotionAssessment(request.deterministic, "duplicate_candidate"));
@@ -109,6 +115,42 @@ export const assessPromotionContent = async (input: {
   }
   return { verdicts, readerHeadlines };
 };
+
+const providerAwareAssessmentOrder = (
+  requests: readonly SourceContentQualityReviewRequest[],
+  priorityByCandidateId: ReadonlyMap<string, PromotionAssessmentPriority> | undefined,
+): SourceContentQualityReviewRequest[] => {
+  const byProvider = new Map<string, SourceContentQualityReviewRequest[]>();
+  for (const request of requests) {
+    const providerFamily = priorityByCandidateId?.get(request.candidateId)?.providerFamily ??
+      request.providerKey;
+    const provider = byProvider.get(providerFamily) ?? [];
+    provider.push(request);
+    byProvider.set(providerFamily, provider);
+  }
+  const priority = (candidateId: string) => {
+    const value = priorityByCandidateId?.get(candidateId)?.engagementSalience;
+    return value !== undefined && Number.isFinite(value) ? value : 0;
+  };
+  const candidateOrder = (a: SourceContentQualityReviewRequest, b: SourceContentQualityReviewRequest) => {
+    const priorityDifference = priority(b.candidateId) - priority(a.candidateId);
+    return priorityDifference || compareStrings(a.candidateId, b.candidateId);
+  };
+  const providers = [...byProvider.entries()].sort(([a], [b]) => compareStrings(a, b));
+  for (const [, providerRequests] of providers) providerRequests.sort(candidateOrder);
+  const ordered: SourceContentQualityReviewRequest[] = [];
+  // A lexical provider round-robin prevents a populous network from consuming
+  // the global cap; each network contributes its strongest remaining item.
+  for (let index = 0; ordered.length < requests.length; index++) {
+    for (const [, providerRequests] of providers) {
+      const request = providerRequests[index];
+      if (request !== undefined) ordered.push(request);
+    }
+  }
+  return ordered;
+};
+
+const compareStrings = (a: string, b: string): number => a < b ? -1 : a > b ? 1 : 0;
 
 const reviewWithinDeadline = async (
   reviewer: SourceContentQualityReviewerPort | undefined,

--- a/libs/relevance/features/rank-feed-items/promotion-snapshot-preparation.spec.ts
+++ b/libs/relevance/features/rank-feed-items/promotion-snapshot-preparation.spec.ts
@@ -66,7 +66,7 @@ describe("promotion preparation observation", () => {
     expect(actual.value.items[0]!.feedItemId).toBe("z");
     expect(actual.value.items.map((item) => item.rank)).toEqual([1, 2, 3, 4, 5]);
     expect(observed.reviewBatch).toHaveBeenCalledTimes(1);
-    expect(observed.reviewBatch.mock.calls[0]![0].map((request) => request.candidateId)).toEqual(["a", "z"]);
+    expect(observed.reviewBatch.mock.calls[0]![0].map((request) => request.candidateId)).toEqual(["z", "a"]);
     expect(observed.feedItems.readPromotionSnapshot).toHaveBeenCalledTimes(1);
     expect(observed.feedItems.list).not.toHaveBeenCalled();
   });

--- a/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
+++ b/libs/relevance/features/rank-feed-items/rank-promotion-snapshot.ts
@@ -109,6 +109,10 @@ export const rankPromotionSnapshot = async (params: {
   const sourceContentById = new Map(snapshot.sourceContent.map((content) =>
     [content.feedItemId, content] as const));
   const reviewRequests: SourceContentQualityReviewRequest[] = [];
+  const assessmentPriorityByCandidateId = new Map<string, {
+    readonly providerFamily: string;
+    readonly engagementSalience: number;
+  }>();
   const projected = snapshot.candidates.map((candidate) => {
     const item = candidate.item.toSnapshot();
     const sourceContent = sourceContentById.get(item.id);
@@ -196,6 +200,10 @@ export const rankPromotionSnapshot = async (params: {
               ? "truncated" : body.trim() ? "body_present" : "title_only",
           }),
         }));
+        assessmentPriorityByCandidateId.set(item.id, {
+          providerFamily: candidate.canonical.providerFamily,
+          engagementSalience: feedPromotionMetricStrength(candidate.canonical.metrics),
+        });
       }
       projectedItem.contentQuality = { ...quality, qualityScore: 0,
         eligibleForSummary: false, eligibleForTopRead: false, needsLlmReview: false,
@@ -204,6 +212,7 @@ export const rankPromotionSnapshot = async (params: {
     return projectedItem;
   });
   const assessed = await assessPromotionContent({ requests: reviewRequests,
+    priorityByCandidateId: assessmentPriorityByCandidateId,
     execution: command.promotionAssessmentExecution,
     observeHeadlineDiagnostic: command.observeHeadlineDiagnostic,
     reviewer: params.qualityReviewer, policy: params.qualityPolicy, clock: params.clock });


### PR DESCRIPTION
## Summary
- prioritize bounded content assessment by provider-normalized engagement
- canonicalize provider aliases before deterministic round-robin fairness
- keep scheduling metadata outside reviewer/model wire payloads

## Regression proof
- exact base 95982005712afffb97305ea8eec441a13b5beff7 fails late-ID popularity and alias fairness scenarios
- focused implementation run: 7 suites, 116 tests passed
- build typecheck, code-quality, source-line-cap, and diff check passed
- independent exact-patch review of ad3b8897ac09832b7412a3216a88eb971c9616de0881a58422f208e6d78ad559: GO, no P0/P1
- reviewer noted one nonblocking P2 test gap: exact multi-round interleaving is verified by implementation inspection but not asserted directly

## Scope
No quality gates, Reader Promotion V2 scoring, wire schemas, supplemental-only flow, or production configuration are weakened.

Refs #293
Refs #294
