### PR TITLE
fix(reader-summary): stabilize authority preflight recovery

### DIFF
--- a/scripts/lib/reader-summary-new-input-refresh-model-singleflight.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model-singleflight.spec.ts
@@ -1,0 +1,50 @@
+import { guardedRefreshRuntime } from "./reader-summary-new-input-refresh-model";
+import { completedRefreshModelRequest, refreshModelCommand } from "./reader-summary-new-input-refresh-model.spec-support";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+import { sourceContentAssessmentPurpose } from "./reader-summary-new-input-refresh-assessment-runtime";
+
+const command = (id: number) => ({ ...refreshModelCommand(sourceContentAssessmentPurpose),
+  requestId: `assessment-${id}`, prompt: JSON.stringify({ candidates: [{ candidateId: `candidate-${id}` }] }) });
+const deferred = () => {
+  let resolve!: () => void, reject!: (error: Error) => void;
+  const promise = new Promise<void>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+};
+
+it("shares overlapping authority checks, preserves per-request consumption, and checks fresh later", async () => {
+  const check = deferred();
+  const assertCurrent = jest.fn(() => check.promise);
+  const runTask = jest.fn(completedRefreshModelRequest), record = jest.fn(), assertLocal = jest.fn();
+  const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), now: () => 0,
+    delegate: { runTask, checkHealth: jest.fn() }, assertCurrent, assertLocal, record });
+  const batch = Array.from({ length: 6 }, (_, index) => runtime.runTask(command(index)));
+  await Promise.resolve();
+  expect(assertCurrent).toHaveBeenCalledTimes(1);
+  expect(runTask).not.toHaveBeenCalled();
+  check.resolve();
+  await Promise.all(batch);
+  expect(runTask).toHaveBeenCalledTimes(6);
+  expect(record.mock.calls.filter(([event]) => event.status === "invocation_consumed")).toHaveLength(6);
+  await runtime.runTask(command(6));
+  expect(assertCurrent).toHaveBeenCalledTimes(2);
+  expect(runTask).toHaveBeenCalledTimes(7);
+  expect(assertLocal.mock.calls.length).toBeGreaterThanOrEqual(7 * 4);
+});
+
+it("invalidates all waiters and the runtime on one rejected authority check", async () => {
+  const check = deferred(), assertCurrent = jest.fn(() => check.promise), runTask = jest.fn(), record = jest.fn();
+  const runtime = guardedRefreshRuntime({ manifest: refreshManifest(), now: () => 0,
+    delegate: { runTask, checkHealth: jest.fn() }, assertCurrent, assertLocal: () => undefined, record });
+  const batch = Promise.allSettled(Array.from({ length: 6 }, (_, index) => runtime.runTask(command(index))));
+  await Promise.resolve();
+  check.reject(new Error("synthetic authority failure"));
+  expect((await batch).every((result) => result.status === "rejected")).toBe(true);
+  expect(assertCurrent).toHaveBeenCalledTimes(1);
+  expect(runTask).not.toHaveBeenCalled();
+  expect(record).toHaveBeenCalledTimes(6);
+  for (const [event] of record.mock.calls) expect(event).toMatchObject({ status: "requires_reconciliation",
+    delegated: false, preDelegationFailureStage: "current_authority" });
+  expect(() => runtime.assertUsable()).toThrow(/reconciliation/);
+  await expect(runtime.runTask(command(6))).rejects.toThrow();
+  expect(assertCurrent).toHaveBeenCalledTimes(1);
+});

--- a/scripts/lib/reader-summary-new-input-refresh-model.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-model.ts
@@ -128,6 +128,14 @@ export function guardedRefreshRuntime(input: {
   let generated = false;
   let exclusiveInFlight = false;
   const assessmentInFlight = new Set<string>();
+  let currentCheck: Promise<void> | undefined;
+  const assertCurrent = (): Promise<void> => {
+    currentCheck ??= Promise.resolve().then(() => input.assertCurrent()).catch((error: unknown) => {
+      ambiguous = true;
+      throw error;
+    }).finally(() => { currentCheck = undefined; });
+    return currentCheck;
+  };
   const assertUsable = () => {
     if (ambiguous) throw new Error("Refresh invocation budget requires reconciliation");
     try { input.assertLocal(); } catch (error) { ambiguous = true; throw error; }
@@ -241,7 +249,7 @@ export function guardedRefreshRuntime(input: {
           metadata: command.metadata ?? {},
         }).canonicalRequest);
         preDelegationFailureStage = "current_authority";
-        await input.assertCurrent();
+        await assertCurrent();
         preDelegationFailureStage = "local";
         assertUsable();
         preDelegationFailureStage = "journal_consumption";

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-current-authority.spec-support.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-current-authority.spec-support.ts
@@ -1,0 +1,46 @@
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { refreshBytesHash, refreshHash } from "./reader-summary-new-input-refresh-manifest";
+import { reconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation.spec-support";
+import { refreshManifest } from "./reader-summary-new-input-refresh.spec-support";
+import type { RefreshCurrentAuthorityReconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation";
+
+type Row = { at: string; event: Record<string, unknown> };
+export function currentAuthorityFixture(change?: (rows: Row[]) => void) {
+  const root = mkdtempSync(join(tmpdir(), "refresh-current-authority-spec-"));
+  const manifest = refreshManifest();
+  const base = { ...reconciliationEvidence(), date: manifest.date, operation: manifest.operation };
+  const observedThrough = manifest.observedThrough;
+  const save = (name: string, text: string) => {
+    const path = join(root, name);
+    writeFileSync(path, text, { mode: 0o600 }); chmodSync(path, 0o400);
+    return { path, hash: refreshBytesHash(Buffer.from(text)) };
+  };
+  const manifestFile = save("manifest.json", JSON.stringify(manifest) + "\n");
+  const row = (status: string, fields: Record<string, unknown> = {}): Row => ({
+    at: manifest.preparedAt, event: { status, operation: base.operation, ...fields } });
+  const failures = Array.from({ length: 6 }, (_, index) => row("requires_reconciliation", {
+    requestId: `synthetic-${index}`, purpose: "social_monitor.relevance.assess_source_content.v1",
+    requestSha256: refreshHash({ index }), observedThrough, model: "gpt-5.6-sol", reasoningEffort: "low",
+    delegated: false, preDelegationFailureStage: "current_authority",
+  }));
+  const attempts = failures.map((failure) => ({
+    requestId: String(failure.event.requestId), purpose: String(failure.event.purpose),
+    requestSha256: String(failure.event.requestSha256), attemptSha256: refreshHash(failure),
+    failedAt: failure.at, delegated: false as const, preDelegationFailureStage: "current_authority" as const,
+  }));
+  const rows = [row("before", { observedThrough, prior: manifest.prior, countsBefore: { jobs: 1, publications: 1, outbox: 1, artifacts: 1 } }),
+    row("admission", { admissionState: "unconsumed", reconciled: [] }),
+    row("preflight", { assessmentCandidateCount: 6, plannedSummaryGenerations: 1 }),
+    row("operation_consumed", { jobId: base.jobId }), ...failures,
+    row("stopped_requires_reconciliation", { manifestSha256: manifestFile.hash })];
+  change?.(rows);
+  const journal = save("journal.jsonl", rows.map((item) => JSON.stringify(item) + "\n").join(""));
+  const evidence: RefreshCurrentAuthorityReconciliationEvidence = { ...base,
+    reason: "consumed_job_without_provider_invocation", manifestSha256: manifestFile.hash,
+    invocation: { evidenceKind: "journal_current_authority", manifestPath: manifestFile.path,
+      journalPath: journal.path, journalSha256: journal.hash, invocationConsumedCount: 0,
+      delegatedInvocationCount: 0, providerUsageReported: false, attempts } };
+  return { root, evidence };
+}

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-current-authority.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-current-authority.spec.ts
@@ -1,0 +1,83 @@
+import { chmodSync, linkSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { assertRefreshReconciliationEvidence, refreshReconciliationAccountingFor } from "./reader-summary-new-input-refresh-reconciliation";
+import { currentAuthorityFixture } from "./reader-summary-new-input-refresh-reconciliation-current-authority.spec-support";
+import { refreshBytesHash, refreshHash } from "./reader-summary-new-input-refresh-manifest";
+
+const roots: string[] = [];
+const fixture = (...args: Parameters<typeof currentAuthorityFixture>) => {
+  const test = currentAuthorityFixture(...args); roots.push(test.root); return test;
+};
+afterEach(() => roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true })));
+const verify = (e: ReturnType<typeof fixture>["evidence"]) => assertRefreshReconciliationEvidence(e, [e.date]);
+
+it("binds all six exact journal failures without a capture and reports zero provider usage", () => {
+  const { evidence } = fixture();
+  expect(() => verify(evidence)).not.toThrow();
+  expect(refreshReconciliationAccountingFor(evidence)).toEqual({ summaryGenerations: 0, publications: 0,
+    artifacts: 0, providerInvocations: 0, providerUsage: "none" });
+});
+it.each(["invocation_consumed", "invocation_returned", "verified_attestation", "completed", "unknown"])(
+  "rejects additional %s evidence", (status) => {
+    const { evidence } = fixture((rows) => { rows.splice(5, 0, { ...rows[4]!, event: { ...rows[4]!.event, status } }); });
+    expect(() => verify(evidence)).toThrow();
+  });
+it.each(["local", "runtime_health", "runtime_mismatch", "assessment_budget", "request_admission", "journal_consumption", "unknown"])(
+  "rejects a rehashed failure at %s", (stage) => {
+    const { evidence } = fixture((rows) => { rows[4]!.event.preDelegationFailureStage = stage; });
+    const row = JSON.parse(readFileSync(evidence.invocation.journalPath, "utf8").split("\n")[4]!);
+    const attempts = evidence.invocation.attempts.map((a, i) => i === 0 ? { ...a, attemptSha256: refreshHash(row) } : a);
+    expect(() => verify({ ...evidence, invocation: { ...evidence.invocation, attempts } })).toThrow();
+  });
+it.each(["delegated", "tokens", "usage", "attestation", "extra"])("rejects conflicting %s fields", (key) => {
+  const { evidence } = fixture((rows) => { rows[4]!.event[key] = key === "delegated" ? true : {}; });
+  expect(() => verify(evidence)).toThrow();
+});
+it.each(["missing", "duplicate", "wrong-job", "wrong-operation", "wrong-manifest", "malformed-time", "missing-stage"])(
+  "rejects %s journal events", (kind) => {
+    const { evidence } = fixture((rows) => {
+      if (kind === "missing") rows.splice(4, 1);
+      if (kind === "duplicate") rows[5] = rows[4]!;
+      if (kind === "wrong-job") rows[3]!.event.jobId = "wrong";
+      if (kind === "wrong-operation") rows[4]!.event.operation = "wrong";
+      if (kind === "wrong-manifest") rows.at(-1)!.event.manifestSha256 = "0".repeat(64);
+      if (kind === "malformed-time") rows[4]!.at = "yesterday";
+      if (kind === "missing-stage") delete rows[4]!.event.preDelegationFailureStage;
+    });
+    expect(() => verify(evidence)).toThrow();
+  });
+it.each(["manifestPath", "journalPath"] as const)("rejects mutable, linked or hash-mismatched %s", (key) => {
+  const { root, evidence } = fixture();
+  const path = evidence.invocation[key];
+  chmodSync(path, 0o600); expect(() => verify(evidence)).toThrow(); chmodSync(path, 0o400);
+  const hard = join(root, "hard"); linkSync(path, hard); expect(() => verify(evidence)).toThrow(); rmSync(hard);
+  const sym = join(root, "sym"); symlinkSync(path, sym);
+  expect(() => verify({ ...evidence, invocation: { ...evidence.invocation, [key]: sym } })).toThrow();
+  chmodSync(path, 0o600); writeFileSync(path, "{}\n"); chmodSync(path, 0o400);
+  expect(() => verify(evidence)).toThrow();
+});
+it("rejects truncated JSONL even when its hash is reviewed", () => {
+  const { evidence } = fixture(), path = evidence.invocation.journalPath;
+  const bytes = Buffer.from(readFileSync(path, "utf8").trimEnd());
+  chmodSync(path, 0o600); writeFileSync(path, bytes); chmodSync(path, 0o400);
+  expect(() => verify({ ...evidence, invocation: { ...evidence.invocation,
+    journalSha256: refreshBytesHash(bytes) } })).toThrow();
+});
+it.each(["missing", "extra", "duplicate", "hash", "time", "usage"])("rejects %s reviewed attempts", (kind) => {
+  const { evidence } = fixture();
+  const attempts = [...evidence.invocation.attempts];
+  if (kind === "missing") attempts.pop();
+  if (kind === "extra") attempts.push({ ...attempts[0]!, requestId: "extra" });
+  if (kind === "duplicate") attempts[1] = attempts[0]!;
+  if (kind === "hash") attempts[0] = { ...attempts[0]!, attemptSha256: "0".repeat(64) };
+  if (kind === "time") attempts[0] = { ...attempts[0]!, failedAt: "2026-09-05T23:00:00.000Z" };
+  if (kind === "usage") Object.assign(attempts[0]!, { usage: { totalTokens: 0 } });
+  expect(() => verify({ ...evidence, invocation: { ...evidence.invocation, attempts } })).toThrow();
+});
+it("rejects nested provider evidence and malformed lifecycle counts", () => {
+  for (const countsBefore of [{ jobs: -1, publications: 1, outbox: 1, artifacts: 1 },
+    { jobs: 1, publications: 1, outbox: 1, artifacts: 1, nested: { usage: {} } }]) {
+    const { evidence } = fixture((rows) => { rows[0]!.event.countsBefore = countsBefore; });
+    expect(() => verify(evidence)).toThrow();
+  }
+});

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation.ts
@@ -1,7 +1,7 @@
 import { lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { IdGenerator } from "@social-monitor/shared-kernel";
-import { refreshBytesHash, refreshDates, refreshHash, refreshKeyPrefix, refreshScope } from
+import { assertRefreshManifest, type RefreshManifest, refreshBytesHash, refreshDates, refreshHash, refreshKeyPrefix, refreshScope } from
   "./reader-summary-new-input-refresh-manifest";
 
 /** Operator-reviewed statement that one consumed new-input-refresh attempt is
@@ -40,8 +40,23 @@ export type RefreshPreProviderReconciliationEvidence = RefreshReconciliationIden
     }>[];
   }>;
 }>;
+/** Journal-only proof is limited to assessment failures at current authority.
+ * attemptSha256 binds the exact timestamped journal row, not a capture event. */
+export type RefreshCurrentAuthorityReconciliationEvidence = RefreshReconciliationIdentity & Readonly<{
+  reason: "consumed_job_without_provider_invocation";
+  invocation: Readonly<{
+    evidenceKind: "journal_current_authority";
+    journalPath: string; manifestPath: string; journalSha256: string;
+    invocationConsumedCount: 0; delegatedInvocationCount: 0; providerUsageReported: false;
+    attempts: readonly Readonly<{
+      requestId: string; purpose: string; requestSha256: string;
+      attemptSha256: string; failedAt: string;
+      delegated: false; preDelegationFailureStage: "current_authority";
+    }>[];
+  }>;
+}>;
 export type RefreshReconciliationEvidence =
-  RefreshProviderReconciliationEvidence | RefreshPreProviderReconciliationEvidence;
+  RefreshProviderReconciliationEvidence | RefreshPreProviderReconciliationEvidence | RefreshCurrentAuthorityReconciliationEvidence;
 
 export const refreshReconciliationAccounting = Object.freeze({
   summaryGenerations: 0, publications: 0, artifacts: 0,
@@ -86,8 +101,12 @@ export function assertRefreshReconciliationEvidence(
       "manifestSha256", "reason", "invocation"])) {
       throw new Error("Refresh reconciliation pre-provider identity is invalid");
     }
-    assertPreProviderInvocation(evidence.invocation);
-    assertPreProviderArtifacts(evidence);
+    if (evidence.invocation && "evidenceKind" in evidence.invocation) {
+      assertCurrentAuthorityArtifacts(evidence as RefreshCurrentAuthorityReconciliationEvidence);
+      return;
+    }
+    assertPreProviderInvocation(evidence.invocation as RefreshPreProviderReconciliationEvidence["invocation"]);
+    assertPreProviderArtifacts(evidence as RefreshPreProviderReconciliationEvidence);
     return;
   }
   const invocation = evidence.invocation;
@@ -283,6 +302,115 @@ function assertPreProviderArtifacts(e: RefreshPreProviderReconciliationEvidence)
   if (failures.size !== requests.size || v.attempts.some((attempt) =>
     Date.parse(attempt.startedAt) < Date.parse(String(consumed[0]!.at)) ||
     Date.parse(attempt.failedAt) > Date.parse(String(stopped[0]!.at)))) invalid();
+}
+
+function assertCurrentAuthorityArtifacts(e: RefreshCurrentAuthorityReconciliationEvidence): void {
+  const invalid = (): never => { throw new Error("Refresh reconciliation current-authority journal integrity is invalid"); };
+  const object = (value: unknown): Record<string, unknown> => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return invalid();
+    return value as Record<string, unknown>;
+  };
+  const exact = (value: object, keys: readonly string[]) =>
+    onlyKeys(value, keys) && Object.keys(value).length === keys.length;
+  const immutable = (path: string, hash: string) => {
+    if (typeof path !== "string" || !path.startsWith("/") || !sha256.test(hash)) return invalid();
+    const absolute = resolve(path), stat = lstatSync(absolute);
+    if (realpathSync(absolute) !== absolute || !stat.isFile() || stat.nlink !== 1 ||
+        (stat.mode & 0o222) !== 0) return invalid();
+    const bytes = readFileSync(absolute);
+    if (refreshBytesHash(bytes) !== hash) return invalid();
+    return bytes.toString("utf8");
+  };
+  const hasProviderEvidence = (value: unknown): boolean => {
+    if (!value || typeof value !== "object") return false;
+    return Object.entries(value).some(([key, child]) =>
+      ["tokens", "usage", "attestation", "inputTokens", "outputTokens", "totalTokens"].includes(key) ||
+      (key === "delegated" && child !== false) || hasProviderEvidence(child));
+  };
+  const v = e.invocation;
+  if (!exact(v, ["evidenceKind", "journalPath", "manifestPath", "journalSha256",
+    "invocationConsumedCount", "delegatedInvocationCount", "providerUsageReported", "attempts"]) ||
+      v.evidenceKind !== "journal_current_authority" || v.invocationConsumedCount !== 0 ||
+      v.delegatedInvocationCount !== 0 || v.providerUsageReported !== false ||
+      !Array.isArray(v.attempts) || v.attempts.length === 0 || v.attempts.length > 6) invalid();
+  const manifest = object(JSON.parse(immutable(v.manifestPath, e.manifestSha256)));
+  if (manifest.format !== "reader-summary-seven-day-new-input-v1" || manifest.operation !== e.operation ||
+      manifest.date !== e.date || manifest.tenantId !== e.tenantId || manifest.workspaceId !== e.workspaceId ||
+      !isoInstant(manifest.observedThrough)) invalid();
+  const text = immutable(v.journalPath, v.journalSha256);
+  if (!text.endsWith("\n")) invalid();
+  const rows = text.slice(0, -1).split("\n").map((line) => {
+    const row = object(JSON.parse(line));
+    // The runtime writes JSON.stringify rows. Require those exact bytes so
+    // duplicate members or ambiguous JSON encodings cannot hide evidence.
+    if (JSON.stringify(row) !== line) invalid();
+    return row;
+  });
+  const attempts = new Map<string, typeof v.attempts[number]>();
+  for (const attempt of v.attempts) {
+    if (!exact(object(attempt), ["requestId", "purpose", "requestSha256", "attemptSha256", "failedAt",
+      "delegated", "preDelegationFailureStage"]) || !nonempty(attempt.requestId) ||
+        attempts.has(attempt.requestId) ||
+        attempt.purpose !== "social_monitor.relevance.assess_source_content.v1" ||
+        !sha256.test(attempt.requestSha256) || !sha256.test(attempt.attemptSha256) ||
+        !isoInstant(attempt.failedAt) || attempt.delegated !== false ||
+        attempt.preDelegationFailureStage !== "current_authority") invalid();
+    attempts.set(attempt.requestId, attempt);
+  }
+  // Require the complete lifecycle, with no extra events anywhere in this
+  // reviewed tape. Historical/mixed tapes are deliberately not this variant.
+  const statuses = ["before", "admission", "preflight", "operation_consumed",
+    ...v.attempts.map(() => "requires_reconciliation"), "stopped_requires_reconciliation"];
+  if (rows.length !== statuses.length) invalid();
+  let previousAt = -Infinity;
+  const seen = new Set<string>();
+  rows.forEach((row, index) => {
+    const event = object(row.event);
+    if (hasProviderEvidence(event) || !exact(row, ["at", "event"]) || !isoInstant(row.at) || Date.parse(String(row.at)) < previousAt ||
+        event.operation !== e.operation || event.status !== statuses[index]) invalid();
+    previousAt = Date.parse(String(row.at));
+    const keys: Record<string, readonly string[]> = {
+      before: ["observedThrough", "prior", "countsBefore"], admission: ["admissionState", "reconciled"],
+      preflight: ["assessmentCandidateCount", "plannedSummaryGenerations"], operation_consumed: ["jobId"],
+      requires_reconciliation: ["requestId", "purpose", "requestSha256", "observedThrough", "model",
+        "reasoningEffort", "delegated", "preDelegationFailureStage"],
+      stopped_requires_reconciliation: ["manifestSha256"],
+    };
+    if (!exact(event, ["status", "operation", ...keys[String(event.status)]!])) invalid();
+    if (event.status === "before" && (event.observedThrough !== manifest.observedThrough ||
+        refreshHash(event.prior) !== refreshHash(manifest.prior))) invalid();
+    if (event.status === "before") {
+      const counts = object(event.countsBefore);
+      if (!exact(counts, ["jobs", "publications", "outbox", "artifacts"]) ||
+          Object.values(counts).some((count) => !Number.isSafeInteger(count) || Number(count) < 0)) invalid();
+    }
+    if (event.status === "admission" && (!["unconsumed", "reconciled"].includes(String(event.admissionState)) ||
+        !Array.isArray(event.reconciled))) invalid();
+    if (event.status === "admission") {
+      for (const value of event.reconciled as unknown[]) {
+        const item = object(value);
+        if (!exact(item, ["reconciliationId", "jobId", "operation"]) ||
+            !uuid.test(String(item.reconciliationId)) || !uuid.test(String(item.jobId)) ||
+            item.jobId === e.jobId || typeof item.operation !== "string" ||
+            !item.operation.startsWith(refreshKeyPrefix(e.date)) || item.operation === e.operation ||
+            !sha256.test(item.operation.slice(refreshKeyPrefix(e.date).length))) invalid();
+      }
+    }
+    if (event.status === "preflight" && (!Number.isSafeInteger(event.assessmentCandidateCount) ||
+        Number(event.assessmentCandidateCount) < attempts.size || event.plannedSummaryGenerations !== 1)) invalid();
+    if (event.status === "operation_consumed" && event.jobId !== e.jobId) invalid();
+    if (event.status === "stopped_requires_reconciliation" && event.manifestSha256 !== e.manifestSha256) invalid();
+    if (event.status === "requires_reconciliation") {
+      const attempt = attempts.get(String(event.requestId));
+      if (!attempt || seen.has(String(event.requestId)) || event.purpose !== attempt.purpose ||
+          event.requestSha256 !== attempt.requestSha256 || row.at !== attempt.failedAt ||
+          refreshHash(row) !== attempt.attemptSha256 || event.observedThrough !== manifest.observedThrough ||
+          event.model !== "gpt-5.6-sol" || event.reasoningEffort !== "low" || event.delegated !== false ||
+          event.preDelegationFailureStage !== "current_authority") invalid();
+      seen.add(String(event.requestId));
+    }
+  });
+  assertRefreshManifest(manifest as unknown as RefreshManifest, new Date(previousAt), false);
 }
 
 export function readReviewedRefreshReconciliation(


### PR DESCRIPTION
Concurrent assessment batches each repeated the current-authority preflight. A transient overlapping check could fail the whole refresh before any provider delegation, while the existing reconciliation contract could not represent that proven zero-delegation failure without a capture directory.

This change coalesces overlapping authority checks into one in-flight promise, keeps later calls fresh, and adds a strict immutable manifest+journal reconciliation path for failures exclusively at `current_authority`. Existing reconciliation variants remain unchanged.

Validation:
- Focused implementation tests: 164 tests across 4 suites passed in the producer workspace
- Focused TypeScript check passed in the producer workspace
- Independent static exact-commit review found no actionable code defects; its test rerun was blocked after hosted dependency cleanup, so GitHub CI is the exact-commit execution gate

Refs #404
Refs #407
