### PR TITLE
fix(reader-summary): reconcile pre-delegation failures

### DIFF
--- a/prisma/migrations/20260913060000_reader_summary_reconciliation_pre_provider/migration.sql
+++ b/prisma/migrations/20260913060000_reader_summary_reconciliation_pre_provider/migration.sql
@@ -1,0 +1,93 @@
+-- @social-monitor-forward-migration
+-- Zero-provider reconciliation is distinct from paid consumption. Preserve the
+-- provider predicate and all table ownership, RLS, foreign keys and append-only guards.
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL ROLE "social_monitor_public_schema_owner";
+ALTER TABLE "reader_summary_new_input_refresh_reconciliations"
+  DROP CONSTRAINT "rs_nir_reconciliations_identity_check",
+  DROP CONSTRAINT "rs_nir_reconciliations_accounting_check";
+ALTER TABLE "reader_summary_new_input_refresh_reconciliations"
+  ADD CONSTRAINT "rs_nir_reconciliations_identity_check" CHECK (
+    "job_status" = 'FAILED'
+    AND "reason" IN ('consumed_provider_invocation_without_summary', 'consumed_job_without_provider_invocation')
+    AND "operation" LIKE 'new-input-refresh:v1:%'
+    AND "period_ended_at" = "period_started_at" + INTERVAL '1 day'
+    AND "job_sha256" ~ '^[0-9a-f]{64}$'
+    AND "manifest_sha256" ~ '^[0-9a-f]{64}$'
+    AND "evidence_sha256" ~ '^[0-9a-f]{64}$'
+  ),
+  ADD CONSTRAINT "rs_nir_reconciliations_accounting_check" CHECK (
+    CASE WHEN "reason" = 'consumed_provider_invocation_without_summary' THEN (
+
+    jsonb_typeof("invocation") = 'object'
+    AND jsonb_typeof("accounting") = 'object'
+    AND "invocation" ?& ARRAY[
+      'requestId', 'purpose', 'requestSha256', 'attemptSha256',
+      'consumedAt', 'returnedAt', 'outcome', 'providerUsageReported'
+    ]
+    AND jsonb_typeof("invocation"->'requestId') = 'string'
+    AND jsonb_typeof("invocation"->'purpose') = 'string'
+    AND "invocation"->>'requestSha256' ~ '^[0-9a-f]{64}$'
+    AND "invocation"->>'attemptSha256' ~ '^[0-9a-f]{64}$'
+    AND "accounting" ?& ARRAY[
+      'summaryGenerations', 'publications', 'artifacts',
+      'providerInvocations', 'providerUsage'
+    ]
+    AND "accounting"->'summaryGenerations' = '0'::JSONB
+    AND "accounting"->'publications' = '0'::JSONB
+    AND "accounting"->'artifacts' = '0'::JSONB
+    AND "accounting"->'providerInvocations' = '1'::JSONB
+    AND (
+      (
+        "invocation"->'providerUsageReported' = 'false'::JSONB
+        AND NOT ("invocation" ? 'usage')
+        AND "accounting"->>'providerUsage' = 'unknown'
+        AND NOT ("accounting" ? 'usage')
+      )
+      OR
+      (
+        "invocation"->'providerUsageReported' = 'true'::JSONB
+        AND jsonb_typeof("invocation"->'usage') = 'object'
+        AND "invocation"->'usage' ?& ARRAY['inputTokens', 'outputTokens', 'totalTokens']
+        AND ("invocation"->'usage'->>'inputTokens') ~ '^(0|[1-9][0-9]*)$'
+        AND ("invocation"->'usage'->>'outputTokens') ~ '^(0|[1-9][0-9]*)$'
+        AND ("invocation"->'usage'->>'totalTokens') ~ '^(0|[1-9][0-9]*)$'
+        AND ("invocation"->'usage'->>'inputTokens')::NUMERIC <= 9007199254740991
+        AND ("invocation"->'usage'->>'outputTokens')::NUMERIC <= 9007199254740991
+        AND ("invocation"->'usage'->>'totalTokens')::NUMERIC <= 9007199254740991
+        AND ("invocation"->'usage'->>'totalTokens')::NUMERIC =
+          ("invocation"->'usage'->>'inputTokens')::NUMERIC +
+          ("invocation"->'usage'->>'outputTokens')::NUMERIC
+        AND "accounting"->>'providerUsage' = 'reported'
+        AND "accounting"->'usage' = "invocation"->'usage'
+      )
+    )
+
+    ) ELSE COALESCE((
+      "reason" = 'consumed_job_without_provider_invocation'
+      AND jsonb_typeof("invocation") = 'object'
+      AND "invocation" ?& ARRAY['capturePath', 'journalPath', 'manifestPath',
+        'captureSha256', 'journalSha256', 'invocationConsumedCount',
+        'delegatedInvocationCount', 'providerUsageReported', 'attempts']
+      AND "invocation" - ARRAY['capturePath', 'journalPath', 'manifestPath',
+        'captureSha256', 'journalSha256', 'invocationConsumedCount',
+        'delegatedInvocationCount', 'providerUsageReported', 'attempts'] = '{}'::jsonb
+      AND jsonb_typeof("invocation"->'capturePath') = 'string'
+      AND jsonb_typeof("invocation"->'journalPath') = 'string'
+      AND jsonb_typeof("invocation"->'manifestPath') = 'string'
+      AND "invocation"->>'capturePath' LIKE '/%'
+      AND "invocation"->>'journalPath' LIKE '/%'
+      AND "invocation"->>'manifestPath' LIKE '/%'
+      AND "invocation"->>'captureSha256' ~ '^[0-9a-f]{64}$'
+      AND "invocation"->>'journalSha256' ~ '^[0-9a-f]{64}$'
+      AND "invocation"->'invocationConsumedCount' = '0'::jsonb
+      AND "invocation"->'delegatedInvocationCount' = '0'::jsonb
+      AND "invocation"->'providerUsageReported' = 'false'::jsonb
+      AND CASE WHEN jsonb_typeof("invocation"->'attempts') = 'array'
+        THEN jsonb_array_length("invocation"->'attempts') > 0 ELSE false END
+      AND "accounting" = '{"summaryGenerations":0,"publications":0,"artifacts":0,
+        "providerInvocations":0,"providerUsage":"none"}'::jsonb
+    ), false) END
+  );
+COMMIT;

--- a/scripts/lib/reader-summary-new-input-refresh-model-pre-delegation.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model-pre-delegation.spec.ts
@@ -1,0 +1,33 @@
+import { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { refreshModelCommand } from "./reader-summary-new-input-refresh-model.spec-support";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+import { RefreshRuntimeAssertionFailure } from "./reader-summary-new-input-refresh-runtime-assertion";
+import { sourceContentAssessmentPurpose } from "./reader-summary-new-input-refresh-assessment-runtime";
+
+it.each(["local", "assessment_budget", "request_admission", "runtime_health", "runtime_mismatch",
+  "current_authority", "journal_consumption"] as const)("records only the sanitized %s failure stage", async (stage) => {
+  const diagnostic = "synthetic private exception text";
+  const fail = () => { throw new Error(diagnostic); };
+  const runTask = jest.fn();
+  const captured: unknown[] = [], journal: unknown[] = [];
+  const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), delegate: { runTask, checkHealth: jest.fn() },
+    assertLocal: stage === "local" ? fail : () => undefined,
+    assertCurrent: async () => {
+      if (stage === "runtime_health" || stage === "runtime_mismatch") throw new RefreshRuntimeAssertionFailure(stage);
+      if (stage === "current_authority") fail();
+    },
+    capture: (event) => captured.push(event), record: (event) => {
+      if (stage === "journal_consumption" && (event as { status?: string }).status === "invocation_consumed") fail();
+      journal.push(event);
+    } });
+  const command = refreshModelCommand(stage === "assessment_budget" ? sourceContentAssessmentPurpose : undefined);
+  // Invalid assessment JSON fails budget admission; conflicting metadata fails the
+  // canonical runtime admission while leaving the outer scope/model gates valid.
+  if (stage === "request_admission") Object.assign(command, { metadata: { ...command.metadata, model: "synthetic-wrong-model" } });
+  await expect(runtime.runTask(command)).rejects.toThrow(/original operation remains consumed/);
+  expect(runTask).not.toHaveBeenCalled();
+  expect(captured.at(-1)).toMatchObject({ kind: "invocation_failed", delegated: false, preDelegationFailureStage: stage });
+  expect(journal.at(-1)).toMatchObject({ status: "requires_reconciliation", delegated: false, preDelegationFailureStage: stage });
+  expect(journal.some((event) => (event as { status?: string }).status === "invocation_consumed")).toBe(false);
+  expect(JSON.stringify({ captured, journal })).not.toContain(diagnostic);
+});

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -18,6 +18,7 @@ import { verifyAndRecordReaderSummaryExecution, type ReaderSummaryAttestedTaskRo
 import type { SourceContentAssessmentFailureStage } from "@social-monitor/relevance/ports";
 import { refreshHash, type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
 import { assertRefreshEqual } from "./reader-summary-new-input-refresh-guard";
+import { RefreshRuntimeAssertionFailure, type RefreshPreDelegationFailureStage } from "./reader-summary-new-input-refresh-runtime-assertion";
 
 const noInvocation: AgentRuntimeClientPort = {
   runTask: async () => { throw new Error("Preparation cannot invoke a model"); },
@@ -102,7 +103,8 @@ export type RefreshModelCaptureEvent =
   | { readonly kind: "invocation_started"; readonly command: AgentRuntimeTaskCommand }
   | { readonly kind: "invocation_returned"; readonly requestId: string; readonly status: AgentRuntimeTaskResult["status"] }
   | { readonly kind: "invocation_aborted"; readonly requestId: string }
-  | { readonly kind: "invocation_failed"; readonly requestId: string; readonly delegated: boolean }
+  | { readonly kind: "invocation_failed"; readonly requestId: string; readonly delegated: boolean;
+      readonly preDelegationFailureStage?: RefreshPreDelegationFailureStage }
   | { readonly kind: "envelope_verified"; readonly command: AgentRuntimeTaskCommand;
       readonly result: Pick<AgentRuntimeTaskResult, "status" | "structuredOutput" | "usage" | "durationMs" | "executionAttestation"> };
 
@@ -181,6 +183,7 @@ export function guardedRefreshRuntime(input: {
       if (isAssessment) assessmentInFlight.add(command.requestId);
       else exclusiveInFlight = true;
       let delegated = false;
+      let preDelegationFailureStage: RefreshPreDelegationFailureStage = "local";
       let returnedResult: AgentRuntimeTaskResult | undefined;
       let canonicalRequestSha256: string | undefined;
       let notConsumedReason: "deadline" | "aborted" | "authority_or_runtime_rejected" = "authority_or_runtime_rejected";
@@ -222,11 +225,13 @@ export function guardedRefreshRuntime(input: {
       try {
         if (capturedCommand) capture({ kind: "invocation_started", command: capturedCommand });
         assertUsable();
+        preDelegationFailureStage = "assessment_budget";
         const assessmentUsage = command.purpose === sourceContentAssessmentPurpose ? assessment.consume(command) : {};
         // Match GrpcAgentRuntimeClient JSON serialization and the service's
         // optional-string normalization, then use the executor's real admission
         // contract for profile defaults/controls. Hash before any awaited work;
         // the journal's refreshHash(command) is not the canonical runtime request.
+        preDelegationFailureStage = "request_admission";
         canonicalRequestSha256 = canonicalJsonSha256(admitSubscriptionRuntimeRequest({
           ...command,
           providerInstanceId: command.providerInstanceId?.trim() || undefined,
@@ -235,9 +240,13 @@ export function guardedRefreshRuntime(input: {
           controlsJson: JSON.stringify(command.controls),
           metadata: command.metadata ?? {},
         }).canonicalRequest);
+        preDelegationFailureStage = "current_authority";
         await input.assertCurrent();
+        preDelegationFailureStage = "local";
         assertUsable();
+        preDelegationFailureStage = "journal_consumption";
         input.record({ ...identity, ...assessmentUsage, status: "invocation_consumed" });
+        preDelegationFailureStage = "local";
         assertUsable(); // fsync/recording can itself cross the cutoff.
 
         if (command.purpose === sourceContentAssessmentPurpose) {
@@ -284,7 +293,7 @@ export function guardedRefreshRuntime(input: {
           result: { status: result.status, structuredOutput: result.structuredOutput, usage: result.usage,
             durationMs: result.durationMs, executionAttestation: result.executionAttestation } });
         return result;
-      } catch {
+      } catch (error) {
         ambiguous = true;
         // A paid response can be independently valid while admission for
         // selection has expired. Retain only verified semantic bytes, without
@@ -301,8 +310,10 @@ export function guardedRefreshRuntime(input: {
                 executionAttestation: returnedResult.executionAttestation } });
           } catch { /* Unvalidated diagnostics never enter the private tape. */ }
         }
-        capture({ kind: "invocation_failed", requestId: command.requestId, delegated });
-        input.record({ ...identity, status: "requires_reconciliation" });
+        const failure = delegated ? {} : { preDelegationFailureStage:
+          error instanceof RefreshRuntimeAssertionFailure ? error.stage : preDelegationFailureStage };
+        capture({ kind: "invocation_failed", requestId: command.requestId, delegated, ...failure });
+        input.record({ ...identity, status: "requires_reconciliation", delegated, ...failure });
         throw new Error("Refresh invocation failed or is ambiguous; original operation remains consumed");
       } finally {
         removeAbortCapture?.();

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-migration.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-migration.spec.ts
@@ -1,0 +1,67 @@
+import type * as PGliteModule from "@electric-sql/pglite";
+import { readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { preProviderFixture } from "./reader-summary-new-input-refresh-reconciliation-pre-provider.spec-support";
+import { reconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation.spec-support";
+import { refreshReconciliationAccountingFor } from "./reader-summary-new-input-refresh-reconciliation";
+
+const migration = (name: string) => readFileSync(join(process.cwd(), "prisma/migrations", name, "migration.sql"), "utf8");
+describe("pre-provider reconciliation migration constraints", () => {
+  let db: PGliteModule.PGlite;
+  const fixture = preProviderFixture();
+  const pre = fixture.evidence, provider = reconciliationEvidence();
+  const insert = (reason: string, invocation: unknown, accounting: unknown) => db.query(`
+    insert into reader_summary_new_input_refresh_reconciliations
+      (job_status, reason, operation, period_started_at, period_ended_at,
+       job_sha256, manifest_sha256, evidence_sha256, invocation, accounting)
+    values ('FAILED', $1, 'new-input-refresh:v1:synthetic', '2026-08-31', '2026-09-01',
+      $2, $2, $2, $3::jsonb, $4::jsonb)`,
+  [reason, "a".repeat(64), JSON.stringify(invocation), JSON.stringify(accounting)]);
+  beforeAll(async () => {
+    const { PGlite } = process.getBuiltinModule("module").createRequire(__filename)("@electric-sql/pglite") as typeof PGliteModule;
+    db = new PGlite();
+    await db.exec(`create role social_monitor_public_schema_owner;
+      grant all on schema public to social_monitor_public_schema_owner;
+      set role social_monitor_public_schema_owner;
+      create table reader_summary_new_input_refresh_reconciliations (
+        job_status text not null, reason text not null, operation text not null,
+        period_started_at timestamptz not null, period_ended_at timestamptz not null,
+        job_sha256 text not null, manifest_sha256 text not null, evidence_sha256 text not null,
+        invocation jsonb not null, accounting jsonb not null,
+        constraint rs_nir_reconciliations_identity_check check (reason = 'consumed_provider_invocation_without_summary'),
+        constraint rs_nir_reconciliations_accounting_check check (true)); reset role;`);
+    await db.exec(migration("20260911015000_reader_summary_reconciliation_reported_usage"));
+    await insert(provider.reason, provider.invocation, refreshReconciliationAccountingFor(provider));
+    await expect(insert(pre.reason, pre.invocation, refreshReconciliationAccountingFor(pre))).rejects.toThrow();
+    await db.exec(migration("20260913060000_reader_summary_reconciliation_pre_provider"));
+  }, 30_000);
+  afterAll(async () => { await db?.close(); rmSync(fixture.root, { recursive: true, force: true }); });
+
+  it("retains existing rows and permits both honest accounting variants", async () => {
+    expect((await db.query("select * from reader_summary_new_input_refresh_reconciliations")).rows).toHaveLength(1);
+    await insert(pre.reason, pre.invocation, refreshReconciliationAccountingFor(pre));
+    await insert(provider.reason, provider.invocation, refreshReconciliationAccountingFor(provider));
+    const reported = { ...provider, invocation: { ...provider.invocation, providerUsageReported: true,
+      usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 } } };
+    await insert(reported.reason, reported.invocation, refreshReconciliationAccountingFor(reported));
+  });
+  it.each([
+    { consumedAt: "2026-09-07T00:00:00.000Z" }, { usage: {} },
+    { providerUsageReported: true }, { delegatedInvocationCount: 1 },
+    { invocationConsumedCount: 1 }, { attempts: [] }, { attempts: null },
+    { captureSha256: null }, { capturePath: 7 },
+  ])("rejects mixed or incomplete zero-provider invocation %j", async (override) => {
+    await expect(insert(pre.reason, { ...pre.invocation, ...override },
+      refreshReconciliationAccountingFor(pre))).rejects.toThrow();
+  });
+  it("rejects crossed reasons/accounting and fabricated usage", async () => {
+    await expect(insert(pre.reason, pre.invocation, refreshReconciliationAccountingFor(provider))).rejects.toThrow();
+    await expect(insert(provider.reason, provider.invocation, refreshReconciliationAccountingFor(pre))).rejects.toThrow();
+    await expect(insert(pre.reason, provider.invocation, refreshReconciliationAccountingFor(pre))).rejects.toThrow();
+    await expect(insert(pre.reason, pre.invocation, { ...refreshReconciliationAccountingFor(pre), usage: {} })).rejects.toThrow();
+    await expect(insert(provider.reason, { ...provider.invocation, providerUsageReported: true,
+      usage: { inputTokens: 2, outputTokens: 3, totalTokens: 6 } },
+    { ...refreshReconciliationAccountingFor(provider), providerUsage: "reported",
+      usage: { inputTokens: 2, outputTokens: 3, totalTokens: 6 } })).rejects.toThrow();
+  });
+});

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-pre-provider.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-pre-provider.spec-support.ts
@@ -1,0 +1,73 @@
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { refreshBytesHash, refreshHash } from "./reader-summary-new-input-refresh-manifest";
+import type { RefreshPreProviderReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
+import { reconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation.spec-support";
+
+export function preProviderFixture(change?: (value: {
+  models: Record<string, unknown>[]; journal: Record<string, unknown>[];
+  manifest: Record<string, unknown>;
+}) => void, commandOverride?: (command: Record<string, unknown>) => void) {
+  const root = mkdtempSync(join(tmpdir(), "refresh-pre-provider-spec-"));
+  const capturePath = join(root, "capture");
+  mkdirSync(capturePath);
+  const base = reconciliationEvidence();
+  const scope = { tenantId: base.tenantId, workspaceId: base.workspaceId,
+    operation: base.operation, observedThrough: "2026-09-07T00:00:00.000Z" };
+  const manifest = { format: "reader-summary-seven-day-new-input-v1", ...scope, date: base.date };
+  const models: Record<string, unknown>[] = [];
+  const journal: Record<string, unknown>[] = [{ at: "2026-09-07T00:00:00.000Z",
+    event: { status: "operation_consumed", operation: base.operation, jobId: base.jobId } }];
+  const attempts = Array.from({ length: 6 }, (_, index) => {
+    // Match the assessment adapter's command shape, including the optional own
+    // property that JSON capture omits but the historical journal hash retains.
+    const command = { tenantId: base.tenantId, workspaceId: base.workspaceId,
+      requestId: `synthetic-${index}`, correlationId: `synthetic-${index}`,
+      provider: "codex", providerInstanceId: undefined,
+      purpose: "social_monitor.relevance.assess_source_content.v1",
+      systemPrompt: "Synthetic instruction", prompt: '{"candidates":[]}', outputSchema: {},
+      controls: { interactive: false, model: "gpt-5.6-sol", reasoningEffort: "low",
+        outputSchemaName: "social_monitor_source_content_quality_review",
+        schemaVersion: "source_content_assessment.v1", maxOutputTokens: 6000 },
+      timeoutMs: 1000, metadata: { adapter: "agent-runtime-source-content-quality-reviewer" } };
+    commandOverride?.(command);
+    const started = { sequence: index + 1, atMs: Date.parse("2026-09-07T00:00:01.000Z"),
+      event: { kind: "invocation_started", command } };
+    const failed = { sequence: index + 7, atMs: Date.parse("2026-09-07T00:00:02.000Z"),
+      event: { kind: "invocation_failed", requestId: command.requestId, delegated: false } };
+    models.push(started, failed);
+    journal.push({ at: "2026-09-07T00:00:02.000Z", event: { status: "requires_reconciliation",
+      operation: base.operation, requestId: command.requestId, purpose: command.purpose,
+      requestSha256: refreshHash(command) } });
+    return { requestId: command.requestId, purpose: command.purpose, requestSha256: refreshHash(command),
+      attemptSha256: refreshHash(JSON.parse(JSON.stringify({ started, failed }))), startedAt: "2026-09-07T00:00:01.000Z",
+      failedAt: "2026-09-07T00:00:02.000Z", outcome: "invocation_failed" as const, delegated: false as const };
+  });
+  models.sort((a, b) => Number(a.sequence) - Number(b.sequence));
+  change?.({ models, journal, manifest });
+  const save = (path: string, text: string) => {
+    writeFileSync(path, text, { mode: 0o600 });
+    chmodSync(path, 0o400);
+    return refreshBytesHash(Buffer.from(text));
+  };
+  const manifestPath = join(root, "manifest.json");
+  const manifestSha256 = save(manifestPath, JSON.stringify(manifest) + "\n");
+  journal.push({ at: "2026-09-07T00:00:03.000Z", event: { status: "stopped_requires_reconciliation",
+    operation: base.operation, manifestSha256 } });
+  const journalPath = join(root, "journal.jsonl");
+  const journalSha256 = save(journalPath, journal.map((row) => JSON.stringify(row) + "\n").join(""));
+  const content = { "started.json": JSON.stringify({ format: "reader-refresh-paired-capture.v1", scope }) + "\n",
+    "controls.json": JSON.stringify({ manifest }) + "\n",
+    "models.jsonl": models.map((row) => JSON.stringify(row) + "\n").join("") };
+  const files = Object.entries(content).map(([name, text]) => ({ name, bytes: Buffer.byteLength(text),
+    sha256: save(join(capturePath, name), text) }));
+  const captureSha256 = save(join(capturePath, "incomplete.json"), JSON.stringify({
+    format: "reader-refresh-paired-capture.v1", scope, complete: false,
+    failures: ["refresh_incomplete"], files, observationCounts: { modelRequests: 6 } }) + "\n");
+  const evidence: RefreshPreProviderReconciliationEvidence = { ...base, manifestSha256,
+    reason: "consumed_job_without_provider_invocation", invocation: {
+      capturePath, journalPath, manifestPath, captureSha256, journalSha256,
+      invocationConsumedCount: 0, delegatedInvocationCount: 0, providerUsageReported: false, attempts } };
+  return { root, evidence };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-pre-provider.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-pre-provider.spec.ts
@@ -1,0 +1,183 @@
+import { chmodSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { assertRefreshReconciliationEvidence, reconcileConsumedRefreshJob, refreshReconciliationAccountingFor,
+  type RefreshReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
+import { FakeReconciliationDatabase, reconciliationDate, reconciliationEvidence, reconciliationJobId,
+  reconciliationOperation } from "./reader-summary-new-input-refresh-reconciliation.spec-support";
+import { preProviderFixture } from "./reader-summary-new-input-refresh-reconciliation-pre-provider.spec-support";
+import { refreshHash, refreshKeyPrefix } from "./reader-summary-new-input-refresh-manifest";
+
+const roots: string[] = [];
+const fixture = (change?: Parameters<typeof preProviderFixture>[0]) => {
+  const value = preProviderFixture(change); roots.push(value.root); return value.evidence;
+};
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+const validate = (evidence: RefreshReconciliationEvidence) =>
+  assertRefreshReconciliationEvidence(evidence, [reconciliationDate]);
+
+it("accepts the original journal hash when JSON drops providerInstanceId: undefined", () => {
+  const e = fixture();
+  const { event: { command } } = JSON.parse(readFileSync(join(e.invocation.capturePath, "models.jsonl"),
+    "utf8").split("\n")[0]!);
+  expect(command).not.toHaveProperty("providerInstanceId");
+  expect(e.invocation.attempts[0]!.requestSha256).not.toBe(refreshHash(command));
+  expect(e.invocation.attempts[0]!.requestSha256).toBe(refreshHash({ ...command, providerInstanceId: undefined }));
+  expect(() => validate(e)).not.toThrow();
+});
+
+it.each(["absent", "present"])("accepts an exact %s provider instance command hash", (shape) => {
+  const value = preProviderFixture(undefined, (command) => {
+    if (shape === "absent") delete command.providerInstanceId;
+    else command.providerInstanceId = "synthetic-instance";
+  });
+  roots.push(value.root);
+  expect(() => validate(value.evidence)).not.toThrow();
+});
+
+it("does not reconstruct other undefined command properties", () => {
+  const value = preProviderFixture(undefined, (command) => { command.cwd = undefined; });
+  roots.push(value.root);
+  expect(() => validate(value.evidence)).toThrow(/integrity is invalid/);
+});
+
+it("still requires evidence to match the exact historical journal hash", () => {
+  const e = fixture(({ models, journal }) => {
+    const { command } = models[0]!.event as { command: Record<string, unknown> };
+    (journal[1]!.event as Record<string, unknown>).requestSha256 =
+      refreshHash(JSON.parse(JSON.stringify(command)));
+  });
+  expect(() => validate(e)).toThrow(/integrity is invalid/);
+});
+
+it.each([null, "synthetic-other-instance"])("rejects changed captured providerInstanceId %j", (providerInstanceId) => {
+  const e = fixture(({ models }) => {
+    const event = models[0]!.event as { command: Record<string, unknown> };
+    event.command.providerInstanceId = providerInstanceId;
+  });
+  expect(() => validate(e)).toThrow(/integrity is invalid/);
+});
+
+it.each(["2026-02-29", "2026-04-31", "2026-9-01"])(
+  "rejects pre-provider noncanonical date %s before opening evidence artifacts", (date) => {
+    const evidence = { ...fixture(), date, operation: refreshKeyPrefix(date) + "a".repeat(64) };
+    expect(() => assertRefreshReconciliationEvidence(evidence, [date])).toThrow(
+      "Refresh reconciliation evidence identity is invalid");
+  });
+
+it("binds all six failed requests to the exact reviewed manifest, capture and consumed job", async () => {
+  const evidence = fixture();
+  expect(() => validate(evidence)).not.toThrow();
+  const accounting = { summaryGenerations: 0, publications: 0, artifacts: 0,
+    providerInvocations: 0, providerUsage: "none" };
+  expect(refreshReconciliationAccountingFor(evidence)).toEqual(accounting);
+  const db = new FakeReconciliationDatabase([{ id: reconciliationJobId, operation: reconciliationOperation,
+    status: "FAILED", artifactId: null, date: reconciliationDate, sha: "f".repeat(64), publications: 0 }]);
+  const input = { client: db.client, evidence, evidenceSha256: "a".repeat(64),
+    now: new Date("2026-09-07T01:00:00.000Z"), ids: { generate: () => "00000000-0000-4000-8000-000000000001" } };
+  expect(await reconcileConsumedRefreshJob(input)).toMatchObject({ status: "reconciled", accounting });
+  expect(await reconcileConsumedRefreshJob(input)).toMatchObject({ status: "already_reconciled", accounting });
+  db.assertJobsUntouched();
+});
+
+it.each([
+  { consumedAt: "2026-09-07T00:00:01.000Z" }, { returnedAt: "2026-09-07T00:00:02.000Z" },
+  { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } }, { providerUsageReported: true },
+  { delegatedInvocationCount: 1 }, { invocationConsumedCount: 1 }, { attempts: [] },
+  { captureSha256: "bad" },
+])("rejects mixed or false pre-provider shape %j", (override) => {
+  const e = fixture();
+  expect(() => validate({ ...e, invocation: { ...e.invocation, ...override } } as RefreshReconciliationEvidence)).toThrow();
+});
+
+it("preserves provider-consumed validation and rejects mixing capture claims into it", () => {
+  const e = reconciliationEvidence();
+  expect(() => validate(e)).not.toThrow();
+  expect(refreshReconciliationAccountingFor(e).providerInvocations).toBe(1);
+  expect(() => validate({ ...e, invocation: { ...e.invocation, captureSha256: "a".repeat(64) } } as
+    RefreshReconciliationEvidence)).toThrow();
+});
+
+it.each(["attemptSha256", "requestSha256", "startedAt", "failedAt", "delegated"])(
+  "rejects a changed attempt %s", (field) => {
+    const e = fixture();
+    const attempts = e.invocation.attempts.map((attempt, i) => i ? attempt : { ...attempt, [field]: "wrong" });
+    expect(() => validate({ ...e, invocation: { ...e.invocation, attempts } } as RefreshReconciliationEvidence)).toThrow();
+  });
+
+it.each(["invocation_returned", "envelope_verified", "envelope_not_consumed", "invocation_aborted"])(
+  "rejects a rehashed capture with %s", (kind) => {
+    const e = fixture(({ models }) => models.push({ sequence: 13, atMs: 1788739202500,
+      event: { kind, requestId: "synthetic-0" } }));
+    expect(() => validate(e)).toThrow();
+  });
+
+it("rejects a delegated failure even when the capture digest was reviewed", () => {
+  const e = fixture(({ models }) => { (models[6]!.event as Record<string, unknown>).delegated = true; });
+  expect(() => validate(e)).toThrow();
+});
+
+it("rejects a missing failed pair", () => {
+  const e = fixture(({ models }) => { models.pop(); });
+  expect(() => validate(e)).toThrow();
+});
+
+it("rejects current-operation consumption hidden among other journal operations", () => {
+  const e = fixture(({ journal }) => journal.push({ at: "2026-09-07T00:00:01.000Z",
+    event: { status: "invocation_consumed", operation: reconciliationOperation, requestId: "synthetic-0" } }));
+  expect(() => validate(e)).toThrow();
+});
+
+it.each(["jobId", "operation"])("rejects a false consumed job %s", (field) => {
+  const e = fixture(({ journal }) => { (journal[0]!.event as Record<string, unknown>)[field] = "wrong"; });
+  expect(() => validate(e)).toThrow();
+});
+
+it("rejects duplicate attempts", () => {
+  const e = fixture();
+  expect(() => validate({ ...e, invocation: { ...e.invocation,
+    attempts: [...e.invocation.attempts, e.invocation.attempts[0]!] } })).toThrow();
+});
+
+it.each(["models.jsonl", "controls.json", "incomplete.json"])("rejects changed capture bytes in %s", (name) => {
+  const e = fixture(), path = join(e.invocation.capturePath, name);
+  chmodSync(path, 0o600); writeFileSync(path, "{}\n"); chmodSync(path, 0o400);
+  expect(() => validate(e)).toThrow();
+});
+
+it("rejects extra unlisted capture files and writable journals", () => {
+  const e = fixture();
+  writeFileSync(join(e.invocation.capturePath, "late.jsonl"), "{}\n");
+  expect(() => validate(e)).toThrow();
+  rmSync(join(e.invocation.capturePath, "late.jsonl"));
+  chmodSync(e.invocation.journalPath, 0o600);
+  expect(() => validate(e)).toThrow();
+});
+
+it.each(["journalPath", "manifestPath"] as const)("rejects changed reviewed bytes at %s", (key) => {
+  const e = fixture(), path = e.invocation[key];
+  chmodSync(path, 0o600); writeFileSync(path, "{}\n"); chmodSync(path, 0o400);
+  expect(() => validate(e)).toThrow();
+});
+
+it("rejects an invocation that claims a different operation for a captured request", () => {
+  const e = fixture(({ journal }) => journal.push({ at: "2026-09-07T00:00:01.000Z",
+    event: { status: "invocation_consumed", operation: "different-operation", requestId: "synthetic-0" } }));
+  expect(() => validate(e)).toThrow();
+});
+
+it("rejects unscoped provider evidence", () => {
+  const e = fixture(({ journal }) => journal.push({ at: "2026-09-07T00:00:01.000Z",
+    event: { status: "verified_attestation", attestation: {} } }));
+  expect(() => validate(e)).toThrow();
+});
+
+it.each(["2026-08-29", "2026-09-06"])("rejects valid calendar date %s outside canonical refreshDates before SQL", async (date) => {
+  const client = { $queryRaw: jest.fn() };
+  for (const original of [reconciliationEvidence(), fixture()]) {
+    const evidence = { ...original, date, operation: refreshKeyPrefix(date) + "a".repeat(64) };
+    await expect(reconcileConsumedRefreshJob({ client, evidence, evidenceSha256: "a".repeat(64),
+      now: new Date("2026-09-07T01:00:00.000Z"), ids: { generate: () => "synthetic" } })).rejects.toThrow(
+      "Refresh reconciliation evidence identity is invalid");
+  }
+  expect(client.$queryRaw).not.toHaveBeenCalled();
+});

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-pre-provider.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-pre-provider.spec.ts
@@ -5,7 +5,7 @@ import { assertRefreshReconciliationEvidence, reconcileConsumedRefreshJob, refre
 import { FakeReconciliationDatabase, reconciliationDate, reconciliationEvidence, reconciliationJobId,
   reconciliationOperation } from "./reader-summary-new-input-refresh-reconciliation.spec-support";
 import { preProviderFixture } from "./reader-summary-new-input-refresh-reconciliation-pre-provider.spec-support";
-import { refreshHash, refreshKeyPrefix } from "./reader-summary-new-input-refresh-manifest";
+import { refreshBytesHash, refreshHash, refreshKeyPrefix } from "./reader-summary-new-input-refresh-manifest";
 
 const roots: string[] = [];
 const fixture = (change?: Parameters<typeof preProviderFixture>[0]) => {
@@ -165,7 +165,65 @@ it("rejects an invocation that claims a different operation for a captured reque
   expect(() => validate(e)).toThrow();
 });
 
-it("rejects unscoped provider evidence", () => {
+it("accepts an unrelated historical unscoped attestation in the immutable daily journal", () => {
+  const e = fixture(({ journal }) => journal.unshift({ at: "2026-09-06T23:00:00.000Z",
+    event: { status: "verified_attestation", operation: undefined,
+      requestId: "synthetic-historical", attestation: {} } }));
+  expect(e.invocation.attempts).toHaveLength(6);
+  expect(e.invocation.attempts.map((attempt) => attempt.requestId)).not.toContain("synthetic-historical");
+  expect(() => validate(e)).not.toThrow();
+});
+
+it.each([
+  { status: "invocation_consumed" }, { status: "invocation_returned" },
+  { status: "verified_attestation", attestation: {} }, { delegated: true },
+  { tokens: 0 }, { usage: {} },
+])("rejects unscoped current-request provider evidence %j", (providerEvidence) => {
+  for (let index = 0; index < 6; index++) {
+    const e = fixture(({ journal }) => journal.push({ at: "2026-09-07T00:00:01.000Z",
+      event: { ...providerEvidence, requestId: `synthetic-${index}` } }));
+    expect(() => validate(e)).toThrow(/integrity is invalid/);
+  }
+});
+
+it.each([
+  { status: "invocation_consumed" }, { status: "invocation_returned" },
+  { status: "verified_attestation", attestation: {} }, { delegated: true },
+  { tokens: 0 }, { usage: {} },
+])("rejects current-operation provider evidence with an unrelated request ID %j", (providerEvidence) => {
+  const e = fixture(({ journal }) => journal.push({ at: "2026-09-07T00:00:01.000Z",
+    event: { ...providerEvidence, operation: reconciliationOperation, requestId: "synthetic-historical" } }));
+  expect(() => validate(e)).toThrow(/integrity is invalid/);
+});
+
+it.each([
+  undefined, { status: "invocation_consumed" }, { status: "invocation_returned" },
+  { status: "verified_attestation", attestation: {} }, { delegated: true },
+  { tokens: 0 }, { usage: {} },
+])("guards rejected captured request evidence %j", (providerEvidence) => {
+  for (const operation of [undefined, "different-operation", reconciliationOperation]) {
+    const e = fixture(({ models, journal }) => {
+      const { command } = models[0]!.event as { command: Record<string, unknown> };
+      models.push({ sequence: 13, atMs: 1788739202500, event: {
+        kind: "invocation_rejected", delegated: false,
+        command: { ...command, requestId: "synthetic-rejected" } } });
+      journal.unshift({ at: "2026-09-06T23:00:00.000Z", event: {
+        status: "verified_attestation", requestId: "synthetic-historical", attestation: {} } });
+      if (providerEvidence) journal.push({ at: "2026-09-07T00:00:02.500Z", event: {
+        ...providerEvidence, operation, requestId: "synthetic-rejected" } });
+    });
+    const path = join(e.invocation.capturePath, "incomplete.json");
+    const capture = JSON.parse(readFileSync(path, "utf8"));
+    capture.observationCounts.modelRequests = 7;
+    const bytes = Buffer.from(JSON.stringify(capture) + "\n");
+    chmodSync(path, 0o600); writeFileSync(path, bytes); chmodSync(path, 0o400);
+    e.invocation.captureSha256 = refreshBytesHash(bytes);
+    if (providerEvidence) expect(() => validate(e)).toThrow(/integrity is invalid/);
+    else expect(() => validate(e)).not.toThrow();
+  }
+});
+
+it("rejects unscoped provider evidence without a request ID", () => {
   const e = fixture(({ journal }) => journal.push({ at: "2026-09-07T00:00:01.000Z",
     event: { status: "verified_attestation", attestation: {} } }));
   expect(() => validate(e)).toThrow();

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-pre-provider.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-pre-provider.spec.ts
@@ -217,7 +217,7 @@ it.each([
     capture.observationCounts.modelRequests = 7;
     const bytes = Buffer.from(JSON.stringify(capture) + "\n");
     chmodSync(path, 0o600); writeFileSync(path, bytes); chmodSync(path, 0o400);
-    e.invocation.captureSha256 = refreshBytesHash(bytes);
+    Object.assign(e.invocation, { captureSha256: refreshBytesHash(bytes) });
     if (providerEvidence) expect(() => validate(e)).toThrow(/integrity is invalid/);
     else expect(() => validate(e)).not.toThrow();
   }

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec-support.ts
@@ -1,5 +1,5 @@
 import { refreshScope } from "./reader-summary-new-input-refresh-manifest";
-import type { RefreshReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
+import type { RefreshProviderReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
 
 export const reconciliationDate = "2026-09-03";
 export const reconciliationJobId = "1767fd5c-2fe5-4fef-84e0-22c380932e81";
@@ -7,8 +7,8 @@ export const reconciliationOperation =
   `new-input-refresh:v1:${reconciliationDate}:${"b".repeat(64)}`;
 
 export const reconciliationEvidence = (
-  override: Partial<RefreshReconciliationEvidence> = {},
-): RefreshReconciliationEvidence => ({
+  override: Partial<RefreshProviderReconciliationEvidence> = {},
+): RefreshProviderReconciliationEvidence => ({
   format: "reader-summary-new-input-refresh-reconciliation-v1",
   ...refreshScope, date: reconciliationDate, jobId: reconciliationJobId,
   operation: reconciliationOperation, manifestSha256: "3".repeat(64),

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.spec.ts
@@ -1,4 +1,4 @@
-import { refreshScope } from "./reader-summary-new-input-refresh-manifest";
+import { refreshKeyPrefix, refreshScope } from "./reader-summary-new-input-refresh-manifest";
 import { assertRefreshReconciliationEvidence, reconcileConsumedRefreshJob,
   refreshReconciliationAccounting } from "./reader-summary-new-input-refresh-reconciliation";
 import { assertRefreshReconciliationCountersEvidence, importRefreshReconciliationCounters } from
@@ -18,6 +18,22 @@ const apply = (database: FakeReconciliationDatabase, override = {}, sha = eviden
     evidenceSha256: sha, now, ids });
 
 describe("new-input refresh consumed-job reconciliation", () => {
+  it.each(["2026-02-29", "2026-04-31", "2026-13-01", "2026-00-01", "2026-09-00",
+    "2026-9-01", "2026-09-01T00:00:00.000Z", " 2026-09-01", "0000-00-00"])(
+    "rejects noncanonical date %s even when explicitly allowed, before database access", async (date) => {
+      const evidence = reconciliationEvidence({ date, operation: refreshKeyPrefix(date) + "a".repeat(64) });
+      expect(() => assertRefreshReconciliationEvidence(evidence, [date])).toThrow(/identity is invalid/u);
+      const query = jest.fn();
+      await expect(reconcileConsumedRefreshJob({ client: { $queryRaw: query }, evidence,
+        evidenceSha256, now, ids })).rejects.toThrow(/identity is invalid/u);
+      expect(query).not.toHaveBeenCalled();
+    });
+
+  it.each(["2024-02-29", "2026-04-30"])("accepts canonical calendar date %s", (date) => {
+    const evidence = reconciliationEvidence({ date, operation: refreshKeyPrefix(date) + "a".repeat(64) });
+    expect(() => assertRefreshReconciliationEvidence(evidence, [date])).not.toThrow();
+  });
+
   it("records the consumed attempt as accounted for, never as completed", async () => {
     const database = new FakeReconciliationDatabase([{ ...consumed }]);
     const receipt = await apply(database);

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
@@ -244,9 +244,11 @@ function assertPreProviderArtifacts(e: RefreshPreProviderReconciliationEvidence)
   for (const row of journal) {
     const event = object(row.event);
     // An event for one of these requests cannot escape validation by claiming
-    // another operation. Unscoped provider evidence cannot prove zero either.
-    if ((requests.has(String(event.requestId)) && event.operation !== e.operation) ||
-        (event.operation === undefined && (event.status === "invocation_consumed" ||
+    // another operation. Unscoped provider evidence needs a distinct request ID
+    // to be unrelated historical evidence; missing IDs still cannot prove zero.
+    if (((requests.has(String(event.requestId)) || rejected.has(String(event.requestId))) &&
+          event.operation !== e.operation) ||
+        (event.operation === undefined && !nonempty(event.requestId) && (event.status === "invocation_consumed" ||
           event.status === "invocation_returned" || event.status === "verified_attestation" ||
           event.delegated === true || "tokens" in event || "usage" in event))) invalid();
   }

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
@@ -1,17 +1,20 @@
-import { lstatSync, readFileSync, realpathSync } from "node:fs";
-import { resolve } from "node:path";
+import { lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { join, resolve } from "node:path";
 import type { IdGenerator } from "@social-monitor/shared-kernel";
-import { refreshBytesHash, refreshHash, refreshKeyPrefix, refreshScope } from
+import { refreshBytesHash, refreshDates, refreshHash, refreshKeyPrefix, refreshScope } from
   "./reader-summary-new-input-refresh-manifest";
 
 /** Operator-reviewed statement that one consumed new-input-refresh attempt is
  * accounted for. It asserts consumption, never success: the original job row is
  * never written to. Provider usage is preserved when the reviewed provider
  * response reports it, and otherwise stays explicitly unknown. */
-export type RefreshReconciliationEvidence = Readonly<{
+type RefreshReconciliationIdentity = Readonly<{
   format: "reader-summary-new-input-refresh-reconciliation-v1";
   tenantId: string; workspaceId: string; date: string;
   jobId: string; operation: string; manifestSha256: string;
+}>;
+
+export type RefreshProviderReconciliationEvidence = RefreshReconciliationIdentity & Readonly<{
   reason: "consumed_provider_invocation_without_summary";
   invocation: Readonly<{
     requestId: string; purpose: string; requestSha256: string;
@@ -21,12 +24,34 @@ export type RefreshReconciliationEvidence = Readonly<{
   }>;
 }>;
 
+/** Reviewed whole-job capture and journal digests attest zero delegation, not
+ * merely failure of one batch. Attempts identify every started failed request.
+ * No provider result or consumption timestamp is asserted by this variant. */
+export type RefreshPreProviderReconciliationEvidence = RefreshReconciliationIdentity & Readonly<{
+  reason: "consumed_job_without_provider_invocation";
+  invocation: Readonly<{
+    capturePath: string; journalPath: string; manifestPath: string;
+    captureSha256: string; journalSha256: string;
+    invocationConsumedCount: 0; delegatedInvocationCount: 0;
+    providerUsageReported: false;
+    attempts: readonly Readonly<{
+      requestId: string; purpose: string; requestSha256: string; attemptSha256: string;
+      startedAt: string; failedAt: string; outcome: "invocation_failed"; delegated: false;
+    }>[];
+  }>;
+}>;
+export type RefreshReconciliationEvidence =
+  RefreshProviderReconciliationEvidence | RefreshPreProviderReconciliationEvidence;
+
 export const refreshReconciliationAccounting = Object.freeze({
   summaryGenerations: 0, publications: 0, artifacts: 0,
   providerInvocations: 1, providerUsage: "unknown" as const,
 });
 export const refreshReconciliationAccountingFor = (evidence: RefreshReconciliationEvidence) =>
-  evidence.invocation.providerUsageReported
+  evidence.reason === "consumed_job_without_provider_invocation"
+    ? Object.freeze({ summaryGenerations: 0, publications: 0, artifacts: 0,
+      providerInvocations: 0, providerUsage: "none" as const })
+    : evidence.invocation.providerUsageReported
     ? Object.freeze({ ...refreshReconciliationAccounting, providerUsage: "reported" as const,
       usage: evidence.invocation.usage! })
     : refreshReconciliationAccounting;
@@ -42,19 +67,33 @@ const isoInstant = (value: unknown): value is string => {
 export function assertRefreshReconciliationEvidence(
   evidence: RefreshReconciliationEvidence, dates: readonly string[],
 ): void {
-  const invocation = evidence?.invocation;
   if (evidence?.format !== "reader-summary-new-input-refresh-reconciliation-v1" ||
       evidence.tenantId !== refreshScope.tenantId ||
       evidence.workspaceId !== refreshScope.workspaceId ||
+      typeof evidence.date !== "string" || !/^\d{4}-\d{2}-\d{2}$/u.test(evidence.date) ||
+      !isoInstant(`${evidence.date}T00:00:00.000Z`) ||
       !dates.includes(evidence.date) || !uuid.test(evidence.jobId) ||
       typeof evidence.operation !== "string" ||
       !evidence.operation.startsWith(refreshKeyPrefix(evidence.date)) ||
       !sha256.test(evidence.operation.slice(refreshKeyPrefix(evidence.date).length)) ||
       !sha256.test(evidence.manifestSha256) ||
-      evidence.reason !== "consumed_provider_invocation_without_summary") {
+      (evidence.reason !== "consumed_provider_invocation_without_summary" &&
+        evidence.reason !== "consumed_job_without_provider_invocation")) {
     throw new Error("Refresh reconciliation evidence identity is invalid");
   }
+  if (evidence.reason === "consumed_job_without_provider_invocation") {
+    if (!onlyKeys(evidence, ["format", "tenantId", "workspaceId", "date", "jobId", "operation",
+      "manifestSha256", "reason", "invocation"])) {
+      throw new Error("Refresh reconciliation pre-provider identity is invalid");
+    }
+    assertPreProviderInvocation(evidence.invocation);
+    assertPreProviderArtifacts(evidence);
+    return;
+  }
+  const invocation = evidence.invocation;
   if (typeof invocation !== "object" || invocation === null ||
+      !onlyKeys(invocation, ["requestId", "purpose", "requestSha256", "attemptSha256",
+        "consumedAt", "returnedAt", "outcome", "providerUsageReported", "usage"]) ||
       typeof invocation.requestId !== "string" || invocation.requestId.trim().length === 0 ||
       typeof invocation.purpose !== "string" || invocation.purpose.trim().length === 0 ||
       !sha256.test(invocation.requestSha256) || !sha256.test(invocation.attemptSha256) ||
@@ -63,12 +102,176 @@ export function assertRefreshReconciliationEvidence(
       typeof invocation.outcome !== "string" || invocation.outcome.trim().length === 0 ||
       typeof invocation.providerUsageReported !== "boolean" ||
       (invocation.providerUsageReported
-        ? invocation.usage === undefined || ![invocation.usage.inputTokens, invocation.usage.outputTokens,
+        ? (typeof invocation.usage !== "object" || invocation.usage === null) || ![invocation.usage.inputTokens, invocation.usage.outputTokens,
           invocation.usage.totalTokens].every((count) => Number.isSafeInteger(count) && count >= 0) ||
           invocation.usage.totalTokens !== invocation.usage.inputTokens + invocation.usage.outputTokens
         : invocation.usage !== undefined)) {
     throw new Error("Refresh reconciliation invocation identity is invalid");
   }
+}
+
+const onlyKeys = (value: object, keys: readonly string[]) =>
+  !Array.isArray(value) && Object.keys(value).every((key) => keys.includes(key));
+const nonempty = (value: unknown) => typeof value === "string" && value.trim().length > 0;
+function assertPreProviderInvocation(value: RefreshPreProviderReconciliationEvidence["invocation"]): void {
+  if (typeof value !== "object" || value === null ||
+      !onlyKeys(value, ["capturePath", "journalPath", "manifestPath", "captureSha256", "journalSha256", "invocationConsumedCount",
+        "delegatedInvocationCount", "providerUsageReported", "attempts"]) ||
+      ![value.capturePath, value.journalPath, value.manifestPath].every((path) =>
+        typeof path === "string" && path.startsWith("/")) ||
+      !sha256.test(value.captureSha256) || !sha256.test(value.journalSha256) ||
+      value.invocationConsumedCount !== 0 || value.delegatedInvocationCount !== 0 ||
+      value.providerUsageReported !== false || !Array.isArray(value.attempts) ||
+      value.attempts.length === 0) {
+    throw new Error("Refresh reconciliation pre-provider identity is invalid");
+  }
+  const requests = new Set<string>();
+  for (const attempt of value.attempts) {
+    if (typeof attempt !== "object" || attempt === null ||
+        !onlyKeys(attempt, ["requestId", "purpose", "requestSha256", "attemptSha256",
+          "startedAt", "failedAt", "outcome", "delegated"]) ||
+        !nonempty(attempt.requestId) || !nonempty(attempt.purpose) || requests.has(attempt.requestId) ||
+        !sha256.test(attempt.requestSha256) || !sha256.test(attempt.attemptSha256) ||
+        !isoInstant(attempt.startedAt) || !isoInstant(attempt.failedAt) ||
+        Date.parse(attempt.failedAt) < Date.parse(attempt.startedAt) ||
+        attempt.outcome !== "invocation_failed" || attempt.delegated !== false) {
+      throw new Error("Refresh reconciliation pre-provider attempt identity is invalid");
+    }
+    requests.add(attempt.requestId);
+  }
+}
+// These are immutable reviewed copies, never live runtime paths. Hash the full
+// capture inventory and journal, then derive every zero-delegation claim from
+// their contents. An incomplete workflow is allowed; an incomplete tape is not.
+function assertPreProviderArtifacts(e: RefreshPreProviderReconciliationEvidence): void {
+  const invalid = (): never => { throw new Error("Refresh reconciliation pre-provider capture/journal integrity is invalid"); };
+  const object = (value: unknown): Record<string, unknown> => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return invalid();
+    return value as Record<string, unknown>;
+  };
+  const array = (value: unknown): unknown[] => Array.isArray(value) ? value : invalid();
+  const immutable = (path: string, hash?: string): Buffer => {
+    const absolute = resolve(path), stat = lstatSync(absolute);
+    if (realpathSync(absolute) !== absolute || !stat.isFile() || stat.nlink !== 1 ||
+        (stat.mode & 0o222) !== 0) return invalid();
+    const bytes = readFileSync(absolute);
+    if (hash !== undefined && refreshBytesHash(bytes) !== hash) return invalid();
+    return bytes;
+  };
+  const parse = (bytes: Buffer) => object(JSON.parse(bytes.toString("utf8")));
+  const lines = (bytes: Buffer) => {
+    const text = bytes.toString("utf8");
+    if (!text.endsWith("\n")) return invalid();
+    return text.slice(0, -1).split("\n").map((line) => object(JSON.parse(line)));
+  };
+  const v = e.invocation;
+  const manifest = parse(immutable(v.manifestPath, e.manifestSha256));
+  if (manifest.format !== "reader-summary-seven-day-new-input-v1" ||
+      manifest.operation !== e.operation || manifest.date !== e.date ||
+      manifest.tenantId !== e.tenantId || manifest.workspaceId !== e.workspaceId) invalid();
+  const directory = resolve(v.capturePath);
+  if (realpathSync(directory) !== directory || !lstatSync(directory).isDirectory()) invalid();
+  const capture = parse(immutable(join(directory, "incomplete.json"), v.captureSha256));
+  const scope = object(capture.scope);
+  if (capture.format !== "reader-refresh-paired-capture.v1" || capture.complete !== false ||
+      scope.tenantId !== e.tenantId || scope.workspaceId !== e.workspaceId ||
+      scope.operation !== e.operation || scope.observedThrough !== manifest.observedThrough) invalid();
+  const permittedFailures = ["refresh_incomplete", "selection_failed", "missing_producer_callback",
+    "assessment_coverage_failed", "assessment_closure_incomplete", "assessment_closure_missing",
+    "missing_canonical-bindings.json"];
+  if (array(capture.failures).some((failure) => !permittedFailures.includes(String(failure)))) invalid();
+  const files = new Map<string, Buffer>();
+  for (const item of array(capture.files)) {
+    const file = object(item);
+    if (typeof file.name !== "string" || !/^[a-z][a-z0-9-]*\.jsonl?$/u.test(file.name) ||
+        file.name === "incomplete.json" || file.name === "complete.json" || files.has(file.name) ||
+        typeof file.sha256 !== "string" || !sha256.test(file.sha256)) invalid();
+    const name = file.name as string;
+    const bytes = immutable(join(directory, name), file.sha256 as string);
+    if (bytes.length !== file.bytes) invalid();
+    files.set(name, bytes);
+  }
+  if (refreshHash(readdirSync(directory).sort()) !==
+      refreshHash([...files.keys(), "incomplete.json"].sort())) invalid();
+  const required = (name: string) => files.get(name) ?? invalid();
+  const controls = parse(required("controls.json"));
+  if (refreshHash(controls.manifest) !== refreshHash(manifest)) invalid();
+  const started = parse(required("started.json"));
+  if (started.format !== capture.format || refreshHash(started.scope) !== refreshHash(scope)) invalid();
+  const models = lines(required("models.jsonl"));
+  const requests = new Map<string, { row: Record<string, unknown>; failed?: Record<string, unknown> }>();
+  const rejected = new Set<string>();
+  let sequence = 0;
+  for (const row of models) {
+    if (!Number.isSafeInteger(row.sequence) || Number(row.sequence) <= sequence ||
+        !Number.isSafeInteger(row.atMs)) invalid();
+    sequence = Number(row.sequence);
+    const event = object(row.event);
+    if (event.kind === "invocation_started" || event.kind === "invocation_rejected") {
+      const command = object(event.command), id = command.requestId;
+      if (!nonempty(id) || command.tenantId !== e.tenantId || command.workspaceId !== e.workspaceId ||
+          requests.has(String(id)) || rejected.has(String(id))) invalid();
+      if (event.kind === "invocation_rejected") {
+        if (event.delegated !== false) invalid();
+        rejected.add(String(id));
+      } else requests.set(String(id), { row });
+    } else if (event.kind === "invocation_failed") {
+      const request = requests.get(String(event.requestId));
+      if (!request || request.failed || event.delegated !== false ||
+          Number(row.atMs) < Number(request.row.atMs)) invalid();
+      request!.failed = row;
+    } else invalid(); // returned, envelope, abort or unknown means zero is unproven
+  }
+  if (requests.size !== v.attempts.length ||
+      object(capture.observationCounts).modelRequests !== requests.size + rejected.size) invalid();
+  for (const attempt of v.attempts) {
+    const request = requests.get(attempt.requestId);
+    if (!request?.failed) invalid();
+    const start = request!.row, failed = request!.failed!;
+    const command = object(object(start.event).command);
+    // The journal hashes the original command; JSON capture drops an own
+    // providerInstanceId: undefined. Reconstruct only that known lost property,
+    // without changing historical hashes or normalizing other command fields.
+    const requestMatches = refreshHash(command) === attempt.requestSha256 ||
+      (!Object.prototype.hasOwnProperty.call(command, "providerInstanceId") &&
+        refreshHash({ ...command, providerInstanceId: undefined }) === attempt.requestSha256);
+    if (command.purpose !== attempt.purpose || !requestMatches ||
+        refreshHash({ started: start, failed }) !== attempt.attemptSha256 ||
+        new Date(Number(start.atMs)).toISOString() !== attempt.startedAt ||
+        new Date(Number(failed.atMs)).toISOString() !== attempt.failedAt) invalid();
+  }
+  const journal = lines(immutable(v.journalPath, v.journalSha256));
+  for (const row of journal) {
+    const event = object(row.event);
+    // An event for one of these requests cannot escape validation by claiming
+    // another operation. Unscoped provider evidence cannot prove zero either.
+    if ((requests.has(String(event.requestId)) && event.operation !== e.operation) ||
+        (event.operation === undefined && (event.status === "invocation_consumed" ||
+          event.status === "invocation_returned" || event.status === "verified_attestation" ||
+          event.delegated === true || "tokens" in event || "usage" in event))) invalid();
+  }
+  const current = journal.filter((row) => object(row.event).operation === e.operation);
+  const consumed = current.filter((row) => object(row.event).status === "operation_consumed");
+  const stopped = current.filter((row) => object(row.event).status === "stopped_requires_reconciliation");
+  if (consumed.length !== 1 || object(consumed[0]!.event).jobId !== e.jobId || stopped.length !== 1 ||
+      object(stopped[0]!.event).manifestSha256 !== e.manifestSha256) invalid();
+  const failures = new Set<string>();
+  const permitted = ["before", "admission", "preflight", "operation_consumed", "requires_reconciliation",
+    "stopped_requires_reconciliation"];
+  for (const row of current) {
+    const event = object(row.event);
+    if (!isoInstant(row.at) || !permitted.includes(String(event.status)) ||
+        event.delegated === true || "tokens" in event || "usage" in event || "attestation" in event) invalid();
+    if (event.status === "requires_reconciliation") {
+      const attempt = v.attempts.find((item) => item.requestId === event.requestId);
+      if (!attempt || failures.has(attempt.requestId) || event.requestSha256 !== attempt.requestSha256 ||
+          event.purpose !== attempt.purpose || Date.parse(String(row.at)) < Date.parse(attempt.failedAt)) invalid();
+      failures.add(attempt!.requestId);
+    }
+  }
+  if (failures.size !== requests.size || v.attempts.some((attempt) =>
+    Date.parse(attempt.startedAt) < Date.parse(String(consumed[0]!.at)) ||
+    Date.parse(attempt.failedAt) > Date.parse(String(stopped[0]!.at)))) invalid();
 }
 
 export function readReviewedRefreshReconciliation(
@@ -184,6 +387,7 @@ export async function reconcileConsumedRefreshJob(input: {
   evidenceSha256: string; now: Date; ids: IdGenerator;
 }): Promise<RefreshReconciliationReceipt> {
   const { client, evidence, evidenceSha256 } = input;
+  assertRefreshReconciliationEvidence(evidence, refreshDates);
   const accounting = refreshReconciliationAccountingFor(evidence);
   const inserted = await insertReconciliation(client,
     { id: input.ids.generate(), evidence, evidenceSha256, now: input.now });

--- a/scripts/lib/reader-summary-new-input-refresh-runtime-assertion.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-runtime-assertion.spec.ts
@@ -1,0 +1,77 @@
+import { singleFlightRefreshRuntimeAssertion } from "./reader-summary-new-input-refresh-runtime-assertion";
+import { resolveReaderSummaryServingAuthority } from "./reader-summary-serving-authority";
+import { assertRefreshEqual } from "./reader-summary-new-input-refresh-guard";
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+describe("refresh live runtime identity single flight", () => {
+  it("shares one health probe among six overlapping assertions and re-probes later", async () => {
+    const first = deferred(), later = deferred();
+    const checkHealth = jest.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(later.promise);
+    const assertIdentity = singleFlightRefreshRuntimeAssertion(checkHealth);
+    const calls = Array.from({ length: 6 }, () => assertIdentity());
+    expect(new Set(calls).size).toBe(1);
+    await Promise.resolve();
+    expect(checkHealth).toHaveBeenCalledTimes(1);
+    first.resolve();
+    await Promise.all(calls);
+    const next = assertIdentity();
+    expect(next).not.toBe(calls[0]);
+    await Promise.resolve();
+    expect(checkHealth).toHaveBeenCalledTimes(2);
+    later.resolve();
+    await next;
+  });
+
+  it("shares the exact rejection with all six callers and clears after failure", async () => {
+    const probe = deferred();
+    const error = new Error("synthetic health failure");
+    const checkHealth = jest.fn().mockReturnValueOnce(probe.promise).mockResolvedValue(undefined);
+    const assertIdentity = singleFlightRefreshRuntimeAssertion(checkHealth);
+    const calls = Array.from({ length: 6 }, () => assertIdentity());
+    const settled = Promise.allSettled(calls);
+    await Promise.resolve();
+    expect(checkHealth).toHaveBeenCalledTimes(1);
+    probe.reject(error);
+    expect(await settled).toEqual(Array.from({ length: 6 }, () => ({ status: "rejected", reason: error })));
+    await expect(assertIdentity()).resolves.toBeUndefined();
+    expect(checkHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it("also clears a synchronous assertion throw", async () => {
+    const checkHealth = jest.fn().mockImplementationOnce(() => { throw new Error("synthetic"); })
+      .mockResolvedValue(undefined);
+    const assertion = singleFlightRefreshRuntimeAssertion(checkHealth);
+    await expect(assertion()).rejects.toThrow("synthetic");
+    await expect(assertion()).resolves.toBeUndefined();
+  });
+});
+
+it.each(["runtimeEngine", "runtimeVersion", "launcherSha256"] as const)(
+  "re-probes the real serving resolver and rejects later %s drift", async (field) => {
+    const probe = deferred();
+    const health = { status: "serving" as const, runtimeEngine: "subscription-runtime-cli",
+      runtimeVersion: "1.2.3", launcherSha256: "a".repeat(64), warnings: [] };
+    const checkHealth = jest.fn(async () => { await probe.promise; return health; });
+    const assertion = singleFlightRefreshRuntimeAssertion(async () => {
+      const serving = await resolveReaderSummaryServingAuthority({ summaryModelMode: "agent-runtime",
+        topicLabelerMode: "agent-runtime", env: {}, agentRuntimeClient: { checkHealth },
+        checkedAt: "2026-09-13T00:00:00.000Z" });
+      assertRefreshEqual(serving.runtime, { engine: "subscription-runtime-cli",
+        packageVersion: "1.2.3", launcherSha256: "a".repeat(64) }, "deployed runtime");
+    });
+    const overlapping = Array.from({ length: 6 }, () => assertion());
+    await Promise.resolve();
+    expect(checkHealth).toHaveBeenCalledTimes(1);
+    probe.resolve();
+    await Promise.all(overlapping);
+    health[field] = field === "runtimeVersion" ? "1.2.4" : field === "launcherSha256" ? "b".repeat(64) : "wrong-engine";
+    await expect(assertion()).rejects.toThrow(/drifted|not production-safe/);
+    expect(checkHealth).toHaveBeenCalledTimes(2);
+    expect(checkHealth).toHaveBeenLastCalledWith("reader-summary-production-day-proof-out");
+  });

--- a/scripts/lib/reader-summary-new-input-refresh-runtime-assertion.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-runtime-assertion.ts
@@ -1,0 +1,22 @@
+/** Share only an unsettled live identity assertion within this refresh process.
+ * Freshness, fences and database checks remain owned by each caller. */
+export function singleFlightRefreshRuntimeAssertion(assertIdentity: () => Promise<void>): () => Promise<void> {
+  let pending: Promise<void> | undefined;
+  return () => {
+    if (pending === undefined) {
+      pending = Promise.resolve().then(assertIdentity).finally(() => { pending = undefined; });
+    }
+    return pending;
+  };
+}
+
+export type RefreshPreDelegationFailureStage = "local" | "assessment_budget" |
+  "request_admission" | "runtime_health" | "runtime_mismatch" |
+  "current_authority" | "journal_consumption";
+
+/** Fixed codes only: neither exception text nor provider payload is retained. */
+export class RefreshRuntimeAssertionFailure extends Error {
+  constructor(readonly stage: "runtime_health" | "runtime_mismatch") {
+    super("Refresh live runtime assertion failed");
+  }
+}

--- a/scripts/lib/reader-summary-new-input-refresh-successor.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-successor.ts
@@ -5,7 +5,7 @@ import type { PrismaReaderSummaryClient } from "@social-monitor/summary/adapters
 import { assertRefreshManifest, refreshBytesHash, refreshHash,
   type RefreshManifest } from "./reader-summary-new-input-refresh-manifest";
 import { refreshReconciliationAccountingFor, assertRefreshReconciliationEvidence,
-  type RefreshReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
+  type RefreshReconciliationEvidence, type RefreshProviderReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
 import { captureRefreshDatabaseAuthority } from "./reader-summary-new-input-refresh-capture";
 import { lockRefreshAuthority, readRefreshJobs, readRefreshPrior, readRefreshReconciliations } from
   "./reader-summary-new-input-refresh-postgres";
@@ -17,8 +17,10 @@ type Client = Pick<PrismaReaderSummaryClient, "$queryRaw">;
 const sourceContentAssessmentPurpose = "social_monitor.relevance.assess_source_content.v1";
 const storyRelationVerificationPurpose = "social_monitor.reader_summary.verify_story_relations.v2";
 const resumablePurposes = new Set([sourceContentAssessmentPurpose, storyRelationVerificationPurpose]);
-const knownTerminalAssessment = (invocation: RefreshReconciliationEvidence["invocation"]) =>
-  invocation.outcome === "failed" || (invocation.outcome === "completed" && invocation.providerUsageReported);
+const knownTerminalAssessment = (invocation: RefreshReconciliationEvidence["invocation"]):
+  invocation is RefreshProviderReconciliationEvidence["invocation"] =>
+  "outcome" in invocation && (invocation.outcome === "failed" ||
+    (invocation.outcome === "completed" && invocation.providerUsageReported));
 
 type RefreshSuccessorHop = Readonly<{
   tenantId: string; workspaceId: string; date: string; startedAt: string; endedAt: string;

--- a/scripts/run-reader-summary-new-input-refresh.ts
+++ b/scripts/run-reader-summary-new-input-refresh.ts
@@ -23,6 +23,8 @@ import { executeNewInputRefresh } from "./lib/reader-summary-new-input-refresh-e
 import { resolveReaderSummaryServingAuthority } from "./lib/reader-summary-serving-authority";
 import { assertRefreshSuccessorCurrent } from "./lib/reader-summary-new-input-refresh-successor";
 
+import { RefreshRuntimeAssertionFailure, singleFlightRefreshRuntimeAssertion } from "./lib/reader-summary-new-input-refresh-runtime-assertion";
+
 export function parseRefreshCommand(argv: readonly string[]) {
   if (argv.length === 1 && argv[0] === "--source-sha256") return { mode: "source" } as const;
   if ((argv.length === 4 || (argv.length === 6 && argv[4] === "--capture-path" && argv[5]?.startsWith("/"))) && argv[0] === "--apply" && argv[2] === "--sha256" && /^[0-9a-f]{64}$/u.test(argv[3]!)) {
@@ -143,12 +145,23 @@ async function main(): Promise<void> {
       try {
         const receipt = await executeNewInputRefresh({ configuredInterests, manifest, summary, feed, clock, env: process.env,
           runtime, assertFences, assertSource, record, capturePath: command.capturePath,
-          assertRuntime: async () => {
+          assertRuntime: singleFlightRefreshRuntimeAssertion(async () => {
             const serving = await resolveReaderSummaryServingAuthority({ summaryModelMode: "agent-runtime",
-              topicLabelerMode: "agent-runtime", env: process.env, agentRuntimeClient: runtime,
-              checkedAt: clock.now().toISOString() });
-            assertRefreshEqual(serving.runtime, manifest.runtime, "deployed runtime");
-          },
+              topicLabelerMode: "agent-runtime", env: process.env,
+              agentRuntimeClient: { checkHealth: async (service) => {
+                try {
+                  const health = await runtime.checkHealth(service);
+                  if (health.status !== "serving") throw new RefreshRuntimeAssertionFailure("runtime_health");
+                  return health;
+                } catch { throw new RefreshRuntimeAssertionFailure("runtime_health"); }
+              } },
+              checkedAt: clock.now().toISOString() }).catch((error: unknown) => {
+                if (error instanceof RefreshRuntimeAssertionFailure) throw error;
+                throw new RefreshRuntimeAssertionFailure("runtime_mismatch");
+              });
+            try { assertRefreshEqual(serving.runtime, manifest.runtime, "deployed runtime"); }
+            catch { throw new RefreshRuntimeAssertionFailure("runtime_mismatch"); }
+          }),
         });
         record({ ...receipt, operation: manifest.operation, manifestSha256: command.sha256,
           observedThrough: manifest.observedThrough });


### PR DESCRIPTION
Repairs Reader Summary refresh attempts that fail before provider delegation. Zero-provider outcomes are now recorded and reconciled explicitly, overlapping runtime assertions share only the in-flight probe, and successor admission still requires a terminal provider outcome.

Validation:
- focused Node harness passed
- source line cap, architecture, code quality and tenant DB guards passed
- git diff --check passed
- independent review approved exact patch after narrowing historical command hash compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reconciliation support for refresh jobs that fail before provider invocation.
  - Improved reconciliation accounting for provider usage and consumed jobs.
  - Added runtime health and configuration checks before delegated refresh work begins.
  - Failure records now identify the stage at which pre-delegation processing stopped.

- **Bug Fixes**
  - Strengthened validation for reconciliation evidence, timestamps, hashes, captured files, and accounting data.
  - Prevented invalid, tampered, incomplete, or inconsistent evidence from being accepted.

- **Tests**
  - Added coverage for pre-delegation failures, runtime checks, date validation, and reconciliation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->