### PR TITLE
fix(deploy): preserve rolling timer state

### DIFF
--- a/ops/deploy/postgres-runtime-deploy-lib.test.sh
+++ b/ops/deploy/postgres-runtime-deploy-lib.test.sh
@@ -375,7 +375,10 @@ for unit in "${base_units[@]}"; do
 done
 : > "$SYSTEMCTL_EVENTS"
 rollback_snapshot=$(snapshot_postgres_runtime_control "$SHA")
+ROLLING_TIMER_NEXT_TRIGGER=
 activate_postgres_runtime_control "$SHA"
+[[ $(<"$ROLLING_TIMER_UNIT_FILE_STATE") == disabled ]]
+[[ $(<"$ROLLING_TIMER_ACTIVE_STATE") == inactive ]]
 release=$POSTGRES_RUNTIME_RELEASES/$SHA
 rm -f \
   "$REPO/ops/deploy/production-runtime/github-premidnight-capture-v1.activation"
@@ -432,7 +435,7 @@ done
   "$unrelated_timer_inode" ]]
 [[ $(grep -E '(^| )(enable|disable|start|stop|restart)( |$)' \
   "$SYSTEMCTL_EVENTS") == \
-  $'enable --now social-monitor-github-premidnight-capture-v1.timer\nenable social-monitor-weekly.timer\nstart social-monitor-weekly.timer\nenable --now social-monitor-rolling.timer' ]]
+  $'enable --now social-monitor-github-premidnight-capture-v1.timer\nenable social-monitor-weekly.timer\nstart social-monitor-weekly.timer' ]]
 [[ $(<"$TIMER_UNIT_FILE_STATE") == enabled ]]
 [[ $(<"$TIMER_ACTIVE_STATE") == active ]]
 [[ $(<"$WEEKLY_TIMER_UNIT_FILE_STATE") == enabled ]]
@@ -577,11 +580,18 @@ set -e
 TIMER_NEXT_TRIGGER='Thu 2026-08-13 23:50:00 UTC'
 printf 'enabled\n' > "$TIMER_UNIT_FILE_STATE"
 printf 'active\n' > "$TIMER_ACTIVE_STATE"
+printf 'enabled\n' > "$ROLLING_TIMER_UNIT_FILE_STATE"
+printf 'active\n' > "$ROLLING_TIMER_ACTIVE_STATE"
+ROLLING_TIMER_NEXT_TRIGGER='Sat 2026-08-15 12:15:00 UTC'
 enabled_timer_snapshot=$(snapshot_postgres_runtime_control "$ENABLED_TIMER_SHA")
 activate_postgres_runtime_control "$ENABLED_TIMER_SHA" >/dev/null 2>&1
 [[ $(<"$TIMER_UNIT_FILE_STATE") == enabled ]]
 [[ $(<"$TIMER_ACTIVE_STATE") == active ]]
+[[ $(<"$ROLLING_TIMER_UNIT_FILE_STATE") == enabled ]]
+[[ $(<"$ROLLING_TIMER_ACTIVE_STATE") == active ]]
 restore_postgres_runtime_control "$enabled_timer_snapshot"
+printf 'disabled\n' > "$ROLLING_TIMER_UNIT_FILE_STATE"
+printf 'inactive\n' > "$ROLLING_TIMER_ACTIVE_STATE"
 [[ $(readlink -f "$POSTGRES_RUNTIME_CURRENT") == "$CONTROL/old-runtime" ]]
 [[ $(cat "$CONTROL/github-premidnight-capture-v1.sh") == \
    old-GitHub-premidnight-runner ]]

--- a/ops/deploy/postgres-runtime-rolling-timer-state.test.sh
+++ b/ops/deploy/postgres-runtime-rolling-timer-state.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FIXTURE=$(mktemp -d "${TMPDIR:-/tmp}/rolling-timer-state-test.XXXXXX")
+trap 'rm -rf "$FIXTURE"' EXIT
+source "$SCRIPT_DIR/fixtures/postgres-runtime-deploy-test-state.sh"
+source "$SCRIPT_DIR/postgres-runtime-weekly-timer-state-lib.sh"
+fail() { printf '%s\n' "$*" >&2; return 1; }
+systemctl() {
+  printf '%s\n' "$*" >> "$FIXTURE/events"
+  case "$*" in
+    'show --property=UnitFileState --value social-monitor-rolling.timer')
+      cat "$ROLLING_TIMER_UNIT_FILE_STATE" ;;
+    'show --property=ActiveState --value social-monitor-rolling.timer')
+      cat "$ROLLING_TIMER_ACTIVE_STATE" ;;
+    'show --property=NextElapseUSecRealtime --value social-monitor-rolling.timer')
+      printf '%s\n' "$ROLLING_TIMER_NEXT_TRIGGER" ;;
+    'show --property=ActiveState --value social-monitor-rolling.service')
+      printf '%s\n' "$SERVICE_ACTIVE_STATE" ;;
+    *) return 91 ;;
+  esac
+}
+for state in 'disabled inactive' 'enabled active'; do
+  read -r unit active <<< "$state"
+  printf '%s\n' "$unit" > "$ROLLING_TIMER_UNIT_FILE_STATE"
+  printf '%s\n' "$active" > "$ROLLING_TIMER_ACTIVE_STATE"
+  SERVICE_ACTIVE_STATE=inactive
+  ROLLING_TIMER_NEXT_TRIGGER=
+  [[ $unit == disabled ]] || ROLLING_TIMER_NEXT_TRIGGER='Sat 2026-08-15 12:15:00 UTC'
+  snapshot_postgres_runtime_rolling_timer "$FIXTURE"
+  : > "$FIXTURE/events"
+  reconcile_postgres_runtime_rolling_timer
+  reconcile_postgres_runtime_rolling_timer
+  [[ $(cat "$FIXTURE/rolling-timer-state") == "$state" ]]
+  [[ $(cat "$ROLLING_TIMER_UNIT_FILE_STATE") == "$unit" ]]
+  [[ $(cat "$ROLLING_TIMER_ACTIVE_STATE") == "$active" ]]
+  ! grep -Ev '^show ' "$FIXTURE/events"
+  SERVICE_ACTIVE_STATE=active
+  if reconcile_postgres_runtime_rolling_timer 2>/dev/null; then
+    fail 'active rolling service was accepted'
+    exit 1
+  fi
+done
+SERVICE_ACTIVE_STATE=inactive
+ROLLING_TIMER_NEXT_TRIGGER=
+if reconcile_postgres_runtime_rolling_timer 2>/dev/null; then
+  fail 'enabled timer without a next trigger was accepted'
+  exit 1
+fi
+for state in 'disabled active' 'enabled inactive' 'masked inactive' 'not-found inactive'; do
+  read -r unit active <<< "$state"
+  printf '%s\n' "$unit" > "$ROLLING_TIMER_UNIT_FILE_STATE"
+  printf '%s\n' "$active" > "$ROLLING_TIMER_ACTIVE_STATE"
+  if reconcile_postgres_runtime_rolling_timer 2>/dev/null; then
+    fail "invalid rolling timer state was accepted: $state"
+    exit 1
+  fi
+done
+echo 'Rolling timer state tests passed'

--- a/ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
+++ b/ops/deploy/postgres-runtime-weekly-timer-state-lib.sh
@@ -184,18 +184,17 @@ restore_postgres_runtime_rolling_timer() {
 reconcile_postgres_runtime_rolling_timer() {
   local timer=social-monitor-rolling.timer
   local unit_state active_state next_trigger service_state
-  systemctl enable --now "$timer" || {
-    fail 'systemd rolling timer could not be enabled and started'
-    return 1
-  }
+  # Installing units and daemon-reload preserve the snapshotted timer state.
+  # Reconciliation must not activate an intentionally disabled rolling timer.
   unit_state=$(systemctl show --property=UnitFileState --value "$timer") || return 1
   active_state=$(systemctl show --property=ActiveState --value "$timer") || return 1
   next_trigger=$(systemctl show --property=NextElapseUSecRealtime --value \
     "$timer") || return 1
   service_state=$(systemctl show --property=ActiveState --value \
     social-monitor-rolling.service) || return 1
-  [[ $unit_state == enabled && $active_state == active && \
-     -n $next_trigger && $service_state == inactive ]] || {
+  [[ $service_state == inactive && (
+     ( $unit_state == enabled && $active_state == active && -n $next_trigger ) ||
+     ( $unit_state == disabled && $active_state == inactive ) ) ]] || {
     fail "systemd rolling timer activation proof is invalid: $unit_state/$active_state/$service_state"
     return 1
   }


### PR DESCRIPTION
Deployment now preserves an intentionally disabled/inactive rolling timer while continuing to validate enabled/active timers and rejecting inconsistent states. This fixes deploy run 34738226063 without activating the production scheduler during the fixed-window E2E.

Validation:
- focused rolling timer state tests passed
- shell syntax and git diff checks passed
- independent review approved exact patch SHA-256 1c29839d170e114b300f1905fc55e5395ae2e9aa997dad0577304365d11fe78c
