### PR TITLE
fix(agent-runtime): preserve assessment account fallback

### DIFF
--- a/apps/agent-runtime/bin/assessment-capacity-fallback.test.mjs
+++ b/apps/agent-runtime/bin/assessment-capacity-fallback.test.mjs
@@ -161,7 +161,7 @@ async function launch({ failures = ["preflight", "success"], mutateResult, abort
       budgets.push(job.safeExecutionPolicy?.maxAttempts ?? 1);
       const value = await super.run(job);
       if (value.status !== "completed") {
-        mutateResult?.(value);
+        mutateResult?.(value, admissions);
         if (abortAfterFailure) abort.abort();
       }
       return value;
@@ -217,6 +217,7 @@ test("all unavailable accounts are bounded to one admission each", async () => {
 });
 
 for (const [name, mutateResult] of [
+  ["generic capacity classification", (r) => { r.reason = "capacity_unavailable"; r.attempts[0].failureReason = "capacity_unavailable"; }],
   ["missing capacity provenance", (r) => { r.error.cause.details = undefined; }],
   ["unknown capacity reason", (r) => { r.error.cause.details.reason = "future_unknown"; }],
   ["inconclusive disabled capacity", (r) => { r.error.cause.details.reason = "quota_recheck_inconclusive"; }],
@@ -252,3 +253,56 @@ for (const reason of ["native_snapshot_stop_unconfirmed", "native_snapshot_clean
     assert.equal(h.task.attempts.length, 1);
   });
 }
+
+function sessionRejection(result, admissions) {
+  result.error = { code: "subscription_worker_pool_slot_failed" };
+  result.attempts.at(-1).failureDetails = {
+    reason: "provider_session_invalid", accountId: admissions.at(-1),
+    subscriptionWorkerCode: "subscription_worker_pool_slot_failed", exitCode: "1",
+  };
+}
+
+for (const [name, mutate, safe] of [
+  ["literal production auth rejection", () => {}, true],
+  ["numeric exit compatibility", (a) => { a.failureDetails.exitCode = 1; }, true],
+  ["other serialized exit", (a) => { a.failureDetails.exitCode = "01"; }],
+  ["missing reason", (a) => { delete a.failureDetails.reason; }],
+  ["unknown reason", (a) => { a.failureDetails.reason = "unknown_error"; }],
+  ["wrong account", (a) => { a.failureDetails.accountId = "not-configured"; }],
+  ["missing exit", (a) => { delete a.failureDetails.exitCode; }],
+  ["wrong code", (a) => { a.failureDetails.subscriptionWorkerCode = "unknown"; }],
+  ["usage", (a) => { a.usage = { totalTokens: 0 }; }],
+  ["output", (a) => { a.lastOutputSummary = ""; }],
+  ["dirty before", (a) => { a.workspaceDirtyBefore = true; }],
+  ["dirty after", (a) => { a.workspaceDirtyAfter = true; }],
+  ["changed files", (a) => { a.changedFiles = ["synthetic"]; }],
+]) test(`serialized session rejection: ${name}`, async () => {
+  const h = await launch({ mutateResult(result, admissions) {
+    sessionRejection(result, admissions);
+    mutate(result.attempts.at(-1));
+  } });
+  assert.equal(h.failure === undefined, safe === true);
+  assert.deepEqual(h.budgets, safe ? [1, 2] : [1]);
+  assert.equal(h.providerCalls.length, safe ? 1 : 0);
+});
+
+for (const [name, contradict] of [
+  ["outer usage", (error) => { error.usage = { totalTokens: 0 }; }],
+  ["immediate cause usage", (error) => {
+    error.cause = { code: "subscription_worker_account_unavailable", usage: { totalTokens: 0 } };
+  }],
+  ["outer provider/task failure", (error) => { error.code = "subscription_worker_run_failed"; }],
+  ["immediate provider/task failure", (error) => {
+    error.cause = { code: "subscription_worker_run_failed" };
+  }],
+  ["unknown outer reason", (error) => { error.code = "future_unknown"; }],
+  ["unknown cause reason", (error) => { error.cause = { code: "future_unknown" }; }],
+]) test(`serialized session rejection rejects contradictory ${name}`, async () => {
+  const h = await launch({ mutateResult(result, admissions) {
+    sessionRejection(result, admissions);
+    contradict(result.error);
+  } });
+  assert.ok(h.failure);
+  assert.deepEqual(h.budgets, [1]);
+  assert.equal(h.providerCalls.length, 0);
+});

--- a/apps/agent-runtime/bin/assessment-cli-launcher.test.mjs
+++ b/apps/agent-runtime/bin/assessment-cli-launcher.test.mjs
@@ -19,7 +19,7 @@ after(async () => { await fixture?.close(); });
 
 // Execute the unmodified launcher source with only explicit fake filesystem/auth/executor imports.
 // Its injected legacy function is the pinned actual entrypoint with fake IO and worker factory.
-async function launch(t, { hold, neverStop = false, failedTask = false, parentLog = false, accountFailure = false } = {}) {
+async function launch(t, { hold, neverStop = false, failedTask = false, parentLog = false, accountFailure = false, admissionFailure } = {}) {
   const sources = new Map();
   for (const name of ["run-codex-subscription-runtime-agent-task.mjs", "assessment-cli-lifecycle.mjs", "assessment-cli-progress.mjs"]) {
     sources.set(name, await readFile(new URL(name, import.meta.url), "utf8"));
@@ -47,10 +47,35 @@ async function launch(t, { hold, neverStop = false, failedTask = false, parentLo
     stderr: { write: (line) => { receive(Buffer.from(line)); parentChild.stderr.emit("data", Buffer.from(line)); return false; } },
   });
   const pause = async (phase) => { events.push(phase); if (hold === phase) await gate.promise; };
+  class SubscriptionWorkerError extends Error {
+    constructor(code, message, options = {}) {
+      super(message, options); this.code = code; this.details = options.details;
+    }
+  }
+  const jobs = [], triedAccounts = [];
   class FakeExecutor {
     constructor(value) { options = value; events.push("executor-created"); }
     async run(job) {
-      runCount++; options.observability.emit({ name: "provider.task.started", metadata: { prompt: "synthetic-private-content" } });
+      runCount++;
+      jobs.push(job); triedAccounts.push(options.accounts[runCount - 1].worker.capacityAccountId);
+      if (admissionFailure && runCount === 1) {
+        if (admissionFailure.endsWith("provider-started")) options.observability.emit({ name: "provider.task.started" });
+        return { status: "waiting_capacity", reason: "account_unavailable",
+          attempts: [{ status: "blocked", failureReason: "account_unavailable",
+            workspaceDirtyBefore: false, workspaceDirtyAfter: false, changedFiles: [],
+            ...(admissionFailure.startsWith("session") ? {
+              failureDetails: { reason: "provider_session_invalid", accountId: triedAccounts[0],
+                subscriptionWorkerCode: "subscription_worker_pool_slot_failed", exitCode: "1" },
+            } : {}),
+          }],
+          ...(admissionFailure.startsWith("session") ? { error: { code: "subscription_worker_pool_slot_failed" } } : admissionFailure === "ambiguous" ? {} : {
+            error: new SubscriptionWorkerError("subscription_worker_account_unavailable", "Synthetic disabled account", {
+              details: { availability: "disabled", reason: "account_unavailable" },
+            }),
+          }),
+        };
+      }
+      options.observability.emit({ name: "provider.task.started", metadata: { prompt: "synthetic-private-content" } });
       job.abortSignal.addEventListener("abort", () => { aborts++; events.push("aborted"); });
       await turn.promise;
       options.observability.emit({ name: "provider.task.completed", metadata: { status: failedTask ? "failed" : "completed" } });
@@ -76,12 +101,13 @@ async function launch(t, { hold, neverStop = false, failedTask = false, parentLo
     ["./pinned-codex-native-binary.mjs", { resolvePinnedCodexBinaryPath: () => "/synthetic/not-executable" }],
     ["./codex-auth-pool-manifest.mjs", { loadCodexAuthPoolFromEnv: async () => {
       await pause("account-setup"); return { accounts: [{ id: "synthetic-account", authJsonPath: "/synthetic/account" },
+        ...(admissionFailure ? [{ id: "synthetic-second", authJsonPath: "/synthetic/second" }] : []),
         ...(accountFailure ? [{ id: "synthetic-failed", authJsonPath: "/synthetic/fail" }] : [])] };
     } }],
     ["@vioxen/subscription-runtime/worker-codex", { FileBackendCodexSafeExecutor: FakeExecutor,
       FileBackendCodexWorker: class { constructor() { throw new Error("Real/default worker forbidden"); } },
       NodeProcessRunner: class { constructor() { throw new Error("Native runner forbidden"); } } }],
-    ["@vioxen/subscription-runtime/worker-core", { SubscriptionWorkerError: class extends Error {} }],
+    ["@vioxen/subscription-runtime/worker-core", { SubscriptionWorkerError }],
     ["../../../node_modules/@vioxen/subscription-runtime/dist/worker-local/agent-task-runner-cli.js", {
       runSubscriptionAgentTaskCli: (argv, _io, factory) => {
         io.readStdin = async () => input;
@@ -130,7 +156,7 @@ async function launch(t, { hold, neverStop = false, failedTask = false, parentLo
     await waitFor(predicate);
     assert.ok(predicate(), JSON.stringify({ events, stderr: io.stderr }));
   };
-  return { clock, records, events, gate, turn, stop, result, until, io, fakeProcess,
+  return { clock, records, events, gate, turn, stop, result, until, io, fakeProcess, jobs, triedAccounts,
     logs, parentResult, get options() { return options; }, get aborts() { return aborts; }, get runCount() { return runCount; },
     get disposeCount() { return disposeCount; }, get returned() { return returned; } };
 }
@@ -202,3 +228,27 @@ test("parallel account setup rejection does not hide another outstanding materia
   h.gate.resolve(); await h.clock.tickAsync(0);
   assert.equal(h.events.includes("executor-created"), false);
 });
+
+for (const admissionFailure of ["pre-provider", "session", "ambiguous", "provider-started", "session-provider-started"]) {
+  test(`launcher ${admissionFailure} account failure only falls back with pre-provider proof`, async (t) => {
+    const h = await launch(t, { admissionFailure });
+    const safe = ["pre-provider", "session"].includes(admissionFailure);
+    await h.until(() => safe ? h.runCount === 2 : h.events.includes("auth-removal"));
+    assert.equal(h.options.safeExecutionPolicy.maxAttempts, 1);
+    assert.equal(h.options.safeExecutionPolicy.retryOnAccountUnavailable, false);
+    assert.equal(h.options.safeExecutionPolicy.continuationMode, "disabled");
+    assert.equal(h.options.effectMode, "read_only");
+    assert.equal(h.options.maxAccountCycles, 1);
+    if (safe) {
+      assert.notEqual(h.triedAccounts[0], h.triedAccounts[1]);
+      assert.equal(h.jobs[1].taskId, h.jobs[0].taskId);
+      assert.equal(h.jobs[1].prompt, h.jobs[0].prompt);
+      assert.equal(h.jobs[1].safeExecutionPolicy.maxAttempts, 2);
+      h.turn.resolve();
+    }
+    await h.clock.tickAsync(11_000);
+    assert.equal(await h.result, safe ? 0 : 1);
+    assert.equal(h.runCount, safe ? 2 : 1);
+    assert.equal(h.disposeCount, 1);
+  });
+}

--- a/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
+++ b/apps/agent-runtime/bin/run-codex-subscription-runtime-agent-task.mjs
@@ -371,9 +371,10 @@ function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
         let result = await executor.run(runInput);
         // Keep the same executor, task journal and round-robin cursor. Grant
         // exactly one more admission attempt only after proven pre-provider
-        // rejection; the executor itself must never retry a provider failure.
+        // account_unavailable rejection; retryMode "never" still forbids replay.
+        // Generic capacity failures cannot authorize another admission.
         for (let attempt = 1; isSourceContentAssessment && attempt < accounts.length; attempt++) {
-          if (providerEffectPossible || !isPreProviderCapacityFailure(result, attempt)) break;
+          if (providerEffectPossible || !isPreProviderAccountUnavailable(result, attempt, accounts)) break;
           lifecycle.checkpoint();
           if (disposed || job.abortSignal?.aborted) break;
           result = await executor.run({
@@ -412,16 +413,27 @@ function createPooledCodexWorker({ input, model, authPool, outputSchemas }) {
   };
 }
 
-function isPreProviderCapacityFailure(result, attemptCount) {
+function isPreProviderAccountUnavailable(result, attemptCount, accounts) {
   if (result.status !== "waiting_capacity" ||
-      !["capacity_unavailable", "account_unavailable"].includes(result.reason) ||
+      result.reason !== "account_unavailable" ||
       result.attempts?.length !== attemptCount) return false;
   if (!result.attempts.every((attempt) =>
     attempt.status === "blocked" &&
-    ["capacity_unavailable", "account_unavailable"].includes(attempt.failureReason) &&
+    attempt.failureReason === "account_unavailable" &&
     attempt.workspaceDirtyBefore === false && attempt.workspaceDirtyAfter === false &&
     attempt.changedFiles?.length === 0 && attempt.usage === undefined &&
     attempt.lastOutputSummary === undefined)) return false;
+  // The pool serializes away the auth rejection cause. Accept only the
+  // confirmed native auth-rejection journal signature, scoped to this account.
+  if (isPreProviderSessionRejection(result.attempts.at(-1), accounts[attemptCount - 1])) {
+    const wrapper = result.error;
+    const cause = wrapper?.cause;
+    return wrapper?.code === "subscription_worker_pool_slot_failed" &&
+      wrapper.usage === undefined &&
+      (cause === undefined ||
+        (cause?.code === "subscription_worker_account_unavailable" &&
+          cause.usage === undefined && cause.cause === undefined));
+  }
   let error = result.error;
   // Only unwrap the pool's immediate slot wrapper, never a provider cause chain.
   if (error instanceof SubscriptionWorkerError &&
@@ -437,6 +449,15 @@ function isPreProviderCapacityFailure(result, attemptCount) {
     error.code === "subscription_worker_account_unavailable" &&
     error.details?.availability === "disabled" &&
     error.details?.reason === "account_unavailable";
+}
+
+function isPreProviderSessionRejection(attempt, account) {
+  const details = attempt.failureDetails;
+  return details?.reason === "provider_session_invalid" &&
+    details.accountId === account?.worker.capacityAccountId &&
+    typeof details.accountId === "string" &&
+    details.subscriptionWorkerCode === "subscription_worker_pool_slot_failed" &&
+    (details.exitCode === "1" || details.exitCode === 1);
 }
 
 async function createAuthMaterializationRoot(stateRootDir, taskId) {

--- a/apps/agent-runtime/src/subscription-runtime-installation.ts
+++ b/apps/agent-runtime/src/subscription-runtime-installation.ts
@@ -14,7 +14,7 @@ import {
 export const approvedSubscriptionRuntimePackageVersion =
   "0.1.0-main.42-sm.1";
 export const approvedSubscriptionRuntimeLauncherSha256 =
-  "196a4ed97db314445e1b7bd97cb8cc5f4156f70cd5f8501041510ae83cb4f545";
+  "babddc722c2a1f4798366171eef578b65adb6b86ece77298a2b3f93aa6e0e6f4";
 
 // Repository wrapper approval, separate from the vendored package provenance.
 // Pin the local import closure too: launcher bytes alone do not bind helpers.


### PR DESCRIPTION
Fixes the production assessment stall where a revoked first Codex session ended the whole 11-account pool after one blocked attempt.

The launcher now accepts only the proven serialized `provider_session_invalid` journal signature for safe account fallback, while still rejecting generic capacity, contradictory wrapper evidence, ambiguous results, and any observed provider-started attempt.

Focused hosted tests: 54 passing. Runtime-profile and source-line-cap guards pass.

Refs #293
Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account fallback handling during subscription task launches.
  - Fallback now occurs only when an account is conclusively unavailable before provider startup.
  - Generic capacity failures, ambiguous rejection details, and failures after provider startup no longer trigger an account switch.
  - Improved validation of provider-session rejection information, including supported production and numeric error formats.

- **Tests**
  - Added coverage for capacity classification, malformed metadata, session rejection, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->