### PR TITLE
fix(reader-summary): admit stale v2 rebuild source

### DIFF
--- a/scripts/lib/reader-summary-promotion-v2-historical-artifact.ts
+++ b/scripts/lib/reader-summary-promotion-v2-historical-artifact.ts
@@ -117,6 +117,28 @@ export const isHistoricalPromotionTargetTuple = (
   value: HistoricalPromotionArtifactVerification,
 ): boolean => value.kind === "valid-v2" || value.kind === "valid-no-signal";
 
+export const isHistoricalPromotionRebuildSourceTuple = (
+  value: HistoricalPromotionArtifactVerification,
+  targetRankingPolicyVersion: string,
+): boolean => value.kind === "strict-v1" ||
+  (value.kind === "valid-v2" && isOlderRankingPolicy(
+    value.rankingPolicyVersion,
+    targetRankingPolicyVersion,
+  ));
+
+const isOlderRankingPolicy = (source: string, target: string): boolean => {
+  const targetOrdinal = rankingPolicyOrdinal(target);
+  if (targetOrdinal === null) return false;
+  if (source === "reader_promotion_policy.v2") return true;
+  const sourceOrdinal = rankingPolicyOrdinal(source);
+  return sourceOrdinal !== null && sourceOrdinal < targetOrdinal;
+};
+
+const rankingPolicyOrdinal = (value: string): number | null => {
+  const match = /^story_ranking_v([1-9][0-9]*)$/u.exec(value);
+  return match === null ? null : Number(match[1]);
+};
+
 const orderedLanes = (
   snapshot: ReturnType<ReaderSummaryArtifact["toSnapshot"]>,
   attestations: NonNullable<

--- a/scripts/lib/reader-summary-promotion-v2-historical-postgres.ts
+++ b/scripts/lib/reader-summary-promotion-v2-historical-postgres.ts
@@ -20,6 +20,7 @@ import type {
   HistoricalPromotionVerifiedOutput,
 } from "./reader-summary-promotion-v2-historical-runner";
 import {
+  isHistoricalPromotionRebuildSourceTuple,
   isHistoricalPromotionTargetTuple,
   verifyHistoricalPromotionArtifact,
   type HistoricalPromotionArtifactRecord,
@@ -216,11 +217,11 @@ export class PostgresHistoricalPromotionAdapter
       }
       if (bundle !== undefined && active !== null &&
           active.publicationId === bundle.sourcePublicationId &&
-          publicationTupleKind(active) !== "strict-v1") {
+          !isRebuildableSourcePublication(active, bundle)) {
         return {
           state: "ambiguous",
           activePublicationId: active.publicationId,
-          reason: "active_source_publication_tuple_is_not_strict_v1",
+          reason: "active_source_publication_tuple_is_not_rebuildable",
         };
       }
       if (jobs.rows.length === 0) {
@@ -852,13 +853,17 @@ const isValidV2Publication = (row: PublicationRow): boolean => {
   }
 };
 
-const publicationTupleKind = (
+const isRebuildableSourcePublication = (
   row: PublicationRow,
-): "strict-v1" | "valid-v2" | "valid-no-signal" | "unknown" => {
+  bundle: HistoricalPromotionEvidenceBundle,
+): boolean => {
   try {
-    return verifyHistoricalPromotionArtifact(row).kind;
+    return isHistoricalPromotionRebuildSourceTuple(
+      verifyHistoricalPromotionArtifact(row),
+      bundle.canonicalInput.generationAuthority.execution.rankingPolicyVersion,
+    );
   } catch {
-    return "unknown";
+    return false;
   }
 };
 

--- a/scripts/lib/reader-summary-promotion-v2-historical-preparation.spec.ts
+++ b/scripts/lib/reader-summary-promotion-v2-historical-preparation.spec.ts
@@ -8,6 +8,10 @@ import { buildReaderSummaryDayDatasetManifest } from
   "./reader-summary-day-dataset-manifest";
 import { historicalPromotionRebuildIdentity } from
   "./reader-summary-promotion-v2-historical-classification";
+import {
+  isHistoricalPromotionRebuildSourceTuple,
+  type HistoricalPromotionArtifactVerification,
+} from "./reader-summary-promotion-v2-historical-artifact";
 import { readerSummaryProductionDayScope } from
   "./reader-summary-production-day-scope";
 import { resolveProductionDayExecutionRequest } from
@@ -33,6 +37,44 @@ const date = "2026-08-01";
 const now = new Date("2026-08-31T12:00:00.000Z");
 
 describe("historical Promotion V2 active-publication preparation", () => {
+  it("admits strict V1 and stale V2 sources only", () => {
+    const tuple = (
+      kind: HistoricalPromotionArtifactVerification["kind"],
+      rankingPolicyVersion: string,
+    ): HistoricalPromotionArtifactVerification => ({
+      kind,
+      rankingPolicyVersion,
+      noSignal: kind === "valid-no-signal",
+      orderedLanes: { top: [], additional: [] },
+      citationCount: 0,
+    });
+
+    expect(isHistoricalPromotionRebuildSourceTuple(
+      tuple("strict-v1", "story_ranking_v10"),
+      "story_ranking_v11",
+    )).toBe(true);
+    expect(isHistoricalPromotionRebuildSourceTuple(
+      tuple("valid-v2", "story_ranking_v10"),
+      "story_ranking_v11",
+    )).toBe(true);
+    expect(isHistoricalPromotionRebuildSourceTuple(
+      tuple("valid-v2", "reader_promotion_policy.v2"),
+      "story_ranking_v11",
+    )).toBe(true);
+    expect(isHistoricalPromotionRebuildSourceTuple(
+      tuple("valid-v2", "story_ranking_v11"),
+      "story_ranking_v11",
+    )).toBe(false);
+    expect(isHistoricalPromotionRebuildSourceTuple(
+      tuple("valid-no-signal", "story_ranking_v10"),
+      "story_ranking_v11",
+    )).toBe(false);
+    expect(isHistoricalPromotionRebuildSourceTuple(
+      tuple("valid-v2", "story_ranking_v12"),
+      "story_ranking_v11",
+    )).toBe(false);
+  });
+
   let directory: string;
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- admit a valid Promotion V2 publication when its ranking lineage is older than the prepared target
- keep current-ranking V2 and explicit no-signal publications non-rebuildable
- cover the exact source-tuple matrix that blocked the Sep 8 production rebuild

## Evidence

- Sep 8 execute stopped before provider invocation with `active_source_publication_tuple_is_not_strict_v1`
- focused historical preparation/rebuild suite: pass
- production TypeScript build typecheck with patched files: pass

Refs #293
Refs #294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved historical promotion rebuild eligibility checks.
  - Stale strict v1 and v2 source records can now be accepted when appropriate.
  - Current-policy v2 records and records without ranking signals are correctly rejected as rebuild sources.
  - Ambiguous state handling now identifies sources that cannot be safely rebuilt.

- **Tests**
  - Added coverage for historical promotion source eligibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->