### PR TITLE
fix(ingestion): renew fixed-window metric authorities

### DIFF
--- a/libs/ingestion/domain/policies/retained-metric-daily-grant.spec.ts
+++ b/libs/ingestion/domain/policies/retained-metric-daily-grant.spec.ts
@@ -1,6 +1,6 @@
 import { retainedMetricDailyAuthorities, retainedMetricDailyGrant } from "./retained-metric-daily-grant";
 
-it("supersedes only the spent August 30 authority with one fixed operation and fresh evidence path", () => {
+it("preserves the August 30 superseding authority with one fixed operation and fresh evidence path", () => {
   const grant = retainedMetricDailyGrant("2026-08-30")!;
   expect(grant).toEqual({
     date: "2026-08-30",
@@ -19,22 +19,22 @@ it("supersedes only the spent August 30 authority with one fixed operation and f
   expect(retainedMetricDailyAuthorities.some((a) => String(a.operationId) === "036aa064-a511-5e4a-a4b0-72c14b0e9844")).toBe(false);
 });
 
-it("preserves all six other daily authorities exactly", () => {
+it("pins four fresh single-use authorities and preserves September 3 and 4 exactly", () => {
   expect(retainedMetricDailyAuthorities.filter((a) => a.date !== "2026-08-30")).toEqual([
   {
     "date": "2026-08-31",
-    "operationId": "b8f0c1b6-8fc1-5a75-b9ba-751b58e58ee6",
-    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260910-2026-08-31"
+    "operationId": "9a4ae7f7-a980-4bc8-84ab-dae3a554979b",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260913-2026-08-31"
   },
   {
     "date": "2026-09-01",
-    "operationId": "7b851fad-99fc-534d-b83b-b11752892569",
-    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260910-2026-09-01"
+    "operationId": "1ce8c0b0-e6eb-4398-8154-7f70b98e666a",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260913-2026-09-01"
   },
   {
     "date": "2026-09-02",
-    "operationId": "f1f6e28f-5098-537a-a579-7772005dca93",
-    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260910-2026-09-02"
+    "operationId": "c778513e-5f8f-40fb-a0fb-d3d04ebbcf0d",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260913-2026-09-02"
   },
   {
     "date": "2026-09-03",
@@ -48,8 +48,8 @@ it("preserves all six other daily authorities exactly", () => {
   },
   {
     "date": "2026-09-05",
-    "operationId": "98a0c5da-4e3b-5c8f-956b-8c982d6fd7ce",
-    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260910-2026-09-05"
+    "operationId": "28a3a18f-f88a-4545-b964-b0058e42452e",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260913-2026-09-05"
   }
 ]);
   expect(retainedMetricDailyAuthorities).toHaveLength(7);

--- a/libs/ingestion/domain/policies/retained-metric-daily-grant.ts
+++ b/libs/ingestion/domain/policies/retained-metric-daily-grant.ts
@@ -1,7 +1,8 @@
-// Seven reviewed single-use incident authorities for the final E2E refresh.
-// Prior September 9 evidence remains immutable at its original paths.
-// August 30 supersedes its spent September 10 authority once; retain that
-// evidence at its original path. The other six authorities remain unchanged.
+// Seven reviewed single-use authorities for August 30–September 5, 2026 UTC.
+// August 31, September 1, 2 and 5 each supersede their spent September 10
+// authority once with a September 13 operation and fresh evidence path.
+// Preserve all prior evidence bytes at their original paths as immutable history.
+// August 30's September 13 authority and September 3/4 authorities stay unchanged.
 import { retainedMetricRenewalGrant } from "./retained-metric-renewal-grant";
 
 export const retainedMetricDailyAuthorities = [
@@ -12,18 +13,18 @@ export const retainedMetricDailyAuthorities = [
   },
   {
     "date": "2026-08-31",
-    "operationId": "b8f0c1b6-8fc1-5a75-b9ba-751b58e58ee6",
-    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260910-2026-08-31"
+    "operationId": "9a4ae7f7-a980-4bc8-84ab-dae3a554979b",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260913-2026-08-31"
   },
   {
     "date": "2026-09-01",
-    "operationId": "7b851fad-99fc-534d-b83b-b11752892569",
-    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260910-2026-09-01"
+    "operationId": "1ce8c0b0-e6eb-4398-8154-7f70b98e666a",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260913-2026-09-01"
   },
   {
     "date": "2026-09-02",
-    "operationId": "f1f6e28f-5098-537a-a579-7772005dca93",
-    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260910-2026-09-02"
+    "operationId": "c778513e-5f8f-40fb-a0fb-d3d04ebbcf0d",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260913-2026-09-02"
   },
   {
     "date": "2026-09-03",
@@ -37,8 +38,8 @@ export const retainedMetricDailyAuthorities = [
   },
   {
     "date": "2026-09-05",
-    "operationId": "98a0c5da-4e3b-5c8f-956b-8c982d6fd7ce",
-    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260910-2026-09-05"
+    "operationId": "28a3a18f-f88a-4545-b964-b0058e42452e",
+    "evidencePath": "seven-day-6101-6102/retained-metrics-daily-20260913-2026-09-05"
   }
 ] as const;
 export type MetricDailyDate = typeof retainedMetricDailyAuthorities[number]["date"];


### PR DESCRIPTION
The fixed-window historical rebuild needs fresh HN/Reddit engagement authority before promotion assessment. Four target dates still pointed at terminal September 10 renewal receipts, so reruns only replayed stale observations.

This change grants one new immutable September 13 renewal operation for August 31, September 1, September 2, and September 5. Existing receipts remain preserved, August 30 keeps its already-issued fresh authority, and the verified no-signal dates September 3/4 remain unchanged.

Validation:
- `git diff --check`
- exact four-authority comparison against `353f64bb0f1da981fc410a338b753978602f80cb`
- independent hosted review and CI tracked on this exact head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated retained-metric daily authority records with refreshed evidence references and operation identifiers.
  - Preserved the existing superseding authority and validation behavior for dates and stale identifiers.

- **Tests**
  - Updated expectations to match the refreshed authorities.
  - Continued verifying authority counts, identifier and evidence-path uniqueness, and rejection of unreviewed or noncanonical dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->