### PR TITLE
fix(reader-summary): allow zero-provider reconciliation

### DIFF
--- a/prisma/migrations/20260913100000_reader_summary_reconciliation_current_authority/migration.sql
+++ b/prisma/migrations/20260913100000_reader_summary_reconciliation_current_authority/migration.sql
@@ -1,0 +1,129 @@
+-- @social-monitor-forward-migration
+-- Accept the strict journal-only current-authority evidence added in e08dfa39.
+-- Preserve provider and paired-capture predicates, existing rows and table guards.
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL ROLE "social_monitor_public_schema_owner";
+ALTER TABLE "reader_summary_new_input_refresh_reconciliations"
+  DROP CONSTRAINT "rs_nir_reconciliations_identity_check",
+  DROP CONSTRAINT "rs_nir_reconciliations_accounting_check";
+ALTER TABLE "reader_summary_new_input_refresh_reconciliations"
+  ADD CONSTRAINT "rs_nir_reconciliations_identity_check" CHECK (
+    "job_status" = 'FAILED'
+    AND "reason" IN ('consumed_provider_invocation_without_summary', 'consumed_job_without_provider_invocation')
+    AND "operation" LIKE 'new-input-refresh:v1:%'
+    AND "period_ended_at" = "period_started_at" + INTERVAL '1 day'
+    AND "job_sha256" ~ '^[0-9a-f]{64}$'
+    AND "manifest_sha256" ~ '^[0-9a-f]{64}$'
+    AND "evidence_sha256" ~ '^[0-9a-f]{64}$'
+  ),
+  ADD CONSTRAINT "rs_nir_reconciliations_accounting_check" CHECK (
+    CASE WHEN "reason" = 'consumed_provider_invocation_without_summary' THEN COALESCE((
+
+    jsonb_typeof("invocation") = 'object'
+    AND jsonb_typeof("accounting") = 'object'
+    AND "invocation" ?& ARRAY[
+      'requestId', 'purpose', 'requestSha256', 'attemptSha256',
+      'consumedAt', 'returnedAt', 'outcome', 'providerUsageReported'
+    ]
+    AND jsonb_typeof("invocation"->'requestId') = 'string'
+    AND jsonb_typeof("invocation"->'purpose') = 'string'
+    AND "invocation"->>'requestSha256' ~ '^[0-9a-f]{64}$'
+    AND "invocation"->>'attemptSha256' ~ '^[0-9a-f]{64}$'
+    AND "accounting" ?& ARRAY[
+      'summaryGenerations', 'publications', 'artifacts',
+      'providerInvocations', 'providerUsage'
+    ]
+    AND "accounting"->'summaryGenerations' = '0'::JSONB
+    AND "accounting"->'publications' = '0'::JSONB
+    AND "accounting"->'artifacts' = '0'::JSONB
+    AND "accounting"->'providerInvocations' = '1'::JSONB
+    AND (
+      (
+        "invocation"->'providerUsageReported' = 'false'::JSONB
+        AND NOT ("invocation" ? 'usage')
+        AND "invocation" - ARRAY[
+          'requestId', 'purpose', 'requestSha256', 'attemptSha256',
+          'consumedAt', 'returnedAt', 'outcome', 'providerUsageReported'
+        ] = '{}'::jsonb
+        AND "accounting"->>'providerUsage' = 'unknown'
+        AND NOT ("accounting" ? 'usage')
+        AND "accounting" - ARRAY[
+          'summaryGenerations', 'publications', 'artifacts',
+          'providerInvocations', 'providerUsage'
+        ] = '{}'::jsonb
+      )
+      OR
+      (
+        "invocation"->'providerUsageReported' = 'true'::JSONB
+        AND "invocation" - ARRAY[
+          'requestId', 'purpose', 'requestSha256', 'attemptSha256',
+          'consumedAt', 'returnedAt', 'outcome', 'providerUsageReported', 'usage'
+        ] = '{}'::jsonb
+        AND jsonb_typeof("invocation"->'usage') = 'object'
+        AND "invocation"->'usage' ?& ARRAY['inputTokens', 'outputTokens', 'totalTokens']
+        AND ("invocation"->'usage'->>'inputTokens') ~ '^(0|[1-9][0-9]*)$'
+        AND ("invocation"->'usage'->>'outputTokens') ~ '^(0|[1-9][0-9]*)$'
+        AND ("invocation"->'usage'->>'totalTokens') ~ '^(0|[1-9][0-9]*)$'
+        AND ("invocation"->'usage'->>'inputTokens')::NUMERIC <= 9007199254740991
+        AND ("invocation"->'usage'->>'outputTokens')::NUMERIC <= 9007199254740991
+        AND ("invocation"->'usage'->>'totalTokens')::NUMERIC <= 9007199254740991
+        AND ("invocation"->'usage'->>'totalTokens')::NUMERIC =
+          ("invocation"->'usage'->>'inputTokens')::NUMERIC +
+          ("invocation"->'usage'->>'outputTokens')::NUMERIC
+        AND "accounting"->>'providerUsage' = 'reported'
+        AND "accounting"->'usage' = "invocation"->'usage'
+        AND "accounting" - ARRAY[
+          'summaryGenerations', 'publications', 'artifacts',
+          'providerInvocations', 'providerUsage', 'usage'
+        ] = '{}'::jsonb
+      )
+    )
+
+    ), false) ELSE COALESCE((
+      "reason" = 'consumed_job_without_provider_invocation'
+      AND jsonb_typeof("invocation") = 'object'
+      AND (
+        (
+          "invocation" ?& ARRAY['capturePath', 'journalPath', 'manifestPath',
+            'captureSha256', 'journalSha256', 'invocationConsumedCount',
+            'delegatedInvocationCount', 'providerUsageReported', 'attempts']
+          AND "invocation" - ARRAY['capturePath', 'journalPath', 'manifestPath',
+            'captureSha256', 'journalSha256', 'invocationConsumedCount',
+            'delegatedInvocationCount', 'providerUsageReported', 'attempts'] = '{}'::jsonb
+          AND jsonb_typeof("invocation"->'capturePath') = 'string'
+          AND jsonb_typeof("invocation"->'journalPath') = 'string'
+          AND jsonb_typeof("invocation"->'manifestPath') = 'string'
+          AND "invocation"->>'capturePath' LIKE '/%'
+          AND "invocation"->>'journalPath' LIKE '/%'
+          AND "invocation"->>'manifestPath' LIKE '/%'
+          AND "invocation"->>'captureSha256' ~ '^[0-9a-f]{64}$'
+          AND "invocation"->>'journalSha256' ~ '^[0-9a-f]{64}$'
+        )
+        OR
+        (
+          "invocation" ?& ARRAY['evidenceKind', 'journalPath', 'manifestPath',
+            'journalSha256', 'invocationConsumedCount', 'delegatedInvocationCount',
+            'providerUsageReported', 'attempts']
+          AND "invocation" - ARRAY['evidenceKind', 'journalPath', 'manifestPath',
+            'journalSha256', 'invocationConsumedCount', 'delegatedInvocationCount',
+            'providerUsageReported', 'attempts'] = '{}'::jsonb
+          AND "invocation"->'evidenceKind' = '"journal_current_authority"'::jsonb
+          AND jsonb_typeof("invocation"->'journalPath') = 'string'
+          AND jsonb_typeof("invocation"->'manifestPath') = 'string'
+          AND "invocation"->>'journalPath' LIKE '/%'
+          AND "invocation"->>'manifestPath' LIKE '/%'
+          AND jsonb_typeof("invocation"->'journalSha256') = 'string'
+          AND "invocation"->>'journalSha256' ~ '^[0-9a-f]{64}$'
+        )
+      )
+      AND "invocation"->'invocationConsumedCount' = '0'::jsonb
+      AND "invocation"->'delegatedInvocationCount' = '0'::jsonb
+      AND "invocation"->'providerUsageReported' = 'false'::jsonb
+      AND CASE WHEN jsonb_typeof("invocation"->'attempts') = 'array'
+        THEN jsonb_array_length("invocation"->'attempts') > 0 ELSE false END
+      AND "accounting" = '{"summaryGenerations":0,"publications":0,"artifacts":0,
+        "providerInvocations":0,"providerUsage":"none"}'::jsonb
+    ), false) END
+  );
+COMMIT;

--- a/scripts/lib/reader-summary-new-input-refresh-reconciliation-migration.spec.ts
+++ b/scripts/lib/reader-summary-new-input-refresh-reconciliation-migration.spec.ts
@@ -1,6 +1,7 @@
 import type * as PGliteModule from "@electric-sql/pglite";
 import { readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { currentAuthorityFixture } from "./reader-summary-new-input-refresh-reconciliation-current-authority.spec-support";
 import { preProviderFixture } from "./reader-summary-new-input-refresh-reconciliation-pre-provider.spec-support";
 import { reconciliationEvidence } from "./reader-summary-new-input-refresh-reconciliation.spec-support";
 import { refreshReconciliationAccountingFor } from "./reader-summary-new-input-refresh-reconciliation";
@@ -9,7 +10,12 @@ const migration = (name: string) => readFileSync(join(process.cwd(), "prisma/mig
 describe("pre-provider reconciliation migration constraints", () => {
   let db: PGliteModule.PGlite;
   const fixture = preProviderFixture();
+  const authorityFixture = currentAuthorityFixture();
+  const authority = authorityFixture.evidence;
   const pre = fixture.evidence, provider = reconciliationEvidence();
+  const reported = { ...provider, invocation: { ...provider.invocation, providerUsageReported: true,
+    usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 } } };
+  let existingRows: unknown[];
   const insert = (reason: string, invocation: unknown, accounting: unknown) => db.query(`
     insert into reader_summary_new_input_refresh_reconciliations
       (job_status, reason, operation, period_started_at, period_ended_at,
@@ -34,16 +40,75 @@ describe("pre-provider reconciliation migration constraints", () => {
     await insert(provider.reason, provider.invocation, refreshReconciliationAccountingFor(provider));
     await expect(insert(pre.reason, pre.invocation, refreshReconciliationAccountingFor(pre))).rejects.toThrow();
     await db.exec(migration("20260913060000_reader_summary_reconciliation_pre_provider"));
+    await insert(pre.reason, pre.invocation, refreshReconciliationAccountingFor(pre));
+    await insert(reported.reason, reported.invocation, refreshReconciliationAccountingFor(reported));
+    existingRows = (await db.query("select * from reader_summary_new_input_refresh_reconciliations")).rows;
+    await expect(insert(authority.reason, authority.invocation, refreshReconciliationAccountingFor(authority)))
+      .rejects.toMatchObject({ code: "23514", constraint: "rs_nir_reconciliations_accounting_check" });
+    await db.exec(migration("20260913100000_reader_summary_reconciliation_current_authority"));
   }, 30_000);
-  afterAll(async () => { await db?.close(); rmSync(fixture.root, { recursive: true, force: true }); });
+  afterAll(async () => { await db?.close(); rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(authorityFixture.root, { recursive: true, force: true }); });
 
   it("retains existing rows and permits both honest accounting variants", async () => {
-    expect((await db.query("select * from reader_summary_new_input_refresh_reconciliations")).rows).toHaveLength(1);
+    expect((await db.query("select * from reader_summary_new_input_refresh_reconciliations")).rows).toEqual(existingRows);
+    await insert(authority.reason, authority.invocation, refreshReconciliationAccountingFor(authority));
     await insert(pre.reason, pre.invocation, refreshReconciliationAccountingFor(pre));
     await insert(provider.reason, provider.invocation, refreshReconciliationAccountingFor(provider));
     const reported = { ...provider, invocation: { ...provider.invocation, providerUsageReported: true,
       usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 } } };
     await insert(reported.reason, reported.invocation, refreshReconciliationAccountingFor(reported));
+  });
+  it.each([
+    ...Object.keys(authority.invocation).map((key) => ({ [key]: undefined })),
+    ...Object.keys(authority.invocation).map((key) => ({ [key]: null })),
+    { evidenceKind: "paired_capture" }, { evidenceKind: 1 },
+    { journalPath: 7 }, { journalPath: "relative" }, { manifestPath: false },
+    { journalSha256: "invalid" }, { journalSha256: 1 },
+    { invocationConsumedCount: 1 }, { invocationConsumedCount: "0" },
+    { delegatedInvocationCount: 1 }, { delegatedInvocationCount: "0" },
+    { providerUsageReported: true }, { providerUsageReported: "false" },
+    { attempts: [] }, { attempts: {} }, { attempts: "attempt" },
+    { capturePath: "/synthetic" }, { captureSha256: "a".repeat(64) },
+    { usage: {} }, { requestId: "provider" },
+  ])("rejects malformed current-authority invocation %j", async (override) => {
+    await expect(insert(authority.reason, { ...authority.invocation, ...override },
+      refreshReconciliationAccountingFor(authority))).rejects.toMatchObject({ code: "23514" });
+  });
+  it.each([
+    { providerInvocations: 1 }, { providerInvocations: "0" },
+    { providerUsage: "unknown" }, { providerUsage: "reported" }, { usage: {} },
+    { summaryGenerations: 1 }, { publications: 1 }, { artifacts: 1 },
+    { providerUsage: null }, { providerUsage: undefined },
+  ])("rejects malformed current-authority accounting %j", async (override) => {
+    await expect(insert(authority.reason, authority.invocation,
+      { ...refreshReconciliationAccountingFor(authority), ...override }))
+      .rejects.toMatchObject({ code: "23514" });
+  });
+  it("rejects provider/current-authority cross-family combinations", async () => {
+    for (const [reason, invocation, accounting] of [
+      [provider.reason, authority.invocation, refreshReconciliationAccountingFor(provider)],
+      [provider.reason, authority.invocation, refreshReconciliationAccountingFor(authority)],
+      [authority.reason, provider.invocation, refreshReconciliationAccountingFor(authority)],
+      [authority.reason, authority.invocation, refreshReconciliationAccountingFor(provider)],
+      [authority.reason, authority.invocation, refreshReconciliationAccountingFor(reported)],
+    ] as const) {
+      await expect(insert(reason, invocation, accounting)).rejects.toMatchObject({ code: "23514" });
+    }
+    await expect(insert(reported.reason, reported.invocation, {
+      ...refreshReconciliationAccountingFor(reported),
+      usage: { inputTokens: 1, outputTokens: 4, totalTokens: 5 },
+    })).rejects.toMatchObject({ code: "23514" });
+    await expect(insert(provider.reason, {
+      ...provider.invocation, evidenceKind: "journal_current_authority",
+      invocationConsumedCount: 0, delegatedInvocationCount: 0, attempts: [{}],
+    }, refreshReconciliationAccountingFor(provider))).rejects.toMatchObject({ code: "23514" });
+    await expect(insert(reported.reason, reported.invocation, {
+      ...refreshReconciliationAccountingFor(reported), usage: undefined,
+    })).rejects.toMatchObject({ code: "23514" });
+    await expect(insert(provider.reason, provider.invocation, {
+      ...refreshReconciliationAccountingFor(provider), providerUsage: null,
+    })).rejects.toMatchObject({ code: "23514" });
   });
   it.each([
     { consumedAt: "2026-09-07T00:00:00.000Z" }, { usage: {} },


### PR DESCRIPTION
Production reconciliation of the Aug 31 zero-delegation failure reached PostgreSQL but failed with `P2010 / 23514`: the database constraints still allowed only provider-consumed accounting. The application evidence validator had already proven six failures occurred exclusively at `current_authority`, with no provider delegation or usage.

This forward migration keeps the existing provider-consumed unknown/reported accounting variants and adds the strict pre-provider family with `providerInvocations=0` and `providerUsage=none`. The focused PostgreSQL contract test covers current-authority acceptance, existing-row preservation, malformed JSON, NULL/type bypasses and cross-family rejection.

Validation:
- Production evidence validator passed for immutable evidence SHA `97e6a691be6d48aee33f7e548f6af1cab64438861048d916341a774ce0badc13`
- Production insert reproduced the constraint failure before this migration
- `git diff --check` passed
- GitHub CI is the exact-commit PostgreSQL execution gate

Refs #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reconciliation record validation to accept only recognized job outcomes, operations, date ranges, and integrity identifiers.
  - Added stricter validation for usage totals and accounting details, reducing the risk of inconsistent or fabricated reconciliation data.
  - Added support for valid current-authority evidence in reconciliation records.
  - Existing valid records remain preserved during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->