### PR TITLE
ci(codecov): publish backend coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,67 @@
+name: Code coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend_unit_coverage:
+    name: Backend coverage shard ${{ matrix.shard }}/4
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    steps:
+      - name: Check out the tested commit
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install exact dependencies
+        run: npm ci
+
+      - name: Generate the pinned Prisma client
+        run: npm run prisma:generate
+
+      - name: Collect backend unit coverage
+        run: >-
+          node scripts/run-with-timeout.mjs
+          --timeout-ms 2700000
+          --node-options --max-old-space-size=4096
+          -- ./node_modules/.bin/jest
+          --config jest.config.ts
+          --runInBand
+          --shard=${{ matrix.shard }}/4
+          --coverage
+          --coverageDirectory=coverage/shard-${{ matrix.shard }}
+          --coverageReporters=lcovonly
+          --coverageReporters=json-summary
+          --coverageReporters=text-summary
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        with:
+          use_oidc: true
+          fail_ci_if_error: true
+          disable_search: true
+          files: ./coverage/shard-${{ matrix.shard }}/lcov.info
+          flags: backend-unit
+          name: backend-unit-shard-${{ matrix.shard }}
+

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  DATABASE_URL: postgresql://social_monitor_ci:social_monitor_local_password@127.0.0.1:5432/social_monitor_ci
+
 jobs:
   backend_unit_coverage:
     name: Backend coverage shard ${{ matrix.shard }}/4
@@ -64,4 +67,3 @@ jobs:
           files: ./coverage/shard-${{ matrix.shard }}/lcov.info
           flags: backend-unit
           name: backend-unit-shard-${{ matrix.shard }}
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <a href="https://discord.gg/MWmrv57Qkt"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FqtqSZSyuEc%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&label=Discord&logo=discord&logoColor=white&color=5865F2&style=flat-square&suffix=%20members" alt="Discord" /></a>
 <a href="https://social-monitor.app/"><img src="https://img.shields.io/badge/Site-social--monitor.app-22C55E?style=flat-square&logo=googlechrome&logoColor=white" alt="Social Monitor Site" /></a>
+<a href="https://codecov.io/gh/777genius/social-monitor"><img src="https://codecov.io/gh/777genius/social-monitor/branch/main/graph/badge.svg" alt="Backend unit test coverage" /></a>
 
 
 Tired of scrolling through hundreds of near-identical posts across every social network just to find the few that actually matter?


### PR DESCRIPTION
## Summary

- collect Jest backend unit coverage in four parallel shards
- upload LCOV reports to Codecov with GitHub OIDC
- add the main branch coverage badge to README

## Verification

- workflow YAML parsed successfully
- git diff --check passed
- Codecov Action pinned to the v7.0.0 commit