### PR TITLE
fix(relevance): admit historical social observations and preserve quality traces

### DIFF
--- a/apps/x-collector/src/x_collector/x_observation/__init__.py
+++ b/apps/x-collector/src/x_collector/x_observation/__init__.py
@@ -1,1 +1,6 @@
-"""Private retained-X observation. No runtime composition or implicit clients."""
+"""Dormant historical X-recovery experiment, not an approved runtime path.
+
+Prefer a simpler bounded and auditable recovery for a concrete missed-post
+incident. Do not compose, activate, or extend this package without fresh
+explicit owner agreement and evidence that the simpler path is insufficient.
+"""

--- a/libs/ingestion/domain/x-observation/x-observation-contract.ts
+++ b/libs/ingestion/domain/x-observation/x-observation-contract.ts
@@ -1,4 +1,9 @@
 import type { XAcquisitionPayload, XSupplementary, XPredecessorEvidence } from "./x-observation-acquisition-contract";
+
+// OWNER STATUS: dormant historical-recovery experiment, not an approved runtime path.
+// Prefer a simpler bounded and auditable recovery for any concrete missed-post incident.
+// Do not compose, activate, or extend this design without fresh explicit owner agreement
+// and evidence that the simpler recovery path cannot safely meet the requirement.
 // Incident-only values. Generated transport types never enter the authority model.
 export const xOperationId = "seven-day-6101-6102/x-observation-v1";
 export const xTenantId = "00000000-0000-7000-8000-000000006101";


### PR DESCRIPTION
## Summary
- Add historical cutoff filter (`observation.observed_at <= $2::timestamptz`) to lateral observation subqueries in `prisma-feed-promotion-exact-evidence.ts`.
- Fall back to latest observation at or before cutoff when engagement snapshot is newer than the target period.
- Ensure `check-reader-summary-source-quality-trace.ts` writes output before throwing on failed blocking gates.
- Polish workspace summary period loading indicator and keep original toggle hover bounds stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Top story cards now support concise reader-facing summaries.
  - Readers can switch between the generated summary and original post content, with expandable long text.
  - Source details now display provider, handle, date, and rating more clearly.
  - Workspace summary views show a progress indicator while refreshing.

- **Improvements**
  - Summary content is validated and preserved consistently across published cards and API responses.
  - Summary generation now favors shorter, focused descriptions of the post, impact, and uncertainty.
  - Displayed summaries and headlines are protected against mismatched or tampered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->